### PR TITLE
feat: improve error message for completely different collections

### DIFF
--- a/Source/aweXpect.Core/Core/ICollectionMatcher.cs
+++ b/Source/aweXpect.Core/Core/ICollectionMatcher.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace aweXpect.Core;
 
 /// <summary>
@@ -10,12 +8,20 @@ public interface ICollectionMatcher<in T, out T2> where T : T2
 	/// <summary>
 	///     Verifies for each <paramref name="value" /> in the subject, if it results in a failure.
 	/// </summary>
-	/// <returns><see langword="null" /> when it results in no failure, the failure text otherwise.</returns>
+	/// <remarks>
+	///     When returning true and the <paramref name="error" /> is <see langword="null" /> this indicates, that there are too
+	///     many deviations.
+	/// </remarks>
+	/// <returns><see langword="true" /> when it results in a failure, otherwise <see langword="false" />.</returns>
 	bool Verify(string it, T value, IOptionsEquality<T2> options, out string? error);
 
 	/// <summary>
 	///     Verifies if it results in a failure when the enumeration is complete.
 	/// </summary>
-	/// <returns><see langword="null" /> when it results in no failure, the failure text otherwise.</returns>
+	/// <remarks>
+	///     When returning true and the <paramref name="error" /> is <see langword="null" /> this indicates, that there are too
+	///     many deviations.
+	/// </remarks>
+	/// <returns><see langword="true" /> when it results in a failure, otherwise <see langword="false" />.</returns>
 	bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error);
 }

--- a/Source/aweXpect.Core/Core/ICollectionMatcher.cs
+++ b/Source/aweXpect.Core/Core/ICollectionMatcher.cs
@@ -11,11 +11,11 @@ public interface ICollectionMatcher<in T, out T2> where T : T2
 	///     Verifies for each <paramref name="value" /> in the subject, if it results in a failure.
 	/// </summary>
 	/// <returns><see langword="null" /> when it results in no failure, the failure text otherwise.</returns>
-	string? Verify(string it, T value, IOptionsEquality<T2> options);
+	bool Verify(string it, T value, IOptionsEquality<T2> options, out string? error);
 
 	/// <summary>
 	///     Verifies if it results in a failure when the enumeration is complete.
 	/// </summary>
 	/// <returns><see langword="null" /> when it results in no failure, the failure text otherwise.</returns>
-	string? VerifyComplete(string it, IOptionsEquality<T2> options);
+	bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error);
 }

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -50,8 +50,10 @@ public static partial class ValueFormatters
 		int count = maxCount;
 		stringBuilder.Append('[');
 		bool hasMoreValues = false;
+		bool isNotEmpty = false;
 		foreach (object? v in value)
 		{
+			isNotEmpty = true;
 			if (count < maxCount)
 			{
 				if (options.UseLineBreaks)
@@ -85,7 +87,7 @@ public static partial class ValueFormatters
 			stringBuilder.Append(ellipsis);
 		}
 
-		if (options.UseLineBreaks)
+		if (options.UseLineBreaks && isNotEmpty)
 		{
 			stringBuilder.AppendLine();
 		}

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
@@ -23,28 +23,25 @@ public partial class CollectionMatchOptions
 			_totalExpectedCount = _missingItems.Count;
 		}
 
-		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		public bool Verify(string it, T value, IOptionsEquality<T2> options, out string? error)
 		{
 			if (_missingItems.All(e => !options.AreConsideredEqual(value, e)))
 			{
 				_additionalItems.Add(_index, value);
 			}
 
-			if (_additionalItems.Count > 20)
-			{
-				return $"{it} was very different (> 20 deviations)";
-			}
-
 			_missingItems.Remove(value);
 			_index++;
-			return null;
+			error = null;
+			return _additionalItems.Count > 2 * CollectionFormatCount;
 		}
 
-		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		public bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error)
 		{
-			if (_missingItems.Count + _additionalItems.Count > 20)
+			if (_additionalItems.Count + _missingItems.Count > 2 * CollectionFormatCount)
 			{
-				return $"{it} was very different (> 20 deviations)";
+				error = null;
+				return true;
 			}
 
 			List<string> errors = new();
@@ -66,7 +63,8 @@ public partial class CollectionMatchOptions
 				errors.Add("contained all expected items");
 			}
 
