### PR TITLE
feat: support `AndMore`/`AndLess`/`OrMore`/`OrLess` for collections

### DIFF
--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.cs
@@ -1,6 +1,9 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using FluentAssertions;
+using FluentAssertions.Collections;
 using FluentAssertions.Primitives;
+using TUnit.Assertions.Enums;
 
 namespace aweXpect.Benchmarks;
 
@@ -10,28 +13,57 @@ public class HappyCaseBenchmarks
 	private readonly bool _boolSubject = true;
 	private readonly string _stringExpectation = "foo";
 	private readonly string _stringSubject = "foo";
+	private readonly string[] _stringArraySubject = ["foo", "bar", "baz"];
+	private readonly string[] _stringArrayExpectation = ["foo", "bar", "baz"];
+	private readonly string[] _stringArrayOtherOrderExpectation = ["foo", "baz", "bar"];
+	private readonly Consumer _consumer = new();
+	
 
 	[Benchmark]
 	public AndConstraint<BooleanAssertions> Bool_FluentAssertions()
 		=> _boolSubject.Should().BeTrue();
-
+	
 	[Benchmark]
 	public async Task<bool> Bool_aweXpect()
 		=> await Expect.That(_boolSubject).Should().BeTrue();
-
+	
 	[Benchmark]
 	public async Task<bool> Bool_TUnit()
 		=> await Assert.That(_boolSubject).IsTrue();
-
+	
 	[Benchmark]
 	public AndConstraint<StringAssertions> String_FluentAssertions()
 		=> _stringSubject.Should().Be(_stringExpectation);
-
+	
 	[Benchmark]
 	public async Task<string?> String_aweXpect()
 		=> await Expect.That(_stringSubject).Should().Be(_stringExpectation);
-
+	
 	[Benchmark]
 	public async Task<string?> String_TUnit()
 		=> await Assert.That(_stringSubject).IsEqualTo(_stringExpectation);
+	
+	[Benchmark]
+	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArray_FluentAssertions()
+		=> _stringArraySubject.Should().Equal(_stringArrayExpectation);
+	
+	[Benchmark]
+	public async Task StringArray_aweXpect()
+		=> (await Expect.That(_stringArraySubject).Should().Be(_stringArrayExpectation)).Consume(_consumer);
+	
+	[Benchmark]
+	public async Task StringArray_TUnit()
+		=> (await Assert.That(_stringArraySubject).IsEquivalentTo(_stringArrayExpectation))?.Consume(_consumer);
+	
+	[Benchmark]
+	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArrayInAnyOrder_FluentAssertions()
+		=> _stringArraySubject.Should().BeEquivalentTo(_stringArrayOtherOrderExpectation);
+	
+	[Benchmark]
+	public async Task StringArrayInAnyOrder_aweXpect()
+		=> (await Expect.That(_stringArraySubject).Should().Be(_stringArrayOtherOrderExpectation).InAnyOrder()).Consume(_consumer);
+	
+	[Benchmark]
+	public async Task StringArrayInAnyOrder_TUnit()
+		=> (await Assert.That(_stringArraySubject).IsEquivalentTo(_stringArrayOtherOrderExpectation, CollectionOrdering.Any))?.Consume(_consumer);
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
 		<PackageVersion Include="NUnit" Version="4.2.2"/>
 		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
 		<PackageVersion Include="NUnit.Analyzers" Version="4.4.0"/>
-		<PackageVersion Include="TUnit" Version="0.4.60"/>
-		<PackageVersion Include="TUnit.Assertions" Version="0.4.63"/>
+		<PackageVersion Include="TUnit" Version="0.4.74"/>
+		<PackageVersion Include="TUnit.Assertions" Version="0.4.74"/>
 		<PackageVersion Include="xunit" Version="2.9.2"/>
 		<PackageVersion Include="xunit.v3" Version="0.6.0-pre.7"/>
 		<PackageVersion Include="xunit.v3.core" Version="0.6.0-pre.7"/>

--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -20,6 +20,38 @@ await Expect.That(values).Should().Be([3, 3, 2, 2, 1, 1]).InAnyOrder().IgnoringD
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
 
 
+### Subset
+
+You can verify, that a collection matches another collection or has fewer items (it is a subset of the expected items):
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 3);
+
+await Expect.That(values).Should().Be([1, 2, 3, 4]).OrLess();
+await Expect.That(values).Should().Be([4, 3, 2, 1]).OrLess().InAnyOrder();
+await Expect.That(values).Should().Be([1, 1, 2, 2, 3, 3, 4, 4]).OrLess().IgnoringDuplicates();
+await Expect.That(values).Should().Be([4, 4, 3, 3, 2, 2, 1, 1]).OrLess().InAnyOrder().IgnoringDuplicates();
+```
+*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+To check for a proper subset, use `AndLess` instead (which would fail for equal collections).
+
+
+### Superset
+
+You can verify, that a collection matches another collection or has more items (it is a superset of the expected items):
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 3);
+
+await Expect.That(values).Should().Be([1, 2]).OrMore();
+await Expect.That(values).Should().Be([3, 2]).OrMore().InAnyOrder();
+await Expect.That(values).Should().Be([1, 1, 2, 2]).OrMore().IgnoringDuplicates();
+await Expect.That(values).Should().Be([3, 3, 1, 1]).OrMore().InAnyOrder().IgnoringDuplicates();
+```
+*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+To check for a proper superset, use `AndMore` instead (which would fail for equal collections).
+
+
 ## Have
 Specifications that match the items on a given number of occurrences.
 

--- a/Source/aweXpect.Core/Core/ICollectionMatcher.cs
+++ b/Source/aweXpect.Core/Core/ICollectionMatcher.cs
@@ -5,8 +5,7 @@ namespace aweXpect.Core;
 /// <summary>
 ///     The matcher for collections.
 /// </summary>
-public interface ICollectionMatcher<in T, out T2> : IDisposable
-	where T : T2
+public interface ICollectionMatcher<in T, out T2> where T : T2
 {
 	/// <summary>
 	///     Verifies for each <paramref name="value" /> in the subject, if it results in a failure.

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class CollectionMatchOptions
+{
+	private sealed class AnyOrderCollectionMatcher<T, T2> : ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly Dictionary<int, T> _additionalItems = new();
+		private readonly List<T> _expectedList;
+		private readonly int _totalExpectedCount;
+		private int _index;
+		private readonly EquivalenceRelation _equivalenceRelation;
+
+		public AnyOrderCollectionMatcher(EquivalenceRelation equivalenceRelation,
+			IEnumerable<T> expected)
+		{
+			_equivalenceRelation = equivalenceRelation;
+			_expectedList = expected.ToList();
+			_totalExpectedCount = _expectedList.Count;
+		}
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (_expectedList.All(e => !options.AreConsideredEqual(value, e)))
+			{
+				_additionalItems.Add(_index, value);
+			}
+
+			if (_additionalItems.Count > 20)
+			{
+				return $"{it} was very different (> 20 deviations)";
+			}
+
+			_expectedList.Remove(value);
+			_index++;
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			if (_expectedList.Count + _additionalItems.Count > 20)
+			{
+				return $"{it} was very different (> 20 deviations)";
+			}
+			
+			string? missingItemsError = MissingItemsError(it, _totalExpectedCount, _expectedList, _equivalenceRelation);
+			
+			bool hasAdditionalItems = _additionalItems.Any();
+			if (hasAdditionalItems && !_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			{
+				if (_additionalItems.Count == 1)
+				{
+					KeyValuePair<int, T> firstAdditionalItem = _additionalItems.Single();
+					return AppendIfNotNull(
+						$"{it} contained item {Formatter.Format(firstAdditionalItem.Value)} at index {firstAdditionalItem.Key} that was not expected",
+						missingItemsError, "  ");
+				}
+
+				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
+						$" and{Environment.NewLine}", _additionalItems.Select(x => $"  item {Formatter.Format(x.Value)} at index {x.Key} that was not expected")),
+					missingItemsError, "  ");
+			}
+
+			if (!hasAdditionalItems && _equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			{
+				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+			}
+
+			return missingItemsError;
+		}
+
+		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
+		{
+			if (suffix == null)
+			{
+				return prefix;
+			}
+
+			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
+		}
+
+		private static string? MissingItemsError(string it, int total, List<T> missingItems,
+			EquivalenceRelation equivalenceRelation)
+		{
+			bool hasMissingItems = missingItems.Any();
+			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			{
+				if (missingItems.Count == 1)
+				{
+					return
+						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
+				}
+
+				StringBuilder sb = new();
+				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
+					.Append(total).Append(" expected items:");
+				foreach (T? missingItem in missingItems)
+				{
+					sb.AppendLine().Append("  ");
+					Formatter.Format(sb, missingItem);
+					sb.Append(",");
+				}
+
+				sb.Length--;
+				return sb.ToString();
+			}
+
+			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
+			{
+				return $"{it} did contain all expected items";
+			}
+
+			return null;
+		}
+
+		public void Dispose() => _index = -1;
+	}
+}

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using aweXpect.Core;
-using aweXpect.Helpers;
 
 namespace aweXpect.Options;
 
@@ -13,22 +10,22 @@ public partial class CollectionMatchOptions
 		where T : T2
 	{
 		private readonly Dictionary<int, T> _additionalItems = new();
-		private readonly List<T> _expectedList;
+		private readonly EquivalenceRelation _equivalenceRelation;
+		private readonly List<T> _missingItems;
 		private readonly int _totalExpectedCount;
 		private int _index;
-		private readonly EquivalenceRelation _equivalenceRelation;
 
 		public AnyOrderCollectionMatcher(EquivalenceRelation equivalenceRelation,
 			IEnumerable<T> expected)
 		{
 			_equivalenceRelation = equivalenceRelation;
-			_expectedList = expected.ToList();
-			_totalExpectedCount = _expectedList.Count;
+			_missingItems = expected.ToList();
+			_totalExpectedCount = _missingItems.Count;
 		}
 
 		public string? Verify(string it, T value, IOptionsEquality<T2> options)
 		{
-			if (_expectedList.All(e => !options.AreConsideredEqual(value, e)))
+			if (_missingItems.All(e => !options.AreConsideredEqual(value, e)))
 			{
 				_additionalItems.Add(_index, value);
 			}
@@ -38,88 +35,38 @@ public partial class CollectionMatchOptions
 				return $"{it} was very different (> 20 deviations)";
 			}
 
-			_expectedList.Remove(value);
+			_missingItems.Remove(value);
 			_index++;
 			return null;
 		}
 
 		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
 		{
-			if (_expectedList.Count + _additionalItems.Count > 20)
+			if (_missingItems.Count + _additionalItems.Count > 20)
 			{
 				return $"{it} was very different (> 20 deviations)";
 			}
-			
-			string? missingItemsError = MissingItemsError(it, _totalExpectedCount, _expectedList, _equivalenceRelation);
-			
-			bool hasAdditionalItems = _additionalItems.Any();
-			if (hasAdditionalItems && !_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
-			{
-				if (_additionalItems.Count == 1)
-				{
-					KeyValuePair<int, T> firstAdditionalItem = _additionalItems.Single();
-					return AppendIfNotNull(
-						$"{it} contained item {Formatter.Format(firstAdditionalItem.Value)} at index {firstAdditionalItem.Key} that was not expected",
-						missingItemsError, "  ");
-				}
 
-				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
-						$" and{Environment.NewLine}", _additionalItems.Select(x => $"  item {Formatter.Format(x.Value)} at index {x.Key} that was not expected")),
-					missingItemsError, "  ");
+			List<string> errors = new();
+			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			{
+				errors.AddRange(AdditionalItemsError(_additionalItems, _equivalenceRelation));
+			}
+			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset) && !_additionalItems.Any())
+			{
+				errors.Add("did not contain any additional items");
 			}
 
-			if (!hasAdditionalItems && _equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
 			{
-				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelation));
+			}
+			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset) && !_missingItems.Any())
+			{
+				errors.Add("contained all expected items");
 			}
 
-			return missingItemsError;
+			return ReturnErrorString(it, errors);
 		}
-
-		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
-		{
-			if (suffix == null)
-			{
-				return prefix;
-			}
-
-			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
-		}
-
-		private static string? MissingItemsError(string it, int total, List<T> missingItems,
-			EquivalenceRelation equivalenceRelation)
-		{
-			bool hasMissingItems = missingItems.Any();
-			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
-			{
-				if (missingItems.Count == 1)
-				{
-					return
-						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
-				}
-
-				StringBuilder sb = new();
-				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
-					.Append(total).Append(" expected items:");
-				foreach (T? missingItem in missingItems)
-				{
-					sb.AppendLine().Append("  ");
-					Formatter.Format(sb, missingItem);
-					sb.Append(",");
-				}
-
-				sb.Length--;
-				return sb.ToString();
-			}
-
-			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
-			{
-				return $"{it} did contain all expected items";
-			}
-
-			return null;
-		}
-
-		public void Dispose() => _index = -1;
 	}
 }

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
@@ -10,15 +10,15 @@ public partial class CollectionMatchOptions
 		where T : T2
 	{
 		private readonly Dictionary<int, T> _additionalItems = new();
-		private readonly EquivalenceRelation _equivalenceRelation;
+		private readonly EquivalenceRelations _equivalenceRelations;
 		private readonly List<T> _missingItems;
 		private readonly int _totalExpectedCount;
 		private int _index;
 
-		public AnyOrderCollectionMatcher(EquivalenceRelation equivalenceRelation,
+		public AnyOrderCollectionMatcher(EquivalenceRelations equivalenceRelation,
 			IEnumerable<T> expected)
 		{
-			_equivalenceRelation = equivalenceRelation;
+			_equivalenceRelations = equivalenceRelation;
 			_missingItems = expected.ToList();
 			_totalExpectedCount = _missingItems.Count;
 		}
@@ -48,20 +48,20 @@ public partial class CollectionMatchOptions
 			}
 
 			List<string> errors = new();
-			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			if (!_equivalenceRelations.HasFlag(EquivalenceRelations.Superset))
 			{
-				errors.AddRange(AdditionalItemsError(_additionalItems, _equivalenceRelation));
+				errors.AddRange(AdditionalItemsError(_additionalItems));
 			}
-			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset) && !_additionalItems.Any())
+			else if (_equivalenceRelations.HasFlag(EquivalenceRelations.ProperSuperset) && !_additionalItems.Any())
 			{
 				errors.Add("did not contain any additional items");
 			}
 
