### PR TITLE
feat: add `Be` collection expectations

### DIFF
--- a/Source/aweXpect.Core/Core/ICollectionMatcher.cs
+++ b/Source/aweXpect.Core/Core/ICollectionMatcher.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace aweXpect.Core;
+
+/// <summary>
+///     The matcher for collections.
+/// </summary>
+public interface ICollectionMatcher<in T, out T2> : IDisposable
+	where T : T2
+{
+	/// <summary>
+	///     Verifies for each <paramref name="value" /> in the subject, if it results in a failure.
+	/// </summary>
+	/// <returns><see langword="null" /> when it results in no failure, the failure text otherwise.</returns>
+	string? Verify(string it, T value, IOptionsEquality<T2> options);
+
+	/// <summary>
+	///     Verifies if it results in a failure when the enumeration is complete.
+	/// </summary>
+	/// <returns><see langword="null" /> when it results in no failure, the failure text otherwise.</returns>
+	string? VerifyComplete(string it, IOptionsEquality<T2> options);
+}

--- a/Source/aweXpect.Core/Core/IOptionsEquality.cs
+++ b/Source/aweXpect.Core/Core/IOptionsEquality.cs
@@ -1,0 +1,13 @@
+﻿namespace aweXpect.Core;
+
+/// <summary>
+///     Determines if two objects are considered equal.
+/// </summary>
+public interface IOptionsEquality<in T>
+{
+	/// <summary>
+	///     Returns <see langword="true" /> if the two objects <paramref name="a" /> and <paramref name="b" /> are considered
+	///     equal; otherwise <see langword="false" />.
+	/// </summary>
+	bool AreConsideredEqual(T a, T b);
+}

--- a/Source/aweXpect/Helpers/EvaluationContextExtensions.cs
+++ b/Source/aweXpect/Helpers/EvaluationContextExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using aweXpect.Core.EvaluationContext;
-using System.Collections;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace aweXpect.Helpers;
 
@@ -33,50 +31,6 @@ internal static class EvaluationContextExtensions
 		return materializedEnumerable;
 	}
 
-	private sealed class MaterializingEnumerable<T> : IEnumerable<T>
-	{
-		private readonly IEnumerator<T> _enumerator;
-		private readonly List<T> _materializedItems = new();
-
-		private MaterializingEnumerable(IEnumerable<T> enumerable)
-		{
-			_enumerator = enumerable.GetEnumerator();
-		}
-
-		#region IEnumerable<T> Members
-
-		/// <inheritdoc />
-		IEnumerator IEnumerable.GetEnumerator()
-			=> GetEnumerator();
-
-		/// <inheritdoc />
-		public IEnumerator<T> GetEnumerator()
-		{
-			foreach (T materializedItem in _materializedItems)
-			{
-				yield return materializedItem;
-			}
-
-			while (_enumerator.MoveNext())
-			{
-				T item = _enumerator.Current;
-				_materializedItems.Add(item);
-				yield return item;
-			}
-		}
-
-		#endregion
-
-		public static IEnumerable<T> Wrap(IEnumerable<T> enumerable)
-		{
-			if (enumerable is ICollection<T> or MaterializingEnumerable<T>)
-			{
-				return enumerable;
-			}
-
-			return new MaterializingEnumerable<T>(enumerable);
-		}
-	}
 #if NET6_0_OR_GREATER
 	private const string MaterializedAsyncEnumerableKey = nameof(MaterializedAsyncEnumerableKey);
 
@@ -101,51 +55,6 @@ internal static class EvaluationContextExtensions
 		// ReSharper disable once PossibleMultipleEnumeration
 		return materializedEnumerable;
 	}
-
-	private sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>
-	{
-		private readonly IAsyncEnumerator<T> _enumerator;
-		private readonly List<T> _materializedItems = new();
-
-		private MaterializingAsyncEnumerable(IAsyncEnumerable<T> enumerable)
-		{
-			_enumerator = enumerable.GetAsyncEnumerator();
-		}
-
-		#region IAsyncEnumerable<T> Members
-
-		public async IAsyncEnumerator<T> GetAsyncEnumerator(
-			CancellationToken cancellationToken = default)
-		{
-			foreach (T materializedItem in _materializedItems)
-			{
-				yield return materializedItem;
-			}
-
-			while (await _enumerator.MoveNextAsync())
-			{
-				if (cancellationToken.IsCancellationRequested)
-				{
-					break;
-				}
-
-				T item = _enumerator.Current;
-				_materializedItems.Add(item);
-				yield return item;
-			}
-		}
-
-		#endregion
-
-		public static IAsyncEnumerable<T> Wrap(IAsyncEnumerable<T> enumerable)
-		{
-			if (enumerable is MaterializingAsyncEnumerable<T>)
-			{
-				return enumerable;
-			}
-
-			return new MaterializingAsyncEnumerable<T>(enumerable);
-		}
-	}
 #endif
+
 }

