### PR TITLE
feat: add `.Within` overload for `DateOnly.Be` and `TimeOnly.Be`

### DIFF
--- a/Docs/pages/docs/expectations/dates-times.md
+++ b/Docs/pages/docs/expectations/dates-times.md
@@ -183,6 +183,14 @@ DateOnly subject = new DateOnly(2024, 12, 24);
 await Expect.That(subject).Should().Be(new DateOnly(2024, 12, 24));
 ```
 
+You can also specify a tolerance:
+
+```csharp
+DateOnly subject = new DateOnly(2024, 12, 24);
+await Expect.That(subject).Should().Be(new DateOnly(2024, 12, 23))
+  .Within(TimeSpan.FromDays(1));
+```
+
 ### After / before
 
 You can also verify that a `DateOnly` is after or before another value

--- a/Docs/pages/docs/expectations/dates-times.md
+++ b/Docs/pages/docs/expectations/dates-times.md
@@ -234,6 +234,14 @@ TimeOnly subject = new TimeOnly(14, 15, 16);
 await Expect.That(subject).Should().Be(new TimeOnly(14, 15, 16));
 ```
 
+You can also specify a tolerance:
+
+```csharp
+TimeOnly subject = new TimeOnly(14, 15, 16);
+await Expect.That(subject).Should().Be(new TimeOnly(14, 15, 17));
+  .Within(TimeSpan.FromSeconds(1));
+```
+
 ### After / before
 
 You can also verify that a `TimeOnly` is after or before another value

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.Be.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.Be.cs
@@ -1,8 +1,8 @@
 ﻿#if NET6_0_OR_GREATER
-using System;
 using aweXpect.Core;
 using aweXpect.Options;
 using aweXpect.Results;
+using System;
 
 namespace aweXpect;
 