-			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			if (!_equivalenceRelations.HasFlag(EquivalenceRelations.Subset))
 			{
-				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelation));
+				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelations));
 			}
-			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset) && !_missingItems.Any())
+			else if (_equivalenceRelations.HasFlag(EquivalenceRelations.ProperSubset) && !_missingItems.Any())
 			{
 				errors.Add("contained all expected items");
 			}

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class CollectionMatchOptions
+{
+	private sealed class AnyOrderIgnoreDuplicatesCollectionMatcher<T, T2> : ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly Dictionary<int, T> _additionalItems = new();
+		private readonly EquivalenceRelation _equivalenceRelation;
+		private readonly List<T> _expectedList;
+		private readonly int _totalExpectedCount;
+		private readonly HashSet<T> _uniqueItems = new();
+		private int _index;
+
+		public AnyOrderIgnoreDuplicatesCollectionMatcher(EquivalenceRelation equivalenceRelation,
+			IEnumerable<T> expected)
+		{
+			_equivalenceRelation = equivalenceRelation;
+			_expectedList = expected.Distinct().ToList();
+			_totalExpectedCount = _expectedList.Count;
+		}
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (_uniqueItems.Contains(value))
+			{
+				return null;
+			}
+
+			if (_expectedList.All(e => !options.AreConsideredEqual(value, e)))
+			{
+				_additionalItems.Add(_index, value);
+			}
+
+			_expectedList.Remove(value);
+			_uniqueItems.Add(value);
+			_index++;
+
+			if (_additionalItems.Count > 20)
+			{
+				return $"{it} was very different (> 20 deviations)";
+			}
+
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			if (_expectedList.Count + _additionalItems.Count > 20)
+			{
+				return $"{it} was very different (> 20 deviations)";
+			}
+
+			string? missingItemsError = MissingItemsError(it, _totalExpectedCount, _expectedList, _equivalenceRelation);
+
+			bool hasAdditionalItems = _additionalItems.Any();
+			if (hasAdditionalItems && !_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			{
+				if (_additionalItems.Count == 1)
+				{
+					KeyValuePair<int, T> firstAdditionalItem = _additionalItems.Single();
+					return AppendIfNotNull(
+						$"{it} contained item {Formatter.Format(firstAdditionalItem.Value)} at index {firstAdditionalItem.Key} that was not expected",
+						missingItemsError, "  ");
+				}
+
+				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
+						$" and{Environment.NewLine}",
+						_additionalItems.Select(x
+							=> $"  item {Formatter.Format(x.Value)} at index {x.Key} that was not expected")),
+					missingItemsError, "  ");
+			}
+
+			if (!hasAdditionalItems && _equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			{
+				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+			}
+
+			return missingItemsError;
+		}
+
+		public void Dispose() => _index = -1;
+
+		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
+		{
+			if (suffix == null)
+			{
+				return prefix;
+			}
+
+			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
+		}
+
+		private static string? MissingItemsError(string it, int total, List<T> missingItems,
+			EquivalenceRelation equivalenceRelation)
+		{
+			bool hasMissingItems = missingItems.Any();
+			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			{
+				if (missingItems.Count == 1)
+				{
+					return
+						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
+				}
+
+				StringBuilder sb = new();
+				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
+					.Append(total).Append(" expected items:");
+				foreach (T? missingItem in missingItems)
+				{
+					sb.AppendLine().Append("  ");
+					Formatter.Format(sb, missingItem);
+					sb.Append(",");
+				}
+
+				sb.Length--;
+				return sb.ToString();
+			}
+
+			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
+			{
+				return $"{it} did contain all expected items";
+			}
+
+			return null;
+		}
+	}
+}

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -10,16 +10,16 @@ public partial class CollectionMatchOptions
 		where T : T2
 	{
 		private readonly Dictionary<int, T> _additionalItems = new();
-		private readonly EquivalenceRelation _equivalenceRelation;
+		private readonly EquivalenceRelations _equivalenceRelations;
 		private readonly List<T> _missingItems;
 		private readonly int _totalExpectedCount;
 		private readonly HashSet<T> _uniqueItems = new();
 		private int _index;
 
-		public AnyOrderIgnoreDuplicatesCollectionMatcher(EquivalenceRelation equivalenceRelation,
+		public AnyOrderIgnoreDuplicatesCollectionMatcher(EquivalenceRelations equivalenceRelation,
 			IEnumerable<T> expected)
 		{
-			_equivalenceRelation = equivalenceRelation;
+			_equivalenceRelations = equivalenceRelation;
 			_missingItems = expected.Distinct().ToList();
 			_totalExpectedCount = _missingItems.Count;
 		}
@@ -56,20 +56,20 @@ public partial class CollectionMatchOptions
 			}
 
 			List<string> errors = new();
-			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			if (!_equivalenceRelations.HasFlag(EquivalenceRelations.Superset))
 			{
-				errors.AddRange(AdditionalItemsError(_additionalItems, _equivalenceRelation));
+				errors.AddRange(AdditionalItemsError(_additionalItems));
 			}
-			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset) && !_additionalItems.Any())
+			else if (_equivalenceRelations.HasFlag(EquivalenceRelations.ProperSuperset) && !_additionalItems.Any())
 			{
 				errors.Add("did not contain any additional items");
 			}
 
-			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			if (!_equivalenceRelations.HasFlag(EquivalenceRelations.Subset))
 			{
-				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelation));
+				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelations));
 			}
-			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset) && !_missingItems.Any())
+			else if (_equivalenceRelations.HasFlag(EquivalenceRelations.ProperSubset) && !_missingItems.Any())
 			{
 				errors.Add("contained all expected items");
 			}

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using aweXpect.Core;
-using aweXpect.Helpers;
 
 namespace aweXpect.Options;
 
@@ -14,7 +11,7 @@ public partial class CollectionMatchOptions
 	{
 		private readonly Dictionary<int, T> _additionalItems = new();
 		private readonly EquivalenceRelation _equivalenceRelation;
-		private readonly List<T> _expectedList;
+		private readonly List<T> _missingItems;
 		private readonly int _totalExpectedCount;
 		private readonly HashSet<T> _uniqueItems = new();
 		private int _index;
@@ -23,8 +20,8 @@ public partial class CollectionMatchOptions
 			IEnumerable<T> expected)
 		{
 			_equivalenceRelation = equivalenceRelation;
-			_expectedList = expected.Distinct().ToList();
-			_totalExpectedCount = _expectedList.Count;
+			_missingItems = expected.Distinct().ToList();
+			_totalExpectedCount = _missingItems.Count;
 		}
 
 		public string? Verify(string it, T value, IOptionsEquality<T2> options)
@@ -34,12 +31,12 @@ public partial class CollectionMatchOptions
 				return null;
 			}
 
-			if (_expectedList.All(e => !options.AreConsideredEqual(value, e)))
+			if (_missingItems.All(e => !options.AreConsideredEqual(value, e)))
 			{
 				_additionalItems.Add(_index, value);
 			}
 
-			_expectedList.Remove(value);
+			_missingItems.Remove(value);
 			_uniqueItems.Add(value);
 			_index++;
 
@@ -53,83 +50,31 @@ public partial class CollectionMatchOptions
 
 		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
 		{
-			if (_expectedList.Count + _additionalItems.Count > 20)
+			if (_missingItems.Count + _additionalItems.Count > 20)
 			{
 				return $"{it} was very different (> 20 deviations)";
 			}
 
-			string? missingItemsError = MissingItemsError(it, _totalExpectedCount, _expectedList, _equivalenceRelation);
-
-			bool hasAdditionalItems = _additionalItems.Any();
-			if (hasAdditionalItems && !_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			List<string> errors = new();
+			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
 			{
-				if (_additionalItems.Count == 1)
-				{
-					KeyValuePair<int, T> firstAdditionalItem = _additionalItems.Single();
-					return AppendIfNotNull(
-						$"{it} contained item {Formatter.Format(firstAdditionalItem.Value)} at index {firstAdditionalItem.Key} that was not expected",
-						missingItemsError, "  ");
-				}
-
-				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
-						$" and{Environment.NewLine}",
-						_additionalItems.Select(x
-							=> $"  item {Formatter.Format(x.Value)} at index {x.Key} that was not expected")),
-					missingItemsError, "  ");
+				errors.AddRange(AdditionalItemsError(_additionalItems, _equivalenceRelation));
+			}
+			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset) && !_additionalItems.Any())
+			{
+				errors.Add("did not contain any additional items");
 			}
 
-			if (!hasAdditionalItems && _equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
 			{
-				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelation));
+			}
+			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset) && !_missingItems.Any())
+			{
+				errors.Add("contained all expected items");
 			}
 
-			return missingItemsError;
-		}
-
-		public void Dispose() => _index = -1;
-
-		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
-		{
-			if (suffix == null)
-			{
-				return prefix;
-			}
-
-			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
-		}
-
-		private static string? MissingItemsError(string it, int total, List<T> missingItems,
-			EquivalenceRelation equivalenceRelation)
-		{
-			bool hasMissingItems = missingItems.Any();
-			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
-			{
-				if (missingItems.Count == 1)
-				{
-					return
-						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
-				}
-
-				StringBuilder sb = new();
-				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
-					.Append(total).Append(" expected items:");
-				foreach (T? missingItem in missingItems)
-				{
-					sb.AppendLine().Append("  ");
-					Formatter.Format(sb, missingItem);
-					sb.Append(",");
-				}
-
-				sb.Length--;
-				return sb.ToString();
-			}
-
-			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
-			{
-				return $"{it} did contain all expected items";
-			}
-
-			return null;
+			return ReturnErrorString(it, errors);
 		}
 	}
 }

--- a/Source/aweXpect/Options/CollectionMatchOptions.SameOrderCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.SameOrderCollectionMatcher.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class CollectionMatchOptions
+{
+	private sealed class SameOrderCollectionMatcher<T, T2>(
+		EquivalenceRelation equivalenceRelation,
+		IEnumerable<T> expected)
+		: ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly Dictionary<int, (T Item, T? Expected)> _additionalItems = new();
+		private readonly IEnumerator<T> _expectedEnumerator = MaterializingEnumerable<T>.Wrap(expected).GetEnumerator();
+		private readonly List<T> _missingItems = new();
+		private int _index;
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (!_expectedEnumerator.MoveNext())
+			{
+				_additionalItems.Add(_index, (value, default));
+			}
+			else if (!options.AreConsideredEqual(value, _expectedEnumerator.Current))
+			{
+				if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value.Item, _expectedEnumerator.Current)))
+				{
+					_missingItems.Add(_expectedEnumerator.Current);
+				}
+
+				_additionalItems.Add(_index, (value, _expectedEnumerator.Current));
+			}
+
+			if (_additionalItems.Count + _missingItems.Count > 20)
+			{
+				return $"{it} was very different (> 20 deviations)";
+			}
+
+			_index++;
+			_missingItems.Remove(value);
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			int total = _index;
+			while (_expectedEnumerator.MoveNext())
+			{
+				total++;
+				if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value.Item, _expectedEnumerator.Current)))
+				{
+					_missingItems.Add(_expectedEnumerator.Current);
+				}
+
+				if (_additionalItems.Count + _missingItems.Count > 20)
+				{
+					return $"{it} was very different (> 20 deviations)";
+				}
+			}
+
+			string? missingItemsError = MissingItemsError(it, total, _missingItems, equivalenceRelation);
+			bool hasAdditionalItems = _additionalItems.Any();
+			if (hasAdditionalItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			{
+				if (_additionalItems.Count == 1)
+				{
+					KeyValuePair<int, (T Item, T? Expected)> firstAdditionalItem = _additionalItems.Single();
+					return AppendIfNotNull(firstAdditionalItem.Value.Expected is null
+							? $"{it} contained item {Formatter.Format(firstAdditionalItem.Value.Item)} at index {firstAdditionalItem.Key} that was not expected"
+							: $"{it} contained item {Formatter.Format(firstAdditionalItem.Value.Item)} at index {firstAdditionalItem.Key} instead of {Formatter.Format(firstAdditionalItem.Value.Expected)}",
+						missingItemsError, "  ");
+				}
+
+				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
+						$" and{Environment.NewLine}", _additionalItems.Select(x => x.Value.Expected is null
+							? $"  item {Formatter.Format(x.Value.Item)} at index {x.Key} that was not expected"
+							: $"  item {Formatter.Format(x.Value.Item)} at index {x.Key} instead of {Formatter.Format(x.Value.Expected)}")),
+					missingItemsError, "  ");
+			}
+
+			if (!hasAdditionalItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			{
+				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+			}
+
+			return missingItemsError;
+		}
+
+		public void Dispose()
+		{
+			_index = -1;
+			_expectedEnumerator.Dispose();
+		}
+
+		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
+		{
+			if (suffix == null)
+			{
+				return prefix;
+			}
+
+			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
+		}
+
+		private static string? MissingItemsError(string it, int total, List<T> missingItems,
+			EquivalenceRelation equivalenceRelation)
+		{
+			bool hasMissingItems = missingItems.Any();
+			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			{
+				if (missingItems.Count == 1)
+				{
+					return
+						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
+				}
+
+				StringBuilder sb = new();
+				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
+					.Append(total).Append(" expected items:");
+				foreach (T? missingItem in missingItems)
+				{
+					sb.AppendLine().Append("  ");
+					Formatter.Format(sb, missingItem);
+					sb.Append(",");
+				}
+
+				sb.Length--;
+				return sb.ToString();
+			}
+
+			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
+			{
+				return $"{it} did contain all expected items";
+			}
+
+			return null;
+		}
+	}
+}