--- a/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
@@ -1,0 +1,52 @@
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
+using System.Threading;
+
+namespace aweXpect.Helpers;
+
+internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>
+{
+	private readonly IAsyncEnumerator<T> _enumerator;
+	private readonly List<T> _materializedItems = new();
+
+	private MaterializingAsyncEnumerable(IAsyncEnumerable<T> enumerable)
+	{
+		_enumerator = enumerable.GetAsyncEnumerator();
+	}
+
+	#region IAsyncEnumerable<T> Members
+
+	public async IAsyncEnumerator<T> GetAsyncEnumerator(
+		CancellationToken cancellationToken = default)
+	{
+		foreach (T materializedItem in _materializedItems)
+		{
+			yield return materializedItem;
+		}
+
+		while (await _enumerator.MoveNextAsync())
+		{
+			if (cancellationToken.IsCancellationRequested)
+			{
+				break;
+			}
+
+			T item = _enumerator.Current;
+			_materializedItems.Add(item);
+			yield return item;
+		}
+	}
+
+	#endregion
+
+	public static IAsyncEnumerable<T> Wrap(IAsyncEnumerable<T> enumerable)
+	{
+		if (enumerable is MaterializingAsyncEnumerable<T>)
+		{
+			return enumerable;
+		}
+
+		return new MaterializingAsyncEnumerable<T>(enumerable);
+	}
+}
+#endif

--- a/Source/aweXpect/Helpers/MaterializingEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingEnumerable.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace aweXpect.Helpers;
+
+internal sealed class MaterializingEnumerable<T> : IEnumerable<T>
+{
+	private readonly IEnumerator<T> _enumerator;
+	private readonly List<T> _materializedItems = new();
+
+	private MaterializingEnumerable(IEnumerable<T> enumerable)
+	{
+		_enumerator = enumerable.GetEnumerator();
+	}
+
+	public static IEnumerable<T> Wrap(IEnumerable<T> enumerable)
+	{
+		if (enumerable is ICollection<T> or MaterializingEnumerable<T>)
+		{
+			return enumerable;
+		}
+
+		return new MaterializingEnumerable<T>(enumerable);
+	}
+
+	#region IEnumerable<T> Members
+
+	/// <inheritdoc />
+	IEnumerator IEnumerable.GetEnumerator()
+		=> GetEnumerator();
+
+	/// <inheritdoc />
+	public IEnumerator<T> GetEnumerator()
+	{
+		foreach (T materializedItem in _materializedItems)
+		{
+			yield return materializedItem;
+		}
+
+		while (_enumerator.MoveNext())
+		{
+			T item = _enumerator.Current;
+			_materializedItems.Add(item);
+			yield return item;
+		}
+	}
+
+	#endregion
+}

