### PR TITLE
feat: highlight benchmarks from aweXpect

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -25,6 +25,9 @@
       "type": "string",
       "enum": [
         "ApiChecks",
+        "BenchmarkComment",
+        "BenchmarkDotNet",
+        "BenchmarkResult",
         "Benchmarks",
         "CalculateNugetVersion",
         "Clean",
@@ -124,6 +127,10 @@
             "Debug",
             "Release"
           ]
+        },
+        "GithubToken": {
+          "type": "string",
+          "description": "Github Token"
         },
         "Solution": {
           "type": "string",

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -111,10 +112,29 @@ partial class Build
 				continue;
 			}
 
+			if (line.StartsWith('|') && line.Contains("_aweXpect") && line.EndsWith('|'))
+			{
+				MakeLineBold(sb, line);
+				continue;
+			}
 			sb.AppendLine(line);
 		}
 
 		string body = sb.ToString();
 		return body;
+	}
+
+	static void MakeLineBold(StringBuilder sb, string line)
+	{
+		var tokens = line.Split("|", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+		sb.Append('|');
+		foreach (var token in tokens)
+		{
+			sb.Append(" **");
+			sb.Append(token);
+			sb.Append("** |");
+		}
+		
+		sb.AppendLine();
 	}
 }

--- a/Source/aweXpect/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect/Options/CollectionMatchOptions.cs
@@ -174,7 +174,7 @@ public partial class CollectionMatchOptions
 			{
 				sb.AppendLine().Append("  ");
 				Formatter.Format(sb, missingItem);
-				sb.Append(",");
+				sb.Append(',');
 			}
 
 			sb.Length--;

--- a/Source/aweXpect/That/Strings/ThatStringShould.Contain.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.Contain.cs
@@ -70,7 +70,7 @@ public static partial class ThatStringShould
 		}
 
 		private static int CountOccurrences(string actual, string expected,
-			IOptionsEquality<string?> comparer)
+			StringEqualityOptions comparer)
 		{
 			if (expected.Length > actual.Length)
 			{


### PR DESCRIPTION
Highlight aweXpect rows by making them bold in the benchmark table.

*Also fix sonar issues.*