### PR TITLE
refactor: add `dependencies` label to dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Europe/Vienna"
+      labels:
+      - "dependencies"
 
   - package-ecosystem: "nuget"
     directory: "/"
@@ -15,3 +17,5 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Europe/Vienna"
+      labels:
+      - "dependencies"


### PR DESCRIPTION
Automatically add the `dependencies` [label](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels) to pull requests created by dependabot