@@ -15,8 +15,7 @@ public static partial class ThatDateOnlyShould
 		DateOnly? expected)
 	{
 		TimeTolerance tolerance = new();
-		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
-			source.ExpectationBuilder.AddConstraint(it
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(source.ExpectationBuilder.AddConstraint(it
 				=> new ConditionConstraintWithTolerance(
 					it,
 					expected,
@@ -43,8 +42,8 @@ public static partial class ThatDateOnlyShould
 					it,
 					unexpected,
 					(e, t) => $"not be {Formatter.Format(e)}{t.ToDayString()}",
-					(a, e, t) => e == null ||
-					             Math.Abs(a.DayNumber - e.Value.DayNumber) > (int)t.TotalDays,
+					(a, u, t) => u == null ||
+					             Math.Abs(a.DayNumber - u.Value.DayNumber) > (int)t.TotalDays,
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.cs
@@ -18,26 +18,6 @@ public static partial class ThatDateOnlyShould
 	public static IThat<DateOnly> Should(this IExpectSubject<DateOnly> subject)
 		=> subject.Should(That.WithoutAction);
 
-	private readonly struct ConditionConstraint(
-		string it,
-		DateOnly? expected,
-		Func<DateOnly, DateOnly?, bool> condition,
-		string expectation) : IValueConstraint<DateOnly>
-	{
-		public ConstraintResult IsMetBy(DateOnly actual)
-		{
-			if (condition(actual, expected))
-			{
-				return new ConstraintResult.Success<DateOnly>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"{it} was {Formatter.Format(actual)}");
-		}
-
-		public override string ToString()
-			=> expectation;
-	}
-
 	private readonly struct PropertyConstraint<T>(
 		string it,
 		T expected,
@@ -69,19 +49,13 @@ public static partial class ThatDateOnlyShould
 	{
 		public ConstraintResult IsMetBy(DateOnly actual)
 		{
-			if (expected is null)
-			{
-				return new ConstraintResult.Failure(ToString(),
-					failureMessageFactory(actual, expected, it));
-			}
-
-			if (condition(actual, expected.Value, tolerance.Tolerance ?? TimeSpan.Zero))
+			if (condition(actual, expected, tolerance.Tolerance ?? TimeSpan.Zero))
 			{
 				return new ConstraintResult.Success<DateOnly>(actual, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				failureMessageFactory(actual, expected.Value, it));
+				failureMessageFactory(actual, expected, it));
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.Be.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.Be.cs
@@ -43,9 +43,9 @@ public static partial class ThatNullableDateOnlyShould
 					it,
 					unexpected,
 					(e, t) => $"not be {Formatter.Format(e)}{t.ToDayString()}",
-					(a, e, t) => ((a == null) != (e == null)) ||
-					             (a != null && e != null &&
-					              Math.Abs(a.Value.DayNumber - e.Value.DayNumber) > (int)t.TotalDays),
+					(a, u, t) => ((a == null) != (u == null)) ||
+					             (a != null && u != null &&
+					              Math.Abs(a.Value.DayNumber - u.Value.DayNumber) > (int)t.TotalDays),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),
 			source,

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.Be.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.Be.cs
@@ -1,6 +1,7 @@
 ﻿#if NET6_0_OR_GREATER
 using System;
 using aweXpect.Core;
+using aweXpect.Options;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -10,31 +11,45 @@ public static partial class ThatNullableDateOnlyShould
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<DateOnly?, IThat<DateOnly?>> Be(this IThat<DateOnly?> source,
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> Be(this IThat<DateOnly?> source,
 		DateOnly? expected)
 	{
-		return new AndOrResult<DateOnly?, IThat<DateOnly?>>(source.ExpectationBuilder.AddConstraint(
-				it
-					=> new ConditionConstraint(
-						it,
-						expected,
-						(a, e) => a.Equals(e),
-						$"be {Formatter.Format(expected)}")),
-			source);
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new ConditionConstraintWithTolerance(
+					it,
+					expected,
+					(e, t) => $"be {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => (a == null && e == null) ||
+					             (a != null && e != null &&
+					              Math.Abs(a.Value.DayNumber - e.Value.DayNumber) <= (int)t.TotalDays),
+					(a, _, i) => $"{i} was {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
 	}
 
 	/// <summary>
 	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
 	/// </summary>
-	public static AndOrResult<DateOnly?, IThat<DateOnly?>> NotBe(
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> NotBe(
 		this IThat<DateOnly?> source,
 		DateOnly? unexpected)
-		=> new(source.ExpectationBuilder.AddConstraint(it
-				=> new ConditionConstraint(
+	{
+		TimeTolerance tolerance = new();
+		return new(source.ExpectationBuilder.AddConstraint(it
+				=> new ConditionConstraintWithTolerance(
 					it,
 					unexpected,
-					(a, e) => !a.Equals(e),
-					$"not be {Formatter.Format(unexpected)}")),
-			source);
+					(e, t) => $"not be {Formatter.Format(e)}{t.ToDayString()}",
+					(a, e, t) => ((a == null) != (e == null)) ||
+					             (a != null && e != null &&
+					              Math.Abs(a.Value.DayNumber - e.Value.DayNumber) > (int)t.TotalDays),
+					(a, _, i) => $"{i} was {Formatter.Format(a)}",
+					tolerance)),
+			source,
+			tolerance);
+	}
 }
 #endif

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.cs
@@ -38,26 +38,6 @@ public static partial class ThatNullableDateOnlyShould
 			=> expectation;
 	}
 
-	private readonly struct ConditionConstraint(
-		string it,
-		DateOnly? expected,
-		Func<DateOnly?, DateOnly?, bool> condition,
-		string expectation) : IValueConstraint<DateOnly?>
-	{
-		public ConstraintResult IsMetBy(DateOnly? actual)
-		{
-			if (condition(actual, expected))
-			{
-				return new ConstraintResult.Success<DateOnly?>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"{it} was {Formatter.Format(actual)}");
-		}
-
-		public override string ToString()
-			=> expectation;
-	}
-
 	private readonly struct ConditionConstraintWithTolerance(
 		string it,
 		DateOnly? expected,
@@ -69,19 +49,13 @@ public static partial class ThatNullableDateOnlyShould
 	{
 		public ConstraintResult IsMetBy(DateOnly? actual)
 		{
-			if (expected is null)
-			{
-				return new ConstraintResult.Failure(ToString(),
-					failureMessageFactory(actual, expected, it));
-			}
-
-			if (condition(actual, expected.Value, tolerance.Tolerance ?? TimeSpan.Zero))
+			if (condition(actual, expected, tolerance.Tolerance ?? TimeSpan.Zero))
 			{
 				return new ConstraintResult.Success<DateOnly?>(actual, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				failureMessageFactory(actual, expected.Value, it));
+				failureMessageFactory(actual, expected, it));
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.cs
@@ -18,26 +18,6 @@ public static partial class ThatNullableTimeOnlyShould
 	public static IThat<TimeOnly?> Should(this IExpectSubject<TimeOnly?> subject)
 		=> subject.Should(That.WithoutAction);
 
-	private readonly struct ConditionConstraint(
-		string it,
-		TimeOnly? expected,
-		Func<TimeOnly?, TimeOnly?, bool> condition,
-		string expectation) : IValueConstraint<TimeOnly?>
-	{
-		public ConstraintResult IsMetBy(TimeOnly? actual)
-		{
-			if (condition(actual, expected))
-			{
-				return new ConstraintResult.Success<TimeOnly?>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"{it} was {Formatter.Format(actual)}");
-		}
-
-		public override string ToString()
-			=> expectation;
-	}
-
 	private readonly struct PropertyConstraint<T>(
 		string it,
 		T expected,
@@ -69,19 +49,13 @@ public static partial class ThatNullableTimeOnlyShould
 	{
 		public ConstraintResult IsMetBy(TimeOnly? actual)
 		{
-			if (expected is null)
-			{
-				return new ConstraintResult.Failure(ToString(),
-					failureMessageFactory(actual, expected, it));
-			}
-
-			if (condition(actual, expected.Value, tolerance.Tolerance ?? TimeSpan.Zero))
+			if (condition(actual, expected, tolerance.Tolerance ?? TimeSpan.Zero))
 			{
 				return new ConstraintResult.Success<TimeOnly?>(actual, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				failureMessageFactory(actual, expected.Value, it));
+				failureMessageFactory(actual, expected, it));
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.cs
@@ -18,26 +18,6 @@ public static partial class ThatTimeOnlyShould
 	public static IThat<TimeOnly> Should(this IExpectSubject<TimeOnly> subject)
 		=> subject.Should(That.WithoutAction);
 
-	private readonly struct ConditionConstraint(
-		string it,
-		TimeOnly expected,
-		Func<TimeOnly, TimeOnly, bool> condition,
-		string expectation) : IValueConstraint<TimeOnly>
-	{
-		public ConstraintResult IsMetBy(TimeOnly actual)
-		{
-			if (condition(actual, expected))
-			{
-				return new ConstraintResult.Success<TimeOnly>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure(ToString(), $"{it} was {Formatter.Format(actual)}");
-		}
-
-		public override string ToString()
-			=> expectation;
-	}
-
 	private readonly struct PropertyConstraint<T>(
 		string it,
 		T expected,
@@ -69,19 +49,13 @@ public static partial class ThatTimeOnlyShould
 	{
 		public ConstraintResult IsMetBy(TimeOnly actual)
 		{
-			if (expected is null)
-			{
-				return new ConstraintResult.Failure(ToString(),
-					failureMessageFactory(actual, expected, it));
-			}
-
-			if (condition(actual, expected.Value, tolerance.Tolerance ?? TimeSpan.Zero))
+			if (condition(actual, expected, tolerance.Tolerance ?? TimeSpan.Zero))
 			{
 				return new ConstraintResult.Success<TimeOnly>(actual, ToString());
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				failureMessageFactory(actual, expected.Value, it));
+				failureMessageFactory(actual, expected, it));
 		}
 
 		public override string ToString()

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -85,7 +85,7 @@ namespace aweXpect
     }
     public static class ThatDateOnlyShould
     {
-        public static aweXpect.Results.AndOrResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> Be(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> Be(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> BeAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> BeBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> BeOnOrAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
@@ -93,7 +93,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> HaveDay(this aweXpect.Core.IThat<System.DateOnly> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> HaveMonth(this aweXpect.Core.IThat<System.DateOnly> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> HaveYear(this aweXpect.Core.IThat<System.DateOnly> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> NotBe(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> NotBe(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> NotBeAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> NotBeBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> NotBeOnOrAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
@@ -295,7 +295,7 @@ namespace aweXpect
     }
     public static class ThatNullableDateOnlyShould
     {
-        public static aweXpect.Results.AndOrResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> Be(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> Be(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> BeAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> BeBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> BeOnOrAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
@@ -303,7 +303,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> HaveDay(this aweXpect.Core.IThat<System.DateOnly?> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> HaveMonth(this aweXpect.Core.IThat<System.DateOnly?> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> HaveYear(this aweXpect.Core.IThat<System.DateOnly?> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> NotBe(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> NotBe(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> NotBeAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> NotBeBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> NotBeOnOrAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
@@ -410,7 +410,7 @@ namespace aweXpect
     }
     public static class ThatNullableTimeOnlyShould
     {
-        public static aweXpect.Results.AndOrResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> Be(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> Be(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> BeAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> BeBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> BeOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
@@ -419,7 +419,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> HaveMillisecond(this aweXpect.Core.IThat<System.TimeOnly?> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> HaveMinute(this aweXpect.Core.IThat<System.TimeOnly?> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> HaveSecond(this aweXpect.Core.IThat<System.TimeOnly?> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> NotBe(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> NotBe(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> NotBeAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> NotBeBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> NotBeOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
@@ -827,7 +827,7 @@ namespace aweXpect
     }
     public static class ThatTimeOnlyShould
     {
-        public static aweXpect.Results.AndOrResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> Be(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> Be(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> BeAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> BeBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> BeOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
@@ -836,7 +836,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> HaveMillisecond(this aweXpect.Core.IThat<System.TimeOnly> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> HaveMinute(this aweXpect.Core.IThat<System.TimeOnly> source, int? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> HaveSecond(this aweXpect.Core.IThat<System.TimeOnly> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> NotBe(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> NotBe(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> NotBeAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> NotBeBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> NotBeOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeTests.cs
@@ -50,7 +50,7 @@ public sealed partial class DateOnlyShould
 
 			await That(Act).Should().NotThrow();
 		}
-		
+
 		[Theory]
 		[InlineData(3, 2, true)]
 		[InlineData(5, 3, true)]
@@ -107,7 +107,19 @@ public sealed partial class DateOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-		
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Theory]
 		[InlineData(3, 2, false)]
 		[InlineData(5, 3, false)]
@@ -117,10 +129,10 @@ public sealed partial class DateOnlyShould
 			int actualDifference, int tolerance, bool expectToThrow)
 		{
 			DateOnly subject = EarlierTime(actualDifference);
-			DateOnly expected = CurrentTime();
+			DateOnly unexpected = CurrentTime();
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected)
+				=> await That(subject).Should().NotBe(unexpected)
 					.Within(TimeSpan.FromDays(tolerance))
 					.Because("we want to test the failure");
 
@@ -128,7 +140,7 @@ public sealed partial class DateOnlyShould
 				.OnlyIf(expectToThrow)
 				.WithMessage($"""
 				              Expected subject to
-				              not be {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+				              not be {Formatter.Format(unexpected)} ± {tolerance} days, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeTests.cs
@@ -6,6 +6,23 @@ public sealed partial class DateOnlyShould
 	public sealed class BeTests
 	{
 		[Fact]
+		public async Task WhenExpectedIsNull_ShouldFail()
+		{
+			DateOnly subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldFail()
 		{
 			DateOnly subject = CurrentTime();
@@ -32,6 +49,31 @@ public sealed partial class DateOnlyShould
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().NotThrow();
+		}
+		
+		[Theory]
+		[InlineData(3, 2, true)]
+		[InlineData(5, 3, true)]
+		[InlineData(2, 2, false)]
+		[InlineData(0, 2, false)]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+			int actualDifference, int tolerance, bool expectToThrow)
+		{
+			DateOnly subject = EarlierTime(actualDifference);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected)
+					.Within(TimeSpan.FromDays(tolerance))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.OnlyIf(expectToThrow)
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+				              but it was {Formatter.Format(subject)}
+				              """);
 		}
 	}
 
@@ -62,6 +104,31 @@ public sealed partial class DateOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
+		
+		[Theory]
+		[InlineData(3, 2, false)]
+		[InlineData(5, 3, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(0, 2, true)]
+		public async Task Within_WhenValuesAreInsideTheTolerance_ShouldFail(
+			int actualDifference, int tolerance, bool expectToThrow)
+		{
+			DateOnly subject = EarlierTime(actualDifference);
+			DateOnly expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected)
+					.Within(TimeSpan.FromDays(tolerance))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.OnlyIf(expectToThrow)
+				.WithMessage($"""
+				              Expected subject to
+				              not be {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeTests.cs
@@ -50,7 +50,7 @@ public sealed partial class NullableDateOnlyShould
 
 			await That(Act).Should().NotThrow();
 		}
-		
+
 		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldFail()
 		{
@@ -67,7 +67,7 @@ public sealed partial class NullableDateOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-		
+
 		[Fact]
 		public async Task WhenSubjectIsTheSame_ShouldSucceed()
 		{
@@ -109,37 +109,37 @@ public sealed partial class NullableDateOnlyShould
 	public sealed class NotBeTests
 	{
 		[Fact]
-		public async Task WhenOnlyExpectedIsNull_ShouldSucceed()
-		{
-			DateOnly? subject = CurrentTime();
-			DateOnly? expected = null;
-
-			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
 		public async Task WhenOnlySubjectIsNull_ShouldSucceed()
 		{
 			DateOnly? subject = null;
-			DateOnly? expected = CurrentTime();
+			DateOnly? unexpected = CurrentTime();
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
+		public async Task WhenOnlyUnexpectedIsNull_ShouldSucceed()
 		{
-			DateOnly? subject = null;
-			DateOnly? expected = null;
+			DateOnly? subject = CurrentTime();
+			DateOnly? unexpected = null;
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndUnexpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = null;
+			DateOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -148,7 +148,7 @@ public sealed partial class NullableDateOnlyShould
 				             but it was <null>
 				             """);
 		}
-		
+
 		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldSucceed()
 		{
@@ -177,7 +177,7 @@ public sealed partial class NullableDateOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-		
+
 		[Theory]
 		[InlineData(3, 2, false)]
 		[InlineData(5, 3, false)]
@@ -187,10 +187,10 @@ public sealed partial class NullableDateOnlyShould
 			int actualDifference, int tolerance, bool expectToThrow)
 		{
 			DateOnly? subject = EarlierTime(actualDifference);
-			DateOnly? expected = CurrentTime();
+			DateOnly? unexpected = CurrentTime();
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected)
+				=> await That(subject).Should().NotBe(unexpected)
 					.Within(TimeSpan.FromDays(tolerance))
 					.Because("we want to test the failure");
 
@@ -198,7 +198,7 @@ public sealed partial class NullableDateOnlyShould
 				.OnlyIf(expectToThrow)
 				.WithMessage($"""
 				              Expected subject to
-				              not be {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+				              not be {Formatter.Format(unexpected)} ± {tolerance} days, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeTests.cs
@@ -6,6 +6,52 @@ public sealed partial class NullableDateOnlyShould
 	public sealed class BeTests
 	{
 		[Fact]
+		public async Task WhenOnlyExpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenOnlySubjectIsNull_ShouldFail()
+		{
+			DateOnly? subject = null;
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)},
+				              but it was <null>
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+		{
+			DateOnly? subject = null;
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+		
+		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldFail()
 		{
 			DateOnly? subject = CurrentTime();
@@ -21,7 +67,7 @@ public sealed partial class NullableDateOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-
+		
 		[Fact]
 		public async Task WhenSubjectIsTheSame_ShouldSucceed()
 		{
@@ -33,10 +79,76 @@ public sealed partial class NullableDateOnlyShould
 
 			await That(Act).Should().NotThrow();
 		}
+
+		[Theory]
+		[InlineData(3, 2, true)]
+		[InlineData(5, 3, true)]
+		[InlineData(2, 2, false)]
+		[InlineData(0, 2, false)]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+			int actualDifference, int tolerance, bool expectToThrow)
+		{
+			DateOnly? subject = EarlierTime(actualDifference);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected)
+					.Within(TimeSpan.FromDays(tolerance))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.OnlyIf(expectToThrow)
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
 	}
 
 	public sealed class NotBeTests
 	{
+		[Fact]
+		public async Task WhenOnlyExpectedIsNull_ShouldSucceed()
+		{
+			DateOnly? subject = CurrentTime();
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenOnlySubjectIsNull_ShouldSucceed()
+		{
+			DateOnly? subject = null;
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
+		{
+			DateOnly? subject = null;
+			DateOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be <null>,
+				             but it was <null>
+				             """);
+		}
+		
 		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldSucceed()
 		{
@@ -62,6 +174,31 @@ public sealed partial class NullableDateOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
+		
+		[Theory]
+		[InlineData(3, 2, false)]
+		[InlineData(5, 3, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(0, 2, true)]
+		public async Task Within_WhenValuesAreInsideTheTolerance_ShouldFail(
+			int actualDifference, int tolerance, bool expectToThrow)
+		{
+			DateOnly? subject = EarlierTime(actualDifference);
+			DateOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected)
+					.Within(TimeSpan.FromDays(tolerance))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.OnlyIf(expectToThrow)
+				.WithMessage($"""
+				              Expected subject to
+				              not be {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeTests.cs
@@ -110,37 +110,37 @@ public sealed partial class NullableTimeOnlyShould
 	public sealed class NotBeTests
 	{
 		[Fact]
-		public async Task WhenOnlyExpectedIsNull_ShouldSucceed()
-		{
-			TimeOnly? subject = CurrentTime();
-			TimeOnly? expected = null;
-
-			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
 		public async Task WhenOnlySubjectIsNull_ShouldSucceed()
 		{
 			TimeOnly? subject = null;
-			TimeOnly? expected = CurrentTime();
+			TimeOnly? unexpected = CurrentTime();
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
+		public async Task WhenOnlyUnexpectedIsNull_ShouldSucceed()
 		{
-			TimeOnly? subject = null;
-			TimeOnly? expected = null;
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? unexpected = null;
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndUnexpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = null;
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -178,7 +178,7 @@ public sealed partial class NullableTimeOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-		
+
 		[Theory]
 		[InlineData(3, 2, false)]
 		[InlineData(5, 3, false)]
@@ -189,10 +189,10 @@ public sealed partial class NullableTimeOnlyShould
 		{
 			TimeSpan tolerance = TimeSpan.FromSeconds(toleranceSeconds);
 			TimeOnly? subject = EarlierTime(actualDifference);
-			TimeOnly? expected = CurrentTime();
+			TimeOnly? unexpected = CurrentTime();
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected)
+				=> await That(subject).Should().NotBe(unexpected)
 					.Within(tolerance)
 					.Because("we want to test the failure");
 
@@ -200,7 +200,7 @@ public sealed partial class NullableTimeOnlyShould
 				.OnlyIf(expectToThrow)
 				.WithMessage($"""
 				              Expected subject to
-				              not be {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+				              not be {Formatter.Format(unexpected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeTests.cs
@@ -6,6 +6,52 @@ public sealed partial class NullableTimeOnlyShould
 	public sealed class BeTests
 	{
 		[Fact]
+		public async Task WhenOnlyExpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be <null>,
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenOnlySubjectIsNull_ShouldFail()
+		{
+			TimeOnly? subject = null;
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)},
+				              but it was <null>
+				              """);
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+		{
+			TimeOnly? subject = null;
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldFail()
 		{
 			TimeOnly? subject = CurrentTime();
@@ -33,10 +79,77 @@ public sealed partial class NullableTimeOnlyShould
 
 			await That(Act).Should().NotThrow();
 		}
+
+		[Theory]
+		[InlineData(3, 2, true)]
+		[InlineData(5, 3, true)]
+		[InlineData(2, 2, false)]
+		[InlineData(0, 2, false)]
+		public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+			int actualDifference, int toleranceSeconds, bool expectToThrow)
+		{
+			TimeSpan tolerance = TimeSpan.FromSeconds(toleranceSeconds);
+			TimeOnly? subject = EarlierTime(actualDifference);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected)
+					.Within(tolerance)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.OnlyIf(expectToThrow)
+				.WithMessage($"""
+				              Expected subject to
+				              be {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
 	}
 
 	public sealed class NotBeTests
 	{
+		[Fact]
+		public async Task WhenOnlyExpectedIsNull_ShouldSucceed()
+		{
+			TimeOnly? subject = CurrentTime();
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenOnlySubjectIsNull_ShouldSucceed()
+		{
+			TimeOnly? subject = null;
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
+		{
+			TimeOnly? subject = null;
+			TimeOnly? expected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             not be <null>,
+				             but it was <null>
+				             """);
+		}
+
 		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldSucceed()
 		{
@@ -62,6 +175,32 @@ public sealed partial class NullableTimeOnlyShould
 				.WithMessage($"""
 				              Expected subject to
 				              not be {Formatter.Format(unexpected)},
+				              but it was {Formatter.Format(subject)}
+				              """);
+		}
+		
+		[Theory]
+		[InlineData(3, 2, false)]
+		[InlineData(5, 3, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(0, 2, true)]
+		public async Task Within_WhenValuesAreInsideTheTolerance_ShouldFail(
+			int actualDifference, int toleranceSeconds, bool expectToThrow)
+		{
+			TimeSpan tolerance = TimeSpan.FromSeconds(toleranceSeconds);
+			TimeOnly? subject = EarlierTime(actualDifference);
+			TimeOnly? expected = CurrentTime();
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(expected)
+					.Within(tolerance)
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.OnlyIf(expectToThrow)
+				.WithMessage($"""
+				              Expected subject to
+				              not be {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class TimeOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-		
+
 		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldFail()
 		{
@@ -50,7 +50,7 @@ public sealed partial class TimeOnlyShould
 
 			await That(Act).Should().NotThrow();
 		}
-		
+
 		[Theory]
 		[InlineData(3, 2, true)]
 		[InlineData(5, 3, true)]
@@ -81,18 +81,6 @@ public sealed partial class TimeOnlyShould
 	public sealed class NotBeTests
 	{
 		[Fact]
-		public async Task WhenExpectedIsNull_ShouldSucceed()
-		{
-			TimeOnly subject = CurrentTime();
-			TimeOnly? expected = null;
-
-			async Task Act()
-				=> await That(subject).Should().NotBe(expected);
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
 		public async Task WhenSubjectIsDifferent_ShouldSucceed()
 		{
 			TimeOnly subject = CurrentTime();
@@ -120,7 +108,19 @@ public sealed partial class TimeOnlyShould
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}
-		
+
+		[Fact]
+		public async Task WhenUnexpectedIsNull_ShouldSucceed()
+		{
+			TimeOnly subject = CurrentTime();
+			TimeOnly? unexpected = null;
+
+			async Task Act()
+				=> await That(subject).Should().NotBe(unexpected);
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Theory]
 		[InlineData(3, 2, false)]
 		[InlineData(5, 3, false)]
@@ -131,10 +131,10 @@ public sealed partial class TimeOnlyShould
 		{
 			TimeSpan tolerance = TimeSpan.FromSeconds(toleranceSeconds);
 			TimeOnly subject = EarlierTime(actualDifference);
-			TimeOnly expected = CurrentTime();
+			TimeOnly unexpected = CurrentTime();
 
 			async Task Act()
-				=> await That(subject).Should().NotBe(expected)
+				=> await That(subject).Should().NotBe(unexpected)
 					.Within(tolerance)
 					.Because("we want to test the failure");
 
@@ -142,7 +142,7 @@ public sealed partial class TimeOnlyShould
 				.OnlyIf(expectToThrow)
 				.WithMessage($"""
 				              Expected subject to
-				              not be {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+				              not be {Formatter.Format(unexpected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 				              but it was {Formatter.Format(subject)}
 				              """);
 		}


### PR DESCRIPTION
Fixes #40 