--- a/Source/aweXpect/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.cs
@@ -1,0 +1,236 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+/// <summary>
+///     Options for matching a collection.
+/// </summary>
+public class CollectionMatchOptions
+{
+	private bool _ignoringDuplicates;
+	private bool _inAnyOrder;
+
+	/// <summary>
+	///     Ignores the order in the subject and expected values.
+	/// </summary>
+	public void InAnyOrder() => _inAnyOrder = true;
+
+	/// <summary>
+	///     Ignores duplicates in both collections.
+	/// </summary>
+	public void IgnoringDuplicates() => _ignoringDuplicates = true;
+
+	/// <summary>
+	///     Get the collection matcher for the <paramref name="expected" /> enumerable.
+	/// </summary>
+	public ICollectionMatcher<T, T2> GetCollectionMatcher<T, T2>(IEnumerable<T> expected)
+		where T : T2
+		=> (_inAnyOrder, _ignoringDuplicates) switch
+		{
+			(true, true) => new AnyOrderIgnoreDuplicatesCollectionMatcher<T, T2>(expected),
+			(true, false) => new AnyOrderCollectionMatcher<T, T2>(expected),
+			(false, true) => new SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(expected),
+			(false, false) => new SameOrderCollectionMatcher<T, T2>(expected)
+		};
+
+	/// <inheritdoc />
+	public override string ToString()
+		=> (_inAnyOrder, _ignoringDuplicates) switch
+		{
+			(true, true) => " in any order ignoring duplicates",
+			(true, false) => " in any order",
+			(false, true) => " ignoring duplicates",
+			(false, false) => ""
+		};
+
+	private class AnyOrderCollectionMatcher<T, T2>(IEnumerable<T> expected) : ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly List<T> expectedList = expected.ToList();
+		private int _index;
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (expectedList.All(e => !options.AreConsideredEqual(value, e)))
+			{
+				return
+					$"{it} contained item {Formatter.Format(value)} at index {_index++} that was not expected";
+			}
+
+			expectedList.Remove(value);
+			_index++;
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			if (expectedList.Any())
+			{
+				return
+					$"{it} lacked {expectedList.Count} of {expectedList.Count + _index} expected items: {Formatter.Format(expectedList)}";
+			}
+
+			return null;
+		}
+
+		public void Dispose() => _index = -1;
+	}
+
+	private class AnyOrderIgnoreDuplicatesCollectionMatcher<T, T2>(IEnumerable<T> expected) : ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly HashSet<T> _uniqueItems = new();
+		private readonly List<T> expectedList = expected.ToList();
+		private int _index;
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (_uniqueItems.Contains(value))
+			{
+				return null;
+			}
+
+			if (expectedList.All(e => !options.AreConsideredEqual(value, e)))
+			{
+				_uniqueItems.Add(value);
+				return
+					$"{it} contained item {Formatter.Format(value)} at index {_index++} that was not expected";
+			}
+
+			_uniqueItems.Add(value);
+			_index++;
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			List<T> missingItems = expectedList.Except(_uniqueItems).Distinct().ToList();
+			if (missingItems.Any())
+			{
+				return
+					$"{it} lacked {missingItems.Count} of {missingItems.Count + _index} expected items: {Formatter.Format(missingItems)}";
+			}
+
+			return null;
+		}
+
+		public void Dispose() => _index = -1;
+	}
+
+	private class SameOrderCollectionMatcher<T, T2>(IEnumerable<T> expected) : ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly IEnumerator<T> _expectedEnumerator = MaterializingEnumerable<T>.Wrap(expected).GetEnumerator();
+		private int _index;
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (!_expectedEnumerator.MoveNext())
+			{
+				return $"{it} contained item {Formatter.Format(value)} at index {_index++} that was not expected";
+			}
+
+			if (!options.AreConsideredEqual(value, _expectedEnumerator.Current))
+			{
+				return
+					$"{it} contained item {Formatter.Format(value)} at index {_index++} instead of {Formatter.Format(_expectedEnumerator.Current)}";
+			}
+
+			_index++;
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			if (_expectedEnumerator.MoveNext())
+			{
+				List<T> missingItems =
+				[
+					_expectedEnumerator.Current
+				];
+				while (_expectedEnumerator.MoveNext())
+				{
+					missingItems.Add(_expectedEnumerator.Current);
+				}
+
+				return
+					$"{it} lacked {missingItems.Count} of {missingItems.Count + _index} expected items: {Formatter.Format(missingItems)}";
+			}
+
+			return null;
+		}
+
+		public void Dispose()
+		{
+			_index = -1;
+			_expectedEnumerator.Dispose();
+		}
+	}
+
+	private class SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(IEnumerable<T> expected)
+		: ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly IEnumerator<T> _expectedEnumerator = MaterializingEnumerable<T>.Wrap(expected).GetEnumerator();
+		private readonly HashSet<T> _uniqueItems = new();
+		private int _index;
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (_uniqueItems.Contains(value))
+			{
+				return null;
+			}
+
+			while (_expectedEnumerator.MoveNext())
+			{
+				if (!_uniqueItems.Contains(_expectedEnumerator.Current))
+				{
+					if (!options.AreConsideredEqual(value, _expectedEnumerator.Current))
+					{
+						_uniqueItems.Add(_expectedEnumerator.Current);
+						return
+							$"{it} contained item {Formatter.Format(value)} at index {_index++} instead of {Formatter.Format(_expectedEnumerator.Current)}";
+					}
+
+					break;
+				}
+			}
+
+			_uniqueItems.Add(value);
+			_index++;
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			List<T> missingItems = new();
+			while (_expectedEnumerator.MoveNext())
+			{
+				T value = _expectedEnumerator.Current;
+				if (_uniqueItems.Add(value))
+				{
+					missingItems.Add(value);
+				}
+			}
+
+			if (missingItems.Any())
+			{
+				return
+					$"{it} lacked {missingItems.Count} of {missingItems.Count + _index} expected items: {Formatter.Format(missingItems)}";
+			}
+
+			return null;
+		}
+
+		public void Dispose()
+		{
+			_uniqueItems.Clear();
+			_index = -1;
+			_expectedEnumerator.Dispose();
+		}
+	}
+}

--- a/Source/aweXpect/Options/ObjectEqualityOptions.cs
+++ b/Source/aweXpect/Options/ObjectEqualityOptions.cs
@@ -1,19 +1,23 @@
-﻿using aweXpect.Equivalency;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using aweXpect.Formatting;
+using aweXpect.Core;
+using aweXpect.Equivalency;
 
 namespace aweXpect.Options;
 
 /// <summary>
 ///     Checks equality of objects.
 /// </summary>