--- a/Source/aweXpect/Options/CollectionMatchOptions.SameOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.SameOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -1,159 +1,152 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using aweXpect.Core;
-using aweXpect.Helpers;
 
 namespace aweXpect.Options;
 
 public partial class CollectionMatchOptions
 {
-	private sealed class SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(
-		EquivalenceRelation equivalenceRelation,
-		IEnumerable<T> expected)
-		: ICollectionMatcher<T, T2>
+	private sealed class SameOrderIgnoreDuplicatesCollectionMatcher<T, T2> : ICollectionMatcher<T, T2>
 		where T : T2
 	{
-		private readonly Dictionary<int, (T Item, T? Expected)> _additionalItems = new();
-		private readonly T[] _expectedDistinctItems = expected.Distinct().ToArray();
+		private readonly Dictionary<int, T> _additionalItems = new();
+		private readonly EquivalenceRelation _equivalenceRelation;
+		private readonly T[] _expectedDistinctItems;
+		private readonly Dictionary<int, (T Item, T Expected)> _incorrectItems = new();
+		private readonly List<T> _matchingItems = new();
 		private readonly List<T> _missingItems = new();
+		private readonly int _totalExpectedItems;
 		private readonly HashSet<T> _uniqueItems = new();
+		private int _expectationIndex = -1;
 		private int _index;
+		private int _matchIndex;
+
+		public SameOrderIgnoreDuplicatesCollectionMatcher(EquivalenceRelation equivalenceRelation,
+			IEnumerable<T> expected)
+		{
+			_equivalenceRelation = equivalenceRelation;
+			_expectedDistinctItems = expected.Distinct().ToArray();
+			_totalExpectedItems = _expectedDistinctItems.Length;
+		}
 
 		public string? Verify(string it, T value, IOptionsEquality<T2> options)
 		{
-			if (_uniqueItems.Contains(value))
+			if (_matchIndex >= _expectedDistinctItems.Length)
 			{
-				return null;
-			}
-
-			if (_expectedDistinctItems.Length > _index)
-			{
-				var expectedItem = _expectedDistinctItems[_index];
-				if (!options.AreConsideredEqual(value, expectedItem))
+				if (!_uniqueItems.Add(value))
 				{
-					if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value.Item, expectedItem)))
-					{
-						_missingItems.Add(expectedItem);
-					}
+					return null;
+				}
 
-					_additionalItems.Add(_index, (value, expectedItem));
+				// All expected items were found -> additional items
+				_additionalItems.Add(_index, value);
+			}
+			else if (options.AreConsideredEqual(value, _expectedDistinctItems[_matchIndex]))
+			{
+				// The current value is equal to the expected value
+				_matchIndex++;
+				_expectationIndex++;
+				_matchingItems.Add(value);
+				_uniqueItems.Add(value);
+				foreach (int key in _additionalItems
+					         .Where(item => options.AreConsideredEqual(item.Value, value))
+					         .Select(x => x.Key)
+					         .ToList())
+				{
+					_additionalItems.Remove(key);
 				}
 			}
 			else
 			{
-				_additionalItems.Add(_index, (value, default));
+				if (!_uniqueItems.Add(value))
+				{
+					return null;
+				}
+
+				if (_expectationIndex >= 0)
+				{
+					_expectationIndex++;
+				}
+
+				_matchIndex = 0;
+
+				if (options.AreConsideredEqual(value, _expectedDistinctItems[_matchIndex]))
+				{
+					for (int i = _index - _matchingItems.Count; i < _index; i++)
+					{
+						_additionalItems.Add(i, _matchingItems[i]);
+					}
+
+					_matchingItems.Clear();
+					_matchIndex++;
+					_expectationIndex = 0;
+					_matchingItems.Add(value);
+				}
+				else if (_expectationIndex < 0 || _expectationIndex >= _expectedDistinctItems.Length)
+				{
+					_additionalItems.Add(_index, value);
+				}
+				else
+				{
+					_incorrectItems.Add(_index, (value, _expectedDistinctItems[_expectationIndex]));
+				}
 			}
 
-			if (_additionalItems.Count + _missingItems.Count > 20)
+			if (_additionalItems.Count + _incorrectItems.Count + _missingItems.Count > 20)
 			{
 				return $"{it} was very different (> 20 deviations)";
 			}
 
 			_index++;
-			_missingItems.Remove(value);
-			_uniqueItems.Add(value);
 			return null;
 		}
 
 		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
 		{
-			int total = _index;
-			foreach (var item in _expectedDistinctItems.Skip(_index))
+			foreach (T item in _expectedDistinctItems.Skip(Math.Max(_expectationIndex - 1, _matchIndex)))
 			{
 				if (!_uniqueItems.Add(item))
 				{
 					continue;
 				}
-				
-				total++;
-				if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value.Item, item)))
+
+				if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value, item)) &&
+				    _incorrectItems.All(x => !options.AreConsideredEqual(x.Value.Item, item)))
 				{
 					_missingItems.Add(item);
 				}
 
-				if (_additionalItems.Count + _missingItems.Count > 20)
+				if (_additionalItems.Count + _incorrectItems.Count + _missingItems.Count > 20)
 				{
 					return $"{it} was very different (> 20 deviations)";
 				}
 			}
 
-			string? missingItemsError = MissingItemsError(it, total, _missingItems, equivalenceRelation);
-			bool hasAdditionalItems = _additionalItems.Any();
-			if (hasAdditionalItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			List<string> errors = new();
+			errors.AddRange(IncorrectItemsError(_incorrectItems, _expectedDistinctItems, _equivalenceRelation));
+			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
 			{
-				if (_additionalItems.Count == 1)
-				{
-					KeyValuePair<int, (T Item, T? Expected)> firstAdditionalItem = _additionalItems.Single();
-					return AppendIfNotNull(firstAdditionalItem.Value.Expected is null
-							? $"{it} contained item {Formatter.Format(firstAdditionalItem.Value.Item)} at index {firstAdditionalItem.Key} that was not expected"
-							: $"{it} contained item {Formatter.Format(firstAdditionalItem.Value.Item)} at index {firstAdditionalItem.Key} instead of {Formatter.Format(firstAdditionalItem.Value.Expected)}",
-						missingItemsError, "  ");
-				}
-
-				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
-						$" and{Environment.NewLine}", _additionalItems.Select(x => x.Value.Expected is null
-							? $"  item {Formatter.Format(x.Value.Item)} at index {x.Key} that was not expected"
-							: $"  item {Formatter.Format(x.Value.Item)} at index {x.Key} instead of {Formatter.Format(x.Value.Expected)}")),
-					missingItemsError, "  ");
+				errors.AddRange(AdditionalItemsError(_additionalItems, _equivalenceRelation));
+			}
+			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset) &&
+			         !_additionalItems.Any() &&
+			         !_incorrectItems.Any(i
+				         => _expectedDistinctItems.All(e => !options.AreConsideredEqual(e, i.Value.Item))))
+			{
+				errors.Add("did not contain any additional items");
 			}
 
-			if (!hasAdditionalItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			if (!_equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
 			{
-				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+				errors.AddRange(MissingItemsError(_totalExpectedItems, _missingItems, _equivalenceRelation));
+			}
+			else if (_equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset) && !_missingItems.Any())
+			{
+				errors.Add("contained all expected items");
 			}
 
-			return missingItemsError;
-		}
-
-		public void Dispose()
-		{
-			_uniqueItems.Clear();
-			_index = -1;
-		}
-		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
-		{
-			if (suffix == null)
-			{
-				return prefix;
-			}
-
-			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
-		}
-
-		private static string? MissingItemsError(string it, int total, List<T> missingItems,
-			EquivalenceRelation equivalenceRelation)
-		{
-			bool hasMissingItems = missingItems.Any();
-			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
-			{
-				if (missingItems.Count == 1)
-				{
-					return
-						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
-				}
-
-				StringBuilder sb = new();
-				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
-					.Append(total).Append(" expected items:");
-				foreach (T? missingItem in missingItems)
-				{
-					sb.AppendLine().Append("  ");
-					Formatter.Format(sb, missingItem);
-					sb.Append(",");
-				}
-
-				sb.Length--;
-				return sb.ToString();
-			}
-
-			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
-			{
-				return $"{it} did contain all expected items";
-			}
-
-			return null;
+			return ReturnErrorString(it, errors);
 		}
 	}
 }

--- a/Source/aweXpect/Options/CollectionMatchOptions.SameOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.SameOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class CollectionMatchOptions
+{
+	private sealed class SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(
+		EquivalenceRelation equivalenceRelation,
+		IEnumerable<T> expected)
+		: ICollectionMatcher<T, T2>
+		where T : T2
+	{
+		private readonly Dictionary<int, (T Item, T? Expected)> _additionalItems = new();
+		private readonly T[] _expectedDistinctItems = expected.Distinct().ToArray();
+		private readonly List<T> _missingItems = new();
+		private readonly HashSet<T> _uniqueItems = new();
+		private int _index;
+
+		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		{
+			if (_uniqueItems.Contains(value))
+			{
+				return null;
+			}
+
+			if (_expectedDistinctItems.Length > _index)
+			{
+				var expectedItem = _expectedDistinctItems[_index];
+				if (!options.AreConsideredEqual(value, expectedItem))
+				{
+					if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value.Item, expectedItem)))
+					{
+						_missingItems.Add(expectedItem);
+					}
+
+					_additionalItems.Add(_index, (value, expectedItem));
+				}
+			}
+			else
+			{
+				_additionalItems.Add(_index, (value, default));
+			}
+
+			if (_additionalItems.Count + _missingItems.Count > 20)
+			{
+				return $"{it} was very different (> 20 deviations)";
+			}
+
+			_index++;
+			_missingItems.Remove(value);
+			_uniqueItems.Add(value);
+			return null;
+		}
+
+		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		{
+			int total = _index;
+			foreach (var item in _expectedDistinctItems.Skip(_index))
+			{
+				if (!_uniqueItems.Add(item))
+				{
+					continue;
+				}
+				
+				total++;
+				if (_additionalItems.All(x => !options.AreConsideredEqual(x.Value.Item, item)))
+				{
+					_missingItems.Add(item);
+				}
+
+				if (_additionalItems.Count + _missingItems.Count > 20)
+				{
+					return $"{it} was very different (> 20 deviations)";
+				}
+			}
+
+			string? missingItemsError = MissingItemsError(it, total, _missingItems, equivalenceRelation);
+			bool hasAdditionalItems = _additionalItems.Any();
+			if (hasAdditionalItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Superset))
+			{
+				if (_additionalItems.Count == 1)
+				{
+					KeyValuePair<int, (T Item, T? Expected)> firstAdditionalItem = _additionalItems.Single();
+					return AppendIfNotNull(firstAdditionalItem.Value.Expected is null
+							? $"{it} contained item {Formatter.Format(firstAdditionalItem.Value.Item)} at index {firstAdditionalItem.Key} that was not expected"
+							: $"{it} contained item {Formatter.Format(firstAdditionalItem.Value.Item)} at index {firstAdditionalItem.Key} instead of {Formatter.Format(firstAdditionalItem.Value.Expected)}",
+						missingItemsError, "  ");
+				}
+
+				return AppendIfNotNull($"{it} contained{Environment.NewLine}" + string.Join(
+						$" and{Environment.NewLine}", _additionalItems.Select(x => x.Value.Expected is null
+							? $"  item {Formatter.Format(x.Value.Item)} at index {x.Key} that was not expected"
+							: $"  item {Formatter.Format(x.Value.Item)} at index {x.Key} instead of {Formatter.Format(x.Value.Expected)}")),
+					missingItemsError, "  ");
+			}
+
+			if (!hasAdditionalItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSuperset))
+			{
+				return AppendIfNotNull($"{it} did not contain any additional items", missingItemsError);
+			}
+
+			return missingItemsError;
+		}
+
+		public void Dispose()
+		{
+			_uniqueItems.Clear();
+			_index = -1;
+		}
+		private static string AppendIfNotNull(string prefix, string? suffix, string indentation = "")
+		{
+			if (suffix == null)
+			{
+				return prefix;
+			}
+
+			return $"{prefix} and{Environment.NewLine}{(indentation == "" ? suffix : suffix.Indent(indentation))}";
+		}
+
+		private static string? MissingItemsError(string it, int total, List<T> missingItems,
+			EquivalenceRelation equivalenceRelation)
+		{
+			bool hasMissingItems = missingItems.Any();
+			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			{
+				if (missingItems.Count == 1)
+				{
+					return
+						$"{it} lacked {missingItems.Count} of {total} expected items: {Formatter.Format(missingItems.Single())}";
+				}
+
+				StringBuilder sb = new();
+				sb.Append(it).Append(" lacked ").Append(missingItems.Count).Append(" of ")
+					.Append(total).Append(" expected items:");
+				foreach (T? missingItem in missingItems)
+				{
+					sb.AppendLine().Append("  ");
+					Formatter.Format(sb, missingItem);
+					sb.Append(",");
+				}
+
+				sb.Length--;
+				return sb.ToString();
+			}
+
+			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
+			{
+				return $"{it} did contain all expected items";
+			}
+
+			return null;
+		}
+	}
+}

--- a/Source/aweXpect/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.cs
@@ -16,7 +16,7 @@ public partial class CollectionMatchOptions
 	///     Specifies the equivalence relation between subject and expected.
 	/// </summary>
 	[Flags]
-	public enum EquivalenceRelation
+	public enum EquivalenceRelations
 	{
 		/// <summary>
 		///     The subject and expected collection must be equivalent (have the same items)
@@ -44,15 +44,15 @@ public partial class CollectionMatchOptions
 		Superset = 8
 	}
 
-	private EquivalenceRelation _equivalenceRelation = EquivalenceRelation.Equivalent;
+	private EquivalenceRelations _equivalenceRelations = EquivalenceRelations.Equivalent;
 	private bool _ignoringDuplicates;
 	private bool _inAnyOrder;
 
 	/// <summary>
 	///     Specifies the equivalence relation between subject and expected.
 	/// </summary>
