### PR TITLE
feat: support verification for `HResult` of exceptions

### DIFF
--- a/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveHResult.cs
+++ b/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveHResult.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using aweXpect.Core.Constraints;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+/// <summary>
+///     Expectations on <see cref="Exception" /> values.
+/// </summary>
+public static partial class ThatExceptionShould
+{
+	/// <summary>
+	///     Verifies that the actual <see cref="Exception" /> has an <paramref name="expected" /> HResult.
+	/// </summary>
+	public static AndOrResult<TException, ThatExceptionShould<TException>>
+		HaveHResult<TException>(
+			this ThatExceptionShould<TException> source,
+			int expected)
+		where TException : Exception?
+		=> new(source.ExpectationBuilder.AddConstraint(it
+				=> new HasHResultValueConstraint(it, "have", expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the actual <see cref="Exception" /> has an <paramref name="expected" /> HResult.
+	/// </summary>
+	public static AndOrResult<TException, ThatDelegateThrows<TException>>
+		WithHResult<TException>(
+			this ThatDelegateThrows<TException> source,
+			int expected)
+		where TException : Exception?
+		=> new(source.ExpectationBuilder.AddConstraint(it
+				=> new HasHResultValueConstraint(it, "with", expected)),
+			source);
+
+	internal readonly struct HasHResultValueConstraint(
+		string it,
+		string verb,
+		int expected)
+		: IValueConstraint<Exception?>
+	{
+		public ConstraintResult IsMetBy(Exception? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					$"{it} was <null>");
+			}
+			if (actual.HResult == expected)
+			{
+				return new ConstraintResult.Success<Exception?>(actual,
+					ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"{it} had HResult {Formatter.Format(actual.HResult)}");
+		}
+
+		public override string ToString()
+			=> $"{verb} HResult {Formatter.Format(expected)}";
+	}
+}

--- a/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveParamName.cs
+++ b/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveParamName.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -31,4 +33,39 @@ public static partial class ThatExceptionShould
 		=> new(source.ExpectationBuilder.AddConstraint(it
 				=> new HasParamNameValueConstraint<TException>(it, "with", expected)),
 			source);
+
+	internal readonly struct HasParamNameValueConstraint<TArgumentException>(
+		string it,
+		string verb,
+		string expected)
+		: IValueConstraint<Exception?>
+		where TArgumentException : ArgumentException?
+	{
+		public ConstraintResult IsMetBy(Exception? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					$"{it} was <null>");
+			}
+
+			if (actual is TArgumentException argumentException)
+			{
+				if (argumentException.ParamName == expected)
+				{
+					return new ConstraintResult.Success<TArgumentException?>(argumentException,
+						ToString());
+				}
+
+				return new ConstraintResult.Failure(ToString(),
+					$"{it} had ParamName {Formatter.Format(argumentException.ParamName)}");
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"{it} was {actual.GetType().Name.PrependAOrAn()}");
+		}
+
+		public override string ToString()
+			=> $"{verb} ParamName {Formatter.Format(expected)}";
+	}
 }

--- a/Source/aweXpect/That/Exceptions/ThatExceptionShould.cs
+++ b/Source/aweXpect/That/Exceptions/ThatExceptionShould.cs
@@ -43,41 +43,6 @@ public static partial class ThatExceptionShould
 			=> $"{verb} Message {options.GetExpectation(expected, false)}";
 	}
 