-			return ReturnErrorString(it, errors);
+			error = ReturnErrorString(it, errors);
+			return error != null;
 		}
 	}
 }

--- a/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -24,11 +24,12 @@ public partial class CollectionMatchOptions
 			_totalExpectedCount = _missingItems.Count;
 		}
 
-		public string? Verify(string it, T value, IOptionsEquality<T2> options)
+		public bool Verify(string it, T value, IOptionsEquality<T2> options, out string? error)
 		{
+			error = null;
 			if (_uniqueItems.Contains(value))
 			{
-				return null;
+				return false;
 			}
 
 			if (_missingItems.All(e => !options.AreConsideredEqual(value, e)))
@@ -40,19 +41,15 @@ public partial class CollectionMatchOptions
 			_uniqueItems.Add(value);
 			_index++;
 
-			if (_additionalItems.Count > 20)
-			{
-				return $"{it} was very different (> 20 deviations)";
-			}
-
-			return null;
+			return _additionalItems.Count > 2 * CollectionFormatCount;
 		}
 
-		public string? VerifyComplete(string it, IOptionsEquality<T2> options)
+		public bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error)
 		{
-			if (_missingItems.Count + _additionalItems.Count > 20)
+			if (_missingItems.Count + _additionalItems.Count > 2 * CollectionFormatCount)
 			{
-				return $"{it} was very different (> 20 deviations)";
+				error = null;
+				return true;
 			}
 
 			List<string> errors = new();
@@ -74,7 +71,8 @@ public partial class CollectionMatchOptions
 				errors.Add("contained all expected items");
 			}
 
-			return ReturnErrorString(it, errors);
+			error = ReturnErrorString(it, errors);
+			return error != null;
 		}
 	}
 }

--- a/Source/aweXpect/Options/EquivalencyOptions.cs
+++ b/Source/aweXpect/Options/EquivalencyOptions.cs
@@ -19,12 +19,4 @@ public class EquivalencyOptions
 		_membersToIgnore.Add(memberToIgnore);
 		return this;
 	}
-
-	/// <inheritdoc />
-	public override string ToString()
-	{
-		return _membersToIgnore.Count > 0
-			? $" ignoring [{string.Join(", ", _membersToIgnore.Select<string, string>(m => Formatter.Format(m)))}]"
-			: "";
-	}
 }

--- a/Source/aweXpect/Options/ObjectEqualityOptions.cs
+++ b/Source/aweXpect/Options/ObjectEqualityOptions.cs
@@ -17,7 +17,7 @@ public class ObjectEqualityOptions : IOptionsEquality<object?>
 
 	/// <inheritdoc />
 	public bool AreConsideredEqual(object? a, object? b)
-		=> AreConsideredEqual(a, b, "").AreConsideredEqual;
+		=> _type.AreConsideredEqual(a, b);
 
 	/// <summary>
 	///     Compares the objects via <see cref="object.Equals(object, object)" />.

--- a/Source/aweXpect/Options/Quantifier.cs
+++ b/Source/aweXpect/Options/Quantifier.cs
@@ -20,7 +20,7 @@ public class Quantifier
 		if (minimum < 0)
 		{
 			throw new ArgumentOutOfRangeException(nameof(minimum),
-				"The parameter 'minimum' must be greater than zero");
+				"The parameter 'minimum' must be non-negative");
 		}
 
 		_minimum = minimum;
@@ -35,7 +35,7 @@ public class Quantifier
 		if (maximum < 0)
 		{
 			throw new ArgumentOutOfRangeException(nameof(maximum),
-				"The parameter 'maximum' must be greater than zero");
+				"The parameter 'maximum' must be non-negative");
 		}
 
 		_minimum = null;
@@ -50,18 +50,18 @@ public class Quantifier
 		if (minimum < 0)
 		{
 			throw new ArgumentOutOfRangeException(nameof(minimum),
-				"The parameter 'minimum' must be greater than zero");
+				"The parameter 'minimum' must be non-negative");
 		}
 
 		if (maximum < 0)
 		{
 			throw new ArgumentOutOfRangeException(nameof(maximum),
-				"The parameter 'maximum' must be greater than zero");
+				"The parameter 'maximum' must be non-negative");
 		}
 
 		if (minimum > maximum)
 		{
-			throw new ArgumentException("The parameter 'maximum' must be greater than 'minimum'");
+			throw new ArgumentException("The parameter 'maximum' must be greater than or equal to 'minimum'");
 		}
 
 		_minimum = minimum;
