### PR TITLE
feat: add `Times` to disambiguate parameters

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -23,7 +23,7 @@ You can verify, that at least a fixed number of items in the collection, satisfy
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
 
-await Expect.That(values).Should().AtLeast(9, x => x.Satisfy(i => i < 10));
+await Expect.That(values).Should().AtLeast(9.Times(), x => x.Satisfy(i => i < 10));
 ```
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
 
@@ -34,7 +34,7 @@ You can verify, that at most a fixed number of items in the collection, satisfy 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
 
-await Expect.That(values).Should().AtMost(1, x => x.Satisfy(i => i < 2));
+await Expect.That(values).Should().AtMost(1.Times(), x => x.Satisfy(i => i < 2));
 ```
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
 
@@ -44,7 +44,7 @@ await Expect.That(values).Should().AtMost(1, x => x.Satisfy(i => i < 2));
 You can verify, that between `minimum` and `maximum` items in the collection, satisfy an expectation:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
-await Expect.That(values).Should().Between(1).And(2, x => x.Satisfy(i => i < 2));
+await Expect.That(values).Should().Between(1).And(2.Times(), x => x.Satisfy(i => i < 2));
 ```
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
 

--- a/Source/aweXpect.Core/Times.cs
+++ b/Source/aweXpect.Core/Times.cs
@@ -1,0 +1,18 @@
+﻿namespace aweXpect;
+
+/// <summary>
+///     Count the number of times something occurred.
+/// </summary>
+public readonly struct Times(int value)
+{
+	/// <summary>
+	///     The number of times something occurred.
+	/// </summary>
+	public int Value { get; } = value;
+
+	/// <summary>
+	///     Implicitly convert the <paramref name="value" /> to a <see cref="Times" /> instance.
+	/// </summary>
+	public static implicit operator Times(int value)
+		=> new(value);
+}

--- a/Source/aweXpect.Core/TimesExtensions.cs
+++ b/Source/aweXpect.Core/TimesExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace aweXpect;
+
+/// <summary>
+///     Extension methods for <see cref="Times" />.
+/// </summary>
+public static class TimesExtensions
+{
+	/// <summary>
+	///     Specifies the number of times something occurs.
+	/// </summary>
+	public static Times Times(this int value)
+		=> new(value);
+}

--- a/Source/aweXpect/Results/CountResult.cs
+++ b/Source/aweXpect/Results/CountResult.cs
@@ -39,18 +39,18 @@ public class CountResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Verifies, that it occurs at least <paramref name="minimum" /> times.
 	/// </summary>
-	public TSelf AtLeast(int minimum)
+	public TSelf AtLeast(Times minimum)
 	{
-		quantifier.AtLeast(minimum);
+		quantifier.AtLeast(minimum.Value);
 		return (TSelf)this;
 	}
 
 	/// <summary>
 	///     Verifies, that it occurs at most <paramref name="maximum" /> times.
 	/// </summary>
-	public TSelf AtMost(int maximum)
+	public TSelf AtMost(Times maximum)
 	{
-		quantifier.AtMost(maximum);
+		quantifier.AtMost(maximum.Value);
 		return (TSelf)this;
 	}
 
@@ -67,9 +67,9 @@ public class CountResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Verifies, that it occurs exactly <paramref name="expected" /> times.
 	/// </summary>
-	public TSelf Exactly(int expected)
+	public TSelf Exactly(Times expected)
 	{
-		quantifier.Exactly(expected);
+		quantifier.Exactly(expected.Value);
 		return (TSelf)this;
 	}
 

--- a/Source/aweXpect/That/Collections/BetweenResult.cs
+++ b/Source/aweXpect/That/Collections/BetweenResult.cs
@@ -11,9 +11,9 @@ public class BetweenResult<TTarget, TExpectation>(
 	/// <summary>
 	///     ... and <paramref name="maximum" /> items satisfy the <paramref name="expectations" />.
 	/// </summary>
-	public TTarget And(int maximum,
+	public TTarget And(Times maximum,
 		Action<TExpectation> expectations)
-			=> callback(maximum, expectations);
+			=> callback(maximum.Value, expectations);
 }
 
 /// <summary>
@@ -25,6 +25,6 @@ public class BetweenResult<TTarget>(
 	/// <summary>
 	///     ... and <paramref name="maximum" /> items.
 	/// </summary>
-	public TTarget And(int maximum)
-		=> callback(maximum);
+	public TTarget And(Times maximum)
+		=> callback(maximum.Value);
 }

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AtLeast.cs
@@ -13,9 +13,9 @@ public static partial class ThatAsyncEnumerableShould
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> AtLeast<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,
-		int minimum,
+		Times minimum,
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
-			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum), expectations)), source);
+			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum.Value), expectations)), source);
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AtMost.cs
@@ -13,9 +13,9 @@ public static partial class ThatAsyncEnumerableShould
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> AtMost<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,
-		int maximum,
+		Times maximum,
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
-			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum), expectations)), source);
+			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum.Value), expectations)), source);
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.AtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.AtLeast.cs
@@ -12,8 +12,8 @@ public static partial class ThatEnumerableShould
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> AtLeast<TItem>(
 		this IThat<IEnumerable<TItem>> source,
-		int minimum,
+		Times minimum,
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
-			=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum), expectations)), source);
+			=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum.Value), expectations)), source);
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.AtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.AtMost.cs
@@ -12,8 +12,8 @@ public static partial class ThatEnumerableShould
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> AtMost<TItem>(
 		this IThat<IEnumerable<TItem>> source,
-		int maximum,
+		Times maximum,
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
-			=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum), expectations)), source);
+			=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum.Value), expectations)), source);
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -215,6 +215,16 @@ namespace aweXpect
     {
         public SkipException(string message) { }
     }
+    public readonly struct Times
+    {
+        public Times(int value) { }
+        public int Value { get; }
+        public static aweXpect.Times op_Implicit(int value) { }
+    }
+    public static class TimesExtensions
+    {
+        public static aweXpect.Times Times(this int value) { }
+    }
 }
 namespace aweXpect.Formatting
 {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -213,6 +213,16 @@ namespace aweXpect
     {
         public SkipException(string message) { }
     }
+    public readonly struct Times
+    {
+        public Times(int value) { }
+        public int Value { get; }
+        public static aweXpect.Times op_Implicit(int value) { }
+    }
+    public static class TimesExtensions
+    {
+        public static aweXpect.Times Times(this int value) { }
+    }
 }
 namespace aweXpect.Formatting
 {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -5,12 +5,12 @@ namespace aweXpect
     public class BetweenResult<TTarget>
     {
         public BetweenResult(System.Func<int, TTarget> callback) { }
-        public TTarget And(int maximum) { }
+        public TTarget And(aweXpect.Times maximum) { }
     }
     public class BetweenResult<TTarget, TExpectation>
     {
         public BetweenResult(System.Func<int, System.Action<TExpectation>, TTarget> callback) { }
-        public TTarget And(int maximum, System.Action<TExpectation> expectations) { }
+        public TTarget And(aweXpect.Times maximum, System.Action<TExpectation> expectations) { }
     }
     public abstract class EnumerableQuantifier
     {
@@ -27,8 +27,8 @@ namespace aweXpect
     public static class ThatAsyncEnumerableShould
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, aweXpect.Times minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> AtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, aweXpect.Times maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static aweXpect.BetweenResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>, aweXpect.Core.IThat<TItem>> Between<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem expected) { }
@@ -191,8 +191,8 @@ namespace aweXpect
     public static class ThatEnumerableShould
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, aweXpect.Times minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, aweXpect.Times maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.BetweenResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>, aweXpect.Core.IThat<TItem>> Between<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
@@ -926,10 +926,10 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.CountResult<TType, TThat, TSelf>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }
-        public TSelf AtLeast(int minimum) { }
-        public TSelf AtMost(int maximum) { }
+        public TSelf AtLeast(aweXpect.Times minimum) { }
+        public TSelf AtMost(aweXpect.Times maximum) { }
         public aweXpect.BetweenResult<TSelf> Between(int minimum) { }
-        public TSelf Exactly(int expected) { }
+        public TSelf Exactly(aweXpect.Times expected) { }
         public TSelf Never() { }
         public TSelf Once() { }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -5,12 +5,12 @@ namespace aweXpect
     public class BetweenResult<TTarget>
     {
         public BetweenResult(System.Func<int, TTarget> callback) { }
-        public TTarget And(int maximum) { }
+        public TTarget And(aweXpect.Times maximum) { }
     }
     public class BetweenResult<TTarget, TExpectation>
     {
         public BetweenResult(System.Func<int, System.Action<TExpectation>, TTarget> callback) { }
-        public TTarget And(int maximum, System.Action<TExpectation> expectations) { }
+        public TTarget And(aweXpect.Times maximum, System.Action<TExpectation> expectations) { }
     }
     public abstract class EnumerableQuantifier
     {
@@ -151,8 +151,8 @@ namespace aweXpect
     public static class ThatEnumerableShould
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, aweXpect.Times minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> AtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, aweXpect.Times maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.BetweenResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>, aweXpect.Core.IThat<TItem>> Between<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
@@ -810,10 +810,10 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.CountResult<TType, TThat, TSelf>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }
-        public TSelf AtLeast(int minimum) { }
-        public TSelf AtMost(int maximum) { }
+        public TSelf AtLeast(aweXpect.Times minimum) { }
+        public TSelf AtMost(aweXpect.Times maximum) { }
         public aweXpect.BetweenResult<TSelf> Between(int minimum) { }
-        public TSelf Exactly(int expected) { }
+        public TSelf Exactly(aweXpect.Times expected) { }
         public TSelf Never() { }
         public TSelf Once() { }
     }

--- a/Tests/aweXpect.Core.Tests/TimesTests.cs
+++ b/Tests/aweXpect.Core.Tests/TimesTests.cs
@@ -1,0 +1,31 @@
+﻿namespace aweXpect.Core.Tests;
+
+public class TimesTests
+{
+	[Theory]
+	[AutoData]
+	public async Task ExplicitConstructor_ShouldSetValueProperty(int value)
+	{
+		Times times = new(value);
+
+		await That(times.Value).Should().Be(value);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task ImplicitOperator_ShouldSetValueProperty(int value)
+	{
+		Times times = value;
+
+		await That(times.Value).Should().Be(value);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task ExtensionMethod_ShouldSetValueProperty(int value)
+	{
+		Times times = value.Times();
+
+		await That(times.Value).Should().Be(value);
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AtLeastTests.cs
@@ -19,7 +19,7 @@ public sealed partial class AsyncEnumerableShould
  GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(6, x => x.Satisfy(y => y < 6))
+				=> await That(subject).Should().AtLeast(6.Times(), x => x.Satisfy(y => y < 6))
 					.WithCancellation(token);
 
 			await That(Act).Should().NotThrow();
@@ -31,7 +31,7 @@ public sealed partial class AsyncEnumerableShould
 			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(0, x => x.Be(1))
+				=> await That(subject).Should().AtLeast(0.Times(), x => x.Be(1))
 					.And.AtLeast(0, x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
@@ -43,7 +43,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(2, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(2.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -54,7 +54,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(3, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -65,7 +65,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(5, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(5.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -81,7 +81,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(5, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(5.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AtMostTests.cs
@@ -19,7 +19,7 @@ public sealed partial class AsyncEnumerableShould
  GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(8, x=> x.Satisfy(y => y < 6))
+				=> await That(subject).Should().AtMost(8.Times(), x=> x.Satisfy(y => y < 6))
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -36,7 +36,7 @@ public sealed partial class AsyncEnumerableShould
 			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(1))
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(1))
 					.And.AtMost(3, x=> x.Be(1));
 
 			await That(Act).Should().NotThrow();
@@ -48,7 +48,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(1, x => x.Be(1));
+				=> await That(subject).Should().AtMost(1.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -64,7 +64,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(2));
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(2));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -75,7 +75,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(1));
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BetweenTests.cs
@@ -19,7 +19,7 @@ public sealed partial class AsyncEnumerableShould
  GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
-				=> await That(subject).Should().Between(6).And(8, x => x.Satisfy(y => y < 6))
+				=> await That(subject).Should().Between(6).And(8.Times(), x => x.Satisfy(y => y < 6))
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -36,7 +36,7 @@ public sealed partial class AsyncEnumerableShould
 			ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 			async Task Act()
-				=> await That(subject).Should().Between(0).And(2, x => x.Be(1))
+				=> await That(subject).Should().Between(0).And(2.Times(), x => x.Be(1))
 					.And.Between(0).And(1, x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
@@ -48,7 +48,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 			async Task Act()
-				=> await That(subject).Should().Between(0).And(1, x => x.Be(1));
+				=> await That(subject).Should().Between(0).And(1.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -64,7 +64,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().Between(3).And(4, x => x.Be(1));
+				=> await That(subject).Should().Between(3).And(4.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -75,7 +75,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().Between(3).And(4, x => x.Be(2));
+				=> await That(subject).Should().Between(3).And(4.Times(), x => x.Be(2));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -91,7 +91,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().Between(1).And(3, x => x.Be(1));
+				=> await That(subject).Should().Between(1).And(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/CollectionShould.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/CollectionShould.AtLeastTests.cs
@@ -10,7 +10,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(3, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -21,7 +21,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(5, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(5.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/CollectionShould.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/CollectionShould.AtMostTests.cs
@@ -10,7 +10,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(2));
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(2));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -21,7 +21,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(1));
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/CollectionShould.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/CollectionShould.BetweenTests.cs
@@ -10,7 +10,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().Between(3).And(4, x => x.Be(1));
+				=> await That(subject).Should().Between(3).And(4.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -21,7 +21,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().Between(3).And(4, x => x.Be(2));
+				=> await That(subject).Should().Between(3).And(4.Times(), x => x.Be(2));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -37,7 +37,7 @@ public sealed partial class CollectionShould
 			int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 			async Task Act()
-				=> await That(subject).Should().Between(1).And(3, x => x.Be(1));
+				=> await That(subject).Should().Between(1).And(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.AtLeastTests.cs
@@ -17,7 +17,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(6, x => x.Satisfy(y => y < 6))
+				=> await That(subject).Should().AtLeast(6.Times(), x => x.Satisfy(y => y < 6))
 					.WithCancellation(token);
 
 			await That(Act).Should().NotThrow();
@@ -29,7 +29,7 @@ public sealed partial class EnumerableShould
 			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(0, x => x.Be(1))
+				=> await That(subject).Should().AtLeast(0.Times(), x => x.Be(1))
 					.And.AtLeast(0, x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
@@ -41,7 +41,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(2, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(2.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -52,7 +52,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(3, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -63,7 +63,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtLeast(5, x => x.Be(1));
+				=> await That(subject).Should().AtLeast(5.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.AtMostTests.cs
@@ -17,7 +17,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(8, x => x.Satisfy(y => y < 6))
+				=> await That(subject).Should().AtMost(8.Times(), x => x.Satisfy(y => y < 6))
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -34,7 +34,7 @@ public sealed partial class EnumerableShould
 			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(1))
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(1))
 					.And.AtMost(3, x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
@@ -46,7 +46,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(1, x => x.Be(1));
+				=> await That(subject).Should().AtMost(1.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -62,7 +62,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(2));
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(2));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -73,7 +73,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().AtMost(3, x => x.Be(1));
+				=> await That(subject).Should().AtMost(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BetweenTests.cs
@@ -17,7 +17,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
 
 			async Task Act()
-				=> await That(subject).Should().Between(6).And(8, x => x.Satisfy(y => y < 6))
+				=> await That(subject).Should().Between(6).And(8.Times(), x => x.Satisfy(y => y < 6))
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -34,7 +34,7 @@ public sealed partial class EnumerableShould
 			ThrowWhenIteratingTwiceEnumerable subject = new();
 
 			async Task Act()
-				=> await That(subject).Should().Between(0).And(2, x => x.Be(1))
+				=> await That(subject).Should().Between(0).And(2.Times(), x => x.Be(1))
 					.And.Between(0).And(1, x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
@@ -46,7 +46,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 			async Task Act()
-				=> await That(subject).Should().Between(0).And(1, x => x.Be(1));
+				=> await That(subject).Should().Between(0).And(1.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -62,7 +62,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().Between(3).And(4, x => x.Be(1));
+				=> await That(subject).Should().Between(3).And(4.Times(), x => x.Be(1));
 
 			await That(Act).Should().NotThrow();
 		}
@@ -73,7 +73,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().Between(3).And(4, x => x.Be(2));
+				=> await That(subject).Should().Between(3).And(4.Times(), x => x.Be(2));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -89,7 +89,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().Between(1).And(3, x => x.Be(1));
+				=> await That(subject).Should().Between(1).And(3.Times(), x => x.Be(1));
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/StringEnumerableShould.ContainTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/StringEnumerableShould.ContainTests.cs
@@ -64,7 +64,7 @@ public partial class StringEnumerableShould
 			string[] sut = ["green", "green", "blue", "yellow"];
 
 			async Task Act()
-				=> await That(sut).Should().Contain("green").AtLeast(3);
+				=> await That(sut).Should().Contain("green").AtLeast(3.Times());
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -80,7 +80,7 @@ public partial class StringEnumerableShould
 			string[] sut = ["green", "green", "green", "green", "blue", "yellow"];
 
 			async Task Act()
-				=> await That(sut).Should().Contain("green").AtMost(2);
+				=> await That(sut).Should().Contain("green").AtMost(2.Times());
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""


### PR DESCRIPTION
Add a `Times` struct and replace the parameters that specify the occurrence with the `Times` parameter.
Add an implicit operator from `int`, so that the usage of the `.Times()` extension method is optional.