### PR TITLE
feat: use latest benchmarks in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
                     git config --global user.name "Benchmark User"
                     git switch benchmarks 2>/dev/null || git switch -c benchmarks;
                     git push --set-upstream origin benchmarks
+                    git merge origin/main --no-edit
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
             -   name: Store benchmark result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
                     fail-on-alert: true
                     alert-threshold: '150%'
                     comment-on-alert: true
-                    alert-comment-cc-users: '@vbreuss'
                     auto-push: false
     
     static-code-analysis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
         name: "Benchmarks"
         if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -95,8 +98,27 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+            -   name: Create benchmarks branch
+                run: |
+                    git config --global user.email "benchmarks@testably.org"
+                    git config --global user.name "Benchmark User"
+                    git switch benchmarks 2>/dev/null || git switch -c benchmarks;
+                    git push --set-upstream origin benchmarks
+                    git merge origin/main --no-edit
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
+            -   name: Store benchmark result
+                uses: rhysd/github-action-benchmark@v1
+                with:
+                    name: Benchmark.Net Benchmark
+                    tool: 'benchmarkdotnet'
+                    output-file-path: Artifacts/Benchmarks/results/aweXpect.Benchmarks.HappyCaseBenchmarks-report-full-compressed.json
+                    github-token: ${{ secrets.GITHUB_TOKEN }}
+                    fail-on-alert: true
+                    alert-threshold: '150%'
+                    comment-on-alert: true
+                    alert-comment-cc-users: '@vbreuss'
+                    auto-push: false
     
     static-code-analysis:
         name: "Static code analysis"

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Bool.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Bool.cs
@@ -1,0 +1,22 @@
+﻿using BenchmarkDotNet.Attributes;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace aweXpect.Benchmarks;
+
+public partial class HappyCaseBenchmarks
+{
+	private readonly bool _boolSubject = true;
+
+	[Benchmark]
+	public AndConstraint<BooleanAssertions> Bool_FluentAssertions()
+		=> _boolSubject.Should().BeTrue();
+
+	[Benchmark]
+	public async Task<bool> Bool_aweXpect()
+		=> await Expect.That(_boolSubject).Should().BeTrue();
+
+	[Benchmark]
+	public async Task<bool> Bool_TUnit()
+		=> await Assert.That(_boolSubject).IsTrue();
+}

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.String.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.String.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace aweXpect.Benchmarks;
+
+public partial class HappyCaseBenchmarks
+{
+	private readonly string _stringExpectation = "foo";
+	private readonly string _stringSubject = "foo";
+
+	[Benchmark]
+	public AndConstraint<StringAssertions> String_FluentAssertions()
+		=> _stringSubject.Should().Be(_stringExpectation);
+
+	[Benchmark]
+	public async Task<string?> String_aweXpect()
+		=> await Expect.That(_stringSubject).Should().Be(_stringExpectation);
+
+	[Benchmark]
+	public async Task<string?> String_TUnit()
+		=> await Assert.That(_stringSubject).IsEqualTo(_stringExpectation);
+}

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.StringArray.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.StringArray.cs
@@ -1,0 +1,40 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using TUnit.Assertions.Enums;
+
+namespace aweXpect.Benchmarks;
+
+public partial class HappyCaseBenchmarks
+{
+	private readonly string[] _stringArrayExpectation = ["foo", "bar", "baz"];
+	private readonly string[] _stringArrayOtherOrderExpectation = ["foo", "baz", "bar"];
+	private readonly string[] _stringArraySubject = ["foo", "bar", "baz"];
+
+	[Benchmark]
+	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArray_FluentAssertions()
+		=> _stringArraySubject.Should().Equal(_stringArrayExpectation);
+
+	[Benchmark]
+	public async Task StringArray_aweXpect()
+		=> (await Expect.That(_stringArraySubject).Should().Be(_stringArrayExpectation)).Consume(_consumer);
+
+	[Benchmark]
+	public async Task StringArray_TUnit()
+		=> (await Assert.That(_stringArraySubject).IsEquivalentTo(_stringArrayExpectation))?.Consume(_consumer);
+
+	[Benchmark]
+	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArrayInAnyOrder_FluentAssertions()
+		=> _stringArraySubject.Should().BeEquivalentTo(_stringArrayOtherOrderExpectation);
+
+	[Benchmark]
+	public async Task StringArrayInAnyOrder_aweXpect()
+		=> (await Expect.That(_stringArraySubject).Should().Be(_stringArrayOtherOrderExpectation).InAnyOrder())
+			.Consume(_consumer);
+
+	[Benchmark]
+	public async Task StringArrayInAnyOrder_TUnit()
+		=> (await Assert.That(_stringArraySubject)
+			.IsEquivalentTo(_stringArrayOtherOrderExpectation, CollectionOrdering.Any))?.Consume(_consumer);
+}

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.cs
@@ -1,69 +1,11 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
-using FluentAssertions;
-using FluentAssertions.Collections;
-using FluentAssertions.Primitives;
-using TUnit.Assertions.Enums;
 
 namespace aweXpect.Benchmarks;
 
 [MemoryDiagnoser]