-	public void SetEquivalenceRelation(EquivalenceRelation equivalenceRelation)
-		=> _equivalenceRelation = equivalenceRelation;
+	public void SetEquivalenceRelation(EquivalenceRelations equivalenceRelation)
+		=> _equivalenceRelations = equivalenceRelation;
 
 	/// <summary>
 	///     Ignores the order in the subject and expected values.
@@ -71,29 +71,29 @@ public partial class CollectionMatchOptions
 		where T : T2
 		=> (_inAnyOrder, _ignoringDuplicates) switch
 		{
-			(true, true) => new AnyOrderIgnoreDuplicatesCollectionMatcher<T, T2>(_equivalenceRelation, expected),
-			(true, false) => new AnyOrderCollectionMatcher<T, T2>(_equivalenceRelation, expected),
-			(false, true) => new SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(_equivalenceRelation, expected),
-			(false, false) => new SameOrderCollectionMatcher<T, T2>(_equivalenceRelation, expected)
+			(true, true) => new AnyOrderIgnoreDuplicatesCollectionMatcher<T, T2>(_equivalenceRelations, expected),
+			(true, false) => new AnyOrderCollectionMatcher<T, T2>(_equivalenceRelations, expected),
+			(false, true) => new SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(_equivalenceRelations, expected),
+			(false, false) => new SameOrderCollectionMatcher<T, T2>(_equivalenceRelations, expected)
 		};
 
 	/// <inheritdoc />
 	public override string ToString()
 		=> (_inAnyOrder, _ignoringDuplicates) switch
 		{
-			(true, true) => ToString(_equivalenceRelation) + " in any order ignoring duplicates",
-			(true, false) => ToString(_equivalenceRelation) + " in any order",
-			(false, true) => ToString(_equivalenceRelation) + " ignoring duplicates",
-			(false, false) => ToString(_equivalenceRelation)
+			(true, true) => ToString(_equivalenceRelations) + " in any order ignoring duplicates",
+			(true, false) => ToString(_equivalenceRelations) + " in any order",
+			(false, true) => ToString(_equivalenceRelations) + " ignoring duplicates",
+			(false, false) => ToString(_equivalenceRelations)
 		};
 
-	private static string ToString(EquivalenceRelation equivalenceRelation)
+	private static string ToString(EquivalenceRelations equivalenceRelation)
 		=> equivalenceRelation switch
 		{
-			EquivalenceRelation.Superset => " or more items",
-			EquivalenceRelation.ProperSuperset => " and at least one more item",
-			EquivalenceRelation.Subset => " or less items",
-			EquivalenceRelation.ProperSubset => " and at least one item less",
+			EquivalenceRelations.Superset => " or more items",
+			EquivalenceRelations.ProperSuperset => " and at least one more item",
+			EquivalenceRelations.Subset => " or less items",
+			EquivalenceRelations.ProperSubset => " and at least one item less",
 			_ => ""
 		};
 
@@ -120,8 +120,7 @@ public partial class CollectionMatchOptions
 		return null;
 	}
 
-		private static IEnumerable<string> AdditionalItemsError<T>(Dictionary<int, T> additionalItems,
-			EquivalenceRelation equivalenceRelation)
+		private static IEnumerable<string> AdditionalItemsError<T>(Dictionary<int, T> additionalItems)
 		{
 			bool hasAdditionalItems = additionalItems.Any();
 			if (hasAdditionalItems)
@@ -136,14 +135,14 @@ public partial class CollectionMatchOptions
 
 		private static IEnumerable<string> IncorrectItemsError<T>(Dictionary<int, (T Item, T Expected)> incorrectItems,
 			T[] expectedItems,
-			EquivalenceRelation equivalenceRelation)
+			EquivalenceRelations equivalenceRelation)
 		{
 			bool hasIncorrectItems = incorrectItems.Any();
 			if (hasIncorrectItems)
 			{
 				foreach (KeyValuePair<int, (T Item, T Expected)> incorrectItem in incorrectItems)
 				{
-					if (equivalenceRelation.HasFlag(EquivalenceRelation.Superset) &&
+					if (equivalenceRelation.HasFlag(EquivalenceRelations.Superset) &&
 					    !expectedItems.Contains(incorrectItem.Value.Item))
 					{
 						continue;
@@ -156,10 +155,10 @@ public partial class CollectionMatchOptions
 		}
 
 		private static IEnumerable<string> MissingItemsError<T>(int total, List<T> missingItems,
-			EquivalenceRelation equivalenceRelation)
+			EquivalenceRelations equivalenceRelation)
 		{
 			bool hasMissingItems = missingItems.Any();
-			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelation.Subset))
+			if (hasMissingItems && !equivalenceRelation.HasFlag(EquivalenceRelations.Subset))
 			{
 				if (missingItems.Count == 1)
 				{
@@ -182,7 +181,7 @@ public partial class CollectionMatchOptions
 				yield return sb.ToString();
 			}
 
-			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelation.ProperSubset))
+			if (!hasMissingItems && equivalenceRelation.HasFlag(EquivalenceRelations.ProperSubset))
 			{
 				yield return "did contain all expected items";
 			}

--- a/Source/aweXpect/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.cs
@@ -1,44 +1,44 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
 using aweXpect.Core;
-using aweXpect.Helpers;
 
 namespace aweXpect.Options;
 
 /// <summary>
 ///     Options for matching a collection.
 /// </summary>
-public class CollectionMatchOptions
+public partial class CollectionMatchOptions
 {
 	/// <summary>
 	///     Specifies the equivalence relation between subject and expected.
 	/// </summary>
+	[Flags]
 	public enum EquivalenceRelation
 	{
 		/// <summary>
 		///     The subject and expected collection must be equivalent (have the same items)
 		/// </summary>
-		Equivalent,
+		Equivalent = 1,
 
 		/// <summary>
 		///     The expected collection contains at least one additional item.
 		/// </summary>
-		ProperSubset,
+		ProperSubset = 2 | Subset,
 
 		/// <summary>
 		///     The subject collection contains at least one additional item.
 		/// </summary>
-		ProperSuperset,
+		ProperSuperset = 2 | Superset,
 
 		/// <summary>
 		///     The expected collection can contain additional items.
 		/// </summary>
-		Subset,
+		Subset = 4,
 
 		/// <summary>
 		///     The subject collection can contain additional items.
 		/// </summary>
-		Superset
+		Superset = 8
 	}
 
 	private EquivalenceRelation _equivalenceRelation = EquivalenceRelation.Equivalent;
@@ -78,215 +78,19 @@ public class CollectionMatchOptions
 	public override string ToString()
 		=> (_inAnyOrder, _ignoringDuplicates) switch
 		{
-			(true, true) => " in any order ignoring duplicates",
-			(true, false) => " in any order",
-			(false, true) => " ignoring duplicates",
-			(false, false) => ""
+			(true, true) => ToString(_equivalenceRelation) + " in any order ignoring duplicates",
+			(true, false) => ToString(_equivalenceRelation) + " in any order",
+			(false, true) => ToString(_equivalenceRelation) + " ignoring duplicates",
+			(false, false) => ToString(_equivalenceRelation)
 		};
 
-	private sealed class AnyOrderCollectionMatcher<T, T2>(
-		EquivalenceRelation equivalenceRelation,
-		IEnumerable<T> expected)
-		: ICollectionMatcher<T, T2>
-		where T : T2
-	{
-		private readonly List<T> expectedList = expected.ToList();
-		private int _index;
-
-		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+	private static string ToString(EquivalenceRelation equivalenceRelation)
+		=> equivalenceRelation switch
 		{
-			_ = equivalenceRelation;
-			if (expectedList.All(e => !options.AreConsideredEqual(value, e)))
-			{
-				return
-					$"{it} contained item {Formatter.Format(value)} at index {_index++} that was not expected";
-			}
-
-			expectedList.Remove(value);
-			_index++;
-			return null;
-		}
-
-		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
-		{
-			if (expectedList.Any())
-			{
-				return
-					$"{it} lacked {expectedList.Count} of {expectedList.Count + _index} expected items: {Formatter.Format(expectedList,
-						expectedList.Count > 1 ? FormattingOptions.MultipleLines : FormattingOptions.SingleLine)}";
-			}
-
-			return null;
-		}
-
-		public void Dispose() => _index = -1;
-	}
-
-	private sealed class AnyOrderIgnoreDuplicatesCollectionMatcher<T, T2>(
-		EquivalenceRelation equivalenceRelation,
-		IEnumerable<T> expected) : ICollectionMatcher<T, T2>
-		where T : T2
-	{
-		private readonly HashSet<T> _uniqueItems = new();
-		private readonly List<T> expectedList = expected.ToList();
-		private int _index;
-
-		public string? Verify(string it, T value, IOptionsEquality<T2> options)
-		{
-			_ = equivalenceRelation;
-			if (_uniqueItems.Contains(value))
-			{
-				return null;
-			}
-
-			if (expectedList.All(e => !options.AreConsideredEqual(value, e)))
-			{
-				_uniqueItems.Add(value);
-				return
-					$"{it} contained item {Formatter.Format(value)} at index {_index++} that was not expected";
-			}
-
-			_uniqueItems.Add(value);
-			_index++;
-			return null;
-		}
-
-		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
-		{
-			List<T> missingItems = expectedList.Except(_uniqueItems).Distinct().ToList();
-			if (missingItems.Any())
-			{
-				return
-					$"{it} lacked {missingItems.Count} of {missingItems.Count + _index} expected items: {Formatter.Format(missingItems,
-						expectedList.Count > 1 ? FormattingOptions.MultipleLines : FormattingOptions.SingleLine)}";
-			}
-
-			return null;
-		}
-
-		public void Dispose() => _index = -1;
-	}
-
-	private sealed class SameOrderCollectionMatcher<T, T2>(
-		EquivalenceRelation equivalenceRelation,
-		IEnumerable<T> expected)
-		: ICollectionMatcher<T, T2>
-		where T : T2
-	{
-		private readonly IEnumerator<T> _expectedEnumerator = MaterializingEnumerable<T>.Wrap(expected).GetEnumerator();
-		private int _index;
-
-		public string? Verify(string it, T value, IOptionsEquality<T2> options)
-		{
-			_ = equivalenceRelation;
-			if (!_expectedEnumerator.MoveNext())
-			{
-				return $"{it} contained item {Formatter.Format(value)} at index {_index++} that was not expected";
-			}
-
-			if (!options.AreConsideredEqual(value, _expectedEnumerator.Current))
-			{
-				return
-					$"{it} contained item {Formatter.Format(value)} at index {_index++} instead of {Formatter.Format(_expectedEnumerator.Current)}";
-			}
-
-			_index++;
-			return null;
-		}
-
-		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
-		{
-			if (_expectedEnumerator.MoveNext())
-			{
-				List<T> missingItems =
-				[
-					_expectedEnumerator.Current
-				];
-				while (_expectedEnumerator.MoveNext())
-				{
-					missingItems.Add(_expectedEnumerator.Current);
-				}
-
-				return
-					$"{it} lacked {missingItems.Count} of {missingItems.Count + _index} expected items: {Formatter.Format(missingItems,
-						missingItems.Count > 1 ? FormattingOptions.MultipleLines : FormattingOptions.SingleLine)}";
-			}
-
-			return null;
-		}
-
-		public void Dispose()
-		{
-			_index = -1;
-			_expectedEnumerator.Dispose();
-		}
-	}
-
-	private sealed class SameOrderIgnoreDuplicatesCollectionMatcher<T, T2>(
-		EquivalenceRelation equivalenceRelation,
-		IEnumerable<T> expected)
-		: ICollectionMatcher<T, T2>
-		where T : T2
-	{
-		private readonly IEnumerator<T> _expectedEnumerator = MaterializingEnumerable<T>.Wrap(expected).GetEnumerator();
-		private readonly HashSet<T> _uniqueItems = new();
-		private int _index;
-
-		public string? Verify(string it, T value, IOptionsEquality<T2> options)
-		{
-			_ = equivalenceRelation;
-			if (_uniqueItems.Contains(value))
-			{
-				return null;
-			}
-
-			while (_expectedEnumerator.MoveNext())
-			{
-				if (!_uniqueItems.Contains(_expectedEnumerator.Current))
-				{
-					if (!options.AreConsideredEqual(value, _expectedEnumerator.Current))
-					{
-						_uniqueItems.Add(_expectedEnumerator.Current);
-						return
-							$"{it} contained item {Formatter.Format(value)} at index {_index++} instead of {Formatter.Format(_expectedEnumerator.Current)}";
-					}
-
-					break;
-				}
-			}
-
-			_uniqueItems.Add(value);
-			_index++;
-			return null;
-		}
-
-		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
-		{
-			List<T> missingItems = new();
-			while (_expectedEnumerator.MoveNext())
-			{
-				T value = _expectedEnumerator.Current;
-				if (_uniqueItems.Add(value))
-				{
-					missingItems.Add(value);
-				}
-			}
-
-			if (missingItems.Any())
-			{
-				return
-					$"{it} lacked {missingItems.Count} of {missingItems.Count + _index} expected items: {Formatter.Format(missingItems,
-						missingItems.Count > 1 ? FormattingOptions.MultipleLines : FormattingOptions.SingleLine)}";
-			}
-
-			return null;
-		}
-
-		public void Dispose()
-		{
-			_uniqueItems.Clear();
-			_index = -1;
-			_expectedEnumerator.Dispose();
-		}
-	}
+			EquivalenceRelation.Superset => " or more items",
+			EquivalenceRelation.ProperSuperset => " and at least one more item",
+			EquivalenceRelation.Subset => " or less items",
+			EquivalenceRelation.ProperSubset => " and at least one item less",
+			_ => ""
+		};
 }

--- a/Source/aweXpect/Results/CollectionBeResult.cs
+++ b/Source/aweXpect/Results/CollectionBeResult.cs
@@ -26,7 +26,7 @@ public class CollectionBeResult<TType, TThat>(
 	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> AndLess()
 	{
-		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.ProperSubset);
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.ProperSubset);
 		return this;
 	}
 