@@ -101,7 +101,7 @@ public class Quantifier
 		if (expected < 0)
 		{
 			throw new ArgumentOutOfRangeException(nameof(expected),
-				"The parameter 'expected' must be greater than zero");
+				"The parameter 'expected' must be non-negative");
 		}
 
 		_minimum = expected;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -1,6 +1,8 @@
 ﻿#if NET6_0_OR_GREATER
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core;
@@ -25,8 +27,8 @@ public static partial class ThatAsyncEnumerableShould
 			IEnumerable<TItem> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityOptions options = new ObjectEqualityOptions();
-		CollectionMatchOptions matchOptions = new CollectionMatchOptions();
+		ObjectEqualityOptions options = new();
+		CollectionMatchOptions matchOptions = new();
 		return new CollectionBeResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(source
 				.ExpectationBuilder
 				.AddConstraint(it
@@ -52,21 +54,55 @@ public static partial class ThatAsyncEnumerableShould
 			ICollectionMatcher<TItem, object?> matcher = matchOptions.GetCollectionMatcher<TItem, object?>(expected);
 			await foreach (TItem item in materializedEnumerable.WithCancellation(cancellationToken))
 			{
-				string? failure = matcher.Verify(it, item, options);
-				if (failure != null)
+				if (matcher.Verify(it, item, options, out string? failure))
 				{
-					return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(), failure);
+					return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(),
+						failure ?? await TooManyDeviationsError(materializedEnumerable));
 				}
 			}
 
-			string? lastFailure = matcher.VerifyComplete(it, options);
-			if (lastFailure != null)
+			if (matcher.VerifyComplete(it, options, out string? lastFailure))
 			{
-				return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(), lastFailure);
+				return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(),
+					lastFailure ?? await TooManyDeviationsError(materializedEnumerable));
 			}
 
 			return new ConstraintResult.Success<IAsyncEnumerable<TItem>>(materializedEnumerable,
 				ToString());
+		}
+
+
+		private async Task<string> TooManyDeviationsError(IAsyncEnumerable<TItem> materializedEnumerable)
+		{
+			var sb = new StringBuilder();
+			sb.Append(it);
+			sb.Append(" was completely different: [");
+			int count = 0;
+			await foreach (var item in materializedEnumerable)
+			{
+				if (count++ >= CollectionFormatCount)
+				{
+					break;
+				}
+				sb.AppendLine();
+				sb.Append("  ");
+				Formatter.Format(sb, item);
+				sb.Append(",");
+			}
+
+			if (count > CollectionFormatCount)
+			{
+				sb.AppendLine();
+				sb.Append("  …,");
+			}
+
+			sb.Length--;
+			sb.AppendLine();
+			sb.Append("] had more than ");
+			sb.Append(2 * CollectionFormatCount);
+			sb.Append(" deviations compared to ");
+			Formatter.Format(sb, expected.Take(CollectionFormatCount+1), FormattingOptions.MultipleLines);
+			return sb.ToString();
 		}
 
 		public override string ToString()

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -104,8 +104,8 @@ namespace aweXpect.Core
     public interface ICollectionMatcher<in T, out T2>
         where in T : T2
     {
-        string? Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options);
-        string? VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options);
+        bool Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options, out string? error);
+        bool VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options, out string? error);
     }
     public interface IExpectSubject<out T>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -104,8 +104,8 @@ namespace aweXpect.Core
     public interface ICollectionMatcher<in T, out T2>
         where in T : T2
     {
-        string? Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options);
-        string? VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options);
+        bool Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options, out string? error);
+        bool VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options, out string? error);
     }
     public interface IExpectSubject<out T>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -876,7 +876,6 @@ namespace aweXpect.Options
     {
         public EquivalencyOptions() { }
         public aweXpect.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
-        public override string ToString() { }
     }
     public class NumberTolerance<TNumber>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -759,7 +759,6 @@ namespace aweXpect.Options
     {
         public EquivalencyOptions() { }
         public aweXpect.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
-        public override string ToString() { }
     }
     public class NumberTolerance<TNumber>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/aweXpect.Tests/Options/NumberToleranceTests.cs