-public class HappyCaseBenchmarks
+public partial class HappyCaseBenchmarks
 {
-	private readonly bool _boolSubject = true;
-	private readonly string _stringExpectation = "foo";
-	private readonly string _stringSubject = "foo";
-	private readonly string[] _stringArraySubject = ["foo", "bar", "baz"];
-	private readonly string[] _stringArrayExpectation = ["foo", "bar", "baz"];
-	private readonly string[] _stringArrayOtherOrderExpectation = ["foo", "baz", "bar"];
 	private readonly Consumer _consumer = new();
 	
-
-	[Benchmark]
-	public AndConstraint<BooleanAssertions> Bool_FluentAssertions()
-		=> _boolSubject.Should().BeTrue();
-	
-	[Benchmark]
-	public async Task<bool> Bool_aweXpect()
-		=> await Expect.That(_boolSubject).Should().BeTrue();
-	
-	[Benchmark]
-	public async Task<bool> Bool_TUnit()
-		=> await Assert.That(_boolSubject).IsTrue();
-	
-	[Benchmark]
-	public AndConstraint<StringAssertions> String_FluentAssertions()
-		=> _stringSubject.Should().Be(_stringExpectation);
-	
-	[Benchmark]
-	public async Task<string?> String_aweXpect()
-		=> await Expect.That(_stringSubject).Should().Be(_stringExpectation);
-	
-	[Benchmark]
-	public async Task<string?> String_TUnit()
-		=> await Assert.That(_stringSubject).IsEqualTo(_stringExpectation);
-	
-	[Benchmark]
-	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArray_FluentAssertions()
-		=> _stringArraySubject.Should().Equal(_stringArrayExpectation);
-	
-	[Benchmark]
-	public async Task StringArray_aweXpect()
-		=> (await Expect.That(_stringArraySubject).Should().Be(_stringArrayExpectation)).Consume(_consumer);
-	
-	[Benchmark]
-	public async Task StringArray_TUnit()
-		=> (await Assert.That(_stringArraySubject).IsEquivalentTo(_stringArrayExpectation))?.Consume(_consumer);
-	
-	[Benchmark]
-	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArrayInAnyOrder_FluentAssertions()
-		=> _stringArraySubject.Should().BeEquivalentTo(_stringArrayOtherOrderExpectation);
-	
-	[Benchmark]
-	public async Task StringArrayInAnyOrder_aweXpect()
-		=> (await Expect.That(_stringArraySubject).Should().Be(_stringArrayOtherOrderExpectation).InAnyOrder()).Consume(_consumer);
-	
-	[Benchmark]
-	public async Task StringArrayInAnyOrder_TUnit()
-		=> (await Assert.That(_stringArraySubject).IsEquivalentTo(_stringArrayOtherOrderExpectation, CollectionOrdering.Any))?.Consume(_consumer);
 }


### PR DESCRIPTION
Use the current benchmarks from `main` in the build pipeline.

Refactor benchmarks to separate the different functionality in separate files (fixes #80).