-public class ObjectEqualityOptions
+public class ObjectEqualityOptions : IOptionsEquality<object?>
 {
 	private static readonly IEquality EqualsType = new EqualsEquality();
 	private IEquality _type = EqualsType;
+
+	/// <inheritdoc />
+	public bool AreConsideredEqual(object? a, object? b)
+		=> AreConsideredEqual(a, b, "").AreConsideredEqual;
 
 	/// <summary>
 	///     Compares the objects via <see cref="object.Equals(object, object)" />.
@@ -73,47 +77,6 @@ public class ObjectEqualityOptions
 	private sealed class EquivalencyEquality(EquivalencyOptions equivalencyOptions)
 		: IEquality
 	{
-		#region IEquality Members
-
-		/// <inheritdoc />
-		public Result AreConsideredEqual(object? a, object? b, string it)
-		{
-			if (HandleSpecialCases(a, b, out bool? specialCaseResult))
-			{
-				return new Result(specialCaseResult.Value,
-					$"{it} was {Formatter.Format(a, FormattingOptions.MultipleLines)}");
-			}
-
-			List<ComparisonFailure> failures = Compare.CheckEquivalent(a, b,
-				new CompareOptions
-				{
-					MembersToIgnore = [.. equivalencyOptions.MembersToIgnore],
-				}).ToList();
-
-			if (failures.FirstOrDefault() is { } firstFailure)
-			{
-				if (firstFailure.Type == MemberType.Value)
-				{
-					return new Result(false,
-						$"{it} was {Formatter.Format(firstFailure.Actual, FormattingOptions.SingleLine)}");
-				}
-
-				return new Result(false, $"""
-				                          {firstFailure.Type} {string.Join(".", firstFailure.NestedMemberNames)} did not match:
-				                            Expected: {Formatter.Format(firstFailure.Expected)}
-				                            Received: {Formatter.Format(firstFailure.Actual)}
-				                          """);
-			}
-
-			return new Result(true);
-		}
-
-		/// <inheritdoc />
-		public string GetExpectation(string expectedExpression)
-			=> $"be equivalent to {expectedExpression}";
-
-		#endregion
-
 		private static bool HandleSpecialCases(object? a, object? b,
 			[NotNullWhen(true)] out bool? isConsideredEqual)
 		{
@@ -139,6 +102,44 @@ public class ObjectEqualityOptions
 			isConsideredEqual = null;
 			return false;
 		}
+
+		#region IEquality Members
+
+		/// <inheritdoc />
+		public Result AreConsideredEqual(object? a, object? b, string it)
+		{
+			if (HandleSpecialCases(a, b, out bool? specialCaseResult))
+			{
+				return new Result(specialCaseResult.Value,
+					$"{it} was {Formatter.Format(a, FormattingOptions.MultipleLines)}");
+			}
+
+			List<ComparisonFailure> failures = Compare.CheckEquivalent(a, b,
+				new CompareOptions { MembersToIgnore = [.. equivalencyOptions.MembersToIgnore] }).ToList();
+
+			if (failures.FirstOrDefault() is { } firstFailure)
+			{
+				if (firstFailure.Type == MemberType.Value)
+				{
+					return new Result(false,
+						$"{it} was {Formatter.Format(firstFailure.Actual, FormattingOptions.SingleLine)}");
+				}
+
+				return new Result(false, $"""
+				                          {firstFailure.Type} {string.Join(".", firstFailure.NestedMemberNames)} did not match:
+				                            Expected: {Formatter.Format(firstFailure.Expected)}
+				                            Received: {Formatter.Format(firstFailure.Actual)}
+				                          """);
+			}
+
+			return new Result(true);
+		}
+
+		/// <inheritdoc />
+		public string GetExpectation(string expectedExpression)
+			=> $"be equivalent to {expectedExpression}";
+
+		#endregion
 	}
 
 	private sealed class EqualsEquality : IEquality

--- a/Source/aweXpect/Results/NullableNumberToleranceResult.cs
+++ b/Source/aweXpect/Results/NullableNumberToleranceResult.cs
@@ -38,9 +38,9 @@ public class NullableNumberToleranceResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Specifies a <paramref name="tolerance" /> to apply on the number comparison.
 	/// </summary>
-	public NullableNumberToleranceResult<TType, TThat, TSelf> Within(TType tolerance)
+	public TSelf Within(TType tolerance)
 	{
 		options.SetTolerance(tolerance);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/NumberToleranceResult.cs
+++ b/Source/aweXpect/Results/NumberToleranceResult.cs
@@ -38,9 +38,9 @@ public class NumberToleranceResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Specifies a <paramref name="tolerance" /> to apply on the number comparison.
 	/// </summary>
-	public NumberToleranceResult<TType, TThat, TSelf> Within(TType tolerance)
+	public TSelf Within(TType tolerance)
 	{
 		options.SetTolerance(tolerance);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/ObjectCollectionMatchResult.cs
+++ b/Source/aweXpect/Results/ObjectCollectionMatchResult.cs
@@ -1,0 +1,55 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     In addition to the combinations from <see cref="ObjectEqualityResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="CollectionMatchOptions" />.
+/// </summary>
+public class ObjectCollectionMatchResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	ObjectEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: ObjectCollectionMatchResult<TType, TThat,
+		ObjectCollectionMatchResult<TType, TThat>>(
+		expectationBuilder,
+		returnValue,
+		options,
+		collectionMatchOptions);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     In addition to the combinations from <see cref="ObjectEqualityResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="CollectionMatchOptions" />.
+/// </summary>
+public class ObjectCollectionMatchResult<TType, TThat, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	ObjectEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: ObjectEqualityResult<TType, TThat, TSelf>(expectationBuilder, returnValue, options)
+	where TSelf : ObjectCollectionMatchResult<TType, TThat, TSelf>
+{
+	/// <summary>
+	///     Ignores the order in the subject and expected values.
+	/// </summary>
+	public TSelf InAnyOrder()
+	{
+		collectionMatchOptions.InAnyOrder();
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Ignores duplicates in both collections.
+	/// </summary>
+	public TSelf IgnoringDuplicates()
+	{
+		collectionMatchOptions.IgnoringDuplicates();
+		return (TSelf)this;
+	}
+}

--- a/Source/aweXpect/Results/ObjectCountResult.cs
+++ b/Source/aweXpect/Results/ObjectCountResult.cs
@@ -40,22 +40,22 @@ public class ObjectCountResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Use equivalency to compare objects.
 	/// </summary>
-	public ObjectCountResult<TType, TThat, TSelf> Equivalent(
+	public TSelf Equivalent(
 		Func<EquivalencyOptions, EquivalencyOptions>? optionsCallback = null)
 	{
 		EquivalencyOptions? equivalencyOptions =
 			optionsCallback?.Invoke(new EquivalencyOptions()) ?? new EquivalencyOptions();
 		options.Equivalent(equivalencyOptions);
-		return this;
+		return (TSelf)this;
 	}
 
 	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="object" />s.
 	/// </summary>
-	public ObjectCountResult<TType, TThat, TSelf> Using(
+	public TSelf Using(
 		IEqualityComparer<object> comparer)
 	{
 		options.Using(comparer);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/ObjectEqualityResult.cs
+++ b/Source/aweXpect/Results/ObjectEqualityResult.cs
@@ -37,22 +37,22 @@ public class ObjectEqualityResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Use equivalency to compare objects.
 	/// </summary>
-	public ObjectEqualityResult<TType, TThat, TSelf> Equivalent(
+	public TSelf Equivalent(
 		Func<EquivalencyOptions, EquivalencyOptions>? optionsCallback = null)
 	{
 		EquivalencyOptions? equivalencyOptions =
 			optionsCallback?.Invoke(new EquivalencyOptions()) ?? new EquivalencyOptions();
 		options.Equivalent(equivalencyOptions);
-		return this;
+		return (TSelf)this;
 	}
 
 	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="object" />s.
 	/// </summary>
-	public ObjectEqualityResult<TType, TThat, TSelf> Using(
+	public TSelf Using(
 		IEqualityComparer<object> comparer)
 	{
 		options.Using(comparer);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/StringCountResult.cs
+++ b/Source/aweXpect/Results/StringCountResult.cs
@@ -39,19 +39,19 @@ public class StringCountResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s.
 	/// </summary>
-	public StringCountResult<TType, TThat, TSelf> IgnoringCase()
+	public TSelf IgnoringCase()
 	{
 		options.IgnoringCase();
-		return this;
+		return (TSelf)this;
 	}
 
 	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
 	/// </summary>
-	public StringCountResult<TType, TThat, TSelf> Using(
+	public TSelf Using(
 		IEqualityComparer<string> comparer)
 	{
 		options.UsingComparer(comparer);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/StringEqualityResult.cs
+++ b/Source/aweXpect/Results/StringEqualityResult.cs
@@ -36,30 +36,30 @@ public class StringEqualityResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s.
 	/// </summary>
-	public StringEqualityResult<TType, TThat, TSelf> IgnoringCase()
+	public TSelf IgnoringCase()
 	{
 		options.IgnoringCase();
-		return this;
+		return (TSelf)this;
 	}
 
 	/// <summary>
 	///     Ignores casing when comparing the <see langword="string" />s, according to the <paramref name="ignoreCase" />
 	///     parameter.
 	/// </summary>
-	public StringEqualityResult<TType, TThat, TSelf> IgnoringCase(
+	public TSelf IgnoringCase(
 		bool ignoreCase)
 	{
 		options.IgnoringCase(ignoreCase);
-		return this;
+		return (TSelf)this;
 	}
 
 	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
 	/// </summary>
-	public StringEqualityResult<TType, TThat, TSelf> Using(
+	public TSelf Using(
 		IEqualityComparer<string> comparer)
 	{
 		options.UsingComparer(comparer);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/TimeToleranceResult.cs
+++ b/Source/aweXpect/Results/TimeToleranceResult.cs
@@ -36,9 +36,9 @@ public class TimeToleranceResult<TType, TThat, TSelf>(
 	/// <summary>
 	///     Specifies a <paramref name="tolerance" /> to apply on the time comparison.
 	/// </summary>
-	public TimeToleranceResult<TType, TThat, TSelf> Within(TimeSpan tolerance)
+	public TSelf Within(TimeSpan tolerance)
 	{
 		options.SetTolerance(tolerance);
-		return this;
+		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -1,0 +1,77 @@
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect;
+
+public static partial class ThatAsyncEnumerableShould
+{
+	/// <summary>
+	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
+	/// </summary>
+	public static ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
+		Be<TItem>(
+			this IThat<IAsyncEnumerable<TItem>> source,
+			IEnumerable<TItem> expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		ObjectEqualityOptions options = new ObjectEqualityOptions();
+		CollectionMatchOptions matchOptions = new CollectionMatchOptions();
+		return new ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(source
+				.ExpectationBuilder
+				.AddConstraint(it
+					=> new BeConstraint<TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+			source,
+			options,
+			matchOptions);
+	}
+
+	private readonly struct BeConstraint<TItem>(
+		string it,
+		string expectedExpression,
+		IEnumerable<TItem> expected,
+		ObjectEqualityOptions options,
+		CollectionMatchOptions matchOptions)
+		: IAsyncContextConstraint<IAsyncEnumerable<TItem>>
+	{
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TItem> actual, IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			IAsyncEnumerable<TItem> materializedEnumerable =
+				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
+			using ICollectionMatcher<TItem, object?> matcher =
+				matchOptions.GetCollectionMatcher<TItem, object?>(expected);
+			await foreach (TItem item in materializedEnumerable.WithCancellation(cancellationToken))
+			{
+				string? failure = matcher.Verify(it, item, options);
+				if (failure != null)
+				{
+					return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(), failure);
+				}
+			}
+
+			string? lastFailure = matcher.VerifyComplete(it, options);
+			if (lastFailure != null)
+			{
+				return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(), lastFailure);
+			}
+
+			return new ConstraintResult.Success<IAsyncEnumerable<TItem>>(materializedEnumerable,
+				ToString());
+		}
+
+		public override string ToString()
+			=> $"match collection {expectedExpression}{matchOptions}";
+	}
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect;
+
+public static partial class ThatEnumerableShould
+{
+	/// <summary>
+	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
+	/// </summary>
+	public static ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
+		Be<TItem>(
+			this IThat<IEnumerable<TItem>> source,
+			IEnumerable<TItem> expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		ObjectEqualityOptions options = new();
+		CollectionMatchOptions matchOptions = new();
+		return new ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(source.ExpectationBuilder
+				.AddConstraint(it
+					=> new BeConstraint<TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+			source,
+			options,
+			matchOptions);
+	}
+
+	private readonly struct BeConstraint<TItem>(
+		string it,
+		string expectedExpression,
+		IEnumerable<TItem> expected,
+		ObjectEqualityOptions options,
+		CollectionMatchOptions matchOptions)
+		: IContextConstraint<IEnumerable<TItem>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<TItem> actual, IEvaluationContext context)
+		{
+			IEnumerable<TItem> materializedEnumerable =
+				context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
+			using ICollectionMatcher<TItem, object?> matcher =
+				matchOptions.GetCollectionMatcher<TItem, object?>(expected);
+			foreach (TItem item in materializedEnumerable)
+			{
+				string? failure = matcher.Verify(it, item, options);
+				if (failure != null)
+				{
+					return new ConstraintResult.Failure<IEnumerable<TItem>>(actual, ToString(), failure);
+				}
+			}
+
+			string? lastFailure = matcher.VerifyComplete(it, options);
+			if (lastFailure != null)
+			{
+				return new ConstraintResult.Failure<IEnumerable<TItem>>(actual, ToString(), lastFailure);
+			}
+
+			return new ConstraintResult.Success<IEnumerable<TItem>>(materializedEnumerable,
+				ToString());
+		}
+
+		public override string ToString()
+			=> $"match collection {expectedExpression}{matchOptions}";
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -101,6 +101,12 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(this aweXpect.Core.ExpectationBuilder expectationBuilder, System.Func<TSource, TTarget> memberSelector, string displayName, bool replaceIt = true) { }
     }
+    public interface ICollectionMatcher<in T, out T2> : System.IDisposable
+        where in T : T2
+    {
+        string? Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options);
+        string? VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options);
+    }
     public interface IExpectSubject<out T>
     {
         bool Equals(object? obj);
@@ -108,6 +114,10 @@ namespace aweXpect.Core
         System.Type GetType();
         aweXpect.Core.IThat<T> Should(System.Action<aweXpect.Core.ExpectationBuilder> builderOptions);
         string? ToString();
+    }
+    public interface IOptionsEquality<in T>
+    {
+        bool AreConsideredEqual(T a, T b);
     }
     public interface IThat<out T>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -101,6 +101,12 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(this aweXpect.Core.ExpectationBuilder expectationBuilder, System.Func<TSource, TTarget> memberSelector, string displayName, bool replaceIt = true) { }
     }
+    public interface ICollectionMatcher<in T, out T2> : System.IDisposable
+        where in T : T2
+    {
+        string? Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options);
+        string? VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options);
+    }
     public interface IExpectSubject<out T>
     {
         bool Equals(object? obj);
@@ -108,6 +114,10 @@ namespace aweXpect.Core
         System.Type GetType();
         aweXpect.Core.IThat<T> Should(System.Action<aweXpect.Core.ExpectationBuilder> builderOptions);
         string? ToString();
+    }
+    public interface IOptionsEquality<in T>
+    {
+        bool AreConsideredEqual(T a, T b);
     }
     public interface IThat<out T>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -26,6 +26,7 @@ namespace aweXpect
     }
     public static class ThatAsyncEnumerableShould
     {
+        public static aweXpect.Results.ObjectCollectionMatchResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -190,6 +191,7 @@ namespace aweXpect
     }
     public static class ThatEnumerableShould
     {
+        public static aweXpect.Results.ObjectCollectionMatchResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -851,6 +853,15 @@ namespace aweXpect.Extensions
 }
 namespace aweXpect.Options
 {
+    public class CollectionMatchOptions
+    {
+        public CollectionMatchOptions() { }
+        public aweXpect.Core.ICollectionMatcher<T, T2> GetCollectionMatcher<T, T2>(System.Collections.Generic.IEnumerable<T> expected)
+            where T : T2 { }
+        public void IgnoringDuplicates() { }
+        public void InAnyOrder() { }
+        public override string ToString() { }
+    }
     public class EquivalencyOptions
     {
         public EquivalencyOptions() { }
@@ -865,9 +876,10 @@ namespace aweXpect.Options
         public void SetTolerance(TNumber tolerance) { }
         public override string ToString() { }
     }
-    public class ObjectEqualityOptions
+    public class ObjectEqualityOptions : aweXpect.Core.IOptionsEquality<object?>
     {
         public ObjectEqualityOptions() { }
+        public bool AreConsideredEqual(object? a, object? b) { }
         public aweXpect.Options.ObjectEqualityOptions Equals() { }
         public aweXpect.Options.ObjectEqualityOptions Equivalent(aweXpect.Options.EquivalencyOptions equivalencyOptions) { }
         public aweXpect.Options.ObjectEqualityOptions Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
@@ -943,7 +955,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, TSelf>
     {
         public NullableNumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
-        public aweXpect.Results.NullableNumberToleranceResult<TType, TThat, TSelf> Within(TType tolerance) { }
+        public TSelf Within(TType tolerance) { }
     }
     public class NumberToleranceResult<TType, TThat> : aweXpect.Results.NumberToleranceResult<TType, TThat, aweXpect.Results.NumberToleranceResult<TType, TThat>>
         where TType :  struct, System.IComparable<TType>
@@ -955,7 +967,18 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.NumberToleranceResult<TType, TThat, TSelf>
     {
         public NumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
-        public aweXpect.Results.NumberToleranceResult<TType, TThat, TSelf> Within(TType tolerance) { }
+        public TSelf Within(TType tolerance) { }
+    }
+    public class ObjectCollectionMatchResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>>
+    {
+        public ObjectCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+    }
+    public class ObjectCollectionMatchResult<TType, TThat, TSelf> : aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf>
+        where TSelf : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TSelf>
+    {
+        public ObjectCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public TSelf IgnoringDuplicates() { }
+        public TSelf InAnyOrder() { }
     }
     public class ObjectCountResult<TType, TThat> : aweXpect.Results.ObjectCountResult<TType, TThat, aweXpect.Results.ObjectCountResult<TType, TThat>>
     {
@@ -965,8 +988,8 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ObjectCountResult<TType, TThat, TSelf>
     {
         public ObjectCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.ObjectEqualityOptions options) { }
-        public aweXpect.Results.ObjectCountResult<TType, TThat, TSelf> Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
-        public aweXpect.Results.ObjectCountResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+        public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class ObjectEqualityResult<TType, TThat> : aweXpect.Results.ObjectEqualityResult<TType, TThat, aweXpect.Results.ObjectEqualityResult<TType, TThat>>
     {
@@ -976,8 +999,8 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf>
     {
         public ObjectEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options) { }
-        public aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
-        public aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+        public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class StringCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat, aweXpect.Results.StringCountResult<TType, TThat>>
     {
@@ -987,8 +1010,8 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringCountResult<TType, TThat, TSelf>
     {
         public StringCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }
-        public aweXpect.Results.StringCountResult<TType, TThat, TSelf> IgnoringCase() { }
-        public aweXpect.Results.StringCountResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+        public TSelf IgnoringCase() { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
     }
     public class StringEqualityResult<TType, TThat> : aweXpect.Results.StringEqualityResult<TType, TThat, aweXpect.Results.StringEqualityResult<TType, TThat>>
     {
@@ -998,9 +1021,9 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringEqualityResult<TType, TThat, TSelf>
     {
         public StringEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
-        public aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> IgnoringCase() { }
-        public aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> IgnoringCase(bool ignoreCase) { }
-        public aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+        public TSelf IgnoringCase() { }
+        public TSelf IgnoringCase(bool ignoreCase) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
     }
     public class StringMatcherResult<TType, TThat> : aweXpect.Results.AndOrResult<TType, TThat>
     {
@@ -1019,6 +1042,6 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.TimeToleranceResult<TType, TThat, TSelf>
     {
         public TimeToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.TimeTolerance options) { }
-        public aweXpect.Results.TimeToleranceResult<TType, TThat, TSelf> Within(System.TimeSpan tolerance) { }
+        public TSelf Within(System.TimeSpan tolerance) { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -150,6 +150,7 @@ namespace aweXpect
     }
     public static class ThatEnumerableShould
     {
+        public static aweXpect.Results.ObjectCollectionMatchResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -735,6 +736,15 @@ namespace aweXpect.Extensions
 }
 namespace aweXpect.Options
 {
+    public class CollectionMatchOptions
+    {
+        public CollectionMatchOptions() { }
+        public aweXpect.Core.ICollectionMatcher<T, T2> GetCollectionMatcher<T, T2>(System.Collections.Generic.IEnumerable<T> expected)
+            where T : T2 { }
+        public void IgnoringDuplicates() { }
+        public void InAnyOrder() { }
+        public override string ToString() { }
+    }
     public class EquivalencyOptions
     {
         public EquivalencyOptions() { }
@@ -749,9 +759,10 @@ namespace aweXpect.Options
         public void SetTolerance(TNumber tolerance) { }
         public override string ToString() { }
     }
-    public class ObjectEqualityOptions
+    public class ObjectEqualityOptions : aweXpect.Core.IOptionsEquality<object?>
     {
         public ObjectEqualityOptions() { }
+        public bool AreConsideredEqual(object? a, object? b) { }
         public aweXpect.Options.ObjectEqualityOptions Equals() { }
         public aweXpect.Options.ObjectEqualityOptions Equivalent(aweXpect.Options.EquivalencyOptions equivalencyOptions) { }
         public aweXpect.Options.ObjectEqualityOptions Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
@@ -827,7 +838,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, TSelf>
     {
         public NullableNumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
-        public aweXpect.Results.NullableNumberToleranceResult<TType, TThat, TSelf> Within(TType tolerance) { }
+        public TSelf Within(TType tolerance) { }
     }
     public class NumberToleranceResult<TType, TThat> : aweXpect.Results.NumberToleranceResult<TType, TThat, aweXpect.Results.NumberToleranceResult<TType, TThat>>
         where TType :  struct, System.IComparable<TType>
@@ -839,7 +850,18 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.NumberToleranceResult<TType, TThat, TSelf>
     {
         public NumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
-        public aweXpect.Results.NumberToleranceResult<TType, TThat, TSelf> Within(TType tolerance) { }
+        public TSelf Within(TType tolerance) { }
+    }
+    public class ObjectCollectionMatchResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>>
+    {
+        public ObjectCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+    }
+    public class ObjectCollectionMatchResult<TType, TThat, TSelf> : aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf>
+        where TSelf : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TSelf>
+    {
+        public ObjectCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public TSelf IgnoringDuplicates() { }
+        public TSelf InAnyOrder() { }
     }
     public class ObjectCountResult<TType, TThat> : aweXpect.Results.ObjectCountResult<TType, TThat, aweXpect.Results.ObjectCountResult<TType, TThat>>
     {
@@ -849,8 +871,8 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ObjectCountResult<TType, TThat, TSelf>
     {
         public ObjectCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.ObjectEqualityOptions options) { }
-        public aweXpect.Results.ObjectCountResult<TType, TThat, TSelf> Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
-        public aweXpect.Results.ObjectCountResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+        public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class ObjectEqualityResult<TType, TThat> : aweXpect.Results.ObjectEqualityResult<TType, TThat, aweXpect.Results.ObjectEqualityResult<TType, TThat>>
     {
@@ -860,8 +882,8 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf>
     {
         public ObjectEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options) { }
-        public aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
-        public aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+        public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class StringCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat, aweXpect.Results.StringCountResult<TType, TThat>>
     {
@@ -871,8 +893,8 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringCountResult<TType, TThat, TSelf>
     {
         public StringCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }
-        public aweXpect.Results.StringCountResult<TType, TThat, TSelf> IgnoringCase() { }
-        public aweXpect.Results.StringCountResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+        public TSelf IgnoringCase() { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
     }
     public class StringEqualityResult<TType, TThat> : aweXpect.Results.StringEqualityResult<TType, TThat, aweXpect.Results.StringEqualityResult<TType, TThat>>
     {
@@ -882,9 +904,9 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringEqualityResult<TType, TThat, TSelf>
     {
         public StringEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
-        public aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> IgnoringCase() { }
-        public aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> IgnoringCase(bool ignoreCase) { }
-        public aweXpect.Results.StringEqualityResult<TType, TThat, TSelf> Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+        public TSelf IgnoringCase() { }
+        public TSelf IgnoringCase(bool ignoreCase) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
     }
     public class StringMatcherResult<TType, TThat> : aweXpect.Results.AndOrResult<TType, TThat>
     {
@@ -903,6 +925,6 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.TimeToleranceResult<TType, TThat, TSelf>
     {
         public TimeToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.TimeTolerance options) { }
-        public aweXpect.Results.TimeToleranceResult<TType, TThat, TSelf> Within(System.TimeSpan tolerance) { }
+        public TSelf Within(System.TimeSpan tolerance) { }
     }
 }

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
@@ -1,0 +1,455 @@
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class AsyncEnumerableShould
+{
+	public sealed class BeTests
+	{
+		[Fact]
+		public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithSameCollection_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item 1 at index 1 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_EmptyCollection_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: [1]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item 3 at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: [3]
+				             """);
+		}
+
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			int[] expected = [1, 1, 2, 3, 1];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			int[] expected = [1, 1, 2];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 2 of 2 expected items: [1, 2]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 3 at index 1 instead of 2
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithSameCollection_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 1 at index 1 instead of 2
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_EmptyCollection_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 2 at index 1 instead of 1
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 3 at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 1 of 4 expected items: [3]
+				             """);
+		}
+
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained item 3 at index 1 instead of 2
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			int[] expected = [1, 1, 2];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 2 of 2 expected items: [1, 2]
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
@@ -1,0 +1,453 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class EnumerableShould
+{
+	public sealed class BeTests
+	{
+		[Fact]
+		public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithSameCollection_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item 1 at index 1 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_EmptyCollection_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: [1]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item 3 at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: [3]
+				             """);
+		}
+
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([]);
+			int[] expected = [1, 1, 2, 3, 1];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([]);
+			int[] expected = [1, 1, 2];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 2 of 2 expected items: [1, 2]
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 3 at index 1 instead of 2
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithSameCollection_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 1 at index 1 instead of 2
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_EmptyCollection_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 2 at index 1 instead of 1
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item 3 at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 1 of 4 expected items: [3]
+				             """);
+		}
+
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained item 3 at index 1 instead of 2
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 3 of 3 expected items: [1, 2, 3]
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([]);
+			int[] expected = [1, 1, 2];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 2 of 2 expected items: [1, 2]
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
+			int[] expected = [1, 2, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+			int[] expected = [1, 2, 3, 3];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
Add an expectation for collection `Be` that takes another collection and verifies, that they have the same values:

```csharp
int[] subject = [1, 1, 2, 3];

await That(subject).Should().Be([1, 1, 2, 3]);
await That(subject).Should().Be([3, 1, 2, 1]).InAnyOrder();
await That(subject).Should().Be([1, 1, 1, 2, 3, 3]).IgnoringDuplicates();
await That(subject).Should().Be([3, 3, 2, 1, 1, 1]).IgnoringDuplicates().InAnyOrder();
```