### PR TITLE
feat: additional configuration for string equality

### DIFF
--- a/Docs/pages/docs/expectations/string.md
+++ b/Docs/pages/docs/expectations/string.md
@@ -9,7 +9,7 @@ Describes the possible expectations for strings.
 ## Equality
 
 You can verify, that the `string` is equal to another one.  
-This expectation can be configured to ignore case, ignore newline style, or use a custom `IEqualityComparer<string>`:
+This expectation can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or use a custom `IEqualityComparer<string>`:
 ```csharp
 string subject = "some text";
 
@@ -19,6 +19,10 @@ await Expect.That(subject).Should().Be("SOME TEXT").IgnoringCase()
   .Because("we ignored the casing");
 await Expect.That("a\r\nb").Should().Be("a\nb").IgnoringNewlineStyle()
   .Because("we ignored the newline style");
+await Expect.That(subject).Should().Be("  some text").IgnoringLeadingWhiteSpace()
+  .Because("we ignored leading white-space");
+await Expect.That(subject).Should().Be("some text \t").IgnoringTrailingWhiteSpace()
+  .Because("we ignored trailing white-space");
 await Expect.That(subject).Should().Be("SOME TEXT").Using(StringComparer.OrdinalIgnoreCase)
   .Because("the comparer ignored the casing");
 ```
