### PR TITLE
fix: code coverage due to incorrect format of Tunit

### DIFF
--- a/Pipeline/Build.CodeCoverage.cs
+++ b/Pipeline/Build.CodeCoverage.cs
@@ -19,7 +19,6 @@ partial class Build
 					framework: "net8.0"))
 				.SetTargetDirectory(TestResultsDirectory / "reports")
 				.AddReports(TestResultsDirectory / "**/coverage.cobertura.xml")
-				.AddReports(TestResultsDirectory / "*.cobertura.xml")
 				.AddReportTypes(ReportTypes.OpenCover)
 				.AddFileFilters("-*.g.cs")
 				.SetAssemblyFilters("+aweXpect*"));

--- a/Pipeline/Build.FrameworkTest.cs
+++ b/Pipeline/Build.FrameworkTest.cs
@@ -80,6 +80,7 @@ partial class Build
 						.SetProcessArgumentConfigurator(args => args
 							.Add("--")
 							.Add("--coverage")
+							.Add("--disable-logo")
 							.Add("--coverage-output-format \"cobertura\"")
 							.Add("--report-trx")
 							.Add($"--report-trx-filename {v.project.Name}_{v.framework}.trx")

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,5 +19,9 @@ partial class Build : NukeBuild
 	AbsolutePath TestResultsDirectory => RootDirectory / "TestResults";
 	GitHubActions GitHubActions => GitHubActions.Instance;
 
-	public static int Main() => Execute<Build>(x => x.ApiChecks, x => x.Benchmarks, x => x.CodeAnalysis);
+	public static int Main() => Execute<Build>([
+		x => x.ApiChecks,
+		x => x.Benchmarks,
+		x => x.CodeAnalysis,
+		]);
 }


### PR DESCRIPTION
The coverage file from TUnit is incompatible with the other coverage files, which results in the number of (uncovered) lines double the actual number. Therefore exclude the TUnit coverage file from the merged report file