+++ b/Tests/aweXpect.Tests/Options/NumberToleranceTests.cs
@@ -1,0 +1,28 @@
+﻿using aweXpect.Options;
+
+namespace aweXpect.Tests.Options;
+
+public class NumberToleranceTests
+{
+	[Fact]
+	public async Task WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+	{
+		NumberTolerance<int> sut = new((_, _, _) => false);
+
+		void Act() => sut.SetTolerance(-1);
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+			.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task WhenToleranceIsZero_ShouldNotThrow()
+	{
+		NumberTolerance<int> sut = new((_, _, _) => false);
+
+		void Act() => sut.SetTolerance(0);
+
+		await That(Act).Should().NotThrow();
+		await That(sut.Tolerance).Should().Be(0);
+	}
+}

--- a/Tests/aweXpect.Tests/Options/ObjectEqualityOptionsTests.cs
+++ b/Tests/aweXpect.Tests/Options/ObjectEqualityOptionsTests.cs
@@ -1,0 +1,27 @@
+﻿using aweXpect.Options;
+
+namespace aweXpect.Tests.Options;
+
+public class ObjectEqualityOptionsTests
+{
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException(bool isEqual)
+	{
+		ObjectEqualityOptions sut = new ObjectEqualityOptions().Equivalent(new EquivalencyOptions());
+		EqualsObject a = new(isEqual);
+		EqualsObject b = new(isEqual);
+
+		sut.Equals();
+
+		await That(sut.AreConsideredEqual(a, b)).Should().Be(isEqual);
+	}
+
+	private class EqualsObject(bool isEqual)
+	{
+		public override bool Equals(object? obj) => isEqual;
+
+		public override int GetHashCode() => throw new NotSupportedException();
+	}
+}

--- a/Tests/aweXpect.Tests/Options/QuantifierTests.cs
+++ b/Tests/aweXpect.Tests/Options/QuantifierTests.cs
@@ -1,0 +1,96 @@
+﻿using aweXpect.Options;
+
+namespace aweXpect.Tests.Options;
+
+public class QuantifierTests
+{
+	[Theory]
+	[InlineData(-1, true)]
+	[InlineData(0, false)]
+	[InlineData(1, false)]
+	public async Task AtLeast_WhenMinimumIsNegative_ShouldThrowArgumentOutOfRangeException(
+		int minimum, bool expectThrow)
+	{
+		Quantifier sut = new();
+
+		void Act() => sut.AtLeast(minimum);
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>().OnlyIf(expectThrow)
+			.WithMessage("*The parameter 'minimum' must be non-negative*").AsWildcard();
+	}
+
+	[Theory]
+	[InlineData(-1, true)]
+	[InlineData(0, false)]
+	[InlineData(1, false)]
+	public async Task AtMost_WhenMaximumIsNegative_ShouldThrowArgumentOutOfRangeException(
+		int maximum, bool expectThrow)
+	{
+		Quantifier sut = new();
+
+		void Act() => sut.AtMost(maximum);
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>().OnlyIf(expectThrow)
+			.WithMessage("*The parameter 'maximum' must be non-negative*").AsWildcard();
+	}
+
+	[Theory]
+	[InlineData(-1, true)]
+	[InlineData(0, false)]
+	[InlineData(1, false)]
+	public async Task Between_WhenMinimumIsNegative_ShouldThrowArgumentOutOfRangeException(
+		int minimum, bool expectThrow)
+	{
+		Quantifier sut = new();
+
+		void Act() => sut.Between(minimum, 1);
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>().OnlyIf(expectThrow)
+			.WithMessage("*The parameter 'minimum' must be non-negative*").AsWildcard();
+	}
+
+	[Theory]
+	[InlineData(-1, true)]
+	[InlineData(0, false)]
+	[InlineData(1, false)]
+	public async Task Between_WhenMaximumIsNegative_ShouldThrowArgumentOutOfRangeException(
+		int maximum, bool expectThrow)
+	{
+		Quantifier sut = new();
+
+		void Act() => sut.Between(0, maximum);
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>().OnlyIf(expectThrow)
+			.WithMessage("*The parameter 'maximum' must be non-negative*").AsWildcard();
+	}
+
+	[Theory]
+	[InlineData(2, 1, true)]
+	[InlineData(1, 1, false)]
+	[InlineData(1, 2, false)]
+	public async Task Between_WhenMaximumIsLessThanMinimum_ShouldThrowArgumentException(
+		int minimum, int maximum, bool expectThrow)
+	{
+		Quantifier sut = new();
+
+		void Act() => sut.Between(minimum, maximum);
+
+		await That(Act).Should().Throw<ArgumentException>().OnlyIf(expectThrow)
+			.WithMessage("*The parameter 'maximum' must be greater than or equal to 'minimum'*").AsWildcard();
+	}
+
+	[Theory]
+	[InlineData(-1, true)]
+	[InlineData(0, false)]
+	[InlineData(1, false)]
+	public async Task Exactly_WhenExpectedIsNegative_ShouldThrowArgumentOutOfRangeException(
+		int expected, bool expectThrow)
+	{
+		Quantifier sut = new();
+
+		void Act() => sut.Exactly(expected);
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>().OnlyIf(expectThrow)
+			.WithMessage("*The parameter 'expected' must be non-negative*").AsWildcard();
+	}
+}

--- a/Tests/aweXpect.Tests/Options/TimeToleranceTests.cs
+++ b/Tests/aweXpect.Tests/Options/TimeToleranceTests.cs
@@ -1,0 +1,28 @@
+﻿using aweXpect.Options;
+
+namespace aweXpect.Tests.Options;
+
+public class TimeToleranceTests
+{
+	[Fact]
+	public async Task WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
+	{
+		TimeTolerance sut = new();
+
+		void Act() => sut.SetTolerance(TimeSpan.FromSeconds(-1));
+
+		await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+			.WithMessage("*Tolerance must be non-negative*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task WhenToleranceIsZero_ShouldNotThrow()
+	{
+		TimeTolerance sut = new();
+
+		void Act() => sut.SetTolerance(TimeSpan.Zero);
+
+		await That(Act).Should().NotThrow();
+		await That(sut.Tolerance).Should().Be(TimeSpan.Zero);
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndLessTests.cs
@@ -25,7 +25,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -291,7 +315,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -572,7 +620,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -841,7 +913,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.AndMoreTests.cs
@@ -25,7 +25,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -305,7 +329,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -616,7 +664,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -901,7 +973,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrLessTests.cs
@@ -25,7 +25,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -272,7 +296,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -515,7 +563,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -769,7 +841,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.Be.OrMoreTests.cs
@@ -25,7 +25,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -283,7 +307,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -549,7 +597,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -817,7 +889,31 @@ public sealed partial class AsyncEnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
@@ -23,7 +23,31 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 
@@ -303,7 +327,31 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 
@@ -576,7 +624,31 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 
@@ -849,7 +921,31 @@ public sealed partial class AsyncEnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
@@ -11,6 +11,34 @@ public sealed partial class AsyncEnumerableShould
 	public sealed class BeTests
 	{
 		[Fact]
+		public async Task AnyOrder_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 21));
+
+			async Task Act()
+				=> await That(subject).Should().Be([]).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [] in any order,
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
+		}
+
+		[Fact]
 		public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 		{
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
@@ -315,6 +343,34 @@ public sealed partial class AsyncEnumerableShould
 		}
 
 		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 21));
+
+			async Task Act()
+				=> await That(subject).Should().Be([]).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [] in any order ignoring duplicates,
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
+		}
+
+		[Fact]
 		public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
 		{
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
@@ -612,6 +668,34 @@ public sealed partial class AsyncEnumerableShould
 		}
 
 		[Fact]