@@ -56,7 +60,7 @@ The regex comparison uses the following [`options`](https://learn.microsoft.com/
 ## One of
 
 You can verify, that the `string` is one of many alternatives.  
-This expectation can be configured to ignore case, ignore newline style, or use a custom `IEqualityComparer<string>`:
+This expectation can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or use a custom `IEqualityComparer<string>`:
 
 ```csharp
 string subject = "some";
@@ -92,7 +96,7 @@ await Expect.That("foo").Should().NotBeNullOrWhiteSpace();
 ## String start / end
 
 You can verify, that the `string` starts or ends with a given string.  
-These expectations can be configured to ignore case, ignore newline style, or use a custom `IEqualityComparer<string>`:
+These expectations can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or use a custom `IEqualityComparer<string>`:
 ```csharp
 string subject = "some text";
 
@@ -113,7 +117,7 @@ await Expect.That(subject).Should().EndWith("TEXT").Using(StringComparer.Ordinal
 ## Contains
 
 You can verify, that the `string` contains a given substring.  
-These expectations can be configured to ignore case, ignore newline style, or use a custom `IEqualityComparer<string>`:
+These expectations can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or use a custom `IEqualityComparer<string>`:
 ```csharp
 string subject = "some text";
 

--- a/Source/aweXpect/Helpers/StringDifference.cs
+++ b/Source/aweXpect/Helpers/StringDifference.cs
@@ -106,7 +106,7 @@ internal class StringDifference(
 		}
 
 		stringBuilder.Append(text
-			.Substring(indexOfStartingPhrase, subjectLength).ToSingleLine());
+			.Substring(indexOfStartingPhrase, subjectLength).DisplayWhitespace().ToSingleLine());
 
 		if (text.Length > indexOfStartingPhrase + subjectLength)
 		{

--- a/Source/aweXpect/Options/StringEqualityOptions.ExactMatchType.cs
+++ b/Source/aweXpect/Options/StringEqualityOptions.ExactMatchType.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class StringEqualityOptions
+{
+	private sealed class ExactMatchType : IMatchType
+	{
+		private static int GetIndexOfFirstMatch(string stringWithLeadingWhitespace, string value,
+			IEqualityComparer<string> comparer)
+		{
+			for (int i = 0; i <= stringWithLeadingWhitespace.Length - value.Length; i++)
+			{
+				if (comparer.Equals(
+					    stringWithLeadingWhitespace.Substring(i, value.Length), value))
+				{
+					return i;
+				}
+			}
+
+			return 0;
+		}
+
+		#region IMatchType Members
+
+		/// <inheritdoc />
+		public string GetExtendedFailure(string it, string? actual, string? pattern,
+			bool ignoreCase,
+			IEqualityComparer<string> comparer)
+		{
+			if (actual == null || pattern == null)
+			{
+				return $"{it} was <null>";
+			}
+
+			string prefix =
+				$"{it} was {Formatter.Format(actual.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}";
+			int minCommonLength = Math.Min(actual.Length, pattern.Length);
+			StringDifference stringDifference = new(actual, pattern, comparer);
+			if (stringDifference.IndexOfFirstMismatch == 0 &&
+			    comparer.Equals(actual.TrimStart(), pattern))
+			{
+				return
+					$"{prefix} which has unexpected whitespace (\"{actual.Substring(0, GetIndexOfFirstMatch(actual, pattern, comparer)).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the beginning)";
+			}
+
+			if (stringDifference.IndexOfFirstMismatch == 0 &&
+			    comparer.Equals(actual, pattern.TrimStart()))
+			{
+				return
+					$"{prefix} which misses some whitespace (\"{pattern.Substring(0, GetIndexOfFirstMatch(pattern, actual, comparer)).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the beginning)";
+			}
+
+			if (stringDifference.IndexOfFirstMismatch == minCommonLength &&
+			    comparer.Equals(actual.TrimEnd(), pattern))
+			{
+				return
+					$"{prefix} which has unexpected whitespace (\"{actual.Substring(stringDifference.IndexOfFirstMismatch).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the end)";
+			}
+
+			if (stringDifference.IndexOfFirstMismatch == minCommonLength &&
+			    comparer.Equals(actual, pattern.TrimEnd()))
+			{
+				return
+					$"{prefix} which misses some whitespace (\"{pattern.Substring(stringDifference.IndexOfFirstMismatch).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the end)";
+			}
+
+			if (actual.Length < pattern.Length &&
+			    stringDifference.IndexOfFirstMismatch == actual.Length)
+			{
+				return
+					$"{prefix} with a length of {actual.Length} which is shorter than the expected length of {pattern.Length} and misses:{Environment.NewLine}  \"{pattern.Substring(actual.Length).TruncateWithEllipsis(100)}\"";
+			}
+
+			if (actual.Length > pattern.Length &&
+			    stringDifference.IndexOfFirstMismatch == pattern.Length)
+			{
+				return
+					$"{prefix} with a length of {actual.Length} which is longer than the expected length of {pattern.Length} and has superfluous:{Environment.NewLine}  \"{actual.Substring(pattern.Length).TruncateWithEllipsis(100)}\"";
+			}
+
+			return $"{prefix} which {new StringDifference(actual, pattern, comparer)}";
+		}
+
+		public bool Matches(string? value, string? pattern, bool ignoreCase,
+			IEqualityComparer<string> comparer)
+		{
+			if (value is null && pattern is null)
+			{
+				return true;
+			}
+
+			if (value is null || pattern is null)
+			{
+				return false;
+			}
+
+			return comparer.Equals(value, pattern);
+		}
+
+		#endregion
+	}
+}

--- a/Source/aweXpect/Options/StringEqualityOptions.RegexMatchType.cs
+++ b/Source/aweXpect/Options/StringEqualityOptions.RegexMatchType.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class StringEqualityOptions
+{
+	private sealed class RegexMatchType : IMatchType
+	{
+		#region IMatchType Members
+
+		/// <inheritdoc />
+		public string GetExtendedFailure(string it, string? actual, string? pattern,
+			bool ignoreCase,
+			IEqualityComparer<string> comparer)
+			=> $"{it} was {Formatter.Format(actual.TruncateWithEllipsisOnWord(LongMaxLength).Indent(indentFirstLine: false))}";
+
+		public bool Matches(string? value, string? pattern, bool ignoreCase,
+			IEqualityComparer<string> comparer)
+		{
+			if (value is null || pattern is null)
+			{
+				return false;
+			}
+
+			RegexOptions options = RegexOptions.Multiline;
+			if (ignoreCase)
+			{
+				options |= RegexOptions.IgnoreCase;
+			}
+
+			return Regex.IsMatch(value, pattern, options, RegexTimeout);
+		}
+
+		#endregion
+	}
+}

--- a/Source/aweXpect/Options/StringEqualityOptions.WildcardMatchType.cs
+++ b/Source/aweXpect/Options/StringEqualityOptions.WildcardMatchType.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using aweXpect.Helpers;
+
+namespace aweXpect.Options;
+
+public partial class StringEqualityOptions
+{
+	private sealed class WildcardMatchType : IMatchType
+	{
+		private static string WildcardToRegularExpression(string value)
+		{
+			string regex = Regex.Escape(value)
+				.Replace("\\?", ".")
+				.Replace("\\*", "(.|\\n)*");
+			return $"^{regex}$";
+		}
+
+		#region IMatchType Members
+
+		/// <inheritdoc />
+		public string GetExtendedFailure(string it, string? actual, string? pattern,
+			bool ignoreCase,
+			IEqualityComparer<string> comparer)
+			=> $"{it} was {Formatter.Format(actual.TruncateWithEllipsisOnWord(LongMaxLength).Indent(indentFirstLine: false))}";
+
+		public bool Matches(string? value, string? pattern, bool ignoreCase,
+			IEqualityComparer<string> comparer)
+		{
+			if (value is null || pattern is null)
+			{
+				return false;
+			}
+
+			RegexOptions options = RegexOptions.Multiline;
+			if (ignoreCase)
+			{
+				options |= RegexOptions.IgnoreCase;
+			}
+
+			return Regex.IsMatch(value, WildcardToRegularExpression(pattern), options,
+				RegexTimeout);
+		}
+
+		#endregion
+	}
+}

--- a/Source/aweXpect/Results/StringCollectionBeResult.cs
+++ b/Source/aweXpect/Results/StringCollectionBeResult.cs
@@ -1,0 +1,68 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     In addition to the combinations from <see cref="ObjectEqualityResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="CollectionMatchOptions" />.
+/// </summary>
+public class StringCollectionBeResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	StringEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: StringCollectionMatchResult<TType, TThat>(expectationBuilder, returnValue, options, collectionMatchOptions)
+{
+	private readonly CollectionMatchOptions _collectionMatchOptions = collectionMatchOptions;
+
+	/// <summary>
+	///     Verifies that all items in the subject are expected, but expected contains at least one more item.
+	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a proper subset of the expected collection.
+	/// </remarks>
+	public StringCollectionMatchResult<TType, TThat> AndLess()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.ProperSubset);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that the subject contain all expected items and at least one additional item.
+	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a proper superset of the expected collection.
+	/// </remarks>
+	public StringCollectionMatchResult<TType, TThat> AndMore()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.ProperSuperset);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that all items in the subject are expected, but expected could contain more items.
+	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a subset of the expected collection.
+	/// </remarks>
+	public StringCollectionMatchResult<TType, TThat> OrLess()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.Subset);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that the subject contain all expected items, but can also contain more items.
+	/// </summary>
+	/// <remarks>
+	///     This means, that the subject is a superset of the expected collection.
+	/// </remarks>
+	public StringCollectionMatchResult<TType, TThat> OrMore()
+	{
+		_collectionMatchOptions.SetEquivalenceRelation(CollectionMatchOptions.EquivalenceRelations.Superset);
+		return this;
+	}
+}

--- a/Source/aweXpect/Results/StringCollectionBeTypeResult.cs
+++ b/Source/aweXpect/Results/StringCollectionBeTypeResult.cs
@@ -1,0 +1,50 @@
+﻿using System.Text.RegularExpressions;
+using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     Allows specifying the equality type for the string equality check.
+/// </summary>
+public class StringCollectionBeTypeResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	StringEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: StringCollectionBeResult<TType, TThat>(
+		expectationBuilder,
+		returnValue,
+		options,
+		collectionMatchOptions)
+{
+	private readonly StringEqualityOptions _options = options;
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
+	/// </summary>
+	public StringCollectionBeResult<TType, TThat> AsRegex()
+	{
+		_options.AsRegex();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </summary>
+	public StringCollectionBeResult<TType, TThat> AsWildcard()
+	{
+		_options.AsWildcard();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public StringCollectionBeResult<TType, TThat> Exactly()
+	{
+		_options.Exactly();
+		return this;
+	}
+}

--- a/Source/aweXpect/Results/StringCollectionMatchResult.cs
+++ b/Source/aweXpect/Results/StringCollectionMatchResult.cs
@@ -1,0 +1,55 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     In addition to the combinations from <see cref="ObjectEqualityResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="CollectionMatchOptions" />.
+/// </summary>
+public class StringCollectionMatchResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	StringEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: StringCollectionMatchResult<TType, TThat,
+		StringCollectionMatchResult<TType, TThat>>(
+		expectationBuilder,
+		returnValue,
+		options,
+		collectionMatchOptions);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     In addition to the combinations from <see cref="ObjectEqualityResult{TResult,TValue}" />, allows specifying
+///     options on the <see cref="CollectionMatchOptions" />.
+/// </summary>
+public class StringCollectionMatchResult<TType, TThat, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	StringEqualityOptions options,
+	CollectionMatchOptions collectionMatchOptions)
+	: StringEqualityResult<TType, TThat>(expectationBuilder, returnValue, options)
+	where TSelf : StringCollectionMatchResult<TType, TThat, TSelf>
+{
+	/// <summary>
+	///     Ignores the order in the subject and expected values.
+	/// </summary>
+	public TSelf InAnyOrder()
+	{
+		collectionMatchOptions.InAnyOrder();
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Ignores duplicates in both collections.
+	/// </summary>
+	public TSelf IgnoringDuplicates()
+	{
+		collectionMatchOptions.IgnoringDuplicates();
+		return (TSelf)this;
+	}
+}

--- a/Source/aweXpect/Results/StringEqualityResult.cs
+++ b/Source/aweXpect/Results/StringEqualityResult.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using aweXpect.Core;
 using aweXpect.Options;
 
@@ -89,34 +88,6 @@ public class StringEqualityResult<TType, TThat, TSelf>(
 		IEqualityComparer<string> comparer)
 	{
 		options.UsingComparer(comparer);
-		return (TSelf)this;
-	}
-
-	/// <summary>
-	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
-	/// </summary>
-	public TSelf AsRegex()
-	{
-		options.AsRegex();
-		return (TSelf)this;
-	}
-
-	/// <summary>
-	///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
-	///     Supports * to match zero or more characters and ? to match exactly one character.
-	/// </summary>
-	public TSelf AsWildcard()
-	{
-		options.AsWildcard();
-		return (TSelf)this;
-	}
-
-	/// <summary>
-	///     Interprets the expected <see langword="string" /> to be exactly equal.
-	/// </summary>
-	public TSelf Exactly()
-	{
-		options.Exactly();
 		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/Results/StringEqualityResult.cs
+++ b/Source/aweXpect/Results/StringEqualityResult.cs
@@ -59,6 +59,30 @@ public class StringEqualityResult<TType, TThat, TSelf>(
 	}
 
 	/// <summary>
+	///     Ignores leading white-space when comparing <see langword="string" />s,
+	///     according to the <paramref name="ignoreLeadingWhiteSpace" /> parameter.
+	/// </summary>
+	/// <remarks>
+	///     Note:<br />
+	///     This affects the index of first mismatch, as the removed whitespace is also ignored for the index calculation!
+	/// </remarks>
+	public TSelf IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true)
+	{
+		options.IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Ignores trailing white-space when comparing <see langword="string" />s,
+	///     according to the <paramref name="ignoreTrailingWhiteSpace" /> parameter.
+	/// </summary>
+	public TSelf IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true)
+	{
+		options.IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
+		return (TSelf)this;
+	}
+
+	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
 	/// </summary>
 	public TSelf Using(
@@ -67,6 +91,7 @@ public class StringEqualityResult<TType, TThat, TSelf>(
 		options.UsingComparer(comparer);
 		return (TSelf)this;
 	}
+
 	/// <summary>
 	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
 	/// </summary>

--- a/Source/aweXpect/Results/StringEqualityTypeCountResult.cs
+++ b/Source/aweXpect/Results/StringEqualityTypeCountResult.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.RegularExpressions;
+using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     Allows specifying the equality type for the string equality check.
+/// </summary>
+public class StringEqualityTypeCountResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	Quantifier quantifier,
+	StringEqualityOptions options)
+	: StringCountResult<TType, TThat>(expectationBuilder, returnValue, quantifier, options)
+{
+	private readonly StringEqualityOptions _options = options;
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
+	/// </summary>
+	public StringCountResult<TType, TThat> AsRegex()
+	{
+		_options.AsRegex();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </summary>
+	public StringCountResult<TType, TThat> AsWildcard()
+	{
+		_options.AsWildcard();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public StringCountResult<TType, TThat> Exactly()
+	{
+		_options.Exactly();
+		return this;
+	}
+}

--- a/Source/aweXpect/Results/StringEqualityTypeResult.cs
+++ b/Source/aweXpect/Results/StringEqualityTypeResult.cs
@@ -1,0 +1,48 @@
+﻿using System.Text.RegularExpressions;
+using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     Allows specifying the equality type for the string equality check.
+/// </summary>
+public class StringEqualityTypeResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	StringEqualityOptions options)
+	: StringEqualityResult<TType, TThat>(
+		expectationBuilder,
+		returnValue,
+		options)
+{
+	private readonly StringEqualityOptions _options = options;
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
+	/// </summary>
+	public StringEqualityResult<TType, TThat> AsRegex()
+	{
+		_options.AsRegex();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </summary>
+	public StringEqualityResult<TType, TThat> AsWildcard()
+	{
+		_options.AsWildcard();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public StringEqualityResult<TType, TThat> Exactly()
+	{
+		_options.Exactly();
+		return this;
+	}
+}

--- a/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect;
+
+public static partial class ThatStringEnumerableShould
+{
+	/// <summary>
+	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
+	/// </summary>
+	public static StringCollectionBeTypeResult<IEnumerable<string>, IThat<IEnumerable<string>>>
+		Be(this IThat<IEnumerable<string>> source,
+			IEnumerable<string> expected,
+			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		StringEqualityOptions options = new();
+		CollectionMatchOptions matchOptions = new();
+		return new StringCollectionBeTypeResult<IEnumerable<string>, IThat<IEnumerable<string>>>(source.ExpectationBuilder
+				.AddConstraint(it
+					=> new BeConstraint(it, doNotPopulateThisValue, expected, options, matchOptions)),
+			source,
+			options,
+			matchOptions);
+	}
+
+	private readonly struct BeConstraint(
+		string it,
+		string expectedExpression,
+		IEnumerable<string> expected,
+		StringEqualityOptions options,
+		CollectionMatchOptions matchOptions)
+		: IContextConstraint<IEnumerable<string>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<string> actual, IEvaluationContext context)
+		{
+			IEnumerable<string> materializedEnumerable =
+				context.UseMaterializedEnumerable<string, IEnumerable<string>>(actual);
+			ICollectionMatcher<string, string?> matcher = matchOptions.GetCollectionMatcher<string, string?>(expected);
+			foreach (string item in materializedEnumerable)
+			{
+				if (matcher.Verify(it, item, options, out string? failure))
+				{
+					return new ConstraintResult.Failure<IEnumerable<string>>(actual, ToString(),
+						failure ?? TooManyDeviationsError(materializedEnumerable));
+				}
+			}
+
+			if (matcher.VerifyComplete(it, options, out string? lastFailure))
+			{
+				return new ConstraintResult.Failure<IEnumerable<string>>(actual, ToString(),
+					lastFailure ?? TooManyDeviationsError(materializedEnumerable));
+			}
+
+			return new ConstraintResult.Success<IEnumerable<string>>(materializedEnumerable,
+				ToString());
+		}
+
+		private string TooManyDeviationsError(IEnumerable<string> materializedEnumerable)
+			=> $"{it} was completely different: {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)} had more than {2 * CollectionFormatCount} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
+
+		public override string ToString()
+			=> $"match collection {expectedExpression}{matchOptions}";
+	}
+}

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithMessage.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithMessage.cs
@@ -8,10 +8,10 @@ public partial class ThatDelegateThrows<TException>
 	/// <summary>
 	///     Verifies that the thrown exception has a message equal to <paramref name="expected" />
 	/// </summary>
-	public StringEqualityResult<TException, ThatDelegateThrows<TException>> WithMessage(string expected)
+	public StringEqualityTypeResult<TException, ThatDelegateThrows<TException>> WithMessage(string expected)
 	{
 		StringEqualityOptions? options = new();
-		return new StringEqualityResult<TException, ThatDelegateThrows<TException>>(ExpectationBuilder.AddConstraint(it
+		return new StringEqualityTypeResult<TException, ThatDelegateThrows<TException>>(ExpectationBuilder.AddConstraint(it
 				=> new ThatExceptionShould.HasMessageValueConstraint<TException>(
 					it, "with", expected, options)),
 			this,

--- a/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveMessage.cs
+++ b/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveMessage.cs
@@ -12,7 +12,7 @@ public partial class ThatExceptionShould<TException>
 	/// <summary>
 	///     Verifies that the actual exception has a message equal to <paramref name="expected" />
 	/// </summary>
-	public StringEqualityResult<TException?, ThatExceptionShould<TException>>
+	public StringEqualityTypeResult<TException?, ThatExceptionShould<TException>>
 		HaveMessage(string expected)
 	{
 		var options = new StringEqualityOptions();

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
@@ -14,13 +14,13 @@ public static partial class ThatHttpResponseMessageShould
 	/// <summary>
 	///     Verifies that the string content is equal to <paramref name="expected" />
 	/// </summary>
-	public static StringEqualityResult<HttpResponseMessage, IThat<HttpResponseMessage?>>
+	public static StringEqualityTypeResult<HttpResponseMessage, IThat<HttpResponseMessage?>>
 		HaveContent(
 			this IThat<HttpResponseMessage?> source,
 			string expected)
 	{
 		StringEqualityOptions options = new StringEqualityOptions();
-		return new StringEqualityResult<HttpResponseMessage, IThat<HttpResponseMessage?>>(
+		return new StringEqualityTypeResult<HttpResponseMessage, IThat<HttpResponseMessage?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new HasContentConstraint(it, expected, options)),
 			source,

--- a/Source/aweXpect/That/Strings/ThatStringShould.Be.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.Be.cs
@@ -10,12 +10,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject is equal to <paramref name="expected" />.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> Be(
+	public static StringEqualityTypeResult<string?, IThat<string?>> Be(
 		this IThat<string?> source,
 		string? expected)
 	{
 		var options = new StringEqualityOptions();
-		return new StringEqualityResult<string?, IThat<string?>>(source.ExpectationBuilder.AddConstraint(it
+		return new StringEqualityTypeResult<string?, IThat<string?>>(source.ExpectationBuilder.AddConstraint(it
 				=> new BeConstraint(it, expected, options)),
 			source,
 			options);

--- a/Source/aweXpect/That/Strings/ThatStringShould.BeOneOf.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.BeOneOf.cs
@@ -11,12 +11,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject is one of the <paramref name="expected" /> values.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> BeOneOf(
+	public static StringEqualityTypeResult<string?, IThat<string?>> BeOneOf(
 		this IThat<string?> source,
 		params string?[] expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new BeOneOfConstraint(it, expected, options)),
 			source,
@@ -26,12 +26,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> NotBeOneOf(
+	public static StringEqualityTypeResult<string?, IThat<string?>> NotBeOneOf(
 		this IThat<string?> source,
 		params string?[] unexpected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new NotBeOneOfConstraint(it, unexpected, options)),
 			source,

--- a/Source/aweXpect/That/Strings/ThatStringShould.Contain.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.Contain.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Options;
@@ -12,13 +11,13 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject contains the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
-	public static StringCountResult<string?, IThat<string?>> Contain(
+	public static StringEqualityTypeCountResult<string?, IThat<string?>> Contain(
 		this IThat<string?> source,
 		string expected)
 	{
 		Quantifier quantifier = new();
 		StringEqualityOptions options = new();
-		return new StringCountResult<string?, IThat<string?>>(
+		return new StringEqualityTypeCountResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new ContainConstraint(it, expected, quantifier, options)),
 			source,
@@ -29,14 +28,14 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject contains the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> NotContain(
+	public static StringEqualityTypeResult<string?, IThat<string?>> NotContain(
 		this IThat<string?> source,
 		string unexpected)
 	{
 		Quantifier quantifier = new();
 		quantifier.Exactly(0);
 		StringEqualityOptions options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new ContainConstraint(it, unexpected, quantifier, options)),
 			source,
@@ -82,8 +81,8 @@ public static partial class ThatStringShould
 			while (index < actual.Length)
 			{
 				if (comparer.AreConsideredEqual(
-					actual.Substring(index, Math.Min(expected.Length, actual.Length - index)),
-					expected))
+					    actual.Substring(index, Math.Min(expected.Length, actual.Length - index)),
+					    expected))
 				{
 					count++;
 					index += expected.Length;

--- a/Source/aweXpect/That/Strings/ThatStringShould.EndWith.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.EndWith.cs
@@ -10,12 +10,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject ends with the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> EndWith(
+	public static StringEqualityTypeResult<string?, IThat<string?>> EndWith(
 		this IThat<string?> source,
 		string expected)
 	{
-		StringEqualityOptions? options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new EndWithConstraint(it, expected, options)),
 			source,
@@ -25,12 +25,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject does not end with the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> NotEndWith(
+	public static StringEqualityTypeResult<string?, IThat<string?>> NotEndWith(
 		this IThat<string?> source,
 		string unexpected)
 	{
-		StringEqualityOptions? options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new NotEndWithConstraint(it, unexpected, options)),
 			source,

--- a/Source/aweXpect/That/Strings/ThatStringShould.StartWith.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.StartWith.cs
@@ -10,12 +10,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject does not start with the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> NotStartWith(
+	public static StringEqualityTypeResult<string?, IThat<string?>> NotStartWith(
 		this IThat<string?> source,
 		string unexpected)
 	{
-		StringEqualityOptions? options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new NotStartWithConstraint(it, unexpected, options)),
 			source,
@@ -25,12 +25,12 @@ public static partial class ThatStringShould
 	/// <summary>
 	///     Verifies that the subject starts with the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityResult<string?, IThat<string?>> StartWith(
+	public static StringEqualityTypeResult<string?, IThat<string?>> StartWith(
 		this IThat<string?> source,
 		string expected)
 	{
-		StringEqualityOptions? options = new();
-		return new StringEqualityResult<string?, IThat<string?>>(
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.ExpectationBuilder.AddConstraint(it
 				=> new StartWithConstraint(it, expected, options)),
 			source,

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -917,7 +917,9 @@ namespace aweXpect.Options
         public aweXpect.Options.StringEqualityOptions AsWildcard() { }
         public aweXpect.Options.StringEqualityOptions Exactly() { }
         public aweXpect.Options.StringEqualityOptions IgnoringCase(bool ignoreCase = true) { }
+        public aweXpect.Options.StringEqualityOptions IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
         public aweXpect.Options.StringEqualityOptions IgnoringNewlineStyle(bool ignoreNewlineStyle = true) { }
+        public aweXpect.Options.StringEqualityOptions IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
         public override string ToString() { }
         public aweXpect.Options.StringEqualityOptions UsingComparer(System.Collections.Generic.IEqualityComparer<string>? comparer) { }
     }
@@ -1036,7 +1038,9 @@ namespace aweXpect.Results
         public TSelf AsWildcard() { }
         public TSelf Exactly() { }
         public TSelf IgnoringCase(bool ignoreCase = true) { }
+        public TSelf IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
         public TSelf IgnoringNewlineStyle(bool ignoreNewlineStyle = true) { }
+        public TSelf IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
     }
     public class TimeToleranceResult<TType, TThat> : aweXpect.Results.TimeToleranceResult<TType, TThat, aweXpect.Results.TimeToleranceResult<TType, TThat>>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -755,6 +755,7 @@ namespace aweXpect
     }
     public static class ThatStringEnumerableShould
     {
+        public static aweXpect.Results.StringCollectionBeTypeResult<System.Collections.Generic.IEnumerable<string>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>>> Be(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>> source, System.Collections.Generic.IEnumerable<string> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.StringCountResult<System.Collections.Generic.IEnumerable<string>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>>> Contain(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>> source, string expected) { }
     }
     public static class ThatStringShould
@@ -1013,6 +1014,32 @@ namespace aweXpect.Results
         public ObjectEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options) { }
         public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+    }
+    public class StringCollectionBeResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat>
+    {
+        public StringCollectionBeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> AndLess() { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> AndMore() { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> OrLess() { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> OrMore() { }
+    }
+    public class StringCollectionBeTypeResult<TType, TThat> : aweXpect.Results.StringCollectionBeResult<TType, TThat>
+    {
+        public StringCollectionBeTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public aweXpect.Results.StringCollectionBeResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringCollectionBeResult<TType, TThat> AsWildcard() { }
+        public aweXpect.Results.StringCollectionBeResult<TType, TThat> Exactly() { }
+    }
+    public class StringCollectionMatchResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat, aweXpect.Results.StringCollectionMatchResult<TType, TThat>>
+    {
+        public StringCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+    }
+    public class StringCollectionMatchResult<TType, TThat, TSelf> : aweXpect.Results.StringEqualityResult<TType, TThat>
+        where TSelf : aweXpect.Results.StringCollectionMatchResult<TType, TThat, TSelf>
+    {
+        public StringCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public TSelf IgnoringDuplicates() { }
+        public TSelf InAnyOrder() { }
     }
     public class StringCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat, aweXpect.Results.StringCountResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -165,7 +165,7 @@ namespace aweXpect
             where TInnerException : System.Exception { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException() { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
-        public aweXpect.Results.StringEqualityResult<TException, aweXpect.ThatDelegateThrows<TException>> WithMessage(string expected) { }
+        public aweXpect.Results.StringEqualityTypeResult<TException, aweXpect.ThatDelegateThrows<TException>> WithMessage(string expected) { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatEnumShould
@@ -227,7 +227,7 @@ namespace aweXpect
             where TInnerException : System.Exception? { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveInnerException() { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
-        public aweXpect.Results.StringEqualityResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveMessage(string expected) { }
+        public aweXpect.Results.StringEqualityTypeResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveMessage(string expected) { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatGeneric
@@ -251,7 +251,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> BeRedirection(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> BeSuccess(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HaveClientError(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
-        public static aweXpect.Results.StringEqualityResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HaveContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HaveContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HaveError(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HaveServerError(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HaveStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode expected) { }
@@ -759,30 +759,30 @@ namespace aweXpect
     }
     public static class ThatStringShould
     {
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> Be(this aweXpect.Core.IThat<string?> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> Be(this aweXpect.Core.IThat<string?> source, string? expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeLowerCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> BeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> BeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeUpperCased(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringCountResult<string?, aweXpect.Core.IThat<string?>> Contain(this aweXpect.Core.IThat<string?> source, string expected) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> EndWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> Contain(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> EndWith(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> HaveLength(this aweXpect.Core.IThat<string?> source, int expected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeLowerCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotBeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotBeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeUpperCased(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotContain(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotContain(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotHaveLength(this aweXpect.Core.IThat<string?> source, int unexpected) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
         public static aweXpect.Core.IThat<string?> Should(this aweXpect.Core.IExpectSubject<string?> subject) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> StartWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartWith(this aweXpect.Core.IThat<string?> source, string expected) { }
     }
     public static class ThatTimeOnlyShould
     {
@@ -1034,14 +1034,25 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringEqualityResult<TType, TThat, TSelf>
     {
         public StringEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
-        public TSelf AsRegex() { }
-        public TSelf AsWildcard() { }
-        public TSelf Exactly() { }
         public TSelf IgnoringCase(bool ignoreCase = true) { }
         public TSelf IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
         public TSelf IgnoringNewlineStyle(bool ignoreNewlineStyle = true) { }
         public TSelf IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+    }
+    public class StringEqualityTypeCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat>
+    {
+        public StringEqualityTypeCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsWildcard() { }
+        public aweXpect.Results.StringCountResult<TType, TThat> Exactly() { }
+    }
+    public class StringEqualityTypeResult<TType, TThat> : aweXpect.Results.StringEqualityResult<TType, TThat>
+    {
+        public StringEqualityTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> AsWildcard() { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> Exactly() { }
     }
     public class TimeToleranceResult<TType, TThat> : aweXpect.Results.TimeToleranceResult<TType, TThat, aweXpect.Results.TimeToleranceResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -124,7 +124,7 @@ namespace aweXpect
             where TInnerException : System.Exception { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException() { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
-        public aweXpect.Results.StringEqualityResult<TException, aweXpect.ThatDelegateThrows<TException>> WithMessage(string expected) { }
+        public aweXpect.Results.StringEqualityTypeResult<TException, aweXpect.ThatDelegateThrows<TException>> WithMessage(string expected) { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatEnumShould
@@ -186,7 +186,7 @@ namespace aweXpect
             where TInnerException : System.Exception? { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveInnerException() { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
-        public aweXpect.Results.StringEqualityResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveMessage(string expected) { }
+        public aweXpect.Results.StringEqualityTypeResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveMessage(string expected) { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatGeneric
@@ -664,30 +664,30 @@ namespace aweXpect
     }
     public static class ThatStringShould
     {
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> Be(this aweXpect.Core.IThat<string?> source, string? expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> Be(this aweXpect.Core.IThat<string?> source, string? expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeLowerCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> BeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> BeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeUpperCased(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringCountResult<string?, aweXpect.Core.IThat<string?>> Contain(this aweXpect.Core.IThat<string?> source, string expected) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> EndWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> Contain(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> EndWith(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> HaveLength(this aweXpect.Core.IThat<string?> source, int expected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeLowerCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotBeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotBeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotBeUpperCased(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotContain(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotContain(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> NotHaveLength(this aweXpect.Core.IThat<string?> source, int unexpected) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> NotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> NotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
         public static aweXpect.Core.IThat<string?> Should(this aweXpect.Core.IExpectSubject<string?> subject) { }
-        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> StartWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartWith(this aweXpect.Core.IThat<string?> source, string expected) { }
     }
     public static class ThatTimeSpanShould
     {
@@ -917,14 +917,25 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringEqualityResult<TType, TThat, TSelf>
     {
         public StringEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
-        public TSelf AsRegex() { }
-        public TSelf AsWildcard() { }
-        public TSelf Exactly() { }
         public TSelf IgnoringCase(bool ignoreCase = true) { }
         public TSelf IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
         public TSelf IgnoringNewlineStyle(bool ignoreNewlineStyle = true) { }
         public TSelf IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+    }
+    public class StringEqualityTypeCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat>
+    {
+        public StringEqualityTypeCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsWildcard() { }
+        public aweXpect.Results.StringCountResult<TType, TThat> Exactly() { }
+    }
+    public class StringEqualityTypeResult<TType, TThat> : aweXpect.Results.StringEqualityResult<TType, TThat>
+    {
+        public StringEqualityTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> AsWildcard() { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> Exactly() { }
     }
     public class TimeToleranceResult<TType, TThat> : aweXpect.Results.TimeToleranceResult<TType, TThat, aweXpect.Results.TimeToleranceResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -660,6 +660,7 @@ namespace aweXpect
     }
     public static class ThatStringEnumerableShould
     {
+        public static aweXpect.Results.StringCollectionBeTypeResult<System.Collections.Generic.IEnumerable<string>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>>> Be(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>> source, System.Collections.Generic.IEnumerable<string> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.StringCountResult<System.Collections.Generic.IEnumerable<string>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>>> Contain(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string>> source, string expected) { }
     }
     public static class ThatStringShould
@@ -896,6 +897,32 @@ namespace aweXpect.Results
         public ObjectEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options) { }
         public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+    }
+    public class StringCollectionBeResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat>
+    {
+        public StringCollectionBeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> AndLess() { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> AndMore() { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> OrLess() { }
+        public aweXpect.Results.StringCollectionMatchResult<TType, TThat> OrMore() { }
+    }
+    public class StringCollectionBeTypeResult<TType, TThat> : aweXpect.Results.StringCollectionBeResult<TType, TThat>
+    {
+        public StringCollectionBeTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public aweXpect.Results.StringCollectionBeResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringCollectionBeResult<TType, TThat> AsWildcard() { }
+        public aweXpect.Results.StringCollectionBeResult<TType, TThat> Exactly() { }
+    }
+    public class StringCollectionMatchResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat, aweXpect.Results.StringCollectionMatchResult<TType, TThat>>
+    {
+        public StringCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+    }
+    public class StringCollectionMatchResult<TType, TThat, TSelf> : aweXpect.Results.StringEqualityResult<TType, TThat>
+        where TSelf : aweXpect.Results.StringCollectionMatchResult<TType, TThat, TSelf>
+    {
+        public StringCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
+        public TSelf IgnoringDuplicates() { }
+        public TSelf InAnyOrder() { }
     }
     public class StringCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat, aweXpect.Results.StringCountResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -800,7 +800,9 @@ namespace aweXpect.Options
         public aweXpect.Options.StringEqualityOptions AsWildcard() { }
         public aweXpect.Options.StringEqualityOptions Exactly() { }
         public aweXpect.Options.StringEqualityOptions IgnoringCase(bool ignoreCase = true) { }
+        public aweXpect.Options.StringEqualityOptions IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
         public aweXpect.Options.StringEqualityOptions IgnoringNewlineStyle(bool ignoreNewlineStyle = true) { }
+        public aweXpect.Options.StringEqualityOptions IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
         public override string ToString() { }
         public aweXpect.Options.StringEqualityOptions UsingComparer(System.Collections.Generic.IEqualityComparer<string>? comparer) { }
     }
@@ -919,7 +921,9 @@ namespace aweXpect.Results
         public TSelf AsWildcard() { }
         public TSelf Exactly() { }
         public TSelf IgnoringCase(bool ignoreCase = true) { }
+        public TSelf IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
         public TSelf IgnoringNewlineStyle(bool ignoreNewlineStyle = true) { }
+        public TSelf IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
     }
     public class TimeToleranceResult<TType, TThat> : aweXpect.Results.TimeToleranceResult<TType, TThat, aweXpect.Results.TimeToleranceResult<TType, TThat>>

--- a/Tests/aweXpect.Tests/TestHelpers/StringExtensions.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/StringExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace aweXpect.Tests.TestHelpers;
+
+internal static class StringExtensions
+{
+	
+	[return: NotNullIfNotNull(nameof(value))]
+	public static string? DisplayWhitespace(this string? value)
+		=> value?.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/StringEnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/StringEnumerableShould.BeTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class StringEnumerableShould
+{
+	public sealed class BeTests
+	{
+		[Fact]
+		public async Task AsWildcard_ShouldNotThrowWhenMatchingWildcard()
+		{
+			IEnumerable<string> subject = ["foo", "bar", "baz"];
+			string[] expected = ["*oo", "*a?", "?a?"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).AsWildcard();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task IgnoringLeadingWhiteSpace_ShouldNotThrowWhenOnlyDifferenceIsInLeadingWhiteSpace()
+		{
+			IEnumerable<string> subject = [" a", "b", "\tc"];
+			string[] expected = ["a", " b", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringLeadingWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task IgnoringTrailingWhiteSpace_ShouldNotThrowWhenOnlyDifferenceIsInTrailingWhiteSpace()
+		{
+			IEnumerable<string> subject = ["a ", "b", "c\t"];
+			string[] expected = ["a", "b ", "c"];
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringTrailingWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Strings/StringShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Strings/StringShould.BeTests.cs
@@ -21,6 +21,36 @@ public sealed partial class StringShould
 		}
 
 		[Theory]
+		[InlineAutoData(" foo", "foo")]
+		[InlineAutoData("foo", " foo")]
+		[InlineAutoData("\tfoo", "\nfoo")]
+		[InlineAutoData("\r\nfoo", "foo")]
+		[InlineAutoData("foo", "\tfoo")]
+		public async Task IgnoringLeadingWhiteSpace_WhenStringsDifferOnlyInLeadingWhiteSpace_ShouldSucceed(
+			string subject, string expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringLeadingWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineAutoData("foo ", "foo")]
+		[InlineAutoData("foo", "foo ")]
+		[InlineAutoData("foo\t", "foo\n")]
+		[InlineAutoData("foo\r\n", "foo")]
+		[InlineAutoData("foo", "foo\t")]
+		public async Task IgnoringTrailingWhiteSpace_WhenStringsDifferOnlyInTrailingWhiteSpace_ShouldSucceed(
+			string subject, string expected)
+		{
+			async Task Act()
+				=> await That(subject).Should().Be(expected).IgnoringTrailingWhiteSpace();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
 		[AutoData]
 		public async Task WhenStringsAreTheSame_ShouldSucceed(string subject)
 		{
@@ -51,74 +81,6 @@ public sealed partial class StringShould
 				               "expected other text"
 				                ↑ (expected)
 				             """);
-		}
-
-		[Theory]
-		[InlineAutoData(" foo", "foo", true)]
-		[InlineAutoData(" foo", "foo", false)]
-		[InlineAutoData("foo", " foo", true)]
-		[InlineAutoData("\tfoo", "\nfoo", false)]
-		[InlineAutoData("\r\nfoo", "foo", true)]
-		[InlineAutoData("foo", "\tfoo", false)]
-		public async Task WhenStringsDifferInLeadingWhiteSpace_ShouldFailIfNotIgnoringLeadingWhiteSpace(
-			string subject, string expected, bool ignoreLeadingWhiteSpace)
-		{
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
-
-			await That(Act).Should().Throw<XunitException>().OnlyIf(!ignoreLeadingWhiteSpace)
-				.WithMessage($"""
-				              Expected subject to
-				              be equal to {Formatter.Format(expected)},
-				              but it was {Formatter.Format(subject)} which has unexpected whitespace ("*" at the beginning)
-				              """).AsWildcard();
-		}
-
-		[Theory]
-		[InlineAutoData("a\rb", "a\r\nb", 2, true)]
-		[InlineAutoData("a\rb", "a\r\nb", 2, false)]
-		[InlineAutoData("a\nb", "a\r\nb", 1)]
-		[InlineAutoData("a\r\nb", "a\rb", 2)]
-		[InlineAutoData("a\r\nb", "a\nb", 1)]
-		[InlineAutoData("a\rb", "a\nb", 1)]
-		[InlineAutoData("a\nb", "a\rb", 1)]
-		public async Task WhenStringsDifferInNewlineStyle_ShouldFailIfNotIgnoringNewlineStyle(
-			string subject, string expected, int indexOfFirstMismatch, bool ignoreNewlineStyle)
-		{
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringNewlineStyle(ignoreNewlineStyle);
-
-			await That(Act).Should().Throw<XunitException>().OnlyIf(!ignoreNewlineStyle)
-				.WithMessage($"""
-				              Expected subject to
-				              be equal to {Formatter.Format(expected)},
-				              but it was {Formatter.Format(subject)} which differs at index {indexOfFirstMismatch}:
-				                {new string(' ', 2 * indexOfFirstMismatch)}↓ (actual)
-				                {Formatter.Format(subject)}
-				                {Formatter.Format(expected)}
-				                {new string(' ', 2 * indexOfFirstMismatch)}↑ (expected)
-				              """);
-		}
-
-		[Theory]
-		[InlineAutoData("foo ", "foo", true)]
-		[InlineAutoData("foo ", "foo", false)]
-		[InlineAutoData("foo", "foo ", true)]
-		[InlineAutoData("foo\t", "foo\n", false)]
-		[InlineAutoData("foo\r\n", "foo", true)]
-		[InlineAutoData("foo", "foo\t", false)]
-		public async Task WhenStringsDifferInTrailingWhiteSpace_ShouldFailIfNotIgnoringTrailingWhiteSpace(
-			string subject, string expected, bool ignoreTrailingWhiteSpace)
-		{
-			async Task Act()
-				=> await That(subject).Should().Be(expected).IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
-
-			await That(Act).Should().Throw<XunitException>().OnlyIf(!ignoreTrailingWhiteSpace)
-				.WithMessage($"""
-				              Expected subject to
-				              be equal to {Formatter.Format(expected)},
-				              but it was {Formatter.Format(subject)} which has unexpected whitespace ("*" at the end)
-				              """).AsWildcard();
 		}
 	}
 }


### PR DESCRIPTION
Implements #52:
- **IgnoringLeadingWhitespace**
  Instructs the comparison to ignore leading whitespace when comparing strings.
- **IgnoringTrailingWhitespace**
  Instructs the comparison to ignore trailing whitespace when comparing strings.

Refactor to always specify the equality type first and add `Be` for string enumerable.