### PR TITLE
feat: support counting items in a collection

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -53,7 +53,7 @@ To check for a proper superset, use `AndMore` instead (which would fail for equa
 
 
 ## Have
-Specifications that match the items on a given number of occurrences.
+Specifications that count the elements in a collection.
 
 ### All
 
@@ -68,24 +68,39 @@ await Expect.That(values).Should().HaveAll(x => x.Satisfy(i => i <= 20));
 
 ### At least
 
-You can verify, that at least a fixed number of items in the collection, satisfy an expectation:
+You can verify, that at least `minimum` items in the collection, satisfy an expectation:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
 
 await Expect.That(values).Should().HaveAtLeast(9, x => x.Satisfy(i => i < 10));
 ```
-*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
 
+You can also verify, that the collection has at least `minimum` items:
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 10);
+
+await Expect.That(values).Should().HaveAtLeast(9).Items;
+```
+
+*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
 
 ### At most
 
-You can verify, that at most a fixed number of items in the collection, satisfy an expectation:
+You can verify, that at most `maximum` items in the collection, satisfy an expectation:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
 
 await Expect.That(values).Should().HaveAtMost(1, x => x.Satisfy(i => i < 2));
 ```
-*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+You can also verify, that the collection has at most `maximum` items:
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 10);
+
+await Expect.That(values).Should().HaveAtMost(11).Items;
+```
+
+*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
 
 
 ### Between
@@ -95,18 +110,34 @@ You can verify, that between `minimum` and `maximum` items in the collection, sa
 IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).Should().HaveBetween(1).And(2, x => x.Satisfy(i => i < 2));
 ```
-*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+You can also verify, that the collection has between `minimum` and `maximum` items:
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 10);
+
+await Expect.That(values).Should().HaveBetween(9).And(11).Items;
+```
+
+*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
 
 
 ### Exactly
 
-You can verify, that exactly a fixed number of items in the collection, satisfy an expectation:
+You can verify, that exactly `expected` items in the collection, satisfy an expectation:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
 
 await Expect.That(values).Should().HaveExactly(9, x => x.Satisfy(i => i < 10));
 ```
-*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+You can also verify, that the collection has exactly `expected` items:
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 10);
+
+await Expect.That(values).Should().HaveExactly(10).Items;
+```
+
+*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
 
 
 ### None