-	internal readonly struct HasParamNameValueConstraint<TArgumentException>(
-		string it,
-		string verb,
-		string expected)
-		: IValueConstraint<Exception?>
-		where TArgumentException : ArgumentException?
-	{
-		public ConstraintResult IsMetBy(Exception? actual)
-		{
-			if (actual == null)
-			{
-				return new ConstraintResult.Failure(ToString(),
-					$"{it} was <null>");
-			}
-
-			if (actual is TArgumentException argumentException)
-			{
-				if (argumentException.ParamName == expected)
-				{
-					return new ConstraintResult.Success<TArgumentException?>(argumentException,
-						ToString());
-				}
-
-				return new ConstraintResult.Failure(ToString(),
-					$"{it} had ParamName {Formatter.Format(argumentException.ParamName)}");
-			}
-
-			return new ConstraintResult.Failure(ToString(),
-				$"{it} was {actual.GetType().Name.PrependAOrAn()}");
-		}
-
-		public override string ToString()
-			=> $"{verb} ParamName {Formatter.Format(expected)}";
-	}
-
 	internal readonly struct HasInnerExceptionValueConstraint<TInnerException>(
 		string verb,
 		string it)

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -207,9 +207,13 @@ namespace aweXpect
     }
     public static class ThatExceptionShould
     {
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveHResult<TException>(this aweXpect.ThatExceptionShould<TException> source, int expected)
+            where TException : System.Exception? { }
         public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveParamName<TException>(this aweXpect.ThatExceptionShould<TException> source, string expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.ThatExceptionShould<TException> Should<TException>(this aweXpect.Core.IExpectSubject<TException> subject)
+            where TException : System.Exception? { }
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithHResult<TException>(this aweXpect.ThatDelegateThrows<TException> source, int expected)
             where TException : System.Exception? { }
         public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.ThatDelegateThrows<TException> source, string expected)
             where TException : System.ArgumentException? { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -166,9 +166,13 @@ namespace aweXpect
     }
     public static class ThatExceptionShould
     {
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveHResult<TException>(this aweXpect.ThatExceptionShould<TException> source, int expected)
+            where TException : System.Exception? { }
         public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveParamName<TException>(this aweXpect.ThatExceptionShould<TException> source, string expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.ThatExceptionShould<TException> Should<TException>(this aweXpect.Core.IExpectSubject<TException> subject)
+            where TException : System.Exception? { }
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithHResult<TException>(this aweXpect.ThatDelegateThrows<TException> source, int expected)
             where TException : System.Exception? { }
         public static aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.ThatDelegateThrows<TException> source, string expected)
             where TException : System.ArgumentException? { }

--- a/Tests/aweXpect.Tests/TestHelpers/HResultException.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/HResultException.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace aweXpect.Tests.TestHelpers;
+
+public class HResultException : Exception
+{
+	public HResultException(int hResult,
+		[CallerMemberName] string message = "",
+		Exception? innerException = null)
+		: base(message, innerException)
+	{
+		HResult = hResult;
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateThrows.WithHResultTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateThrows.WithHResultTests.cs
@@ -1,0 +1,41 @@
+﻿using aweXpect.Tests.TestHelpers;
+
+namespace aweXpect.Tests.ThatTests.Delegates;
+
+public sealed partial class DelegateThrows
+{
+	public class WithHResultTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenHResultMatchesExpected_ShouldSucceed(int hResult)
+		{
+			Exception exception = new HResultException(hResult);
+
+			async Task Act()
+				=> await That(() => throw exception).Should()
+					.ThrowException().WithHResult(hResult);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenHResultIsDifferent_ShouldFail(int hResult)
+		{
+			int expectedHResult = hResult + 1;
+			Exception exception = new HResultException(hResult);
+
+			async Task Act()
+				=> await That(() => throw exception).Should()
+					.ThrowException().WithHResult(expectedHResult);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected () => throw exception to
+				              throw an Exception with HResult {expectedHResult},
+				              but it had HResult {hResult}
+				              """);
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateThrows.WithParamNameTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateThrows.WithParamNameTests.cs
@@ -1,0 +1,38 @@
+﻿namespace aweXpect.Tests.ThatTests.Delegates;
+
+public sealed partial class DelegateThrows
+{
+	public class WithParamNameTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenParamNameMatchesExpected_ShouldSucceed(string message)
+		{
+			ArgumentException exception = new(message, nameof(message));
+
+			async Task Act()
+				=> await That(() => throw exception).Should()
+					.Throw<ArgumentException>().WithParamName("message");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenParamNameIsDifferent_ShouldFail(string message)
+		{
+			ArgumentException exception = new(message, nameof(message));
+
+			async Task Act()
+				=> await That(() => throw exception).Should()
+					.Throw<ArgumentException>().WithParamName("somethingElse");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected () => throw exception to
+				             throw an ArgumentException with ParamName "somethingElse",
+				             but it had ParamName "message"
+				             """);
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Exceptions/ExceptionShould.HaveHResultTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Exceptions/ExceptionShould.HaveHResultTests.cs
@@ -1,0 +1,39 @@
+﻿using aweXpect.Tests.TestHelpers;
+
+namespace aweXpect.Tests.ThatTests.Exceptions;
+
+public sealed partial class ExceptionShould
+{
+	public class HaveHResultTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenHResultMatchesExpected_ShouldSucceed(int hResult)
+		{
+			Exception subject = new HResultException(hResult);
+
+			async Task Act()
+				=> await That(subject).Should().HaveHResult(hResult);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenHResultIsDifferent_ShouldFail(int hResult)
+		{
+			int expectedHResult = hResult + 1;
+			Exception subject = new HResultException(hResult);
+
+			async Task Act()
+				=> await That(subject).Should().HaveHResult(expectedHResult);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected subject to
+				              have HResult {expectedHResult},
+				              but it had HResult {hResult}
+				              """);
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatTests/Exceptions/ExceptionShould.HaveParamNameTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Exceptions/ExceptionShould.HaveParamNameTests.cs
@@ -1,0 +1,36 @@
+﻿namespace aweXpect.Tests.ThatTests.Exceptions;
+
+public sealed partial class ExceptionShould
+{
+	public class HaveParamNameTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenParamNameMatchesExpected_ShouldSucceed(string message)
+		{
+			ArgumentException subject = new(message, nameof(message));
+
+			async Task Act()
+				=> await That(subject).Should().HaveParamName("message");
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenParamNameIsDifferent_ShouldFail(string message)
+		{
+			ArgumentException subject = new(message, nameof(message));
+
+			async Task Act()
+				=> await That(subject).Should().HaveParamName("somethingElse");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have ParamName "somethingElse",
+				             but it had ParamName "message"
+				             """);
+		}
+	}
+}


### PR DESCRIPTION
It is now possible to verify the `HResult` of expectations:

```csharp
Exception exception = // Exception with HResult set to 12389021

await Expect.That(exception).Should()
    .HaveHResult(12389021);
// or
await Expect.That(() => throw exception).Should().ThrowException()
    .WithHResult(12389021);
```