+		public async Task SameOrder_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 21));
+
+			async Task Act()
+				=> await That(subject).Should().Be([]);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [],
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
+		}
+
+		[Fact]
 		public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
 		{
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
@@ -906,6 +990,34 @@ public sealed partial class AsyncEnumerableShould
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 21));
+
+			async Task Act()
+				=> await That(subject).Should().Be([]).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [] ignoring duplicates,
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
 		}
 
 		[Fact]

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndLessTests.cs
@@ -24,7 +24,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -290,7 +314,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -571,7 +619,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -840,7 +912,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one item less ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.AndMoreTests.cs
@@ -24,7 +24,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -304,7 +328,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -615,7 +663,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -900,7 +972,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected and at least one more item ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrLessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrLessTests.cs
@@ -24,7 +24,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -271,7 +295,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -514,7 +562,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -768,7 +840,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or less items ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrMoreTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.Be.OrMoreTests.cs
@@ -24,7 +24,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items in any order,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -282,7 +306,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items in any order ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -548,7 +596,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 
@@ -816,7 +888,31 @@ public sealed partial class EnumerableShould
 					.WithMessage("""
 					             Expected subject to
 					             match collection expected or more items ignoring duplicates,
-					             but it was very different (> 20 deviations)
+					             but it was completely different: [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ] had more than 20 deviations compared to [
+					               100,
+					               101,
+					               102,
+					               103,
+					               104,
+					               105,
+					               106,
+					               107,
+					               108,
+					               109,
+					               …
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
@@ -19,10 +19,34 @@ public sealed partial class EnumerableShould
 				=> await That(subject).Should().Be(expected).InAnyOrder();
 
 			await That(Act).Should().Throw<XunitException>()
-				.WithMessage("""
+				.WithMessage($"""
 				             Expected subject to
 				             match collection expected in any order,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 
@@ -285,7 +309,31 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order ignoring duplicates,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 
@@ -546,7 +594,31 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 
@@ -819,7 +891,31 @@ public sealed partial class EnumerableShould
 				.WithMessage("""
 				             Expected subject to
 				             match collection expected ignoring duplicates,
-				             but it was very different (> 20 deviations)
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to [
+				               100,
+				               101,
+				               102,
+				               103,
+				               104,
+				               105,
+				               106,
+				               107,
+				               108,
+				               109,
+				               …
+				             ]
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.BeTests.cs
@@ -10,6 +10,34 @@ public sealed partial class EnumerableShould
 	public sealed class BeTests
 	{
 		[Fact]
+		public async Task AnyOrder_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 21);
+
+			async Task Act()
+				=> await That(subject).Should().Be([]).InAnyOrder();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [] in any order,
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
+		}
+
+		[Fact]
 		public async Task AnyOrder_CompletelyDifferentCollections_ShouldFail()
 		{
 			IEnumerable<int> subject = Enumerable.Range(1, 11);
@@ -19,7 +47,7 @@ public sealed partial class EnumerableShould
 				=> await That(subject).Should().Be(expected).InAnyOrder();
 
 			await That(Act).Should().Throw<XunitException>()
-				.WithMessage($"""
+				.WithMessage("""
 				             Expected subject to
 				             match collection expected in any order,
 				             but it was completely different: [
@@ -295,6 +323,35 @@ public sealed partial class EnumerableShould
 
 			await That(Act).Should().NotThrow();
 		}
+
+		[Fact]
+		public async Task AnyOrderIgnoringDuplicates_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 21);
+
+			async Task Act()
+				=> await That(subject).Should().Be([]).InAnyOrder().IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [] in any order ignoring duplicates,
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
+		}
+
 
 		[Fact]
 		public async Task AnyOrderIgnoringDuplicates_CompletelyDifferentCollections_ShouldFail()
@@ -580,6 +637,35 @@ public sealed partial class EnumerableShould
 
 			await That(Act).Should().NotThrow();
 		}
+
+		[Fact]
+		public async Task SameOrder_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 21);
+
+			async Task Act()
+				=> await That(subject).Should().Be([]);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [],
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
+		}
+
 
 		[Fact]
 		public async Task SameOrder_CompletelyDifferentCollections_ShouldFail()
@@ -876,6 +962,34 @@ public sealed partial class EnumerableShould
 				=> await That(subject).Should().Be(expected);
 
 			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task SameOrderIgnoringDuplicates_CollectionWithMoreThan20Deviations_ShouldFail()
+		{
+			IEnumerable<int> subject = Enumerable.Range(1, 21);
+
+			async Task Act()
+				=> await That(subject).Should().Be([]).IgnoringDuplicates();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             match collection [] ignoring duplicates,
+				             but it was completely different: [
+				               1,
+				               2,
+				               3,
+				               4,
+				               5,
+				               6,
+				               7,
+				               8,
+				               9,
+				               10,
+				               …
+				             ] had more than 20 deviations compared to []
+				             """);
 		}
 
 		[Fact]


### PR DESCRIPTION
Include subject and expected in error message for completely different collections, improve test coverage and refactor the `ICollectionMatcher` interface.