@@ -38,7 +38,7 @@ public class CollectionBeResult<TType, TThat>(
 	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> AndMore()
 	{
-		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.ProperSuperset);
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.ProperSuperset);
 		return this;
 	}
 
@@ -50,7 +50,7 @@ public class CollectionBeResult<TType, TThat>(
 	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> OrLess()
 	{
-		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.Subset);
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.Subset);
 		return this;
 	}
 
@@ -62,7 +62,7 @@ public class CollectionBeResult<TType, TThat>(
 	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> OrMore()
 	{
-		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.Superset);
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.Superset);
 		return this;
 	}
 }

--- a/Source/aweXpect/Results/CollectionBeResult.cs
+++ b/Source/aweXpect/Results/CollectionBeResult.cs
@@ -1,0 +1,60 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     In addition to the combinations from <see cref="ObjectEqualityResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="CollectionMatchOptions" />.
+/// </summary>
+public class CollectionBeResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	ObjectEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: ObjectCollectionMatchResult<TType, TThat>(expectationBuilder, returnValue, options, collectionMatchOptions)
+{
+	private readonly CollectionMatchOptions _collectionMatchOptions = collectionMatchOptions;
+
+	/// <summary>
+	///     Verifies that all items in the subject are expected, but expected contains at least one more item. This means, that
+	///     subject is a proper subset of the expected collection.
+	/// </summary>
+	public ObjectCollectionMatchResult<TType, TThat> AndLess()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.ProperSubset);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that the subject contain all expected items and at least one additional item. This means, that subject is
+	///     a proper superset of the expected collection.
+	/// </summary>
+	public ObjectCollectionMatchResult<TType, TThat> AndMore()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.ProperSuperset);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that all items in the subject are expected, but expected could contain more items. This means, that
+	///     subject is a subset of the expected collection.
+	/// </summary>
+	public ObjectCollectionMatchResult<TType, TThat> OrLess()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.Subset);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that the subject contain all expected items, but can also contain more items. This means, that subject is
+	///     a superset of the expected collection.
+	/// </summary>
+	public ObjectCollectionMatchResult<TType, TThat> OrMore()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.Superset);
+		return this;
+	}
+}

