### PR TITLE
feat: always use latest benchmark data when publishing to GitHub pages (2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,7 @@ jobs:
                     cache-dependency-path: ./Docs/pages/package-lock.json
             -   name: Download benchmark data
                 run: |
-                    curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js
+                    curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js?ref=benchmarks
                 working-directory: ./Docs/pages/static/js
             -   name: Install dependencies
                 working-directory: ./Docs/pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,7 @@ jobs:
                     cache-dependency-path: ./Docs/pages/package-lock.json
             -   name: Download benchmark data
                 run: |
+                    rm data.js
                     curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js?ref=benchmarks
                 working-directory: ./Docs/pages/static/js
             -   name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
                     cache-dependency-path: ./Docs/pages/package-lock.json
             -   name: Download benchmark data
                 run: |
-                    curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js
+                    curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js?ref=benchmarks
                 working-directory: ./Docs/pages/static/js
             -   name: Install dependencies
                 working-directory: ./Docs/pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
                     cache-dependency-path: ./Docs/pages/package-lock.json
             -   name: Download benchmark data
                 run: |
+                    rm data.js
                     curl -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/aweXpect/aweXpect/contents/Docs/pages/static/js/data.js?ref=benchmarks
                 working-directory: ./Docs/pages/static/js
             -   name: Install dependencies

--- a/Docs/pages/docs/extensibility/write-extensions.md
+++ b/Docs/pages/docs/extensibility/write-extensions.md
@@ -64,7 +64,7 @@ public static class DirectoryInfoExtensions
 }
 ```
 
-Then you can add the [extension method on `IThat<DirectoryInfo>`](#additional-methods-for-existing-types):
+Then you can add the [extension method on `IThat<DirectoryInfo>`](#for-existing-types):
 ```csharp
 /// <summary>
 ///     Verifies that the <paramref name="directory"/> is empty.


### PR DESCRIPTION
From #63 
Add `ref` to download url (see [here](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28))