### PR TITLE
feat: add `HaveSingle()` for collections

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -52,6 +52,60 @@ await Expect.That(values).Should().Be([3, 3, 1, 1]).OrMore().InAnyOrder().Ignori
 To check for a proper superset, use `AndMore` instead (which would fail for equal collections).
 
 
+## Contain
+
+You can verify, that the collection contains a specific item or not:
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 20);
+
+await Expect.That(values).Should().Contain(13);
+await Expect.That(values).Should().NotContain(42);
+```
+
+You can also set occurrence constraints on `Contain`:
+```csharp
+IEnumerable<int> values = [1, 1, 1, 2];
+
+await Expect.That(values).Should().Contain(1).AtLeast(2.Times());
+await Expect.That(values).Should().Contain(1).Exactly(3.Times());
+await Expect.That(values).Should().Contain(1).AtMost(4.Times());
+await Expect.That(values).Should().Contain(1).Between(1).And(5.Times());
+```
+
+You can also use a [custom comparer](/docs/expectations/object#custom-comparer) or configure [equivalence](/docs/expectations/object#equivalence):
+```csharp
+IEnumerable<MyClass> values = //...
+MyClass expected = //...
+
+await Expect.That(values).Should().Contain(expected).Equivalent();
+await Expect.That(values).Should().Contain(expected).Using(new MyClassComparer());
+```
+
+*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+
+### Predicate
+You can verify, that the collection contains an item that satisfies a condition:
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 20);
+
+await Expect.That(values).Should().Contain(x => x > 12 && x < 14);
+await Expect.That(values).Should().NotContain(x => x >= 42);
+```
+
+You can also set occurrence constraints on `Contain`:
+```csharp
+IEnumerable<int> values = [1, 1, 1, 2];
+
+await Expect.That(values).Should().Contain(x => x == 1).AtLeast(2.Times());
+await Expect.That(values).Should().Contain(x => x == 1).Exactly(3.Times());
+await Expect.That(values).Should().Contain(x => x == 1).AtMost(4.Times());
+await Expect.That(values).Should().Contain(x => x == 1).Between(1).And(5.Times());
+```
+
+*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+
 ## Have
 Specifications that count the elements in a collection.
 
@@ -159,55 +213,22 @@ await Expect.That(values).Should().BeEmpty();
 *Note: The same expectations works also for `IAsyncEnumerable<T>`.*
 
 
-## Contain
+## Have single
 
-You can verify, that the collection contains a specific item or not:
+You can verify, that the collection contains a single element that satisfies an expectation.
 ```csharp
-IEnumerable<int> values = Enumerable.Range(1, 20);
+IEnumerable<int> values = [42];
 
-await Expect.That(values).Should().Contain(13);
-await Expect.That(values).Should().NotContain(42);
+await Expect.That(values).Should().HaveSingle();
+await Expect.That(values).Should().HaveSingle().Which.Should().BeGreaterThan(41);
 ```
 
