### PR TITLE
coverage: add missing formatter tests

### DIFF
--- a/Tests/aweXpect.Core.Tests/Formatting/DefaultFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/DefaultFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting;
 
 public sealed class DefaultFormatterTests
 {
@@ -10,12 +12,16 @@ public sealed class DefaultFormatterTests
 			Inner = new InnerDummy { InnerValue = "foo" },
 			Value = 2
 		};
+		string expectedResult = """
+		                        Dummy { Inner = InnerDummy { InnerValue = "foo" }, Value = 2 }
+		                        """;
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value, FormattingOptions.SingleLine);
+		Formatter.Format(sb, value, FormattingOptions.SingleLine);
 
-		await That(result).Should().Be("""
-		                               Dummy { Inner = InnerDummy { InnerValue = "foo" }, Value = 2 }
-		                               """);
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
@@ -26,17 +32,21 @@ public sealed class DefaultFormatterTests
 			Inner = new InnerDummy { InnerValue = "foo" },
 			Value = 2
 		};
+		string expectedResult = """
+		                        Dummy {
+		                          Inner = InnerDummy {
+		                            InnerValue = "foo"
+		                          },
+		                          Value = 2
+		                        }
+		                        """;
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value, FormattingOptions.MultipleLines);
+		Formatter.Format(sb, value, FormattingOptions.MultipleLines);
 
-		await That(result).Should().Be("""
-		                               Dummy {
-		                                 Inner = InnerDummy {
-		                                   InnerValue = "foo"
-		                                 },
-		                                 Value = 2
-		                               }
-		                               """);
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Theory]
@@ -44,12 +54,15 @@ public sealed class DefaultFormatterTests
 	public async Task ShouldUseToStringWhenImplemented_Default(string[] values)
 	{
 		string value = string.Join(Environment.NewLine, values);
-		string expected = string.Join($"{Environment.NewLine}  ", values) + Environment.NewLine;
+		string expectedResult = string.Join($"{Environment.NewLine}  ", values) + Environment.NewLine;
 		ClassWithToString subject = new(value);
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(subject, FormattingOptions.MultipleLines);
+		Formatter.Format(sb, subject, FormattingOptions.MultipleLines);
 
-		await That(result).Should().Be(expected);
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Theory]
@@ -57,30 +70,42 @@ public sealed class DefaultFormatterTests
 	public async Task ShouldUseToStringWhenImplemented_WithSingleLine(string value)
 	{
 		ClassWithToString subject = new(value);
+		string expectedResult = value;
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(subject, FormattingOptions.SingleLine);
+		Formatter.Format(sb, subject, FormattingOptions.SingleLine);
 
-		await That(result).Should().Be(value);
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task WhenClassContainsField_ShouldDisplayFieldValue()
 	{
 		object value = new ClassWithField { Value = 42 };
+		string expectedResult = "ClassWithField { Value = 42 }";
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value, FormattingOptions.SingleLine);
+		Formatter.Format(sb, value, FormattingOptions.SingleLine);
 
-		await That(result).Should().Be("ClassWithField { Value = 42 }");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task WhenClassIsEmpty_ShouldDisplayClassName()
 	{
 		object value = new EmptyClass();
+		string expectedResult = "EmptyClass { }";
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value, FormattingOptions.SingleLine);
+		Formatter.Format(sb, value, FormattingOptions.SingleLine);
 
-		await That(result).Should().Be("EmptyClass { }");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
@@ -88,22 +113,28 @@ public sealed class DefaultFormatterTests
 	{
 		Exception exception = new("foo");
 		object value = new ClassWithExceptionProperty(exception);
+		string expectedResult = "ClassWithExceptionProperty { Value = [Member 'Value' threw an exception: 'foo'] }";
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value, FormattingOptions.SingleLine);
+		Formatter.Format(sb, value, FormattingOptions.SingleLine);
 
-		await That(result).Should()
-			.Be(
-				"ClassWithExceptionProperty { Value = [Member 'Value' threw an exception: 'foo'] }");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task WhenObject_ShouldDisplayHashCode()
 	{
 		object value = new();
+		string expectedResult = "System.Object (HashCode=*)";
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value, FormattingOptions.SingleLine);
+		Formatter.Format(sb, value, FormattingOptions.SingleLine);
 
-		await That(result).Should().Be("System.Object (HashCode=*)").AsWildcard();
+		await That(result).Should().Be(expectedResult).AsWildcard();
+		await That(sb.ToString()).Should().Be(expectedResult).AsWildcard();
 	}
 
 	private sealed class ClassWithExceptionProperty(Exception exception)