--- a/Source/aweXpect/Results/CollectionBeResult.cs
+++ b/Source/aweXpect/Results/CollectionBeResult.cs
@@ -19,9 +19,11 @@ public class CollectionBeResult<TType, TThat>(
 	private readonly CollectionMatchOptions _collectionMatchOptions = collectionMatchOptions;
 
 	/// <summary>
-	///     Verifies that all items in the subject are expected, but expected contains at least one more item. This means, that
-	///     subject is a proper subset of the expected collection.
+	///     Verifies that all items in the subject are expected, but expected contains at least one more item.
 	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a proper subset of the expected collection.
+	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> AndLess()
 	{
 		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.ProperSubset);
@@ -29,9 +31,11 @@ public class CollectionBeResult<TType, TThat>(
 	}
 
 	/// <summary>
-	///     Verifies that the subject contain all expected items and at least one additional item. This means, that subject is
-	///     a proper superset of the expected collection.
+	///     Verifies that the subject contain all expected items and at least one additional item.
 	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a proper superset of the expected collection.
+	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> AndMore()
 	{
 		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.ProperSuperset);
@@ -39,9 +43,11 @@ public class CollectionBeResult<TType, TThat>(
 	}
 
 	/// <summary>
-	///     Verifies that all items in the subject are expected, but expected could contain more items. This means, that
-	///     subject is a subset of the expected collection.
+	///     Verifies that all items in the subject are expected, but expected could contain more items.
 	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a subset of the expected collection.
+	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> OrLess()
 	{
 		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.Subset);
@@ -49,9 +55,11 @@ public class CollectionBeResult<TType, TThat>(
 	}
 
 	/// <summary>
-	///     Verifies that the subject contain all expected items, but can also contain more items. This means, that subject is
-	///     a superset of the expected collection.
+	///     Verifies that the subject contain all expected items, but can also contain more items.
 	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a superset of the expected collection.
+	/// </remarks>
 	public ObjectCollectionMatchResult<TType, TThat> OrMore()
 	{
 		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelation.Superset);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -19,7 +19,7 @@ public static partial class ThatAsyncEnumerableShould
 	/// <summary>
 	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
+	public static CollectionBeResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Be<TItem>(
 			this IThat<IAsyncEnumerable<TItem>> source,
 			IEnumerable<TItem> expected,
@@ -27,7 +27,7 @@ public static partial class ThatAsyncEnumerableShould
 	{
 		ObjectEqualityOptions options = new ObjectEqualityOptions();
 		CollectionMatchOptions matchOptions = new CollectionMatchOptions();
-		return new ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(source
+		return new CollectionBeResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(source
 				.ExpectationBuilder
 				.AddConstraint(it
 					=> new BeConstraint<TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -49,8 +49,7 @@ public static partial class ThatAsyncEnumerableShould
 		{
 			IAsyncEnumerable<TItem> materializedEnumerable =
 				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
-			using ICollectionMatcher<TItem, object?> matcher =
-				matchOptions.GetCollectionMatcher<TItem, object?>(expected);
+			ICollectionMatcher<TItem, object?> matcher = matchOptions.GetCollectionMatcher<TItem, object?>(expected);
 			await foreach (TItem item in materializedEnumerable.WithCancellation(cancellationToken))
 			{
 				string? failure = matcher.Verify(it, item, options);

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
@@ -16,7 +16,7 @@ public static partial class ThatEnumerableShould
 	/// <summary>
 	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
+	public static CollectionBeResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		Be<TItem>(
 			this IThat<IEnumerable<TItem>> source,
 			IEnumerable<TItem> expected,
@@ -24,7 +24,7 @@ public static partial class ThatEnumerableShould
 	{
 		ObjectEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(source.ExpectationBuilder
+		return new CollectionBeResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(source.ExpectationBuilder
 				.AddConstraint(it
 					=> new BeConstraint<TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
 			source,

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
@@ -44,8 +44,7 @@ public static partial class ThatEnumerableShould
 		{
 			IEnumerable<TItem> materializedEnumerable =
 				context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
-			using ICollectionMatcher<TItem, object?> matcher =
-				matchOptions.GetCollectionMatcher<TItem, object?>(expected);
+			ICollectionMatcher<TItem, object?> matcher = matchOptions.GetCollectionMatcher<TItem, object?>(expected);
 			foreach (TItem item in materializedEnumerable)
 			{
 				string? failure = matcher.Verify(it, item, options);

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -101,7 +101,7 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(this aweXpect.Core.ExpectationBuilder expectationBuilder, System.Func<TSource, TTarget> memberSelector, string displayName, bool replaceIt = true) { }
     }
-    public interface ICollectionMatcher<in T, out T2> : System.IDisposable
+    public interface ICollectionMatcher<in T, out T2>
         where in T : T2
     {
         string? Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options);

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -101,7 +101,7 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(this aweXpect.Core.ExpectationBuilder expectationBuilder, System.Func<TSource, TTarget> memberSelector, string displayName, bool replaceIt = true) { }
     }
-    public interface ICollectionMatcher<in T, out T2> : System.IDisposable
+    public interface ICollectionMatcher<in T, out T2>
         where in T : T2
     {
         string? Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options);

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -26,7 +26,7 @@ namespace aweXpect
     }
     public static class ThatAsyncEnumerableShould
     {
-        public static aweXpect.Results.ObjectCollectionMatchResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.CollectionBeResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -191,7 +191,7 @@ namespace aweXpect
     }
     public static class ThatEnumerableShould
     {
-        public static aweXpect.Results.ObjectCollectionMatchResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.CollectionBeResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -860,7 +860,16 @@ namespace aweXpect.Options
             where T : T2 { }
         public void IgnoringDuplicates() { }
         public void InAnyOrder() { }
+        public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelation equivalenceRelation) { }
         public override string ToString() { }
+        public enum EquivalenceRelation
+        {
+            Equivalent = 0,
+            ProperSubset = 1,
+            ProperSuperset = 2,
+            Subset = 3,
+            Superset = 4,
+        }
     }
     public class EquivalencyOptions
     {
@@ -930,6 +939,14 @@ namespace aweXpect.Options
 }
 namespace aweXpect.Results
 {
+    public class CollectionBeResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>
+    {
+        public CollectionBeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> AndLess() { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> AndMore() { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrLess() { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrMore() { }
+    }
     public class CountResult<TType, TThat> : aweXpect.Results.CountResult<TType, TThat, aweXpect.Results.CountResult<TType, TThat>>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -862,13 +862,14 @@ namespace aweXpect.Options
         public void InAnyOrder() { }
         public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelation equivalenceRelation) { }
         public override string ToString() { }
+        [System.Flags]
         public enum EquivalenceRelation
         {
-            Equivalent = 0,
-            ProperSubset = 1,
-            ProperSuperset = 2,
-            Subset = 3,
-            Superset = 4,
+            Equivalent = 1,
+            ProperSubset = 6,
+            ProperSuperset = 10,
+            Subset = 4,
+            Superset = 8,
         }
     }
     public class EquivalencyOptions

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -860,10 +860,10 @@ namespace aweXpect.Options
             where T : T2 { }
         public void IgnoringDuplicates() { }
         public void InAnyOrder() { }
-        public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelation equivalenceRelation) { }
+        public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelations equivalenceRelation) { }
         public override string ToString() { }
         [System.Flags]
-        public enum EquivalenceRelation
+        public enum EquivalenceRelations
         {
             Equivalent = 1,
             ProperSubset = 6,

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -150,7 +150,7 @@ namespace aweXpect
     }
     public static class ThatEnumerableShould
     {
-        public static aweXpect.Results.ObjectCollectionMatchResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.CollectionBeResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Be<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> BeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -743,7 +743,16 @@ namespace aweXpect.Options
             where T : T2 { }
         public void IgnoringDuplicates() { }
         public void InAnyOrder() { }
+        public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelation equivalenceRelation) { }
         public override string ToString() { }
+        public enum EquivalenceRelation
+        {
+            Equivalent = 0,
+            ProperSubset = 1,
+            ProperSuperset = 2,
+            Subset = 3,
+            Superset = 4,
+        }
     }
     public class EquivalencyOptions
     {
@@ -813,6 +822,14 @@ namespace aweXpect.Options
 }
 namespace aweXpect.Results
 {
+    public class CollectionBeResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>
+    {
+        public CollectionBeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> AndLess() { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> AndMore() { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrLess() { }
+        public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrMore() { }
+    }
     public class CountResult<TType, TThat> : aweXpect.Results.CountResult<TType, TThat, aweXpect.Results.CountResult<TType, TThat>>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -745,13 +745,14 @@ namespace aweXpect.Options
         public void InAnyOrder() { }
         public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelation equivalenceRelation) { }
         public override string ToString() { }
+        [System.Flags]
         public enum EquivalenceRelation
         {
-            Equivalent = 0,
-            ProperSubset = 1,
-            ProperSuperset = 2,
-            Subset = 3,
-            Superset = 4,
+            Equivalent = 1,
+            ProperSubset = 6,
+            ProperSuperset = 10,
+            Subset = 4,
+            Superset = 8,
         }
     }
     public class EquivalencyOptions

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -743,10 +743,10 @@ namespace aweXpect.Options
             where T : T2 { }
         public void IgnoringDuplicates() { }
         public void InAnyOrder() { }
-        public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelation equivalenceRelation) { }
+        public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelations equivalenceRelation) { }
         public override string ToString() { }
         [System.Flags]
-        public enum EquivalenceRelation
+        public enum EquivalenceRelations
         {
             Equivalent = 1,
             ProperSubset = 6,

--- a/Tests/aweXpect.Tests/Options/CollectionMatchOptionsTests.cs
+++ b/Tests/aweXpect.Tests/Options/CollectionMatchOptionsTests.cs
@@ -4,34 +4,34 @@ namespace aweXpect.Tests.Options;
 
 public class CollectionMatchOptionsTests
 {
-	public class EquivalenceRelationTests
+	public class EquivalenceRelationsTests
 	{
 		[Fact]
 		public async Task ProperSubset_ShouldHaveSubsetFlag()
 		{
-			CollectionMatchOptions.EquivalenceRelation subject
-				= CollectionMatchOptions.EquivalenceRelation.ProperSubset;
+			CollectionMatchOptions.EquivalenceRelations subject
+				= CollectionMatchOptions.EquivalenceRelations.ProperSubset;
 
-			await That(subject).Should().HaveFlag(CollectionMatchOptions.EquivalenceRelation.Subset);
+			await That(subject).Should().HaveFlag(CollectionMatchOptions.EquivalenceRelations.Subset);
 		}
 
 		[Fact]
 		public async Task ProperSuperset_ShouldHaveSupersetFlag()
 		{
-			CollectionMatchOptions.EquivalenceRelation subject
-				= CollectionMatchOptions.EquivalenceRelation.ProperSuperset;
+			CollectionMatchOptions.EquivalenceRelations subject
+				= CollectionMatchOptions.EquivalenceRelations.ProperSuperset;
 
-			await That(subject).Should().HaveFlag(CollectionMatchOptions.EquivalenceRelation.Superset);
+			await That(subject).Should().HaveFlag(CollectionMatchOptions.EquivalenceRelations.Superset);
 		}
 
 		[Fact]
 		public async Task Equivalent_ShouldNotHaveSubsetOrSupersetFlag()
 		{
-			CollectionMatchOptions.EquivalenceRelation subject
-				= CollectionMatchOptions.EquivalenceRelation.Equivalent;
+			CollectionMatchOptions.EquivalenceRelations subject
+				= CollectionMatchOptions.EquivalenceRelations.Equivalent;
 
-			await That(subject).Should().NotHaveFlag(CollectionMatchOptions.EquivalenceRelation.Subset);
-			await That(subject).Should().NotHaveFlag(CollectionMatchOptions.EquivalenceRelation.Superset);
+			await That(subject).Should().NotHaveFlag(CollectionMatchOptions.EquivalenceRelations.Subset);
+			await That(subject).Should().NotHaveFlag(CollectionMatchOptions.EquivalenceRelations.Superset);
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Options/CollectionMatchOptionsTests.cs
+++ b/Tests/aweXpect.Tests/Options/CollectionMatchOptionsTests.cs
@@ -1,0 +1,37 @@
+﻿using aweXpect.Options;
+
+namespace aweXpect.Tests.Options;
+
+public class CollectionMatchOptionsTests
+{
+	public class EquivalenceRelationTests
+	{
+		[Fact]
+		public async Task ProperSubset_ShouldHaveSubsetFlag()
+		{
+			CollectionMatchOptions.EquivalenceRelation subject
+				= CollectionMatchOptions.EquivalenceRelation.ProperSubset;
+
+			await That(subject).Should().HaveFlag(CollectionMatchOptions.EquivalenceRelation.Subset);
+		}
+
+		[Fact]
+		public async Task ProperSuperset_ShouldHaveSupersetFlag()
+		{
+			CollectionMatchOptions.EquivalenceRelation subject
+				= CollectionMatchOptions.EquivalenceRelation.ProperSuperset;
+
+			await That(subject).Should().HaveFlag(CollectionMatchOptions.EquivalenceRelation.Superset);
+		}
+
+		[Fact]
+		public async Task Equivalent_ShouldNotHaveSubsetOrSupersetFlag()
+		{
+			CollectionMatchOptions.EquivalenceRelation subject
+				= CollectionMatchOptions.EquivalenceRelation.Equivalent;
+
+			await That(subject).Should().NotHaveFlag(CollectionMatchOptions.EquivalenceRelation.Subset);
+			await That(subject).Should().NotHaveFlag(CollectionMatchOptions.EquivalenceRelation.Superset);
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndLessTests.cs
@@ -76,6 +76,18 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldFail()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -327,6 +339,18 @@ public sealed partial class AsyncEnumerableShould
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
 					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]
@@ -611,6 +635,18 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldFail()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -877,6 +913,18 @@ public sealed partial class AsyncEnumerableShould
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
 					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndLessTests.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
 using System.Linq;
 
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests.ThatTests.Collections;
 
-public sealed partial class EnumerableShould
+public sealed partial class AsyncEnumerableShould
 {
 	public partial class Be
 	{
@@ -14,7 +15,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -31,7 +32,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -58,7 +59,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -77,7 +78,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -96,7 +97,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -116,7 +117,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -128,7 +129,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -145,7 +146,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -164,7 +165,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -176,7 +177,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -195,7 +196,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -207,7 +208,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -226,7 +227,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -238,7 +239,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -251,7 +252,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -268,7 +269,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -285,7 +286,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -312,7 +313,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -331,7 +332,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -350,7 +351,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -370,7 +371,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b", "c", "a"];
 
 				async Task Act()
@@ -382,7 +383,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -394,7 +395,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -411,7 +412,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -428,7 +429,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -445,7 +446,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -462,7 +463,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -479,7 +480,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -496,7 +497,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -508,7 +509,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -520,7 +521,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -537,7 +538,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -554,7 +555,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -566,7 +567,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -593,7 +594,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -612,7 +613,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -631,7 +632,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -651,7 +652,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -671,7 +672,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -690,7 +691,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -702,7 +703,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -721,7 +722,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -733,7 +734,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -752,7 +753,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -764,7 +765,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -777,7 +778,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -794,7 +795,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -811,7 +812,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -823,7 +824,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -835,7 +836,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -862,7 +863,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -881,7 +882,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -900,7 +901,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -920,7 +921,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -940,7 +941,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -957,7 +958,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -974,7 +975,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -991,7 +992,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -1008,7 +1009,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -1025,7 +1026,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -1037,7 +1038,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -1049,7 +1050,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -1065,3 +1066,4 @@ public sealed partial class EnumerableShould
 		}
 	}
 }
+#endif

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndMoreTests.cs
@@ -77,6 +77,27 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item in any order,
+					             but it
+					               did not contain any additional items and
+					               lacked 2 of 6 expected items:
+					                 "a",
+					                 "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -332,6 +353,27 @@ public sealed partial class AsyncEnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item in any order ignoring duplicates,
+					             but it
+					               did not contain any additional items and
+					               lacked 2 of 5 expected items:
+					                 "a",
+					                 "e"
 					             """);
 			}
 
@@ -650,6 +692,25 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item,
+					             but it lacked 2 of 6 expected items:
+					               "a",
+					               "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -931,6 +992,25 @@ public sealed partial class AsyncEnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item ignoring duplicates,
+					             but it lacked 2 of 5 expected items:
+					               "a",
+					               "e"
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndMoreTests.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
 using System.Linq;
 
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests.ThatTests.Collections;
 
-public sealed partial class EnumerableShould
+public sealed partial class AsyncEnumerableShould
 {
 	public partial class Be
 	{
@@ -14,7 +15,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -31,7 +32,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -58,7 +59,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -78,7 +79,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -90,7 +91,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -102,7 +103,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -124,7 +125,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -141,7 +142,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -153,7 +154,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -172,7 +173,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -184,7 +185,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -203,7 +204,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -215,7 +216,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -234,7 +235,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -256,7 +257,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -273,7 +274,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -290,7 +291,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -317,7 +318,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -337,7 +338,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -349,7 +350,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -361,7 +362,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b", "c", "a"];
 
 				async Task Act()
@@ -383,7 +384,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -404,7 +405,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -421,7 +422,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -438,7 +439,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -455,7 +456,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -472,7 +473,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -489,7 +490,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -506,7 +507,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -525,7 +526,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -546,7 +547,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -563,7 +564,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -580,7 +581,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -602,7 +603,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -629,7 +630,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -651,7 +652,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -663,7 +664,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -675,7 +676,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -695,7 +696,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -707,7 +708,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -726,7 +727,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -738,7 +739,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -759,7 +760,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -771,7 +772,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -790,7 +791,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -812,7 +813,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -829,7 +830,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -846,7 +847,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -868,7 +869,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -889,7 +890,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -916,7 +917,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -936,7 +937,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -948,7 +949,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -960,7 +961,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -980,7 +981,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -997,7 +998,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -1014,7 +1015,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -1031,7 +1032,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -1048,7 +1049,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -1065,7 +1066,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -1084,7 +1085,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -1105,7 +1106,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -1121,3 +1122,4 @@ public sealed partial class EnumerableShould
 		}
 	}
 }
+#endif

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrLessTests.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
 using System.Linq;
 
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests.ThatTests.Collections;
 
-public sealed partial class EnumerableShould
+public sealed partial class AsyncEnumerableShould
 {
 	public partial class Be
 	{
@@ -14,7 +15,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -31,7 +32,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -58,7 +59,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -77,7 +78,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -94,7 +95,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -113,7 +114,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -125,7 +126,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -137,7 +138,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -154,7 +155,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -166,7 +167,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -183,7 +184,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -195,7 +196,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -212,7 +213,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -224,7 +225,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -237,7 +238,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -249,7 +250,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -266,7 +267,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -293,7 +294,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -312,7 +313,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -329,7 +330,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -348,7 +349,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b", "c", "a"];
 
 				async Task Act()
@@ -360,7 +361,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -372,7 +373,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -384,7 +385,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -396,7 +397,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -408,7 +409,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -420,7 +421,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -432,7 +433,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -444,7 +445,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -456,7 +457,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -468,7 +469,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -480,7 +481,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -497,7 +498,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -509,7 +510,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -536,7 +537,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -555,7 +556,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -572,7 +573,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -591,7 +592,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -610,7 +611,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtBeginOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -627,7 +628,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -639,7 +640,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -656,7 +657,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -668,7 +669,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -685,7 +686,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -697,7 +698,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -710,7 +711,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -722,7 +723,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -739,7 +740,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -751,7 +752,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -763,7 +764,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -790,7 +791,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -809,7 +810,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -826,7 +827,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -845,7 +846,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -864,7 +865,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -876,7 +877,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -888,7 +889,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -900,7 +901,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -912,7 +913,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -924,7 +925,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -936,7 +937,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -948,7 +949,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -959,3 +960,4 @@ public sealed partial class EnumerableShould
 		}
 	}
 }
+#endif

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrLessTests.cs
@@ -76,6 +76,18 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldFail()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -308,6 +320,18 @@ public sealed partial class AsyncEnumerableShould
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
 					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]
@@ -551,6 +575,18 @@ public sealed partial class AsyncEnumerableShould
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
 					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]
@@ -805,6 +841,18 @@ public sealed partial class AsyncEnumerableShould
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
 					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrMoreTests.cs
@@ -77,6 +77,25 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items in any order,
+					             but it lacked 2 of 6 expected items:
+					               "a",
+					               "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -312,6 +331,25 @@ public sealed partial class AsyncEnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items in any order ignoring duplicates,
+					             but it lacked 2 of 5 expected items:
+					               "a",
+					               "e"
 					             """);
 			}
 
@@ -583,6 +621,25 @@ public sealed partial class AsyncEnumerableShould
 			}
 
 			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items,
+					             but it lacked 2 of 6 expected items:
+					               "a",
+					               "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
@@ -847,6 +904,25 @@ public sealed partial class AsyncEnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items ignoring duplicates,
+					             but it lacked 2 of 5 expected items:
+					               "a",
+					               "e"
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrMoreTests.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
 using System.Linq;
 
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests.ThatTests.Collections;
 
-public sealed partial class EnumerableShould
+public sealed partial class AsyncEnumerableShould
 {
 	public partial class Be
 	{
@@ -14,7 +15,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -31,7 +32,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -58,7 +59,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -78,7 +79,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -90,7 +91,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -102,7 +103,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -122,7 +123,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -134,7 +135,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -146,7 +147,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -163,7 +164,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -175,7 +176,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -192,7 +193,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -204,7 +205,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -221,7 +222,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -241,7 +242,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrder_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -253,7 +254,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -270,7 +271,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -297,7 +298,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -317,7 +318,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -329,7 +330,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -341,7 +342,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b", "c", "a"];
 
 				async Task Act()
@@ -361,7 +362,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -380,7 +381,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -392,7 +393,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -404,7 +405,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -416,7 +417,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -428,7 +429,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -440,7 +441,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -452,7 +453,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -469,7 +470,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -488,7 +489,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -500,7 +501,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -517,7 +518,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -537,7 +538,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -564,7 +565,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -584,7 +585,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -596,7 +597,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -608,7 +609,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -627,7 +628,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -639,7 +640,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -656,7 +657,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -668,7 +669,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -688,7 +689,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -700,7 +701,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -717,7 +718,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -737,7 +738,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrder_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -749,7 +750,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
 				IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 				async Task Act()
@@ -766,7 +767,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -786,7 +787,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 				string[] expected = ["a", "a", "b"];
 
 				async Task Act()
@@ -805,7 +806,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 			{
-				IEnumerable<int> subject = Enumerable.Range(1, 10);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
 				IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 				async Task Act()
@@ -832,7 +833,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 				async Task Act()
@@ -852,7 +853,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItem_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -864,7 +865,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithAdditionalItems_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -876,7 +877,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -895,7 +896,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["c", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -907,7 +908,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "c"];
 
 				async Task Act()
@@ -919,7 +920,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -931,7 +932,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "a", "b", "c"];
 
 				async Task Act()
@@ -943,7 +944,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -955,7 +956,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d"];
 
 				async Task Act()
@@ -972,7 +973,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c", "d", "e"];
 
 				async Task Act()
@@ -991,7 +992,7 @@ public sealed partial class EnumerableShould
 			[Fact]
 			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
 			{
-				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
 				string[] expected = ["a", "b", "c"];
 
 				async Task Act()
@@ -1002,3 +1003,4 @@ public sealed partial class EnumerableShould
 		}
 	}
 }
+#endif

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
@@ -15,7 +15,7 @@ public sealed partial class AsyncEnumerableShould
 			using CancellationTokenSource cts = new();
 			cts.Cancel();
 			CancellationToken token = cts.Token;
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty().WithCancellation(token);
@@ -84,7 +84,7 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty();
@@ -109,7 +109,7 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 			async Task Act()
 				=> await That(subject).Should().NotBeEmpty();

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Linq;
 
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -10,34 +11,10 @@ public sealed partial class AsyncEnumerableShould
 	public sealed class BeTests
 	{
 		[Fact]
-		public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+		public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrder_WithSameCollection_ShouldSucceed()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -46,15 +23,112 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained item 1 at index 1 that was not expected
+				             but it was very different (> 20 deviations)
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_VeryDifferentCollections_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithAdditionalAndMissingItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected and
+				               lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithAdditionalItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithAdditionalItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
 				             """);
 		}
 
 		[Fact]
 		public async Task AnyOrder_EmptyCollection_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -63,36 +137,30 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
-		public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+		public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
 
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected subject to
-				             match collection expected in any order,
-				             but it lacked 1 of 4 expected items: [1]
-				             """);
+			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		public async Task AnyOrder_WithDuplicatesAtBeginOfSubject_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -101,15 +169,15 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained item 3 at index 3 that was not expected
+				             but it contained item "c" at index 3 that was not expected
 				             """);
 		}
 
 		[Fact]
 		public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -118,52 +186,115 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it lacked 1 of 4 expected items: [3]
+				             but it lacked 1 of 4 expected items: "c"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item "c" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: "a"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item "a" at index 1 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithMissingItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithMissingItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
 				             """);
 		}
 
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		public async Task AnyOrder_WithSameCollection_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+				=> await That(subject).Should().Be(expected).InAnyOrder();
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
-			int[] expected = [1, 1, 2, 3, 1];
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -172,19 +303,132 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it was very different (> 20 deviations)
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected and
+				               lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "a", "b", "c", "a"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
 		public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
-			int[] expected = [1, 1, 2];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "a", "b"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -193,18 +437,17 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it lacked 2 of 2 expected items: [
-				               1,
-				               2
-				             ]
+				             but it lacked 2 of 2 expected items:
+				               "a",
+				               "b"
 				             """);
 		}
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -213,10 +456,10 @@ public sealed partial class AsyncEnumerableShould
 		}
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -227,8 +470,8 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -237,39 +480,94 @@ public sealed partial class AsyncEnumerableShould
 		}
 
 		[Fact]
-		public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected subject to
-				             match collection expected,
-				             but it contained item 3 at index 1 instead of 2
-				             """);
-		}
-
-		[Fact]
-		public async Task SameOrder_WithSameCollection_ShouldSucceed()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -278,15 +576,15 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained item 1 at index 1 instead of 2
+				             but it was very different (> 20 deviations)
 				             """);
 		}
 
 		[Fact]
 		public async Task SameOrder_EmptyCollection_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -295,19 +593,18 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
-		public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+		public async Task SameOrder_VeryDifferentCollections_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -316,15 +613,36 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained item 2 at index 1 instead of 1
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
 				             """);
 		}
 
 		[Fact]
-		public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		public async Task SameOrder_WithAdditionalAndMissingItems_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -333,15 +651,93 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained item 3 at index 3 that was not expected
+				             but it
+				               contained item "d" at index 3 instead of "x" and
+				               contained item "e" at index 4 instead of "y" and
+				               lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithAdditionalItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithAdditionalItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it
+				               contained item "c" at index 1 instead of "b" and
+				               contained item "b" at index 2 instead of "c"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtBeginOfSubject_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item "c" at index 0 that was not expected
 				             """);
 		}
 
 		[Fact]
 		public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -350,16 +746,101 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it lacked 1 of 4 expected items: [3]
+				             but it lacked 1 of 4 expected items: "c"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item "c" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it
+				               contained item "b" at index 1 instead of "a" and
+				               contained item "c" at index 2 instead of "b" and
+				               lacked 1 of 4 expected items: "a"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithMissingItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithMissingItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
 				             """);
 		}
 
 
 		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		public async Task SameOrder_WithSameCollection_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -368,39 +849,15 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it contained item 3 at index 1 instead of 2
+				             but it was very different (> 20 deviations)
 				             """);
-		}
-
-		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
-		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
 		public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -409,19 +866,18 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
 		public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
-			int[] expected = [1, 1, 2];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "a", "b"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -430,30 +886,133 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it lacked 2 of 2 expected items: [
-				               1,
-				               2
-				             ]
+				             but it lacked 2 of 2 expected items:
+				               "a",
+				               "b"
 				             """);
 		}
 
 		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		public async Task SameOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 10));
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
 
