### PR TITLE
fix: allow nullable `DateTime` with "Unspecified" kind to be equal to "Local" and "Universal" `DateTime`

### DIFF
--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTimeShould.Be.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTimeShould.Be.cs
@@ -21,8 +21,8 @@ public static partial class ThatNullableDateTimeShould
 					it,
 					expected,
 					$"be {Formatter.Format(expected)}{tolerance}",
-					(a, e, t) => a?.Kind == e?.Kind && IsWithinTolerance(t, a - e),
-					(a, e, i) => a?.Kind == e?.Kind
+					(a, e, t) => AreKindCompatible(a?.Kind, e?.Kind) && IsWithinTolerance(t, a - e),
+					(a, e, i) => AreKindCompatible(a?.Kind, e?.Kind)
 						? $"{i} was {Formatter.Format(a)}"
 						: $"{i} differed in the Kind property",
 					tolerance)),
@@ -44,10 +44,20 @@ public static partial class ThatNullableDateTimeShould
 					it,
 					unexpected,
 					$"not be {Formatter.Format(unexpected)}{tolerance}",
-					(a, e, t) => a?.Kind != e?.Kind || !IsWithinTolerance(t, a - e),
+					(a, e, t) => !AreKindCompatible(a?.Kind, e?.Kind) || !IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),
 			source,
 			tolerance);
+	}
+
+	private static bool AreKindCompatible(DateTimeKind? actualKind, DateTimeKind? expectedKind)
+	{
+		if (actualKind == DateTimeKind.Unspecified || expectedKind == DateTimeKind.Unspecified)
+		{
+			return true;
+		}
+
+		return actualKind == expectedKind;
 	}
 }

--- a/Tests/aweXpect.Tests/ThatTests/DateTimes/NullableDateTimeShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateTimes/NullableDateTimeShould.BeTests.cs
@@ -4,6 +4,22 @@ public sealed partial class NullableDateTimeShould
 {
 	public sealed class BeTests
 	{
+		[Theory]
+		[InlineData(DateTimeKind.Local)]
+		[InlineData(DateTimeKind.Utc)]
+		[InlineData(DateTimeKind.Unspecified)]
+		public async Task WhenExpectedKindIsUnspecified_ShouldSucceed(DateTimeKind subjectKind)
+		{
+			DateTime? subject = new(2024, 11, 1, 14, 15, 0, subjectKind);
+			DateTime? expected = new(2024, 11, 1, 14, 15, 0, DateTimeKind.Unspecified);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected)
+					.Because("the subject has Unspecified kind");
+
+			await That(Act).Should().NotThrow();
+		}
+
 		[Fact]
 		public async Task WhenNullableSubjectIsTheExpectedValue_ShouldSucceed()
 		{
@@ -24,6 +40,22 @@ public sealed partial class NullableDateTimeShould
 
 			async Task Act()
 				=> await That(subject).Should().Be(expected);
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[InlineData(DateTimeKind.Local)]
+		[InlineData(DateTimeKind.Utc)]
+		[InlineData(DateTimeKind.Unspecified)]
+		public async Task WhenNullableSubjectKindIsUnspecified_ShouldSucceed(DateTimeKind expectedKind)
+		{
+			DateTime? subject = new(2024, 11, 1, 14, 15, 0, DateTimeKind.Unspecified);
+			DateTime? expected = new(2024, 11, 1, 14, 15, 0, expectedKind);
+
+			async Task Act()
+				=> await That(subject).Should().Be(expected)
+					.Because("the subject has Unspecified kind");
 
 			await That(Act).Should().NotThrow();
 		}


### PR DESCRIPTION
[`DateTimeKind.Unspecified`](https://learn.microsoft.com/en-us/dotnet/api/system.datetimekind?view=net-8.0#fields), does indicate that it could be both a local and universal `DateTime` and should be considered accordingly in `.Be(DateTime)`:

> The time represented is not specified as either local time or Coordinated Universal Time (UTC).

*Bugfix from #112 now also for nullable `DateTime`*