--- a/Tests/aweXpect.Core.Tests/Formatting/DefaultFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/DefaultFormatterTests.cs
@@ -7,11 +7,7 @@ public sealed class DefaultFormatterTests
 	[Fact]
 	public async Task ShouldDisplayNestedObjects()
 	{
-		Dummy value = new()
-		{
-			Inner = new InnerDummy { InnerValue = "foo" },
-			Value = 2
-		};
+		Dummy value = new() { Inner = new InnerDummy { InnerValue = "foo" }, Value = 2 };
 		string expectedResult = """
 		                        Dummy { Inner = InnerDummy { InnerValue = "foo" }, Value = 2 }
 		                        """;
@@ -27,11 +23,7 @@ public sealed class DefaultFormatterTests
 	[Fact]
 	public async Task ShouldUseMultipleLinesPerDefault()
 	{
-		Dummy value = new()
-		{
-			Inner = new InnerDummy { InnerValue = "foo" },
-			Value = 2
-		};
+		Dummy value = new() { Inner = new InnerDummy { InnerValue = "foo" }, Value = 2 };
 		string expectedResult = """
 		                        Dummy {
 		                          Inner = InnerDummy {

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/BooleanFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/BooleanFormatterTests.cs
@@ -10,7 +10,7 @@ public sealed class BooleanFormatterTests
 	public async Task Booleans_ShouldHaveCapitalizedFirstLetter(bool value, string expectedResult)
 	{
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -25,7 +25,7 @@ public sealed class BooleanFormatterTests
 	public async Task NullableBooleans_ShouldHaveCapitalizedFirstLetter(bool? value, string expectedResult)
 	{
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/BooleanFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/BooleanFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting.Formatters;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class BooleanFormatterTests
 {
@@ -7,8 +9,27 @@ public sealed class BooleanFormatterTests
 	[InlineData(false, "False")]
 	public async Task Booleans_ShouldHaveCapitalizedFirstLetter(bool value, string expectedResult)
 	{
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(true, "True")]
+	[InlineData(false, "False")]
+	[InlineData(null, "<null>")]
+	public async Task NullableBooleans_ShouldHaveCapitalizedFirstLetter(bool? value, string expectedResult)
+	{
+		StringBuilder sb = new();
+		
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/CollectionFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/CollectionFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Core.Tests.Formatting.Formatters;

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/CollectionFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/CollectionFormatterTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
@@ -10,10 +12,13 @@ public sealed class CollectionFormatterTests
 	{
 		string expectedResult = "[\"1\", \"2\", \"3\", \"4\"]";
 		IEnumerable<string> value = Enumerable.Range(1, 4).Select(x => x.ToString());
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
@@ -21,9 +26,12 @@ public sealed class CollectionFormatterTests
 	{
 		string expectedResult = "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, …]";
 		IEnumerable<int> value = Enumerable.Range(1, 20);
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateOnlyFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateOnlyFormatterTests.cs
@@ -1,6 +1,6 @@
-﻿using System.Text;
+﻿#if NET6_0_OR_GREATER
+using System.Text;
 
-#if NET6_0_OR_GREATER
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class DateOnlyFormatterTests
@@ -11,7 +11,7 @@ public sealed class DateOnlyFormatterTests
 		DateOnly value = new(2024, 11, 2);
 		string expectedResult = "2024-11-02";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateOnlyFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateOnlyFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿#if NET6_0_OR_GREATER
+﻿using System.Text;
+
+#if NET6_0_OR_GREATER
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class DateOnlyFormatterTests
@@ -7,9 +9,14 @@ public sealed class DateOnlyFormatterTests
 	public async Task ShouldUseRoundtripFormat()
 	{
 		DateOnly value = new(2024, 11, 2);
+		string expectedResult = "2024-11-02";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("2024-11-02");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }
 #endif

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateOnlyFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateOnlyFormatterTests.cs
@@ -6,6 +6,20 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 public sealed class DateOnlyFormatterTests
 {
 	[Fact]
+	public async Task Nullable_ShouldUseRoundtripFormat()
+	{
+		DateOnly? value = new(2024, 11, 2);
+		string expectedResult = "2024-11-02";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
 	public async Task ShouldUseRoundtripFormat()
 	{
 		DateOnly value = new(2024, 11, 2);

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting.Formatters;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class DateTimeFormatterTests
 {
@@ -6,8 +8,13 @@ public sealed class DateTimeFormatterTests
 	public async Task ShouldUseRoundtripFormat()
 	{
 		DateTime value = new(2024, 11, 2, 15, 42, 08, 123);
+		string expectedResult = "2024-11-02T15:42:08.1230000";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("2024-11-02T15:42:08.1230000");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
@@ -5,6 +5,20 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 public sealed class DateTimeFormatterTests
 {
 	[Fact]
+	public async Task Nullable_ShouldUseRoundtripFormat()
+	{
+		DateTime? value = new(2024, 11, 2, 15, 42, 08, 123);
+		string expectedResult = "2024-11-02T15:42:08.1230000";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
 	public async Task ShouldUseRoundtripFormat()
 	{
 		DateTime value = new(2024, 11, 2, 15, 42, 08, 123);

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeFormatterTests.cs
@@ -10,7 +10,7 @@ public sealed class DateTimeFormatterTests
 		DateTime value = new(2024, 11, 2, 15, 42, 08, 123);
 		string expectedResult = "2024-11-02T15:42:08.1230000";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting.Formatters;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class DateTimeOffsetFormatterTests
 {
@@ -6,8 +8,13 @@ public sealed class DateTimeOffsetFormatterTests
 	public async Task ShouldUseRoundtripFormat()
 	{
 		DateTimeOffset value = new(2024, 11, 2, 15, 42, 08, 123, TimeSpan.FromHours(3));
+		string expectedResult = "2024-11-02T15:42:08.1230000+03:00";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("2024-11-02T15:42:08.1230000+03:00");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
@@ -5,6 +5,20 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 public sealed class DateTimeOffsetFormatterTests
 {
 	[Fact]
+	public async Task Nullable_ShouldUseRoundtripFormat()
+	{
+		DateTimeOffset? value = new(2024, 11, 2, 15, 42, 08, 123, TimeSpan.FromHours(3));
+		string expectedResult = "2024-11-02T15:42:08.1230000+03:00";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
 	public async Task ShouldUseRoundtripFormat()
 	{
 		DateTimeOffset value = new(2024, 11, 2, 15, 42, 08, 123, TimeSpan.FromHours(3));

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/DateTimeOffsetFormatterTests.cs
@@ -10,7 +10,7 @@ public sealed class DateTimeOffsetFormatterTests
 		DateTimeOffset value = new(2024, 11, 2, 15, 42, 08, 123, TimeSpan.FromHours(3));
 		string expectedResult = "2024-11-02T15:42:08.1230000+03:00";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/EnumFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/EnumFormatterTests.cs
@@ -13,6 +13,21 @@ public sealed class EnumFormatterTests
 	[Theory]
 	[InlineData(Dummy.Foo, "Foo")]
 	[InlineData(Dummy.Bar, "Bar")]
+	[InlineData(null, "<null>")]
+	public async Task NullableShouldUseStringRepresentation(Dummy? value, string expectedResult)
+	{
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(Dummy.Foo, "Foo")]
+	[InlineData(Dummy.Bar, "Bar")]
 	public async Task ShouldUseStringRepresentation(Dummy value, string expectedResult)
 	{
 		StringBuilder sb = new();

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/EnumFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/EnumFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting.Formatters;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class EnumFormatterTests
 {
@@ -7,9 +9,13 @@ public sealed class EnumFormatterTests
 	[InlineData(Dummy.Bar, "Bar")]
 	public async Task ShouldUseStringRepresentation(Dummy value, string expectedResult)
 	{
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	public enum Dummy

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/EnumFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/EnumFormatterTests.cs
@@ -4,23 +4,23 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class EnumFormatterTests
 {
+	public enum Dummy
+	{
+		Foo,
+		Bar
+	}
+
 	[Theory]
 	[InlineData(Dummy.Foo, "Foo")]
 	[InlineData(Dummy.Bar, "Bar")]
 	public async Task ShouldUseStringRepresentation(Dummy value, string expectedResult)
 	{
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
 		await That(sb.ToString()).Should().Be(expectedResult);
-	}
-
-	public enum Dummy
-	{
-		Foo,
-		Bar
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/GuidFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/GuidFormatterTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 
-#if NET6_0_OR_GREATER
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class GuidFormatterTests
@@ -33,4 +32,3 @@ public sealed class GuidFormatterTests
 		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }
-#endif

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/GuidFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/GuidFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿#if NET6_0_OR_GREATER
+﻿using System.Text;
+
+#if NET6_0_OR_GREATER
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class GuidFormatterTests
@@ -7,19 +9,28 @@ public sealed class GuidFormatterTests
 	public async Task Empty_ShouldUseDefaultFormat()
 	{
 		Guid value = Guid.Empty;
+		string expectedResult = "00000000-0000-0000-0000-000000000000";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("00000000-0000-0000-0000-000000000000");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldUseRoundtripFormat()
 	{
 		Guid value = Guid.NewGuid();
-		string expected = value.ToString();
+		string expectedResult = value.ToString();
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be(expected);
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }
 #endif

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/GuidFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/GuidFormatterTests.cs
@@ -10,7 +10,35 @@ public sealed class GuidFormatterTests
 		Guid value = Guid.Empty;
 		string expectedResult = "00000000-0000-0000-0000-000000000000";
 		StringBuilder sb = new();
-		
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task NullableEmpty_ShouldUseDefaultFormat()
+	{
+		Guid? value = Guid.Empty;
+		string expectedResult = "00000000-0000-0000-0000-000000000000";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task NullableShouldUseRoundtripFormat()
+	{
+		Guid? value = Guid.NewGuid();
+		string? expectedResult = value.ToString();
+		StringBuilder sb = new();
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -24,7 +52,7 @@ public sealed class GuidFormatterTests
 		Guid value = Guid.NewGuid();
 		string expectedResult = value.ToString();
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/HttpStatusCodeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/HttpStatusCodeFormatterTests.cs
@@ -9,10 +9,25 @@ public sealed class HttpStatusCodeFormatterTests
 	[Theory]
 	[InlineData(HttpStatusCode.OK, "200 OK")]
 	[InlineData(HttpStatusCode.BadRequest, "400 BadRequest")]
+	[InlineData(null, "<null>")]
+	public async Task Nullable_ShouldIncludeNumberAndDescription(HttpStatusCode? value, string expectedResult)
+	{
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Theory]
+	[InlineData(HttpStatusCode.OK, "200 OK")]
+	[InlineData(HttpStatusCode.BadRequest, "400 BadRequest")]
 	public async Task ShouldIncludeNumberAndDescription(HttpStatusCode value, string expectedResult)
 	{
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/HttpStatusCodeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/HttpStatusCodeFormatterTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Net;
+using System.Text;
 
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
@@ -10,9 +11,13 @@ public sealed class HttpStatusCodeFormatterTests
 	[InlineData(HttpStatusCode.BadRequest, "400 BadRequest")]
 	public async Task ShouldIncludeNumberAndDescription(HttpStatusCode value, string expectedResult)
 	{
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }
 #endif

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting.Formatters;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class NumberFormatterTests
 {
@@ -7,9 +9,13 @@ public sealed class NumberFormatterTests
 	{
 		decimal value = new(11.3);
 		string expectedResult = "11.3";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
@@ -17,9 +23,13 @@ public sealed class NumberFormatterTests
 	{
 		nint value = -123;
 		string expectedResult = "-123";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
@@ -27,9 +37,13 @@ public sealed class NumberFormatterTests
 	{
 		nuint value = 123;
 		string expectedResult = "123";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Theory]
@@ -45,8 +59,12 @@ public sealed class NumberFormatterTests
 	[InlineData(10.2, "10.2")]
 	public async Task Numbers_ShouldReturnExpectedValue(object value, string expectedResult)
 	{
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -10,7 +10,7 @@ public sealed class NumberFormatterTests
 		decimal value = new(11.3);
 		string expectedResult = "11.3";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -24,7 +24,7 @@ public sealed class NumberFormatterTests
 		nint value = -123;
 		string expectedResult = "-123";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -38,7 +38,7 @@ public sealed class NumberFormatterTests
 		nuint value = 123;
 		string expectedResult = "123";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -60,7 +60,7 @@ public sealed class NumberFormatterTests
 	public async Task Numbers_ShouldReturnExpectedValue(object value, string expectedResult)
 	{
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/NumberFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/NumberFormatterTests.cs
@@ -4,19 +4,32 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class NumberFormatterTests
 {
-	[Fact]
-	public async Task Numbers_Decimal_ShouldReturnExpectedValue()
-	{
-		decimal value = new(11.3);
-		string expectedResult = "11.3";
-		StringBuilder sb = new();
-
-		string result = Formatter.Format(value);
-		Formatter.Format(sb, value);
-
-		await That(result).Should().Be(expectedResult);
-		await That(sb.ToString()).Should().Be(expectedResult);
-	}
+	public static TheoryData<object?, string> GetValues
+		=> new()
+		{
+			{ -1, "-1" },
+			{ (uint)2, "2" },
+			{ (byte)3, "3" },
+			{ (sbyte)-4, "-4" },
+			{ (short)-5, "-5" },
+			{ (ushort)6, "6" },
+			{ (long)-7, "-7" },
+			{ (ulong)8, "8" },
+			{ 9.1F, "9.1" },
+			{ 10.2, "10.2" },
+			{ new decimal(11.3), "11.3" },
+			{ (int?)-10, "-10" },
+			{ (uint?)20, "20" },
+			{ (byte?)30, "30" },
+			{ (sbyte?)-40, "-40" },
+			{ (short?)-50, "-50" },
+			{ (ushort?)60, "60" },
+			{ (long?)-70, "-70" },
+			{ (ulong?)80, "80" },
+			{ (float?)9.01F, "9.01" },
+			{ (double?)10.02, "10.02" },
+			{ (decimal?)new decimal(11.03), "11.03" }
+		};
 
 	[Fact]
 	public async Task Numbers_Nint_ShouldReturnExpectedValue()
@@ -47,18 +60,37 @@ public sealed class NumberFormatterTests
 	}
 
 	[Theory]
-	[InlineData(-1, "-1")]
-	[InlineData((uint)2, "2")]
-	[InlineData((byte)3, "3")]
-	[InlineData((sbyte)-4, "-4")]
-	[InlineData((short)-5, "-5")]
-	[InlineData((ushort)6, "6")]
-	[InlineData((long)-7, "-7")]
-	[InlineData((ulong)8, "8")]
-	[InlineData(9.1F, "9.1")]
-	[InlineData(10.2, "10.2")]
-	public async Task Numbers_ShouldReturnExpectedValue(object value, string expectedResult)
+	[MemberData(nameof(GetValues))]
+	public async Task Numbers_ShouldReturnExpectedValue(object? value, string expectedResult)
 	{
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task NullableNumbers_Nint_ShouldReturnExpectedValue()
+	{
+		nint? value = -123;
+		string expectedResult = "-123";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task NullableNumbers_Nuint_ShouldReturnExpectedValue()
+	{
+		nuint? value = 123;
+		string expectedResult = "123";
 		StringBuilder sb = new();
 
 		string result = Formatter.Format(value);

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/StringFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/StringFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Core.Tests.Formatting.Formatters;
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class StringFormatterTests
 {
@@ -6,9 +8,13 @@ public sealed class StringFormatterTests
 	public async Task Strings_ShouldUseDoubleQuotationMarks()
 	{
 		string value = "foo";
+		string expectedResult = "\"foo\"";
+		StringBuilder sb = new();
 
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("\"foo\"");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeOnlyFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeOnlyFormatterTests.cs
@@ -6,6 +6,20 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 public sealed class TimeOnlyFormatterTests
 {
 	[Fact]
+	public async Task Nullable_ShouldUseRoundtripFormat()
+	{
+		TimeOnly? value = new(15, 42, 15, 234);
+		string expectedResult = "15:42:15.2340000";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
 	public async Task ShouldUseRoundtripFormat()
 	{
 		TimeOnly value = new(15, 42, 15, 234);

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeOnlyFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeOnlyFormatterTests.cs
@@ -1,6 +1,6 @@
-﻿using System.Text;
+﻿#if NET6_0_OR_GREATER
+using System.Text;
 
-#if NET6_0_OR_GREATER
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class TimeOnlyFormatterTests
@@ -11,7 +11,7 @@ public sealed class TimeOnlyFormatterTests
 		TimeOnly value = new(15, 42, 15, 234);
 		string expectedResult = "15:42:15.2340000";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeOnlyFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeOnlyFormatterTests.cs
@@ -1,4 +1,6 @@
-﻿#if NET6_0_OR_GREATER
+﻿using System.Text;
+
+#if NET6_0_OR_GREATER
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
 public sealed class TimeOnlyFormatterTests
@@ -7,9 +9,14 @@ public sealed class TimeOnlyFormatterTests
 	public async Task ShouldUseRoundtripFormat()
 	{
 		TimeOnly value = new(15, 42, 15, 234);
+		string expectedResult = "15:42:15.2340000";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("15:42:15.2340000");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }
 #endif

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
@@ -6,6 +6,90 @@ namespace aweXpect.Core.Tests.Formatting.Formatters;
 public sealed class TimeSpanFormatterTests
 {
 	[Fact]
+	public async Task Nullable_ShouldIncludeSingleDigitMinuteEvenWhenOnlySecondsAreSpecified()
+	{
+		TimeSpan? value = 12.Seconds();
+		string expectedResult = "0:12";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task Nullable_ShouldSupportDoubleDigitDays()
+	{
+		TimeSpan? value = 13.Days(14.Hours(15.Minutes(16.Seconds())));
+		string expectedResult = "13.14:15:16";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task Nullable_ShouldSupportDoubleDigitHours()
+	{
+		TimeSpan? value = 14.Hours(15.Minutes(16.Seconds()));
+		string expectedResult = "14:15:16";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task Nullable_ShouldSupportDoubleDigitsMinutes()
+	{
+		TimeSpan? value = 13.Minutes(14.Seconds());
+		string expectedResult = "13:14";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task Nullable_ShouldSupportSingleDigitDays()
+	{
+		TimeSpan? value = 25.Hours(15.Minutes(16.Seconds()));
+		string expectedResult = "1.01:15:16";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
+	public async Task Nullable_ShouldSupportSingleDigitHours()
+	{
+		TimeSpan? value = 73.Minutes(14.Seconds());
+		string expectedResult = "1:13:14";
+		StringBuilder sb = new();
+
+		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
+
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
+	}
+
+	[Fact]
 	public async Task ShouldIncludeSingleDigitMinuteEvenWhenOnlySecondsAreSpecified()
 	{
 		TimeSpan value = 12.Seconds();

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Extensions;
+﻿using System.Text;
+using aweXpect.Extensions;
 
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
@@ -8,53 +9,83 @@ public sealed class TimeSpanFormatterTests
 	public async Task ShouldIncludeSingleDigitMinuteEvenWhenOnlySecondsAreSpecified()
 	{
 		TimeSpan value = 12.Seconds();
+		string expectedResult = "0:12";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("0:12");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportDoubleDigitDays()
 	{
 		TimeSpan value = 13.Days(14.Hours(15.Minutes(16.Seconds())));
+		string expectedResult = "13.14:15:16";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("13.14:15:16");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportDoubleDigitHours()
 	{
 		TimeSpan value = 14.Hours(15.Minutes(16.Seconds()));
+		string expectedResult = "14:15:16";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("14:15:16");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportDoubleDigitsMinutes()
 	{
 		TimeSpan value = 13.Minutes(14.Seconds());
+		string expectedResult = "13:14";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("13:14");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportSingleDigitDays()
 	{
 		TimeSpan value = 25.Hours(15.Minutes(16.Seconds()));
+		string expectedResult = "1.01:15:16";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("1.01:15:16");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportSingleDigitHours()
 	{
 		TimeSpan value = 73.Minutes(14.Seconds());
+		string expectedResult = "1:13:14";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("1:13:14");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TimeSpanFormatterTests.cs
@@ -11,7 +11,7 @@ public sealed class TimeSpanFormatterTests
 		TimeSpan value = 12.Seconds();
 		string expectedResult = "0:12";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -25,7 +25,7 @@ public sealed class TimeSpanFormatterTests
 		TimeSpan value = 13.Days(14.Hours(15.Minutes(16.Seconds())));
 		string expectedResult = "13.14:15:16";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -39,7 +39,7 @@ public sealed class TimeSpanFormatterTests
 		TimeSpan value = 14.Hours(15.Minutes(16.Seconds()));
 		string expectedResult = "14:15:16";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -53,7 +53,7 @@ public sealed class TimeSpanFormatterTests
 		TimeSpan value = 13.Minutes(14.Seconds());
 		string expectedResult = "13:14";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -67,7 +67,7 @@ public sealed class TimeSpanFormatterTests
 		TimeSpan value = 25.Hours(15.Minutes(16.Seconds()));
 		string expectedResult = "1.01:15:16";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -81,7 +81,7 @@ public sealed class TimeSpanFormatterTests
 		TimeSpan value = 73.Minutes(14.Seconds());
 		string expectedResult = "1:13:14";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TypeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TypeFormatterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Text;
 
 namespace aweXpect.Core.Tests.Formatting.Formatters;
 
@@ -51,54 +52,82 @@ public sealed class TypeFormatterTests
 	public async Task ShouldSupportArraySyntax()
 	{
 		Type value = typeof(int[]);
+		string expectedResult = "int[]";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("int[]");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportArraySyntaxWithComplexObjects()
 	{
 		Type value = typeof(TypeFormatterTests[]);
+		string expectedResult = $"{nameof(TypeFormatterTests)}[]";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be($"{nameof(TypeFormatterTests)}[]");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportGenericTypeDefinitions()
 	{
 		Type value = typeof(IEnumerable<int>);
+		string expectedResult = "IEnumerable<int>";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be("IEnumerable<int>");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task ShouldSupportNestedGenericTypeDefinitions()
 	{
 		Type value = typeof(Expression<Func<TypeFormatterTests[], bool>>);
+		string expectedResult = $"Expression<Func<{nameof(TypeFormatterTests)}[], bool>>";
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should()
-			.Be($"Expression<Func<{nameof(TypeFormatterTests)}[], bool>>");
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Theory]
 	[MemberData(nameof(SimpleTypes))]
 	public async Task SimpleTypes_ShouldUseSimpleNames(Type value, string expectedResult)
 	{
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
 		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 
 	[Fact]
 	public async Task Types_ShouldOnlyIncludeTheName()
 	{
 		Type value = typeof(TypeFormatterTests);
+		string expectedResult = nameof(TypeFormatterTests);
+		StringBuilder sb = new();
+		
 		string result = Formatter.Format(value);
+		Formatter.Format(sb, value);
 
-		await That(result).Should().Be(nameof(TypeFormatterTests));
+		await That(result).Should().Be(expectedResult);
+		await That(sb.ToString()).Should().Be(expectedResult);
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/Formatters/TypeFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/Formatters/TypeFormatterTests.cs
@@ -43,7 +43,7 @@ public sealed class TypeFormatterTests
 			{ typeof(bool?), "bool?" },
 			{ typeof(char), "char" },
 			{ typeof(char?), "char?" },
-			{ typeof(void), "void" },
+			{ typeof(void), "void" }
 		};
 
 	#endregion
@@ -54,7 +54,7 @@ public sealed class TypeFormatterTests
 		Type value = typeof(int[]);
 		string expectedResult = "int[]";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -68,7 +68,7 @@ public sealed class TypeFormatterTests
 		Type value = typeof(TypeFormatterTests[]);
 		string expectedResult = $"{nameof(TypeFormatterTests)}[]";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -82,7 +82,7 @@ public sealed class TypeFormatterTests
 		Type value = typeof(IEnumerable<int>);
 		string expectedResult = "IEnumerable<int>";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -96,7 +96,7 @@ public sealed class TypeFormatterTests
 		Type value = typeof(Expression<Func<TypeFormatterTests[], bool>>);
 		string expectedResult = $"Expression<Func<{nameof(TypeFormatterTests)}[], bool>>";
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -109,7 +109,7 @@ public sealed class TypeFormatterTests
 	public async Task SimpleTypes_ShouldUseSimpleNames(Type value, string expectedResult)
 	{
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 
@@ -123,7 +123,7 @@ public sealed class TypeFormatterTests
 		Type value = typeof(TypeFormatterTests);
 		string expectedResult = nameof(TypeFormatterTests);
 		StringBuilder sb = new();
-		
+
 		string result = Formatter.Format(value);
 		Formatter.Format(sb, value);
 


### PR DESCRIPTION
Extend Formatter tests to also include the overload with a `StringBuilder`