### PR TITLE
fix: only update benchmarks on main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
         - name: Run benchmarks
           run: ./build.sh Benchmarks
         - name: Store benchmark result
+          if: github.ref == 'refs/heads/main'
           uses: rhysd/github-action-benchmark@v1
           with:
             name: Benchmark.Net Benchmark
@@ -114,6 +115,7 @@ jobs:
             benchmark-data-dir-path: 'Docs/pages/static/js'
             auto-push: false
         - name: Push benchmark result
+          if: github.ref == 'refs/heads/main'
           run: |
             git config --global user.email "benchmarks@testably.org"
             git config --global user.name "Benchmark User"


### PR DESCRIPTION
The release build [fails](https://github.com/aweXpect/aweXpect/actions/runs/12052836995/job/33607077568) because the benchmarks cannot be updated (and should not) on the tag build