@@ -117,7 +148,15 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 
 await Expect.That(values).Should().HaveNone(x => x.Satisfy(i => i > 20));
 ```
-*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+You can also verify, that the collection is empty.
+```csharp
+IEnumerable<int> values = Array.Empty<int>();
+
+await Expect.That(values).Should().BeEmpty();
+```
+
+*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
 
 
 ## Contain

--- a/Source/aweXpect.Core/Results/BetweenResult.cs
+++ b/Source/aweXpect.Core/Results/BetweenResult.cs
@@ -5,20 +5,6 @@ namespace aweXpect.Results;
 /// <summary>
 ///     An intermediate type to collect the maximum of the range.
 /// </summary>
-public class BetweenResult<TTarget, TExpectation>(
-	Func<int, Action<TExpectation>, TTarget> callback)
-{
-	/// <summary>
-	///     ... and <paramref name="maximum" /> items satisfy the <paramref name="expectations" />.
-	/// </summary>
-	public TTarget And(int maximum,
-		Action<TExpectation> expectations)
-		=> callback(maximum, expectations);
-}
-
-/// <summary>
-///     An intermediate type to collect the maximum of the range.
-/// </summary>
 public class BetweenResult<TTarget>(
 	Func<int, TTarget> callback)
 {

--- a/Source/aweXpect/Results/BetweenResult.cs
+++ b/Source/aweXpect/Results/BetweenResult.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     An intermediate type to collect the maximum of the range.
+/// </summary>
+public class BetweenResult<TTarget, TExpectation>(
+	Func<int, Action<TExpectation>, TTarget> callback,
+	Func<int, TTarget> itemsCallback)
+{
+	/// <summary>
+	///     ... and <paramref name="maximum" /> items satisfy the <paramref name="expectations" />.
+	/// </summary>
+	public TTarget And(int maximum,
+		Action<TExpectation> expectations)
+		=> callback(maximum, expectations);
+
+	/// <summary>
+	///     ... and <paramref name="maximum" /> items.
+	/// </summary>
+	public ItemsResult<TTarget> And(int maximum)
+		=> new(itemsCallback(maximum));
+}

--- a/Source/aweXpect/Results/ItemsResult.cs
+++ b/Source/aweXpect/Results/ItemsResult.cs
@@ -1,0 +1,12 @@
+﻿namespace aweXpect.Results;
+
+/// <summary>
+///     The result for counting items in a collection.
+/// </summary>
+public class ItemsResult<TReturn>(TReturn value)
+{
+	/// <summary>
+	///     The number of items in a collection.
+	/// </summary>
+	public TReturn Items => value;
+}

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.All.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.All.cs
@@ -19,13 +19,15 @@ public abstract partial class EnumerableQuantifier
 			=> notMatchingCount > 0;
 
 		/// <inheritdoc />
-		public override string GetExpectation(string it, ExpectationBuilder expectationBuilder)
-			=> $"have all items {expectationBuilder}";
+		public override string GetExpectation(string it, ExpectationBuilder? expectationBuilder)
+			=> expectationBuilder == null
+				? "have all items"
+				: $"have all items {expectationBuilder}";
 
 		/// <inheritdoc />
 		public override ConstraintResult GetResult<TEnumerable>(TEnumerable actual,
 			string it,
-			ExpectationBuilder expectationBuilder,
+			ExpectationBuilder? expectationBuilder,
 			int matchingCount,
 			int notMatchingCount,
 			int? totalCount)

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.AtLeast.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.AtLeast.cs
@@ -6,7 +6,7 @@ namespace aweXpect;
 public abstract partial class EnumerableQuantifier
 {
 	/// <summary>
-	///     Matches at least <paramref name="minimum"/> items.
+	///     Matches at least <paramref name="minimum" /> items.
 	/// </summary>
 	public static EnumerableQuantifier AtLeast(int minimum) => new AtLeastQuantifier(minimum);
 
@@ -19,13 +19,15 @@ public abstract partial class EnumerableQuantifier
 			=> matchingCount >= minimum;
 
 		/// <inheritdoc />
-		public override string GetExpectation(string it, ExpectationBuilder expectationBuilder)
-			=> $"have at least {minimum} items {expectationBuilder}";
+		public override string GetExpectation(string it, ExpectationBuilder? expectationBuilder)
+			=> expectationBuilder == null
+				? $"have at least {minimum} items"
+				: $"have at least {minimum} items {expectationBuilder}";
 
 		/// <inheritdoc />
 		public override ConstraintResult GetResult<TEnumerable>(TEnumerable actual,
 			string it,
-			ExpectationBuilder expectationBuilder,
+			ExpectationBuilder? expectationBuilder,
 			int matchingCount,
 			int notMatchingCount,
 			int? totalCount)
@@ -40,7 +42,9 @@ public abstract partial class EnumerableQuantifier
 			{
 				return new ConstraintResult.Failure<TEnumerable>(actual,
 					GetExpectation(it, expectationBuilder),
-					$"only {matchingCount} of {totalCount} were");
+					expectationBuilder == null
+						? $"found only {matchingCount}"
+						: $"only {matchingCount} of {totalCount} were");
 			}
 
 			return new ConstraintResult.Failure<TEnumerable>(actual,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.AtMost.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.AtMost.cs
@@ -20,9 +20,13 @@ public abstract partial class EnumerableQuantifier
 
 		/// <inheritdoc />
 		public override string GetExpectation(string it, ExpectationBuilder? expectationBuilder)
-			=> expectationBuilder is null
-				? $"have at most {(maximum == 1 ? "one item" : $"{maximum} items")}"
-				: $"have at most {(maximum == 1 ? "one item" : $"{maximum} items")} {expectationBuilder}";
+			=> (maximum, expectationBuilder is null) switch
+			{
+				(1, true) => "have at most one item",
+				(1, false) => $"have at most one item {expectationBuilder}",
+				(_, true) => $"have at most {maximum} items",
+				(_, false) => $"have at most {maximum} items {expectationBuilder}"
+			};
 
 		/// <inheritdoc />
 		public override ConstraintResult GetResult<TEnumerable>(TEnumerable actual,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.Between.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.Between.cs
@@ -6,7 +6,7 @@ namespace aweXpect;
 public abstract partial class EnumerableQuantifier
 {
 	/// <summary>
-	///     Matches between <paramref name="minimum"/> and <paramref name="maximum"/> items.
+	///     Matches between <paramref name="minimum" /> and <paramref name="maximum" /> items.
 	/// </summary>
 	public static EnumerableQuantifier Between(int minimum, int maximum) => new BetweenQuantifier(minimum, maximum);
 
@@ -19,13 +19,15 @@ public abstract partial class EnumerableQuantifier
 			=> matchingCount > maximum;
 
 		/// <inheritdoc />
-		public override string GetExpectation(string it, ExpectationBuilder expectationBuilder)
-			=> $"have between {minimum} and {maximum} items {expectationBuilder}";
+		public override string GetExpectation(string it, ExpectationBuilder? expectationBuilder)
+			=> expectationBuilder is null
+				? $"have between {minimum} and {maximum} items"
+				: $"have between {minimum} and {maximum} items {expectationBuilder}";
 
 		/// <inheritdoc />
 		public override ConstraintResult GetResult<TEnumerable>(TEnumerable actual,
 			string it,
-			ExpectationBuilder expectationBuilder,
+			ExpectationBuilder? expectationBuilder,
 			int matchingCount,
 			int notMatchingCount,
 			int? totalCount)
@@ -34,9 +36,13 @@ public abstract partial class EnumerableQuantifier
 			{
 				return new ConstraintResult.Failure<TEnumerable>(actual,
 					GetExpectation(it, expectationBuilder),
-					totalCount.HasValue
-						? $"{matchingCount} of {totalCount} were"
-						: $"at least {matchingCount} were");
+					(totalCount.HasValue, expectationBuilder is null) switch
+					{
+						(true, true) => $"found {matchingCount}",
+						(true, false) => $"{matchingCount} of {totalCount} were",
+						(false, true) => $"found at least {matchingCount}",
+						(false, false) => $"at least {matchingCount} were"
+					});
 			}
 
 			if (matchingCount >= minimum)
@@ -49,7 +55,10 @@ public abstract partial class EnumerableQuantifier
 			{
 				return new ConstraintResult.Failure<TEnumerable>(actual,
 					GetExpectation(it, expectationBuilder),
-					$"only {matchingCount} of {totalCount} were");
+					expectationBuilder is null
+						? $"found only {matchingCount}"
+						: $"only {matchingCount} of {totalCount} were"
+				);
 			}
 
 			return new ConstraintResult.Failure<TEnumerable>(actual,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
@@ -19,13 +19,15 @@ public abstract partial class EnumerableQuantifier
 			=> matchingCount > 0;
 
 		/// <inheritdoc />
-		public override string GetExpectation(string it, ExpectationBuilder expectationBuilder)
-			=> $"have no items {expectationBuilder}";
+		public override string GetExpectation(string it, ExpectationBuilder? expectationBuilder)
+			=> expectationBuilder is null
+				? "have no items"
+				: $"have no items {expectationBuilder}";
 
 		/// <inheritdoc />
 		public override ConstraintResult GetResult<TEnumerable>(TEnumerable actual,
 			string it,
-			ExpectationBuilder expectationBuilder,
+			ExpectationBuilder? expectationBuilder,
 			int matchingCount,
 			int notMatchingCount,
 			int? totalCount)

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
@@ -17,7 +17,7 @@ public abstract partial class EnumerableQuantifier
 	/// <summary>
 	///     Returns the expectation text.
 	/// </summary>
-	public abstract string GetExpectation(string it, ExpectationBuilder expectationBuilder);
+	public abstract string GetExpectation(string it, ExpectationBuilder? expectationBuilder);
 
 	/// <summary>
 	///     Returns the result.
@@ -25,7 +25,7 @@ public abstract partial class EnumerableQuantifier
 	public abstract ConstraintResult GetResult<TEnumerable>(
 		TEnumerable actual,
 		string it,
-		ExpectationBuilder expectationBuilder,
+		ExpectationBuilder? expectationBuilder,
 		int matchingCount,
 		int notMatchingCount,
 		int? totalCount);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtLeast.cs
@@ -18,5 +18,16 @@ public static partial class ThatAsyncEnumerableShould
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
 			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum), expectations)), source);
+
+	/// <summary>
+	///     Verifies that the asynchronous enumerable has at least <paramref name="minimum" /> items.
+	/// </summary>
+	public static ItemsResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>> HaveAtLeast<TItem>(
+		this IThat<IAsyncEnumerable<TItem>> source,
+		int minimum)
+		=> new(new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new AsyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum))),
+			source));
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtMost.cs
@@ -18,5 +18,16 @@ public static partial class ThatAsyncEnumerableShould
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
 			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum), expectations)), source);
+
+	/// <summary>
+	///     Verifies that the asynchronous enumerable has at most <paramref name="maximum" /> items.
+	/// </summary>
+	public static ItemsResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>> HaveAtMost<TItem>(
+		this IThat<IAsyncEnumerable<TItem>> source,
+		int maximum)
+		=> new(new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new AsyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum))),
+			source));
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveBetween.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveBetween.cs
@@ -16,6 +16,10 @@ public static partial class ThatAsyncEnumerableShould
 			source.ExpectationBuilder.AddConstraint(it
 				=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.Between(minimum, maximum),
 					expectations)),
-			source));
+			source),
+			maximum => new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(
+				source.ExpectationBuilder.AddConstraint(it
+					=> new AsyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.Between(minimum, maximum))),
+				source));
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveExactly.cs
@@ -18,5 +18,16 @@ public static partial class ThatAsyncEnumerableShould
 		Action<IThat<TItem>> expectations)
 		=> new(source.ExpectationBuilder.AddConstraint(it
 			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.Exactly(expected), expectations)), source);
+
+	/// <summary>
+	///     Verifies that the asynchronous enumerable has exactly <paramref name="expected" /> items.
+	/// </summary>
+	public static ItemsResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>> HaveExactly<TItem>(
+		this IThat<IAsyncEnumerable<TItem>> source,
+		int expected)
+		=> new(new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new AsyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.Exactly(expected))),
+			source));
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtLeast.cs
@@ -18,4 +18,15 @@ public static partial class ThatEnumerableShould
 		=> new(source.ExpectationBuilder.AddConstraint(it
 				=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum), expectations)),
 			source);
+
+	/// <summary>
+	///     Verifies that the synchronous enumerable has at least <paramref name="minimum" /> items.
+	/// </summary>
+	public static ItemsResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>> HaveAtLeast<TItem>(
+		this IThat<IEnumerable<TItem>> source,
+		int minimum)
+		=> new(new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new SyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum))),
+			source));
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtMost.cs
@@ -18,4 +18,15 @@ public static partial class ThatEnumerableShould
 		=> new(source.ExpectationBuilder.AddConstraint(it
 				=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum), expectations)),
 			source);
+
+	/// <summary>
+	///     Verifies that the synchronous enumerable has at most <paramref name="maximum" /> items.
+	/// </summary>
+	public static ItemsResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>> HaveAtMost<TItem>(
+		this IThat<IEnumerable<TItem>> source,
+		int maximum)
+		=> new(new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new SyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum))),
+			source));
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveBetween.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveBetween.cs
@@ -15,5 +15,9 @@ public static partial class ThatEnumerableShould
 			source.ExpectationBuilder.AddConstraint(it
 				=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.Between(minimum, maximum),
 					expectations)),
-			source));
+			source),
+			maximum => new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(
+				source.ExpectationBuilder.AddConstraint(it
+					=> new SyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.Between(minimum, maximum))),
+				source));
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveExactly.cs
@@ -18,4 +18,15 @@ public static partial class ThatEnumerableShould
 		=> new(source.ExpectationBuilder.AddConstraint(it
 				=> new SyncCollectionConstraint<TItem>(it, EnumerableQuantifier.Exactly(expected), expectations)),
 			source);
+
+	/// <summary>
+	///     Verifies that the synchronous enumerable has exactly <paramref name="expected" /> items.
+	/// </summary>
+	public static ItemsResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>> HaveExactly<TItem>(
+		this IThat<IEnumerable<TItem>> source,
+		int expected)
+		=> new(new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new SyncCollectionCountConstraint<TItem>(it, EnumerableQuantifier.Exactly(expected))),
+			source));
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -474,11 +474,6 @@ namespace aweXpect.Results
         public BetweenResult(System.Func<int, TTarget> callback) { }
         public TTarget And(aweXpect.Times maximum) { }
     }
-    public class BetweenResult<TTarget, TExpectation>
-    {
-        public BetweenResult(System.Func<int, System.Action<TExpectation>, TTarget> callback) { }
-        public TTarget And(int maximum, System.Action<TExpectation> expectations) { }
-    }
     public class CountResult<TType, TThat> : aweXpect.Results.CountResult<TType, TThat, aweXpect.Results.CountResult<TType, TThat>>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -464,11 +464,6 @@ namespace aweXpect.Results
         public BetweenResult(System.Func<int, TTarget> callback) { }
         public TTarget And(aweXpect.Times maximum) { }
     }
-    public class BetweenResult<TTarget, TExpectation>
-    {
-        public BetweenResult(System.Func<int, System.Action<TExpectation>, TTarget> callback) { }
-        public TTarget And(int maximum, System.Action<TExpectation> expectations) { }
-    }
     public class CountResult<TType, TThat> : aweXpect.Results.CountResult<TType, TThat, aweXpect.Results.CountResult<TType, TThat>>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -7,8 +7,8 @@ namespace aweXpect
         protected EnumerableQuantifier() { }
         public static aweXpect.EnumerableQuantifier All { get; }
         public static aweXpect.EnumerableQuantifier None { get; }
-        public abstract string GetExpectation(string it, aweXpect.Core.ExpectationBuilder expectationBuilder);
-        public abstract aweXpect.Core.Constraints.ConstraintResult GetResult<TEnumerable>(TEnumerable actual, string it, aweXpect.Core.ExpectationBuilder expectationBuilder, int matchingCount, int notMatchingCount, int? totalCount);
+        public abstract string GetExpectation(string it, aweXpect.Core.ExpectationBuilder? expectationBuilder);
+        public abstract aweXpect.Core.Constraints.ConstraintResult GetResult<TEnumerable>(TEnumerable actual, string it, aweXpect.Core.ExpectationBuilder? expectationBuilder, int matchingCount, int notMatchingCount, int? totalCount);
         public abstract bool IsDeterminable(int matchingCount, int notMatchingCount);
         public static aweXpect.EnumerableQuantifier AtLeast(int minimum) { }
         public static aweXpect.EnumerableQuantifier AtMost(int maximum) { }
@@ -28,9 +28,12 @@ namespace aweXpect
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveAll<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>> HaveAtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveAtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>> HaveAtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveAtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>, aweXpect.Core.IThat<TItem>> HaveBetween<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int minimum) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int expected, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveNone<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> NotBeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
@@ -195,9 +198,12 @@ namespace aweXpect
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveAll<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveAtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveAtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveAtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveAtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>, aweXpect.Core.IThat<TItem>> HaveBetween<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveNone<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
@@ -858,6 +864,12 @@ namespace aweXpect.Extensions
 }
 namespace aweXpect.Results
 {
+    public class BetweenResult<TTarget, TExpectation>
+    {
+        public BetweenResult(System.Func<int, System.Action<TExpectation>, TTarget> callback, System.Func<int, TTarget> itemsCallback) { }
+        public aweXpect.Results.ItemsResult<TTarget> And(int maximum) { }
+        public TTarget And(int maximum, System.Action<TExpectation> expectations) { }
+    }
     public class CollectionBeResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>
     {
         public CollectionBeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
@@ -865,6 +877,11 @@ namespace aweXpect.Results
         public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> AndMore() { }
         public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrLess() { }
         public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrMore() { }
+    }
+    public class ItemsResult<TReturn>
+    {
+        public ItemsResult(TReturn value) { }
+        public TReturn Items { get; }
     }
     public class ObjectCollectionMatchResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -7,8 +7,8 @@ namespace aweXpect
         protected EnumerableQuantifier() { }
         public static aweXpect.EnumerableQuantifier All { get; }
         public static aweXpect.EnumerableQuantifier None { get; }
-        public abstract string GetExpectation(string it, aweXpect.Core.ExpectationBuilder expectationBuilder);
-        public abstract aweXpect.Core.Constraints.ConstraintResult GetResult<TEnumerable>(TEnumerable actual, string it, aweXpect.Core.ExpectationBuilder expectationBuilder, int matchingCount, int notMatchingCount, int? totalCount);
+        public abstract string GetExpectation(string it, aweXpect.Core.ExpectationBuilder? expectationBuilder);
+        public abstract aweXpect.Core.Constraints.ConstraintResult GetResult<TEnumerable>(TEnumerable actual, string it, aweXpect.Core.ExpectationBuilder? expectationBuilder, int matchingCount, int notMatchingCount, int? totalCount);
         public abstract bool IsDeterminable(int matchingCount, int notMatchingCount);
         public static aweXpect.EnumerableQuantifier AtLeast(int minimum) { }
         public static aweXpect.EnumerableQuantifier AtMost(int maximum) { }
@@ -153,9 +153,12 @@ namespace aweXpect
         public static aweXpect.Results.ObjectCountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem expected) { }
         public static aweXpect.Results.CountResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> Contain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveAll<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveAtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveAtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveAtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveAtMost<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int maximum, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>, aweXpect.Core.IThat<TItem>> HaveBetween<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int minimum) { }
+        public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveNone<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
@@ -740,6 +743,12 @@ namespace aweXpect.Extensions
 }
 namespace aweXpect.Results
 {
+    public class BetweenResult<TTarget, TExpectation>
+    {
+        public BetweenResult(System.Func<int, System.Action<TExpectation>, TTarget> callback, System.Func<int, TTarget> itemsCallback) { }
+        public aweXpect.Results.ItemsResult<TTarget> And(int maximum) { }
+        public TTarget And(int maximum, System.Action<TExpectation> expectations) { }
+    }
     public class CollectionBeResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>
     {
         public CollectionBeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
@@ -747,6 +756,11 @@ namespace aweXpect.Results
         public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> AndMore() { }
         public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrLess() { }
         public aweXpect.Results.ObjectCollectionMatchResult<TType, TThat> OrMore() { }
+    }
+    public class ItemsResult<TReturn>
+    {
+        public ItemsResult(TReturn value) { }
+        public TReturn Items { get; }
     }
     public class ObjectCollectionMatchResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtLeastTests.cs
@@ -49,6 +49,64 @@ public sealed partial class AsyncEnumerableShould
 		}
 
 		[Fact]
+		public async Task Items_ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject =
+				GetCancellingAsyncEnumerable(4, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(6).Items
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have at least 6 items,
+				             but could not verify, because it was cancelled early
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsMatchingItems_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(3).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooFewItems_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(4).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have at least 4 items,
+				             but found only 3
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooManyItems_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(2).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
 		public async Task WhenEnumerableContainsEnoughEqualItems_ShouldSucceed()
 		{
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtMostTests.cs
@@ -59,6 +59,64 @@ public sealed partial class AsyncEnumerableShould
 		}
 
 		[Fact]
+		public async Task Items_ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject =
+				GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtMost(6).Items
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have at most 6 items,
+				             but could not verify, because it was cancelled early
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsMatchingItems_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtMost(3).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooFewItems_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtMost(4).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooManyItems_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtMost(2).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have at most 2 items,
+				             but found at least 3
+				             """);
+		}
+
+		[Fact]
 		public async Task WhenEnumerableContainsSufficientlyFewEqualItems_ShouldSucceed()
 		{
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveExactlyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveExactlyTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;
+
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests.ThatTests.Collections;
@@ -16,7 +17,7 @@ public sealed partial class AsyncEnumerableShould
 			using CancellationTokenSource cts = new();
 			CancellationToken token = cts.Token;
 			IAsyncEnumerable<int> subject =
- GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
+				GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
 				=> await That(subject).Should().HaveExactly(6, x => x.Satisfy(y => y < 6))
@@ -55,6 +56,69 @@ public sealed partial class AsyncEnumerableShould
 				             Expected subject to
 				             have exactly 1 items be equal to 1,
 				             but at least 2 were
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IAsyncEnumerable<int> subject =
+				GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(6).Items
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have exactly 6 items,
+				             but could not verify, because it was cancelled early
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsMatchingItems_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(3).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooFewItems_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(4).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have exactly 4 items,
+				             but found only 3
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooManyItems_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(2).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have exactly 2 items,
+				             but found at least 3
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAtLeastTests.cs
@@ -37,6 +37,63 @@ public sealed partial class EnumerableShould
 		}
 
 		[Fact]
+		public async Task Items_ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(6).Items
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have at least 6 items,
+				             but could not verify, because it was cancelled early
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsMatchingItems_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(3).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooFewItems_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(4).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have at least 4 items,
+				             but found only 3
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooManyItems_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveAtLeast(2).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
 		public async Task DoesNotMaterializeEnumerable()
 		{
 			IEnumerable<int> subject = Factory.GetFibonacciNumbers();

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveBetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveBetweenTests.cs
@@ -58,6 +58,68 @@ public sealed partial class EnumerableShould
 		}
 
 		[Fact]
+		public async Task Items_ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
+
+			async Task Act()
+				=> await That(subject).Should().HaveBetween(3).And(6).Items
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have between 3 and 6 items,
+				             but could not verify, because it was cancelled early
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsMatchingItems_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooFewItems_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have between 3 and 6 items,
+				             but found only 2
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooManyItems_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 4, 5, 6, 7]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have between 3 and 6 items,
+				             but found at least 7
+				             """);
+		}
+
+		[Fact]
 		public async Task WhenEnumerableContainsSufficientlyEqualItems_ShouldSucceed()
 		{
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveExactlyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveExactlyTests.cs
@@ -58,6 +58,68 @@ public sealed partial class EnumerableShould
 		}
 
 		[Fact]
+		public async Task Items_ConsidersCancellationToken()
+		{
+			using CancellationTokenSource cts = new();
+			CancellationToken token = cts.Token;
+			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(6).Items
+					.WithCancellation(token);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have exactly 6 items,
+				             but could not verify, because it was cancelled early
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsMatchingItems_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(3).Items;
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooFewItems_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(4).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have exactly 4 items,
+				             but found only 3
+				             """);
+		}
+
+		[Fact]
+		public async Task Items_WhenEnumerableContainsTooManyItems_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveExactly(2).Items;
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have exactly 2 items,
+				             but found at least 3
+				             """);
+		}
+
+		[Fact]
 		public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
 		{
 			IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);


### PR DESCRIPTION
Implement #95 

Add expectations to count the items in a collection.

Use the [Have-Syntax](https://awexpect.github.io/aweXpect/docs/expectations/collections#have) without the expectations:
```csharp
await That(Enumerable.Range(1,10)).Should().HaveAtLeast(9).Items;
await That(Enumerable.Range(1,10)).Should().HaveExactly(10).Items;
```