### PR TITLE
fix: avoid conflicting Stryker Dashboard configuration

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -36,13 +36,21 @@ partial class Build
 
 			foreach (KeyValuePair<Project, Project[]> project in projects)
 			{
+				string branchName = GitVersion.BranchName;
+				if (GitHubActions?.Ref.StartsWith("refs/tags/", StringComparison.OrdinalIgnoreCase) == true)
+				{
+					string version = GitHubActions.Ref.Substring("refs/tags/".Length);
+					branchName = "release/" + version;
+					Log.Information("Use release branch analysis for '{BranchName}'", branchName);
+				}
+				
 				string configText = $$"""
 				                      {
 				                      	"stryker-config": {
 				                      		"project-info": {
 				                      			"name": "github.com/aweXpect/aweXpect",
 				                      			"module": "{{project.Key.Name}}",
-				                      			"version": "{{GitVersion.BranchName}}"
+				                      			"version": "{{branchName}}"
 				                      		},
 				                      		"test-projects": [
 				                      			{{string.Join(",\n\t\t\t", project.Value.Select(PathForJson))}}
@@ -68,17 +76,9 @@ partial class Build
 				File.WriteAllText(configFile, configText);
 				Log.Debug($"Created '{configFile}':{Environment.NewLine}{configText}");
 
-				string branchName = GitVersion.BranchName;
-				if (GitHubActions?.Ref.StartsWith("refs/tags/", StringComparison.OrdinalIgnoreCase) == true)
-				{
-					string version = GitHubActions.Ref.Substring("refs/tags/".Length);
-					branchName = "release/" + version;
-					Log.Information("Use release branch analysis for '{BranchName}'", branchName);
-				}
-
 				string arguments = IsServerBuild
-					? $"-f \"{configFile}\" -v \"{branchName}\" -r \"Dashboard\" -r \"cleartext\""
-					: $"-f \"{configFile}\" -v \"{branchName}\" -r \"cleartext\"";
+					? $"-f \"{configFile}\" -r \"Dashboard\" -r \"cleartext\""
+					: $"-f \"{configFile}\" -r \"cleartext\"";
 
 				string executable = EnvironmentInfo.IsWin ? "dotnet-stryker.exe" : "dotnet-stryker";
 				IProcess process = ProcessTasks.StartProcess(


### PR DESCRIPTION
Currently the [`project-info.version`](https://stryker-mutator.io/docs/stryker-net/configuration/#project-infoversion-committish) is specified twice (and differently), once in the config file and once via command line parameters.

This PR changes that only one configuration (config file) is used.