-			await That(Act).Should().NotThrow();
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
+				             """);
 		}
 
 		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		public async Task SameOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it
+				               contained item "d" at index 3 instead of "x" and
+				               contained item "e" at index 4 instead of "y" and
+				               lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it
+				               contained item "c" at index 1 instead of "b" and
+				               contained item "b" at index 2 instead of "c"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtBeginOfSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["c", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -464,8 +1023,92 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAllTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAllTests.cs
@@ -76,7 +76,7 @@ public sealed partial class AsyncEnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 		{
-			IAsyncEnumerable<int> subject = ToAsyncEnumerable([]);
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 			async Task Act()
 				=> await That(subject).Should().HaveAll(x => x.Be(0));

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.cs
@@ -7,9 +7,18 @@ namespace aweXpect.Tests.ThatTests.Collections;
 
 public partial class AsyncEnumerableShould
 {
-	public static async IAsyncEnumerable<int> ToAsyncEnumerable(int[] items)
+	public static async IAsyncEnumerable<int> ToAsyncEnumerable(IEnumerable<int> items)
 	{
 		foreach (int item in items)
+		{
+			await Task.Yield();
+			yield return item;
+		}
+	}
+
+	public static async IAsyncEnumerable<string> ToAsyncEnumerable(string[] items)
+	{
+		foreach (string item in items)
 		{
 			await Task.Yield();
 			yield return item;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndLessTests.cs
@@ -1,0 +1,502 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class EnumerableShould
+{
+	public partial class Be
+	{
+		public sealed class AndLessTests
+		{
+			[Fact]
+			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "a" at index 1 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["a"]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b", "c", "a"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "c" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithSameCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item,
+					             but it did not contain any additional items
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "a" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c" and
+					               item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "b" at index 1 instead of "a" and
+					               item "c" at index 2 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it contained item "c" at index 1 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndLessTests.cs
@@ -75,6 +75,18 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldFail()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -326,6 +338,18 @@ public sealed partial class EnumerableShould
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
 					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]
@@ -610,6 +634,18 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldFail()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -876,6 +912,18 @@ public sealed partial class EnumerableShould
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
 					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndLess().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndMoreTests.cs
@@ -76,6 +76,27 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item in any order,
+					             but it
+					               did not contain any additional items and
+					               lacked 2 of 6 expected items:
+					                 "a",
+					                 "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -331,6 +352,27 @@ public sealed partial class EnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item in any order ignoring duplicates,
+					             but it
+					               did not contain any additional items and
+					               lacked 2 of 5 expected items:
+					                 "a",
+					                 "e"
 					             """);
 			}
 
@@ -649,6 +691,25 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item,
+					             but it lacked 2 of 6 expected items:
+					               "a",
+					               "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -930,6 +991,25 @@ public sealed partial class EnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item ignoring duplicates,
+					             but it lacked 2 of 5 expected items:
+					               "a",
+					               "e"
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndMoreTests.cs
@@ -1,0 +1,502 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class EnumerableShould
+{
+	public partial class Be
+	{
+		public sealed class AndMoreTests
+		{
+			[Fact]
+			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "a" at index 1 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["a"]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b", "c", "a"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "c" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithSameCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected and at least one more item,
+					             but it did not contain any additional items
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "a" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c" and
+					               item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "b" at index 1 instead of "a" and
+					               item "c" at index 2 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it contained item "c" at index 1 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).AndMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrLessTests.cs
@@ -75,6 +75,18 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldFail()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -307,6 +319,18 @@ public sealed partial class EnumerableShould
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
 					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]
@@ -550,6 +574,18 @@ public sealed partial class EnumerableShould
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
 					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]
@@ -804,6 +840,18 @@ public sealed partial class EnumerableShould
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
 					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrLess().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrLessTests.cs
@@ -1,0 +1,497 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class EnumerableShould
+{
+	public partial class Be
+	{
+		public sealed class OrLessTests
+		{
+			[Fact]
+			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "a" at index 1 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["a"]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b", "c", "a"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "c" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "a" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c" and
+					               item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "b" at index 1 instead of "a" and
+					               item "c" at index 2 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it contained item "c" at index 1 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrMoreTests.cs
@@ -76,6 +76,25 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task AnyOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items in any order,
+					             but it lacked 2 of 6 expected items:
+					               "a",
+					               "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task AnyOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -311,6 +330,25 @@ public sealed partial class EnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items in any order ignoring duplicates,
+					             but it lacked 2 of 5 expected items:
+					               "a",
+					               "e"
 					             """);
 			}
 
@@ -582,6 +620,25 @@ public sealed partial class EnumerableShould
 			}
 
 			[Fact]
+			public async Task SameOrder_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items,
+					             but it lacked 2 of 6 expected items:
+					               "a",
+					               "e"
+					             """);
+			}
+
+			[Fact]
 			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
@@ -846,6 +903,25 @@ public sealed partial class EnumerableShould
 					               "x",
 					               "y",
 					               "z"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithAdditionalExpectedItemAtBeginningAndEnd_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["b", "b", "c", "d"]);
+				string[] expected = ["a", "b", "b", "c", "d", "e"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected or more items ignoring duplicates,
+					             but it lacked 2 of 5 expected items:
+					               "a",
+					               "e"
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrMoreTests.cs
@@ -1,0 +1,497 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class EnumerableShould
+{
+	public partial class Be
+	{
+		public sealed class OrMoreTests
+		{
+			[Fact]
+			public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "a" at index 1 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["a"]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b", "c", "a"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected in any order ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "c" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithAdditionalItem_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "a" at index 1 instead of "b" and
+					               item "b" at index 2 instead of "c" and
+					               item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected);
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained
+					               item "b" at index 1 instead of "a" and
+					               item "c" at index 2 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it contained item "c" at index 3 that was not expected
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected,
+					             but it lacked 1 of 4 expected items: ["c"]
+					             """);
+			}
+
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it contained item "c" at index 1 instead of "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 3 of 3 expected items: [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+				string[] expected = ["a", "a", "b"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             match collection expected ignoring duplicates,
+					             but it lacked 2 of 2 expected items: [
+					               "a",
+					               "b"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+				string[] expected = ["a", "b", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+				string[] expected = ["a", "b", "c", "c"];
+
+				async Task Act()
+					=> await That(subject).Should().Be(expected).OrMore().IgnoringDuplicates();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeEmptyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeEmptyTests.cs
@@ -43,7 +43,7 @@ public sealed partial class EnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
+			IEnumerable<int> subject = ToEnumerable((int[])[]);
 
 			async Task Act()
 				=> await That(subject).Should().BeEmpty();
@@ -91,7 +91,7 @@ public sealed partial class EnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
+			IEnumerable<int> subject = ToEnumerable((int[])[]);
 
 			async Task Act()
 				=> await That(subject).Should().NotBeEmpty();

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -9,34 +10,10 @@ public sealed partial class EnumerableShould
 	public sealed class BeTests
 	{
 		[Fact]
-		public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
+		public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrder_WithSameCollection_ShouldSucceed()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<int> subject = Enumerable.Range(1, 11);
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -45,15 +22,112 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained item 1 at index 1 that was not expected
+				             but it was very different (> 20 deviations)
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_VeryDifferentCollections_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 10);
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained
+				               item 1 at index 0 that was not expected and
+				               item 2 at index 1 that was not expected and
+				               item 3 at index 2 that was not expected and
+				               item 4 at index 3 that was not expected and
+				               item 5 at index 4 that was not expected and
+				               item 6 at index 5 that was not expected and
+				               item 7 at index 6 that was not expected and
+				               item 8 at index 7 that was not expected and
+				               item 9 at index 8 that was not expected and
+				               item 10 at index 9 that was not expected and
+				               it lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithAdditionalAndMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained
+				               item "d" at index 3 that was not expected and
+				               item "e" at index 4 that was not expected and
+				               it lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithAdditionalItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithAdditionalItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained
+				               item "d" at index 3 that was not expected and
+				               item "e" at index 4 that was not expected
 				             """);
 		}
 
 		[Fact]
 		public async Task AnyOrder_EmptyCollection_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -62,19 +136,30 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
-		public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
+		public async Task AnyOrder_WithCollectionInDifferentOrder_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -83,15 +168,15 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it lacked 1 of 4 expected items: [1]
+				             but it lacked 1 of 4 expected items: "c"
 				             """);
 		}
 
 		[Fact]
 		public async Task AnyOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -100,15 +185,15 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained item 3 at index 3 that was not expected
+				             but it contained item "c" at index 3 that was not expected
 				             """);
 		}
 
 		[Fact]
-		public async Task AnyOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
+		public async Task AnyOrder_WithDuplicatesInExpected_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder();
@@ -117,52 +202,81 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it lacked 1 of 4 expected items: [3]
+				             but it lacked 1 of 4 expected items: "a"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it contained item "a" at index 1 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithMissingItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrder_WithMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
 				             """);
 		}
 
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		public async Task AnyOrder_WithSameCollection_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+				=> await That(subject).Should().Be(expected).InAnyOrder();
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
-		{
-			IEnumerable<int> subject = ToEnumerable([]);
-			int[] expected = [1, 1, 2, 3, 1];
+			IEnumerable<int> subject = Enumerable.Range(1, 11);
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -171,19 +285,132 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it was very different (> 20 deviations)
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 10);
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it contained
+				               item 1 at index 0 that was not expected and
+				               item 2 at index 1 that was not expected and
+				               item 3 at index 2 that was not expected and
+				               item 4 at index 3 that was not expected and
+				               item 5 at index 4 that was not expected and
+				               item 6 at index 5 that was not expected and
+				               item 7 at index 6 that was not expected and
+				               item 8 at index 7 that was not expected and
+				               item 9 at index 8 that was not expected and
+				               item 10 at index 9 that was not expected and
+				               it lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it contained
+				               item "d" at index 3 that was not expected and
+				               item "e" at index 4 that was not expected and
+				               it lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it contained
+				               item "d" at index 3 that was not expected and
+				               item "e" at index 4 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "a", "b", "c", "a"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
 		public async Task AnyOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
-			int[] expected = [1, 1, 2];
+			IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "a", "b"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -192,30 +419,17 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it lacked 2 of 2 expected items: [
-				               1,
-				               2
-				             ]
+				             but it lacked 2 of 2 expected items:
+				               "a",
+				               "b"
 				             """);
 		}
 
 		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		public async Task AnyOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -226,8 +440,8 @@ public sealed partial class EnumerableShould
 		[Fact]
 		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
@@ -236,39 +450,94 @@ public sealed partial class EnumerableShould
 		}
 
 		[Fact]
-		public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
-				=> await That(subject).Should().Be(expected);
-
-			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
-				             Expected subject to
-				             match collection expected,
-				             but it contained item 3 at index 1 instead of 2
-				             """);
-		}
-
-		[Fact]
-		public async Task SameOrder_WithSameCollection_ShouldSucceed()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected);
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
 
 			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
-		public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected in any order ignoring duplicates,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
+				             """);
+		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 11);
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -277,15 +546,15 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained item 1 at index 1 instead of 2
+				             but it was very different (> 20 deviations)
 				             """);
 		}
 
 		[Fact]
 		public async Task SameOrder_EmptyCollection_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -294,19 +563,18 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
-		public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+		public async Task SameOrder_VeryDifferentCollections_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IEnumerable<int> subject = Enumerable.Range(1, 10);
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -315,15 +583,36 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained item 2 at index 1 instead of 1
+				             but it contained
+				               item 1 at index 0 instead of 101 and
+				               item 2 at index 1 instead of 102 and
+				               item 3 at index 2 instead of 103 and
+				               item 4 at index 3 instead of 104 and
+				               item 5 at index 4 instead of 105 and
+				               item 6 at index 5 instead of 106 and
+				               item 7 at index 6 instead of 107 and
+				               item 8 at index 7 instead of 108 and
+				               item 9 at index 8 instead of 109 and
+				               item 10 at index 9 instead of 110 and
+				               it lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
 				             """);
 		}
 
 		[Fact]
