### PR TITLE
fix: change collection has `Items` to a method

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -79,7 +79,7 @@ You can also verify, that the collection has at least `minimum` items:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 10);
 
-await Expect.That(values).Should().HaveAtLeast(9).Items;
+await Expect.That(values).Should().HaveAtLeast(9).Items();
 ```
 
 *Note: The same expectations works also for `IAsyncEnumerable<T>`.*
@@ -97,7 +97,7 @@ You can also verify, that the collection has at most `maximum` items:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 10);
 
-await Expect.That(values).Should().HaveAtMost(11).Items;
+await Expect.That(values).Should().HaveAtMost(11).Items();
 ```
 
 *Note: The same expectations works also for `IAsyncEnumerable<T>`.*
@@ -115,7 +115,7 @@ You can also verify, that the collection has between `minimum` and `maximum` ite
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 10);
 
-await Expect.That(values).Should().HaveBetween(9).And(11).Items;
+await Expect.That(values).Should().HaveBetween(9).And(11).Items();
 ```
 
 *Note: The same expectations works also for `IAsyncEnumerable<T>`.*
@@ -134,7 +134,7 @@ You can also verify, that the collection has exactly `expected` items:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 10);
 
-await Expect.That(values).Should().HaveExactly(10).Items;
+await Expect.That(values).Should().HaveExactly(10).Items();
 ```
 
 *Note: The same expectations works also for `IAsyncEnumerable<T>`.*

--- a/Source/aweXpect/Results/ItemsResult.cs
+++ b/Source/aweXpect/Results/ItemsResult.cs
@@ -8,5 +8,5 @@ public class ItemsResult<TReturn>(TReturn value)
 	/// <summary>
 	///     The number of items in a collection.
 	/// </summary>
-	public TReturn Items => value;
+	public TReturn Items() => value;
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -881,7 +881,7 @@ namespace aweXpect.Results
     public class ItemsResult<TReturn>
     {
         public ItemsResult(TReturn value) { }
-        public TReturn Items { get; }
+        public TReturn Items() { }
     }
     public class ObjectCollectionMatchResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -760,7 +760,7 @@ namespace aweXpect.Results
     public class ItemsResult<TReturn>
     {
         public ItemsResult(TReturn value) { }
-        public TReturn Items { get; }
+        public TReturn Items() { }
     }
     public class ObjectCollectionMatchResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>>
     {

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtLeastTests.cs
@@ -57,7 +57,7 @@ public sealed partial class AsyncEnumerableShould
 				GetCancellingAsyncEnumerable(4, cts, CancellationToken.None);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(6).Items
+				=> await That(subject).Should().HaveAtLeast(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -74,7 +74,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(3).Items;
+				=> await That(subject).Should().HaveAtLeast(3).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -85,7 +85,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(4).Items;
+				=> await That(subject).Should().HaveAtLeast(4).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -101,7 +101,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(2).Items;
+				=> await That(subject).Should().HaveAtLeast(2).Items();
 
 			await That(Act).Should().NotThrow();
 		}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtMostTests.cs
@@ -67,7 +67,7 @@ public sealed partial class AsyncEnumerableShould
 				GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(6).Items
+				=> await That(subject).Should().HaveAtMost(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -84,7 +84,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(3).Items;
+				=> await That(subject).Should().HaveAtMost(3).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -95,7 +95,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(4).Items;
+				=> await That(subject).Should().HaveAtMost(4).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -106,7 +106,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(2).Items;
+				=> await That(subject).Should().HaveAtMost(2).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveBetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveBetweenTests.cs
@@ -66,7 +66,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, token);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items
+				=> await That(subject).Should().HaveBetween(3).And(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -83,7 +83,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+				=> await That(subject).Should().HaveBetween(3).And(6).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -94,7 +94,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+				=> await That(subject).Should().HaveBetween(3).And(6).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -110,7 +110,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3, 4, 5, 6, 7]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+				=> await That(subject).Should().HaveBetween(3).And(6).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveExactlyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveExactlyTests.cs
@@ -68,7 +68,7 @@ public sealed partial class AsyncEnumerableShould
 				GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(6).Items
+				=> await That(subject).Should().HaveExactly(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -85,7 +85,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(3).Items;
+				=> await That(subject).Should().HaveExactly(3).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -96,7 +96,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(4).Items;
+				=> await That(subject).Should().HaveExactly(4).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -112,7 +112,7 @@ public sealed partial class AsyncEnumerableShould
 			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(2).Items;
+				=> await That(subject).Should().HaveExactly(2).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAtLeastTests.cs
@@ -44,7 +44,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(6).Items
+				=> await That(subject).Should().HaveAtLeast(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -61,7 +61,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(3).Items;
+				=> await That(subject).Should().HaveAtLeast(3).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -72,7 +72,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(4).Items;
+				=> await That(subject).Should().HaveAtLeast(4).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -88,7 +88,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtLeast(2).Items;
+				=> await That(subject).Should().HaveAtLeast(2).Items();
 
 			await That(Act).Should().NotThrow();
 		}

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveAtMostTests.cs
@@ -65,7 +65,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(6).Items
+				=> await That(subject).Should().HaveAtMost(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -82,7 +82,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(3).Items;
+				=> await That(subject).Should().HaveAtMost(3).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -93,7 +93,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(4).Items;
+				=> await That(subject).Should().HaveAtMost(4).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -104,7 +104,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveAtMost(2).Items;
+				=> await That(subject).Should().HaveAtMost(2).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveBetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveBetweenTests.cs
@@ -65,7 +65,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items
+				=> await That(subject).Should().HaveBetween(3).And(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -82,7 +82,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+				=> await That(subject).Should().HaveBetween(3).And(6).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -93,7 +93,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+				=> await That(subject).Should().HaveBetween(3).And(6).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -109,7 +109,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3, 4, 5, 6, 7]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveBetween(3).And(6).Items;
+				=> await That(subject).Should().HaveBetween(3).And(6).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveExactlyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveExactlyTests.cs
@@ -65,7 +65,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = GetCancellingEnumerable(4, cts);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(6).Items
+				=> await That(subject).Should().HaveExactly(6).Items()
 					.WithCancellation(token);
 
 			await That(Act).Should().Throw<XunitException>()
@@ -82,7 +82,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(3).Items;
+				=> await That(subject).Should().HaveExactly(3).Items();
 
 			await That(Act).Should().NotThrow();
 		}
@@ -93,7 +93,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(4).Items;
+				=> await That(subject).Should().HaveExactly(4).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
@@ -109,7 +109,7 @@ public sealed partial class EnumerableShould
 			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
 
 			async Task Act()
-				=> await That(subject).Should().HaveExactly(2).Items;
+				=> await That(subject).Should().HaveExactly(2).Items();
 
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""


### PR DESCRIPTION
Fixes #110 
If you have a collection of collection, you can't use the item count expectations in the expectation on the outer collection:

```csharp
IEnumerable<string> subject = ["foo", "bar", "baz"];
// This results in a compiler error
await That(subject).Should().HaveAll(x => x.HaveExactly(3).Items); // Compiler error
// Possible workaround
await That(subject).Should().HaveAll(x => _ = x.HaveExactly(3).Items);
```