### PR TITLE
fix: correct permissions for jobs in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,7 @@ jobs:
       - name: Publish
         run: nuget push Artifacts/Packages/*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
       - name: Create GitHub release
+        continue-on-error: true
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.tag.outputs.release_version }}
@@ -188,10 +189,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ push ]
     permissions:
-        contents: write
+        issues: write
         pull-requests: write
+        contents: write
     steps:
       - name: Comment relevant issues and pull requests
+        continue-on-error: true
         uses: apexskier/github-release-commenter@v1.3.6
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -206,5 +209,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Delete release branch
+        continue-on-error: true
         shell: bash
         run: git push origin -d "${GITHUB_REF}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     needs: [ pack ]
+    permissions:
+      contents: write
     steps:
       - name: Download packages
         uses: actions/download-artifact@v4
@@ -185,6 +187,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [ push ]
+    permissions:
+        contents: write
+        pull-requests: write
     steps:
       - name: Comment relevant issues and pull requests
         uses: apexskier/github-release-commenter@v1.3.6


### PR DESCRIPTION
The jobs did not have sufficient permissions to create a release for [v0.1.0](https://github.com/aweXpect/aweXpect/actions/runs/11984960188):

Adjust permissions and set [`continue-on-error`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) to `true` for actions after the nuget packages were pushed.