-		public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		public async Task SameOrder_WithAdditionalAndMissingItems_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -332,15 +621,76 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained item 3 at index 3 that was not expected
+				             but it contained
+				               item "d" at index 3 instead of "x" and
+				               item "e" at index 4 instead of "y" and
+				               it lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithAdditionalItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithAdditionalItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained
+				               item "d" at index 3 that was not expected and
+				               item "e" at index 4 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained
+				               item "c" at index 1 instead of "b" and
+				               item "b" at index 2 instead of "c"
 				             """);
 		}
 
 		[Fact]
 		public async Task SameOrder_WithDuplicatesAtEndOfExpected_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
@@ -349,16 +699,121 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it lacked 1 of 4 expected items: [3]
+				             but it lacked 1 of 4 expected items: "c"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesAtEndOfSubject_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained item "c" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInExpected_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained
+				               item "b" at index 1 instead of "a" and
+				               item "c" at index 2 instead of "b" and
+				               it lacked 1 of 4 expected items: "a"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithDuplicatesInSubject_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it contained
+				               item "a" at index 1 instead of "b" and
+				               item "b" at index 2 instead of "c" and
+				               item "c" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithMissingItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrder_WithMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
 				             """);
 		}
 
 
 		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		public async Task SameOrder_WithSameCollection_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 3, 2]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 11);
+			IEnumerable<int> expected = Enumerable.Range(100, 11);
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -367,39 +822,15 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it contained item 3 at index 1 instead of 2
+				             but it was very different (> 20 deviations)
 				             """);
-		}
-
-		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
-		}
-
-		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
-		{
-			IEnumerable<int> subject = ToEnumerable([1, 1, 2, 3]);
-			int[] expected = [1, 2, 3];
-
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
-
-			await That(Act).Should().NotThrow();
 		}
 
 		[Fact]
 		public async Task SameOrderIgnoringDuplicates_EmptyCollection_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -408,19 +839,18 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it lacked 3 of 3 expected items: [
-				               1,
-				               2,
-				               3
-				             ]
+				             but it lacked 3 of 3 expected items:
+				               "a",
+				               "b",
+				               "c"
 				             """);
 		}
 
 		[Fact]
 		public async Task SameOrderIgnoringDuplicates_EmptyCollectionWithDuplicatesInExpected_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
-			int[] expected = [1, 1, 2];
+			IEnumerable<string> subject = ToEnumerable(Array.Empty<string>());
+			string[] expected = ["a", "a", "b"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -429,18 +859,133 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it lacked 2 of 2 expected items: [
-				               1,
-				               2
-				             ]
+				             but it lacked 2 of 2 expected items:
+				               "a",
+				               "b"
 				             """);
 		}
 
 		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
+		public async Task SameOrderIgnoringDuplicates_VeryDifferentCollections_ShouldFail()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 1, 2, 3];
+			IEnumerable<int> subject = Enumerable.Range(1, 10);
+			IEnumerable<int> expected = Enumerable.Range(101, 10);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained
+				               item 1 at index 0 instead of 101 and
+				               item 2 at index 1 instead of 102 and
+				               item 3 at index 2 instead of 103 and
+				               item 4 at index 3 instead of 104 and
+				               item 5 at index 4 instead of 105 and
+				               item 6 at index 5 instead of 106 and
+				               item 7 at index 6 instead of 107 and
+				               item 8 at index 7 instead of 108 and
+				               item 9 at index 8 instead of 109 and
+				               item 10 at index 9 instead of 110 and
+				               it lacked 10 of 10 expected items:
+				                 101,
+				                 102,
+				                 103,
+				                 104,
+				                 105,
+				                 106,
+				                 107,
+				                 108,
+				                 109,
+				                 110
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithAdditionalAndMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c", "x", "y", "z"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained
+				               item "d" at index 3 instead of "x" and
+				               item "e" at index 4 instead of "y" and
+				               it lacked 3 of 6 expected items:
+				                 "x",
+				                 "y",
+				                 "z"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithAdditionalItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained item "d" at index 3 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithAdditionalItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained
+				               item "d" at index 3 that was not expected and
+				               item "e" at index 4 that was not expected
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithCollectionInDifferentOrder_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "c", "b"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it contained
+				               item "c" at index 1 instead of "b" and
+				               item "b" at index 2 instead of "c"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -451,8 +996,8 @@ public sealed partial class EnumerableShould
 		[Fact]
 		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfSubject_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 3]);
-			int[] expected = [1, 2, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
@@ -461,10 +1006,70 @@ public sealed partial class EnumerableShould
 		}
 
 		[Fact]
-		public async Task SameOrderIgnoringDuplicates_WithDuplicatesAtEndOfExpected_ShouldSucceed()
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInExpected_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
-			int[] expected = [1, 2, 3, 3];
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithDuplicatesInSubject_ShouldSucceed()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithMissingItem_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 1 of 4 expected items: "d"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithMissingItems_ShouldFail()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c", "d", "e"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection expected ignoring duplicates,
+				             but it lacked 2 of 5 expected items:
+				               "d",
+				               "e"
+				             """);
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_WithSameCollection_ShouldSucceed()
+		{
+			IEnumerable<string> subject = ToEnumerable(["a", "b", "c"]);
+			string[] expected = ["a", "b", "c"];
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected).IgnoringDuplicates();

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
@@ -39,18 +39,18 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained
-				               item 1 at index 0 that was not expected and
-				               item 2 at index 1 that was not expected and
-				               item 3 at index 2 that was not expected and
-				               item 4 at index 3 that was not expected and
-				               item 5 at index 4 that was not expected and
-				               item 6 at index 5 that was not expected and
-				               item 7 at index 6 that was not expected and
-				               item 8 at index 7 that was not expected and
-				               item 9 at index 8 that was not expected and
-				               item 10 at index 9 that was not expected and
-				               it lacked 10 of 10 expected items:
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
 				                 101,
 				                 102,
 				                 103,
@@ -77,10 +77,10 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained
-				               item "d" at index 3 that was not expected and
-				               item "e" at index 4 that was not expected and
-				               it lacked 3 of 6 expected items:
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected and
+				               lacked 3 of 6 expected items:
 				                 "x",
 				                 "y",
 				                 "z"
@@ -117,9 +117,9 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it contained
-				               item "d" at index 3 that was not expected and
-				               item "e" at index 4 that was not expected
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
 				             """);
 		}
 
@@ -302,18 +302,18 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it contained
-				               item 1 at index 0 that was not expected and
-				               item 2 at index 1 that was not expected and
-				               item 3 at index 2 that was not expected and
-				               item 4 at index 3 that was not expected and
-				               item 5 at index 4 that was not expected and
-				               item 6 at index 5 that was not expected and
-				               item 7 at index 6 that was not expected and
-				               item 8 at index 7 that was not expected and
-				               item 9 at index 8 that was not expected and
-				               item 10 at index 9 that was not expected and
-				               it lacked 10 of 10 expected items:
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
 				                 101,
 				                 102,
 				                 103,
@@ -340,10 +340,10 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it contained
-				               item "d" at index 3 that was not expected and
-				               item "e" at index 4 that was not expected and
-				               it lacked 3 of 6 expected items:
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected and
+				               lacked 3 of 6 expected items:
 				                 "x",
 				                 "y",
 				                 "z"
@@ -380,9 +380,9 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it contained
-				               item "d" at index 3 that was not expected and
-				               item "e" at index 4 that was not expected
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
 				             """);
 		}
 
@@ -583,18 +583,18 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained
-				               item 1 at index 0 instead of 101 and
-				               item 2 at index 1 instead of 102 and
-				               item 3 at index 2 instead of 103 and
-				               item 4 at index 3 instead of 104 and
-				               item 5 at index 4 instead of 105 and
-				               item 6 at index 5 instead of 106 and
-				               item 7 at index 6 instead of 107 and
-				               item 8 at index 7 instead of 108 and
-				               item 9 at index 8 instead of 109 and
-				               item 10 at index 9 instead of 110 and
-				               it lacked 10 of 10 expected items:
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
 				                 101,
 				                 102,
 				                 103,
@@ -621,10 +621,10 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained
-				               item "d" at index 3 instead of "x" and
-				               item "e" at index 4 instead of "y" and
-				               it lacked 3 of 6 expected items:
+				             but it
+				               contained item "d" at index 3 instead of "x" and
+				               contained item "e" at index 4 instead of "y" and
+				               lacked 3 of 6 expected items:
 				                 "x",
 				                 "y",
 				                 "z"
@@ -661,9 +661,9 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained
-				               item "d" at index 3 that was not expected and
-				               item "e" at index 4 that was not expected
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
 				             """);
 		}
 
@@ -680,9 +680,9 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained
-				               item "c" at index 1 instead of "b" and
-				               item "b" at index 2 instead of "c"
+				             but it
+				               contained item "c" at index 1 instead of "b" and
+				               contained item "b" at index 2 instead of "c"
 				             """);
 		}
 
@@ -733,10 +733,10 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained
-				               item "b" at index 1 instead of "a" and
-				               item "c" at index 2 instead of "b" and
-				               it lacked 1 of 4 expected items: "a"
+				             but it
+				               contained item "b" at index 1 instead of "a" and
+				               contained item "c" at index 2 instead of "b" and
+				               lacked 1 of 4 expected items: "a"
 				             """);
 		}
 
@@ -753,10 +753,7 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it contained
-				               item "a" at index 1 instead of "b" and
-				               item "b" at index 2 instead of "c" and
-				               item "c" at index 3 that was not expected
+				             but it contained item "a" at index 0 that was not expected
 				             """);
 		}
 
@@ -878,18 +875,18 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it contained
-				               item 1 at index 0 instead of 101 and
-				               item 2 at index 1 instead of 102 and
-				               item 3 at index 2 instead of 103 and
-				               item 4 at index 3 instead of 104 and
-				               item 5 at index 4 instead of 105 and
-				               item 6 at index 5 instead of 106 and
-				               item 7 at index 6 instead of 107 and
-				               item 8 at index 7 instead of 108 and
-				               item 9 at index 8 instead of 109 and
-				               item 10 at index 9 instead of 110 and
-				               it lacked 10 of 10 expected items:
+				             but it
+				               contained item 1 at index 0 that was not expected and
+				               contained item 2 at index 1 that was not expected and
+				               contained item 3 at index 2 that was not expected and
+				               contained item 4 at index 3 that was not expected and
+				               contained item 5 at index 4 that was not expected and
+				               contained item 6 at index 5 that was not expected and
+				               contained item 7 at index 6 that was not expected and
+				               contained item 8 at index 7 that was not expected and
+				               contained item 9 at index 8 that was not expected and
+				               contained item 10 at index 9 that was not expected and
+				               lacked 10 of 10 expected items:
 				                 101,
 				                 102,
 				                 103,
@@ -916,10 +913,10 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it contained
-				               item "d" at index 3 instead of "x" and
-				               item "e" at index 4 instead of "y" and
-				               it lacked 3 of 6 expected items:
+				             but it
+				               contained item "d" at index 3 instead of "x" and
+				               contained item "e" at index 4 instead of "y" and
+				               lacked 3 of 6 expected items:
 				                 "x",
 				                 "y",
 				                 "z"
@@ -956,9 +953,9 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it contained
-				               item "d" at index 3 that was not expected and
-				               item "e" at index 4 that was not expected
+				             but it
+				               contained item "d" at index 3 that was not expected and
+				               contained item "e" at index 4 that was not expected
 				             """);
 		}
 
@@ -975,9 +972,9 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it contained
-				               item "c" at index 1 instead of "b" and
-				               item "b" at index 2 instead of "c"
+				             but it
+				               contained item "c" at index 1 instead of "b" and
+				               contained item "b" at index 2 instead of "c"
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAllTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAllTests.cs
@@ -74,7 +74,7 @@ public sealed partial class EnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
+			IEnumerable<int> subject = ToEnumerable((int[])[]);
 
 			async Task Act()
 				=> await That(subject).Should().HaveAll(x => x.Be(0));

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveNoneTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveNoneTests.cs
@@ -75,7 +75,7 @@ public sealed partial class EnumerableShould
 		[Fact]
 		public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 		{
-			IEnumerable<int> subject = ToEnumerable([]);
+			IEnumerable<int> subject = ToEnumerable((int[])[]);
 
 			async Task Act()
 				=> await That(subject).Should().HaveNone(x => x.Be(0));

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.cs
@@ -13,6 +13,13 @@ public partial class EnumerableShould
 			yield return item;
 		}
 	}
+	public static IEnumerable<string> ToEnumerable(string[] items)
+	{
+		foreach (string item in items)
+		{
+			yield return item;
+		}
+	}
 
 	/// <summary>
 	///     Returns an <see cref="IEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the

--- a/aweXpect.sln.DotSettings
+++ b/aweXpect.sln.DotSettings
@@ -2,5 +2,9 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/LOCAL_FUNCTION_BODY/@EntryValue">ExpressionBody</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">ExpressionBody</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nupkg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xpect/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Implements #69 with a different syntax:
You can now specify e.g. `OrMore()` to indicate that the subject could have more items than expected (it is a superset of the expected)

```csharp
int[] subject = [1, 1, 2, 3];

await That(subject).Should().Be([1, 2]).OrMore();
await That(subject).Should().Be([2, 1]).OrMore().InAnyOrder();
await That(subject).Should().Be([0, 1, 1, 2, 3, 4]).OrLess();
await That(subject).Should().Be([2, 1, 3, 1, 4]).OrLess().InAnyOrder();
```