### PR TITLE
feat: add `.Which` for delegates

### DIFF
--- a/Docs/pages/docs/expectations/delegates.md
+++ b/Docs/pages/docs/expectations/delegates.md
@@ -106,6 +106,22 @@ void Act() => throw new AggregateException("outer", new CustomException("inner")
 await Expect.That(Act).Should().ThrowException().WithRecursiveInnerExceptions(a => a.HaveAtLeast(1).Be<CustomException>());
 ```
 
+### Other members
+
+You can recursively verify additional members of the exception:
+```csharp
+void Act() => throw new MyException("outer", paramName: "paramName", hResult: 12345);
+
+await Expect.That(Act).Should().ThrowException().WithParamName("paramName")
+  .Because("you can verify the `paramName`");
+await Expect.That(Act).Should().ThrowException().WithHResult(12345)
+  .Because("you can verify the `HResult`");
+await Expect.That(Act).Should().ThrowException()
+  .Which(e => e.HResult, h => h.Should().BeGreaterThan(12340))
+  .Because("you can verify arbitrary additional members");
+
+```
+
 
 ## Execute within
 

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.Which.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.Which.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq.Expressions;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public partial class ThatDelegateThrows<TException>
+{
+	/// <summary>
+	///     Verifies the <paramref name="expectations" /> on the member selected by the <paramref name="memberSelector" />.
+	/// </summary>
+	public AndOrResult<TException, ThatDelegateThrows<TException>> Which<TMember>(
+		Expression<Func<TException, TMember?>> memberSelector,
+		Action<IExpectSubject<TMember?>> expectations)
+		=> new(ExpectationBuilder.ForMember(
+					MemberAccessor<TException, TMember?>.FromExpression(memberSelector),
+					(member, expectation) => $"which {member}should {expectation}")
+				.AddExpectations(e => expectations(new That.Subject<TMember?>(e))),
+			this);
+}

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq.Expressions;
 using aweXpect.Core;
+using aweXpect.Helpers;
 using aweXpect.Results;
 
 namespace aweXpect;

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -157,6 +157,7 @@ namespace aweXpect
     {
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
         public aweXpect.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
+        public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> Which<TMember>(System.Linq.Expressions.Expression<System.Func<TException, TMember?>> memberSelector, System.Action<aweXpect.Core.IExpectSubject<TMember?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInner<TInnerException>()

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -116,6 +116,7 @@ namespace aweXpect
     {
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
         public aweXpect.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
+        public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> Which<TMember>(System.Linq.Expressions.Expression<System.Func<TException, TMember?>> memberSelector, System.Action<aweXpect.Core.IExpectSubject<TMember?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInner<TInnerException>()

--- a/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateThrows.WhichTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateThrows.WhichTests.cs
@@ -1,0 +1,41 @@
+﻿using aweXpect.Tests.TestHelpers;
+
+namespace aweXpect.Tests.ThatTests.Delegates;
+
+public sealed partial class DelegateThrows
+{
+	public class WhichTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task WhenMemberMatchesExpected_ShouldSucceed(int hResult)
+		{
+			Exception exception = new HResultException(hResult);
+
+			async Task Act()
+				=> await That(() => throw exception).Should().ThrowException()
+					.Which(e => e.HResult, h => h.Should().Be(hResult));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task WhenMemberIsDifferent_ShouldFail(int hResult)
+		{
+			int expectedHResult = hResult + 1;
+			Exception exception = new HResultException(hResult);
+
+			async Task Act()
+				=> await That(() => throw exception).Should().ThrowException()
+					.Which(e => e.HResult, h => h.Should().Be(expectedHResult));
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($"""
+				              Expected () => throw exception to
+				              throw an Exception which .HResult should be equal to {expectedHResult},
+				              but .HResult was {hResult}
+				              """);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #89 
Add `.Which` extension for delegates, that allow adding expectations for arbitrary members:

```csharp
var exception = // Some exception...

await Expect.That(() => throw exception).Should().ThrowException()
  .Which(e => e.HResult, h => h.Should().BeGreaterThan(12340))
  .Because("you can verify arbitrary additional members");
```