### PR TITLE
feat: add analysis for release branches

### DIFF
--- a/Pipeline/Build.Push.cs
+++ b/Pipeline/Build.Push.cs
@@ -36,5 +36,5 @@ partial class Build
 
 	string BranchSpec => GitHubActions?.Ref;
 
-	bool IsTag => BranchSpec != null && BranchSpec.Contains("refs/tags", StringComparison.OrdinalIgnoreCase);
+	bool IsTag => BranchSpec != null && BranchSpec.StartsWith("refs/tags/", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
Support Sonarcloud analysis for release branches by mapping builds on release tags to a long-lived release-branch