### PR TITLE
feat: always use latest benchmark data when publishing to GitHub pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,10 @@ jobs:
                     node-version: 18
                     cache: npm
                     cache-dependency-path: ./Docs/pages/package-lock.json
+            -   name: Download benchmark data
+                run: |
+                    curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js
+                working-directory: ./Docs/pages/static/js
             -   name: Install dependencies
                 working-directory: ./Docs/pages
                 run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,10 @@ jobs:
                     node-version: 18
                     cache: npm
                     cache-dependency-path: ./Docs/pages/package-lock.json
+            -   name: Download benchmark data
+                run: |
+                    curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js
+                working-directory: ./Docs/pages/static/js
             -   name: Install dependencies
                 working-directory: ./Docs/pages
                 run: npm ci


### PR DESCRIPTION
Download the benchmark data from the [`benchmarks`](https://github.com/aweXpect/aweXpect/blob/benchmarks/Docs/pages/static/js/data.js) branch before building and deploying the website.