### PR TITLE
fix: use `Environment.NewLine` when creating error messages.

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
@@ -200,11 +201,13 @@ public abstract class ExpectationBuilder
 	///     Creates the exception message from the <paramref name="failure" />.
 	/// </summary>
 	internal static string FromFailure(string subject, ConstraintResult.Failure failure)
-		=> $"""
-		    Expected {subject} to
-		    {failure.ExpectationText},
-		    but {failure.ResultText}
-		    """;
+	{
+		StringBuilder sb = new();
+		sb.Append("Expected ").Append(subject).AppendLine(" to");
+		sb.Append(failure.ExpectationText).AppendLine(",");
+		sb.Append("but ").Append(failure.ResultText);
+		return sb.ToString();
+	}
 
 	internal Node GetRootNode()
 	{

--- a/Source/aweXpect.Core/Results/Expectation.cs
+++ b/Source/aweXpect.Core/Results/Expectation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Helpers;
@@ -168,12 +169,15 @@ public abstract class Expectation
 				new ConstraintResult.Success(expectationText));
 		}
 
-		private string CreateFailureMessage(ConstraintResult.Failure failure) => $"""
-			 {GetSubjectLine()}
-			 {failure.ExpectationText}
-			 but
-			 {failure.ResultText}
-			 """;
+		private string CreateFailureMessage(ConstraintResult.Failure failure)
+		{
+			StringBuilder sb = new();
+			sb.AppendLine(GetSubjectLine());
+			sb.AppendLine(failure.ExpectationText);
+			sb.AppendLine("but");
+			sb.Append(failure.ResultText);
+			return sb.ToString();
+		}
 
 		private async Task GetResultOrThrow()
 		{

--- a/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using aweXpect.Core;
 using aweXpect.Equivalency;
 using aweXpect.Options;
@@ -58,11 +59,18 @@ public static class EquivalencyExtensions
 				return $"{it} was {Formatter.Format(_firstFailure.Actual, FormattingOptions.SingleLine)}";
 			}
 
-			return $"""
-			        {_firstFailure.Type} {string.Join(".", _firstFailure.NestedMemberNames)} did not match:
-			          Expected: {Formatter.Format(_firstFailure.Expected)}
-			          Received: {Formatter.Format(_firstFailure.Actual)}
-			        """;
+			StringBuilder sb = new();
+			sb.Append(_firstFailure.Type).Append(' ')
+				.Append(string.Join(".", _firstFailure.NestedMemberNames))
+				.AppendLine(" did not match:");
+
+			sb.Append("  Expected: ");
+			Formatter.Format(sb, _firstFailure.Expected);
+			sb.AppendLine();
+
+			sb.Append("  Received: ");
+			Formatter.Format(sb, _firstFailure.Actual);
+			return sb.ToString();
 		}
 
 		bool IEqualityComparer<object>.Equals(object? x, object? y)


### PR DESCRIPTION
Replace creation of multi-line failure messages with string builder to use a correct newline.