-You can also set occurrence constraints on `Contain`:
+The awaited result is the single element:
 ```csharp
-IEnumerable<int> values = [1, 1, 1, 2];
+IEnumerable<int> values = [42];
 
-await Expect.That(values).Should().Contain(1).AtLeast(2.Times());
-await Expect.That(values).Should().Contain(1).Exactly(3.Times());
-await Expect.That(values).Should().Contain(1).AtMost(4.Times());
-await Expect.That(values).Should().Contain(1).Between(1).And(5.Times());
-```
-
-You can also use a [custom comparer](/docs/expectations/object#custom-comparer) or configure [equivalence](/docs/expectations/object#equivalence):
-```csharp
-IEnumerable<MyClass> values = //...
-MyClass expected = //...
-
-await Expect.That(values).Should().Contain(expected).Equivalent();
-await Expect.That(values).Should().Contain(expected).Using(new MyClassComparer());
-```
-
-*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
-
-
-### Predicate
-You can verify, that the collection contains an item that satisfies a condition:
-```csharp
-IEnumerable<int> values = Enumerable.Range(1, 20);
-
-await Expect.That(values).Should().Contain(x => x > 12 && x < 14);
-await Expect.That(values).Should().NotContain(x => x >= 42);
-```
-
-You can also set occurrence constraints on `Contain`:
-```csharp
-IEnumerable<int> values = [1, 1, 1, 2];
-
-await Expect.That(values).Should().Contain(x => x == 1).AtLeast(2.Times());
-await Expect.That(values).Should().Contain(x => x == 1).Exactly(3.Times());
-await Expect.That(values).Should().Contain(x => x == 1).AtMost(4.Times());
-await Expect.That(values).Should().Contain(x => x == 1).Between(1).And(5.Times());
+int result = await Expect.That(values).Should().HaveSingle();
+await Expect.That(result).Should().BeGreaterThan(41);
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -185,15 +185,44 @@ public abstract class ExpectationBuilder
 	}
 
 	/// <summary>
-	///     Specifies a global mapping for the value to test.
+	///     Specifies a mapping to add expectations on the member from the <paramref name="memberAccessor" />.
 	/// </summary>
 	/// <remarks>
 	///     Intended for mapping the <see cref="DelegateValue{TValue}" /> to an exception.
 	/// </remarks>
 	public ExpectationBuilder ForWhich<TSource, TTarget>(
-		Func<TSource, TTarget?> whichAccessor)
+		Func<TSource, TTarget?> memberAccessor,
+		string? separator = null)
 	{
-		_whichNode = new WhichNode<TSource, TTarget>(whichAccessor);
+		Node? parentNode = null;
+		if (_node is not ExpectationNode e || !e.IsEmpty())
+		{
+			parentNode = _node;
+			_node = new ExpectationNode();
+		}
+
+		_whichNode = new WhichNode<TSource, TTarget>(parentNode, memberAccessor, separator);
+		return this;
+	}
+
+	/// <summary>
+	///     Specifies a mapping to add expectations on the member from the <paramref name="asyncMemberAccessor" />.
+	/// </summary>
+	/// <remarks>
+	///     Intended for mapping the <see cref="DelegateValue{TValue}" /> to an exception.
+	/// </remarks>
+	public ExpectationBuilder ForWhich<TSource, TTarget>(
+		Func<TSource, Task<TTarget?>> asyncMemberAccessor,
+		string? separator = null)
+	{
+		Node? parentNode = null;
+		if (_node is not ExpectationNode e || !e.IsEmpty())
+		{
+			parentNode = _node;
+			_node = new ExpectationNode();
+		}
+
+		_whichNode = new WhichNode<TSource, TTarget>(parentNode, asyncMemberAccessor, separator);
 		return this;
 	}
 

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -187,9 +187,6 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Specifies a mapping to add expectations on the member from the <paramref name="memberAccessor" />.
 	/// </summary>
-	/// <remarks>
-	///     Intended for mapping the <see cref="DelegateValue{TValue}" /> to an exception.
-	/// </remarks>
 	public ExpectationBuilder ForWhich<TSource, TTarget>(
 		Func<TSource, TTarget?> memberAccessor,
 		string? separator = null)
@@ -208,9 +205,6 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Specifies a mapping to add expectations on the member from the <paramref name="asyncMemberAccessor" />.
 	/// </summary>
-	/// <remarks>
-	///     Intended for mapping the <see cref="DelegateValue{TValue}" /> to an exception.
-	/// </remarks>
 	public ExpectationBuilder ForWhich<TSource, TTarget>(
 		Func<TSource, Task<TTarget?>> asyncMemberAccessor,
 		string? separator = null)

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -13,7 +13,7 @@ internal class WhichNode<TSource, TMember> : Node
 	private readonly Func<TSource, TMember?>? _memberAccessor;
 	private readonly string? _separator;
 	private Node? _inner;
-	private Node? _parent;
+	private readonly Node? _parent;
 
 	public WhichNode(
 		Node? parent,

--- a/Source/aweXpect/Results/SingleItemResult.cs
+++ b/Source/aweXpect/Results/SingleItemResult.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using aweXpect.Core;
+using aweXpect.Helpers;
 
 namespace aweXpect.Results;
 
 /// <summary>
-///     An <see cref="ExpectationResult" /> when an exception was thrown.
+///     An <see cref="ExpectationResult" /> for a single item from a collection.
 /// </summary>
 public class SingleItemResult<TCollection, TItem>
 	: ExpectationResult<TItem, SingleItemResult<TCollection, TItem>>
@@ -25,12 +25,15 @@ public class SingleItemResult<TCollection, TItem>
 	///     Further expectations on the single <typeparamref name="TItem" />
 	/// </summary>
 	public IExpectSubject<TItem> Which
-		=> new ThatSubject<TItem>(_expectationBuilder.ForWhich(_memberAccessor, " which should "));
+		=> new That.Subject<TItem>(_expectationBuilder.ForWhich(_memberAccessor, " which should "));
 
+	/// <summary>
+	///     An <see cref="ExpectationResult" /> for a single item from an asynchronous collection.
+	/// </summary>
 	public class Async : ExpectationResult<TItem, Async>
 	{
-		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly Func<TCollection, Task<TItem?>> _asyncMemberAccessor;
+		private readonly ExpectationBuilder _expectationBuilder;
 
 		internal Async(ExpectationBuilder expectationBuilder, Func<TCollection, Task<TItem?>> asyncMemberAccessor)
 			: base(expectationBuilder)
@@ -43,20 +46,6 @@ public class SingleItemResult<TCollection, TItem>
 		///     Further expectations on the single item.
 		/// </summary>
 		public IExpectSubject<TItem> Which
-			=> new ThatSubject<TItem>(_expectationBuilder.ForWhich(_asyncMemberAccessor, " which should "));
-	}
-
-	[DebuggerDisplay("Expect.ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]
-	private readonly struct ThatSubject<T>(ExpectationBuilder expectationBuilder)
-		: IExpectSubject<T>, IThat<T>
-	{
-		public ExpectationBuilder ExpectationBuilder { get; } = expectationBuilder;
-
-		/// <inheritdoc />
-		public IThat<T> Should(Action<ExpectationBuilder> builderOptions)
-		{
-			builderOptions.Invoke(ExpectationBuilder);
-			return this;
-		}
+			=> new That.Subject<TItem>(_expectationBuilder.ForWhich(_asyncMemberAccessor, " which should "));
 	}
 }

--- a/Source/aweXpect/Results/SingleItemResult.cs
+++ b/Source/aweXpect/Results/SingleItemResult.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using aweXpect.Core;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     An <see cref="ExpectationResult" /> when an exception was thrown.
+/// </summary>
+public class SingleItemResult<TCollection, TItem>
+	: ExpectationResult<TItem, SingleItemResult<TCollection, TItem>>
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly Func<TCollection, TItem?> _memberAccessor;
+
+	internal SingleItemResult(ExpectationBuilder expectationBuilder, Func<TCollection, TItem?> memberAccessor)
+		: base(expectationBuilder)
+	{
+		_expectationBuilder = expectationBuilder;
+		_memberAccessor = memberAccessor;
+	}
+
+	/// <summary>
+	///     Further expectations on the single <typeparamref name="TItem" />
+	/// </summary>
+	public IExpectSubject<TItem> Which
+		=> new ThatSubject<TItem>(_expectationBuilder.ForWhich(_memberAccessor, " which should "));
+
+	public class Async : ExpectationResult<TItem, Async>
+	{
+		private readonly ExpectationBuilder _expectationBuilder;
+		private readonly Func<TCollection, Task<TItem?>> _asyncMemberAccessor;
+
+		internal Async(ExpectationBuilder expectationBuilder, Func<TCollection, Task<TItem?>> asyncMemberAccessor)
+			: base(expectationBuilder)
+		{
+			_expectationBuilder = expectationBuilder;
+			_asyncMemberAccessor = asyncMemberAccessor;
+		}
+
+		/// <summary>
+		///     Further expectations on the single item.
+		/// </summary>
+		public IExpectSubject<TItem> Which
+			=> new ThatSubject<TItem>(_expectationBuilder.ForWhich(_asyncMemberAccessor, " which should "));
+	}
+
+	[DebuggerDisplay("Expect.ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]
+	private readonly struct ThatSubject<T>(ExpectationBuilder expectationBuilder)
+		: IExpectSubject<T>, IThat<T>
+	{
+		public ExpectationBuilder ExpectationBuilder { get; } = expectationBuilder;
+
+		/// <inheritdoc />
+		public IThat<T> Should(Action<ExpectationBuilder> builderOptions)
+		{
+			builderOptions.Invoke(ExpectationBuilder);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
@@ -4,7 +4,7 @@ using aweXpect.Core.Constraints;
 namespace aweXpect;
 
 /// <summary>
-///     Quantifier for evaluating enumerables.
+///     Quantifier for evaluating collections.
 /// </summary>
 public abstract partial class EnumerableQuantifier
 {

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -19,7 +19,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual collection matches the provided <paramref name="expected" /> collection.
+	///     Verifies that the collection matches the provided <paramref name="expected" /> collection.
 	/// </summary>
 	public static CollectionBeResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Be<TItem>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -19,7 +19,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
+	///     Verifies that the actual collection matches the provided <paramref name="expected" /> collection.
 	/// </summary>
 	public static CollectionBeResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Be<TItem>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
@@ -7,13 +7,14 @@ using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
 using aweXpect.Helpers;
 using aweXpect.Results;
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect;
 
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable is empty.
+	///     Verifies that the actual collection is empty.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		BeEmpty<TItem>(
@@ -23,7 +24,7 @@ public static partial class ThatAsyncEnumerableShould
 			source);
 
 	/// <summary>
-	///     Verifies that the actual enumerable is not empty.
+	///     Verifies that the actual collection is not empty.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		NotBeEmpty<TItem>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
@@ -14,7 +14,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual collection is empty.
+	///     Verifies that the collection is empty.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		BeEmpty<TItem>(
@@ -24,7 +24,7 @@ public static partial class ThatAsyncEnumerableShould
 			source);
 
 	/// <summary>
-	///     Verifies that the actual collection is not empty.
+	///     Verifies that the collection is not empty.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		NotBeEmpty<TItem>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
@@ -18,7 +18,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable contains the <paramref name="expected" /> value.
+	///     Verifies that the actual collection contains the <paramref name="expected" /> value.
 	/// </summary>
 	public static ObjectCountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Contain<TItem>(
@@ -39,7 +39,7 @@ public static partial class ThatAsyncEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual enumerable contains an item that satisfies the <paramref name="predicate" />.
+	///     Verifies that the actual collection contains an item that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Contain<TItem>(
@@ -61,7 +61,7 @@ public static partial class ThatAsyncEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual enumerable does not contain the <paramref name="unexpected" /> value.
+	///     Verifies that the actual collection does not contain the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		NotContain<TItem>(
@@ -77,7 +77,7 @@ public static partial class ThatAsyncEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual enumerable contains no item that satisfies the <paramref name="predicate" />.
+	///     Verifies that the actual collection contains no item that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		NotContain<TItem>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
@@ -18,7 +18,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual collection contains the <paramref name="expected" /> value.
+	///     Verifies that the collection contains the <paramref name="expected" /> value.
 	/// </summary>
 	public static ObjectCountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Contain<TItem>(
@@ -39,7 +39,7 @@ public static partial class ThatAsyncEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual collection contains an item that satisfies the <paramref name="predicate" />.
+	///     Verifies that the collection contains an item that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		Contain<TItem>(
@@ -61,7 +61,7 @@ public static partial class ThatAsyncEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual collection does not contain the <paramref name="unexpected" /> value.
+	///     Verifies that the collection does not contain the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		NotContain<TItem>(
@@ -77,7 +77,7 @@ public static partial class ThatAsyncEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual collection contains no item that satisfies the <paramref name="predicate" />.
+	///     Verifies that the collection contains no item that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>
 		NotContain<TItem>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAll.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAll.cs
@@ -9,7 +9,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that all items in the asynchronous enumerable satisfy the <paramref name="expectations" />.
+	///     Verifies that all items in the collection satisfy the <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> HaveAll<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtLeast.cs
@@ -9,7 +9,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that at least <paramref name="minimum" /> items in the asynchronous enumerable satisfy the
+	///     Verifies that at least <paramref name="minimum" /> items in the collection satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> HaveAtLeast<TItem>(
@@ -20,7 +20,7 @@ public static partial class ThatAsyncEnumerableShould
 			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtLeast(minimum), expectations)), source);
 
 	/// <summary>
-	///     Verifies that the asynchronous enumerable has at least <paramref name="minimum" /> items.
+	///     Verifies that the collection has at least <paramref name="minimum" /> items.
 	/// </summary>
 	public static ItemsResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>> HaveAtLeast<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtMost.cs
@@ -9,7 +9,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that at most <paramref name="maximum" /> items in the asynchronous enumerable satisfy the
+	///     Verifies that at most <paramref name="maximum" /> items in the collection satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> HaveAtMost<TItem>(
@@ -20,7 +20,7 @@ public static partial class ThatAsyncEnumerableShould
 			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.AtMost(maximum), expectations)), source);
 
 	/// <summary>
-	///     Verifies that the asynchronous enumerable has at most <paramref name="maximum" /> items.
+	///     Verifies that the collection has at most <paramref name="maximum" /> items.
 	/// </summary>
 	public static ItemsResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>> HaveAtMost<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveExactly.cs
@@ -9,7 +9,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that exactly <paramref name="expected" /> items in the asynchronous enumerable satisfy the
+	///     Verifies that exactly <paramref name="expected" /> items in the collection satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> HaveExactly<TItem>(
@@ -20,7 +20,7 @@ public static partial class ThatAsyncEnumerableShould
 			=> new AsyncCollectionConstraint<TItem>(it, EnumerableQuantifier.Exactly(expected), expectations)), source);
 
 	/// <summary>
-	///     Verifies that the asynchronous enumerable has exactly <paramref name="expected" /> items.
+	///     Verifies that the collection has exactly <paramref name="expected" /> items.
 	/// </summary>
 	public static ItemsResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>>> HaveExactly<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveNone.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveNone.cs
@@ -9,7 +9,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that no items in the asynchronous enumerable satisfy the <paramref name="expectations" />.
+	///     Verifies that no items in the collection satisfy the <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>>> HaveNone<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveSingle.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+#if NET6_0_OR_GREATER
+namespace aweXpect;
+
+public static partial class ThatAsyncEnumerableShould
+{
+	/// <summary>
+	///     Verifies that the asynchronous enumerable contains exactly one element.
+	/// </summary>
+	public static SingleItemResult<IAsyncEnumerable<TItem>, TItem>.Async HaveSingle<TItem>(
+		this IThat<IAsyncEnumerable<TItem>> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(it => new HaveSingleConstraint<TItem>(it)),
+			async f =>
+			{
+				await using IAsyncEnumerator<TItem> enumerator = f.GetAsyncEnumerator();
+				return await enumerator.MoveNextAsync() ? enumerator.Current : default;
+			});
+
+	private readonly struct HaveSingleConstraint<TItem>(string it) : IAsyncContextConstraint<IAsyncEnumerable<TItem>>
+	{
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TItem> actual, IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			IAsyncEnumerable<TItem> materialized =
+				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
+			TItem? singleItem = default;
+			int count = 0;
+
+			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
+			{
+				singleItem = item;
+				if (++count > 1)
+				{
+					break;
+				}
+			}
+
+			switch (count)
+			{
+				case 1:
+					return new ConstraintResult.Success<TItem>(singleItem!, ToString());
+				case 0:
+					return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(materialized, ToString(),
+						$"{it} was empty");
+				default:
+					return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(materialized, ToString(),
+						$"{it} contained more than one item");
+			}
+		}
+
+		public override string ToString() => "have a single item";
+	}
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveSingle.cs
@@ -6,6 +6,7 @@ using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
 using aweXpect.Helpers;
 using aweXpect.Results;
+// ReSharper disable PossibleMultipleEnumeration
 
 #if NET6_0_OR_GREATER
 namespace aweXpect;
@@ -13,7 +14,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the asynchronous enumerable contains exactly one element.
+	///     Verifies that the collection contains exactly one element.
 	/// </summary>
 	public static SingleItemResult<IAsyncEnumerable<TItem>, TItem>.Async HaveSingle<TItem>(
 		this IThat<IAsyncEnumerable<TItem>> source)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.cs
@@ -17,7 +17,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Start delegate expectations on the current collection of <typeparamref name="TItem" /> values.
+	///     Start expectations on the collection of <typeparamref name="TItem" /> values.
 	/// </summary>
 	public static IThat<IAsyncEnumerable<TItem>> Should<TItem>(
 		this IExpectSubject<IAsyncEnumerable<TItem>> subject)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.cs
@@ -17,7 +17,7 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerableShould
 {
 	/// <summary>
-	///     Start delegate expectations on the current async enumerable of <typeparamref name="TItem" /> values.
+	///     Start delegate expectations on the current collection of <typeparamref name="TItem" /> values.
 	/// </summary>
 	public static IThat<IAsyncEnumerable<TItem>> Should<TItem>(
 		this IExpectSubject<IAsyncEnumerable<TItem>> subject)

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
@@ -14,7 +14,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual collection matches the provided <paramref name="expected" /> collection.
+	///     Verifies that the collection matches the provided <paramref name="expected" /> collection.
 	/// </summary>
 	public static CollectionBeResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		Be<TItem>(

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
@@ -14,7 +14,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
+	///     Verifies that the actual collection matches the provided <paramref name="expected" /> collection.
 	/// </summary>
 	public static CollectionBeResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		Be<TItem>(

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.BeEmpty.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.BeEmpty.cs
@@ -5,13 +5,14 @@ using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
 using aweXpect.Helpers;
 using aweXpect.Results;
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect;
 
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable is empty.
+	///     Verifies that the collection is empty.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		BeEmpty<TItem>(this IThat<IEnumerable<TItem>> source)
@@ -20,7 +21,7 @@ public static partial class ThatEnumerableShould
 			source);
 
 	/// <summary>
-	///     Verifies that the actual enumerable is not empty.
+	///     Verifies that the collection is not empty.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		NotBeEmpty<TItem>(
@@ -53,7 +54,7 @@ public static partial class ThatEnumerableShould
 	{
 		public ConstraintResult IsMetBy(IEnumerable<TItem> actual, IEvaluationContext context)
 		{
-			IEnumerable<TItem>? materializedEnumerable =
+			IEnumerable<TItem> materializedEnumerable =
 				context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
 			using IEnumerator<TItem> enumerator = materializedEnumerable.GetEnumerator();
 			if (enumerator.MoveNext())

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Contain.cs
@@ -16,7 +16,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable contains the <paramref name="expected" /> value.
+	///     Verifies that the collection contains the <paramref name="expected" /> value.
 	/// </summary>
 	public static ObjectCountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		Contain<TItem>(
@@ -37,7 +37,7 @@ public static partial class ThatEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual enumerable contains an item that satisfies the <paramref name="predicate" />.
+	///     Verifies that the collection contains an item that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		Contain<TItem>(
@@ -59,7 +59,7 @@ public static partial class ThatEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual enumerable does not contain the <paramref name="unexpected" /> value.
+	///     Verifies that the collection does not contain the <paramref name="unexpected" /> value.
 	/// </summary>
 	public static ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		NotContain<TItem>(
@@ -74,7 +74,7 @@ public static partial class ThatEnumerableShould
 	}
 
 	/// <summary>
-	///     Verifies that the actual enumerable contains no item that satisfies the <paramref name="predicate" />.
+	///     Verifies that the collection contains no item that satisfies the <paramref name="predicate" />.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>
 		NotContain<TItem>(

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAll.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAll.cs
@@ -8,7 +8,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that all items in the synchronous enumerable satisfy the <paramref name="expectations" />.
+	///     Verifies that all items in the collection satisfy the <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> HaveAll<TItem>(
 		this IThat<IEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtLeast.cs
@@ -8,7 +8,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that at least <paramref name="minimum" /> items in the synchronous enumerable satisfy the
+	///     Verifies that at least <paramref name="minimum" /> items in the collection satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> HaveAtLeast<TItem>(
@@ -20,7 +20,7 @@ public static partial class ThatEnumerableShould
 			source);
 
 	/// <summary>
-	///     Verifies that the synchronous enumerable has at least <paramref name="minimum" /> items.
+	///     Verifies that the collection has at least <paramref name="minimum" /> items.
 	/// </summary>
 	public static ItemsResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>> HaveAtLeast<TItem>(
 		this IThat<IEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveAtMost.cs
@@ -8,7 +8,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that at most <paramref name="maximum" /> items in the synchronous enumerable satisfy the
+	///     Verifies that at most <paramref name="maximum" /> items in the collection satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> HaveAtMost<TItem>(
@@ -20,7 +20,7 @@ public static partial class ThatEnumerableShould
 			source);
 
 	/// <summary>
-	///     Verifies that the synchronous enumerable has at most <paramref name="maximum" /> items.
+	///     Verifies that the collection has at most <paramref name="maximum" /> items.
 	/// </summary>
 	public static ItemsResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>> HaveAtMost<TItem>(
 		this IThat<IEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveExactly.cs
@@ -8,7 +8,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that exactly <paramref name="expected" /> items in the synchronous enumerable satisfy the
+	///     Verifies that exactly <paramref name="expected" /> items in the collection satisfy the
 	///     <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> HaveExactly<TItem>(
@@ -20,7 +20,7 @@ public static partial class ThatEnumerableShould
 			source);
 
 	/// <summary>
-	///     Verifies that the synchronous enumerable has exactly <paramref name="expected" /> items.
+	///     Verifies that the collection has exactly <paramref name="expected" /> items.
 	/// </summary>
 	public static ItemsResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>>> HaveExactly<TItem>(
 		this IThat<IEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveNone.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveNone.cs
@@ -8,7 +8,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that no items in the synchronous enumerable satisfy the <paramref name="expectations" />.
+	///     Verifies that no items in the collection satisfy the <paramref name="expectations" />.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>>> HaveNone<TItem>(
 		this IThat<IEnumerable<TItem>> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveSingle.cs
@@ -13,7 +13,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the synchronous enumerable contains exactly one element.
+	///     Verifies that the collection contains exactly one element.
 	/// </summary>
 	public static SingleItemResult<IEnumerable<TItem>, TItem> HaveSingle<TItem>(
 		this IThat<IEnumerable<TItem>> source)

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.HaveSingle.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect;
+
+public static partial class ThatEnumerableShould
+{
+	/// <summary>
+	///     Verifies that the synchronous enumerable contains exactly one element.
+	/// </summary>
+	public static SingleItemResult<IEnumerable<TItem>, TItem> HaveSingle<TItem>(
+		this IThat<IEnumerable<TItem>> source)
+		=> new(source.ExpectationBuilder
+				.AddConstraint(it => new HaveSingleConstraint<TItem>(it)),
+			f => f.FirstOrDefault()
+		);
+
+	private readonly struct HaveSingleConstraint<TItem>(string it) : IContextConstraint<IEnumerable<TItem>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<TItem> actual, IEvaluationContext context)
+		{
+			IEnumerable<TItem> materialized = context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
+			TItem? singleItem = default;
+			int count = 0;
+
+			foreach (TItem item in materialized)
+			{
+				singleItem = item;
+				if (++count > 1)
+				{
+					break;
+				}
+			}
+
+			switch (count)
+			{
+				case 1:
+					return new ConstraintResult.Success<TItem>(singleItem!, ToString());
+				case 0:
+					return new ConstraintResult.Failure<IEnumerable<TItem>>(materialized, ToString(),
+						$"{it} was empty");
+				default:
+					return new ConstraintResult.Failure<IEnumerable<TItem>>(materialized, ToString(),
+						$"{it} contained more than one item");
+			}
+		}
+
+		public override string ToString() => "have a single item";
+	}
+}

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.cs
@@ -16,7 +16,7 @@ namespace aweXpect;
 public static partial class ThatEnumerableShould
 {
 	/// <summary>
-	///     Start delegate expectations on the current enumerable of <typeparamref name="TItem" /> values.
+	///     Start expectations on the current enumerable of <typeparamref name="TItem" /> values.
 	/// </summary>
 	public static IThat<IEnumerable<TItem>> Should<TItem>(
 		this IExpectSubject<IEnumerable<TItem>> subject)

--- a/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
@@ -14,7 +14,7 @@ namespace aweXpect;
 public static partial class ThatStringEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual collection matches the provided <paramref name="expected" /> collection.
+	///     Verifies that the collection matches the provided <paramref name="expected" /> collection.
 	/// </summary>
 	public static StringCollectionBeTypeResult<IEnumerable<string>, IThat<IEnumerable<string>>>
 		Be(this IThat<IEnumerable<string>> source,

--- a/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
@@ -14,7 +14,7 @@ namespace aweXpect;
 public static partial class ThatStringEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual enumerable matches the provided <paramref name="expected" /> collection.
+	///     Verifies that the actual collection matches the provided <paramref name="expected" /> collection.
 	/// </summary>
 	public static StringCollectionBeTypeResult<IEnumerable<string>, IThat<IEnumerable<string>>>
 		Be(this IThat<IEnumerable<string>> source,

--- a/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Contain.cs
@@ -3,13 +3,14 @@ using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Options;
 using aweXpect.Results;
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect;
 
 public static partial class ThatStringEnumerableShould
 {
 	/// <summary>
-	///     Verifies that the actual collection contains the <paramref name="expected" /> value.
+	///     Verifies that the collection contains the <paramref name="expected" /> value.
 	/// </summary>
 	public static StringCountResult<IEnumerable<string>, IThat<IEnumerable<string>>> Contain(
 		this IThat<IEnumerable<string>> source,

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -88,7 +88,8 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Func<aweXpect.Core.MemberAccessor, string, string>? expectationTextGenerator = null, bool replaceIt = true) { }
-        public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> whichAccessor) { }
+        public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
+        public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null) { }
         public override string? ToString() { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public class MemberExpectationBuilder<TSource, TMember>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -88,7 +88,8 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Func<aweXpect.Core.MemberAccessor, string, string>? expectationTextGenerator = null, bool replaceIt = true) { }
-        public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> whichAccessor) { }
+        public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
+        public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null) { }
         public override string? ToString() { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public class MemberExpectationBuilder<TSource, TMember>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -36,6 +36,7 @@ namespace aweXpect
         public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, int expected, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> HaveNone<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>, TItem>.Async HaveSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> NotBeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> NotContain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, TItem unexpected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>>> NotContain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -206,6 +207,7 @@ namespace aweXpect
         public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveNone<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HaveSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotContain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem unexpected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotContain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -904,6 +906,14 @@ namespace aweXpect.Results
         public ObjectCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.ObjectEqualityOptions options) { }
         public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+    }
+    public class SingleItemResult<TCollection, TItem> : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>>
+    {
+        public aweXpect.Core.IExpectSubject<TItem> Which { get; }
+        public class Async : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>.Async>
+        {
+            public aweXpect.Core.IExpectSubject<TItem> Which { get; }
+        }
     }
     public class StringCollectionBeResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -161,6 +161,7 @@ namespace aweXpect
         public static aweXpect.Results.ItemsResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveExactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, int expected, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> HaveNone<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
+        public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HaveSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotBeEmpty<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotContain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, TItem unexpected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>>> NotContain<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -783,6 +784,14 @@ namespace aweXpect.Results
         public ObjectCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.ObjectEqualityOptions options) { }
         public TSelf Equivalent(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
+    }
+    public class SingleItemResult<TCollection, TItem> : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>>
+    {
+        public aweXpect.Core.IExpectSubject<TItem> Which { get; }
+        public class Async : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>.Async>
+        {
+            public aweXpect.Core.IExpectSubject<TItem> Which { get; }
+        }
     }
     public class StringCollectionBeResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat>
     {

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveSingleTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveSingleTests.cs
@@ -1,0 +1,134 @@
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class AsyncEnumerableShould
+{
+	public sealed class HaveSingleTests
+	{
+		[Fact]
+		public async Task ShouldReturnSingleItem()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([42]);
+
+			int result = await That(subject).Should().HaveSingle();
+
+			await That(result).Should().Be(42);
+		}
+
+		[Fact]
+		public async Task WhenAsyncEnumerableContainsMoreThanOneElement_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item,
+				             but it contained more than one item
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenAsyncEnumerableContainsSingleElement_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1]);
+
+			int result = await That(subject).Should().HaveSingle();
+
+			await That(result).Should().Be(1);
+		}
+
+		[Fact]
+		public async Task WhenAsyncEnumerableIsEmpty_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item,
+				             but it was empty
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_ShouldReturnSingleItem()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([42]);
+
+			int result = await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(41).And.BeLessThan(43);
+
+			await That(result).Should().Be(42);
+		}
+
+		[Fact]
+		public async Task Which_WhenAsyncEnumerableContainsMoreThanOneElement_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(4);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item which should be greater than 4,
+				             but it contained more than one item
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_WhenAsyncEnumerableIsEmpty_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(4);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item which should be greater than 4,
+				             but it was empty
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_WhenSingleItemDoesNotSatisfyExpectation_ShouldFail()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(4);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item which should be greater than 4,
+				             but it was 3
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_WhenSingleItemSatisfiesExpectation_ShouldSucceed()
+		{
+			IAsyncEnumerable<int> subject = ToAsyncEnumerable([3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(2);
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveSingleTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/EnumerableShould.HaveSingleTests.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests.ThatTests.Collections;
+
+public sealed partial class EnumerableShould
+{
+	public sealed class HaveSingleTests
+	{
+		[Fact]
+		public async Task ShouldReturnSingleItem()
+		{
+			IEnumerable<int> subject = ToEnumerable([42]);
+
+			int result = await That(subject).Should().HaveSingle();
+
+			await That(result).Should().Be(42);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item,
+				             but it contained more than one item
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([1]);
+
+			int result = await That(subject).Should().HaveSingle();
+
+			await That(result).Should().Be(1);
+		}
+
+		[Fact]
+		public async Task WhenEnumerableIsEmpty_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable(Array.Empty<int>());
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle();
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item,
+				             but it was empty
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_ShouldReturnSingleItem()
+		{
+			IEnumerable<int> subject = ToEnumerable([42]);
+
+			int result = await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(41).And.BeLessThan(43);
+
+			await That(result).Should().Be(42);
+		}
+
+		[Fact]
+		public async Task Which_WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([1, 2, 3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(4);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item which should be greater than 4,
+				             but it contained more than one item
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_WhenEnumerableIsEmpty_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable(Array.Empty<int>());
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(4);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item which should be greater than 4,
+				             but it was empty
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_WhenSingleItemDoesNotSatisfyExpectation_ShouldFail()
+		{
+			IEnumerable<int> subject = ToEnumerable([3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(4);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected subject to
+				             have a single item which should be greater than 4,
+				             but it was 3
+				             """);
+		}
+
+		[Fact]
+		public async Task Which_WhenSingleItemSatisfiesExpectation_ShouldSucceed()
+		{
+			IEnumerable<int> subject = ToEnumerable([3]);
+
+			async Task Act()
+				=> await That(subject).Should().HaveSingle().Which.Should().BeGreaterThan(2);
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
*From #94*

Add an extension on collection `HaveSingle()` which
- verifies, that the collection contains exactly one element and
- return only this one element when awaited

This simplifies the following workaround
```csharp
IEnumerable<int> values = [1];
var value = values.Single();
await Expect.That(value).Should().Be(1);
// with
var value = await That(values).Should().HaveSingle()
.Which.Should().Be(1);
```