### PR TITLE
feat: add customization options

### DIFF
--- a/Source/aweXpect.Core/Core/Ambient/Initialization.cs
+++ b/Source/aweXpect.Core/Core/Ambient/Initialization.cs
@@ -16,6 +16,7 @@ internal static class Initialization
 		"mscorlib",
 		"System",
 		"Microsoft",
+		"JetBrains",
 		"xunit",
 		"Castle",
 		"DynamicProxyGenAssembly2"

--- a/Source/aweXpect.Core/Core/Ambient/Initialization.cs
+++ b/Source/aweXpect.Core/Core/Ambient/Initialization.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using aweXpect.Core.Adapters;
+using aweXpect.Customization;
 
 namespace aweXpect.Core.Ambient;
 
@@ -11,22 +11,11 @@ internal static class Initialization
 {
 	public static Lazy<InitializationState> State { get; } = new(Initialize);
 
-	private static List<string> ExcludedAssemblyNamespaces { get; } =
-	[
-		"mscorlib",
-		"System",
-		"Microsoft",
-		"JetBrains",
-		"xunit",
-		"Castle",
-		"DynamicProxyGenAssembly2"
-	];
-
 	private static ITestFrameworkAdapter DetectFramework()
 	{
 		Type frameworkInterface = typeof(ITestFrameworkAdapter);
 		foreach (Type frameworkType in AppDomain.CurrentDomain.GetAssemblies()
-			         .Where(a => ExcludedAssemblyNamespaces.All(x => !a.FullName!.StartsWith(x)))
+			         .Where(a => Customize.Reflection.ExcludedAssemblyPrefixes.All(x => !a.FullName!.StartsWith(x)))
 			         .SelectMany(a => a.GetTypes())
 			         .Where(x => x is { IsClass: true, IsAbstract: false })
 			         .Where(frameworkInterface.IsAssignableFrom))

--- a/Source/aweXpect.Core/Customization/Customize.Formatting.cs
+++ b/Source/aweXpect.Core/Customization/Customize.Formatting.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading;
+
+namespace aweXpect.Customization;
+
+public partial class Customize : ICustomizeFormatting
+{
+	private static readonly int MaximumNumberOfCollectionItemsDefaultValue = 10;
+
+	private readonly AsyncLocal<int?> _maximumNumberOfCollectionItems = new();
+
+	/// <summary>
+	///     Customizes the formatting settings.
+	/// </summary>
+	public static ICustomizeFormatting Formatting => Instance;
+
+	/// <inheritdoc />
+	int ICustomizeFormatting.MaximumNumberOfCollectionItems
+		=> _maximumNumberOfCollectionItems.Value ?? MaximumNumberOfCollectionItemsDefaultValue;
+
+	/// <inheritdoc />
+	IDisposable ICustomizeFormatting.SetMaximumNumberOfCollectionItems(int value)
+	{
+		_maximumNumberOfCollectionItems.Value = value;
+		return new ActionDisposable(() => _maximumNumberOfCollectionItems.Value = null);
+	}
+}

--- a/Source/aweXpect.Core/Customization/Customize.Reflection.cs
+++ b/Source/aweXpect.Core/Customization/Customize.Reflection.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace aweXpect.Customization;
+
+public partial class Customize : ICustomizeReflection
+{
+	private static readonly string[] ExcludedAssemblyPrefixesDefaultValue =
+	[
+		"mscorlib",
+		"System",
+		"Microsoft",
+		"JetBrains",
+		"xunit",
+		"Castle",
+		"DynamicProxyGenAssembly2"
+	];
+
+	private readonly AsyncLocal<string[]?> _excludedAssemblyPrefixes = new();
+
+	/// <summary>
+	///     Customizes the reflection settings.
+	/// </summary>
+	public static ICustomizeReflection Reflection => Instance;
+
+	/// <inheritdoc />
+	string[] ICustomizeReflection.ExcludedAssemblyPrefixes
+		=> _excludedAssemblyPrefixes.Value ?? ExcludedAssemblyPrefixesDefaultValue;
+
+	/// <inheritdoc />
+	IDisposable ICustomizeReflection.ExcludeAssemblies(Action<List<string>> excludedAssemblyPrefixes)
+	{
+		List<string> list = new(_excludedAssemblyPrefixes.Value ?? ExcludedAssemblyPrefixesDefaultValue);
+		excludedAssemblyPrefixes(list);
+		_excludedAssemblyPrefixes.Value = list.ToArray();
+		return new ActionDisposable(() => _excludedAssemblyPrefixes.Value = null);
+	}
+}

--- a/Source/aweXpect.Core/Customization/Customize.cs
+++ b/Source/aweXpect.Core/Customization/Customize.cs
@@ -14,7 +14,7 @@ public partial class Customize
 	/// </summary>
 	private static readonly Customize Instance = new();
 
-	private class ActionDisposable(Action callback) : IDisposable
+	private sealed class ActionDisposable(Action callback) : IDisposable
 	{
 		public void Dispose() => callback();
 	}

--- a/Source/aweXpect.Core/Customization/Customize.cs
+++ b/Source/aweXpect.Core/Customization/Customize.cs
@@ -12,7 +12,7 @@ public partial class Customize
 	/// <summary>
 	///     The current customization values.
 	/// </summary>
-	public static Customize Instance { get; } = new();
+	private static readonly Customize Instance = new();
 
 	private class ActionDisposable(Action callback) : IDisposable
 	{

--- a/Source/aweXpect.Core/Customization/Customize.cs
+++ b/Source/aweXpect.Core/Customization/Customize.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace aweXpect.Customization;
+
+/// <summary>
+///     Allows customizing the static behaviour of aweXpect.
+/// </summary>
+public partial class Customize
+{
+	private Customize() { }
+
+	/// <summary>
+	///     The current customization values.
+	/// </summary>
+	public static Customize Instance { get; } = new();
+
+	private class ActionDisposable(Action callback) : IDisposable
+	{
+		public void Dispose() => callback();
+	}
+}

--- a/Source/aweXpect.Core/Customization/ICustomizeFormatting.cs
+++ b/Source/aweXpect.Core/Customization/ICustomizeFormatting.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace aweXpect.Customization;
+
+/// <summary>
+///     Customizes the formatting settings.
+/// </summary>
+public interface ICustomizeFormatting
+{
+	/// <summary>
+	///     The maximum number of displayed items in a collection.
+	/// </summary>
+	int MaximumNumberOfCollectionItems { get; }
+	
+	/// <summary>
+	///     Specifies the maximum number of displayed items in a collection.
+	/// </summary>
+	/// <returns>An object, that will revert the maximum number of displayed items in a collection to the default value upon disposal.</returns>
+	IDisposable SetMaximumNumberOfCollectionItems(int value);
+}

--- a/Source/aweXpect.Core/Customization/ICustomizeReflection.cs
+++ b/Source/aweXpect.Core/Customization/ICustomizeReflection.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace aweXpect.Customization;
+
+/// <summary>
+///     Customizes the reflection settings.
+/// </summary>
+public interface ICustomizeReflection
+{
+	/// <summary>
+	///     The assembly namespace prefixes that are excluded during reflection.
+	/// </summary>
+	/// <remarks>
+	///     Defaults to<br />
+	///     - mscorlib<br />
+	///     - System<br />
+	///     - Microsoft<br />
+	///     - JetBrains<br />
+	///     - xunit<br />
+	///     - Castle<br />
+	///     - DynamicProxyGenAssembly2
+	/// </remarks>
+	string[] ExcludedAssemblyPrefixes { get; }
+
+	/// <summary>
+	///     Specifies the assembly prefixes that should be excluded.
+	/// </summary>
+	/// <returns>An object, that will revert the excluded assemblies to the default value upon disposal.</returns>
+	/// <remarks>The <see cref="Action{T}" /> allows changing the excluded assembly prefixes.</remarks>
+	IDisposable ExcludeAssemblies(Action<List<string>> excludedAssemblyPrefixes);
+}

--- a/Source/aweXpect.Core/Formatting/Format.cs
+++ b/Source/aweXpect.Core/Formatting/Format.cs
@@ -8,11 +8,6 @@ namespace aweXpect.Formatting;
 public static class Format
 {
 	/// <summary>
-	///     The number of collection items that are formatted.
-	/// </summary>
-	public static int CollectionFormatCount { get; } = 10;
-
-	/// <summary>
 	///     The formatter to use for formatting values.
 	/// </summary>
 	public static ValueFormatter Formatter { get; } = Initialization.State.Value.Formatter;

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -46,7 +46,7 @@ public static partial class ValueFormatters
 		FormattingOptions? options = null)
 	{
 		options ??= FormattingOptions.SingleLine;
-		int maxCount = CollectionFormatCount;
+		int maxCount = Customization.Customize.Formatting.MaximumNumberOfCollectionItems;
 		int count = maxCount;
 		stringBuilder.Append('[');
 		bool hasMoreValues = false;

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
@@ -33,12 +33,12 @@ public partial class CollectionMatchOptions
 			_missingItems.Remove(value);
 			_index++;
 			error = null;
-			return _additionalItems.Count > 2 * CollectionFormatCount;
+			return _additionalItems.Count > 2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems;
 		}
 
 		public bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error)
 		{
-			if (_additionalItems.Count + _missingItems.Count > 2 * CollectionFormatCount)
+			if (_additionalItems.Count + _missingItems.Count > 2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 			{
 				error = null;
 				return true;

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -41,12 +41,12 @@ public partial class CollectionMatchOptions
 			_uniqueItems.Add(value);
 			_index++;
 
-			return _additionalItems.Count > 2 * CollectionFormatCount;
+			return _additionalItems.Count > 2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems;
 		}
 
 		public bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error)
 		{
-			if (_missingItems.Count + _additionalItems.Count > 2 * CollectionFormatCount)
+			if (_missingItems.Count + _additionalItems.Count > 2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 			{
 				error = null;
 				return true;

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.SameOrderCollectionMatcher.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.SameOrderCollectionMatcher.cs
@@ -50,7 +50,7 @@ public partial class CollectionMatchOptions
 
 			_index++;
 			error = null;
-			return _additionalItems.Count + _incorrectItems.Count + _missingItems.Count > 2 * CollectionFormatCount;
+			return _additionalItems.Count + _incorrectItems.Count + _missingItems.Count > 2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems;
 		}
 
 		public bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error)
@@ -68,7 +68,7 @@ public partial class CollectionMatchOptions
 					}
 
 					if (_additionalItems.Count + _incorrectItems.Count + _missingItems.Count >
-					    2 * CollectionFormatCount)
+					    2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 					{
 						error = null;
 						return true;

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.SameOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.SameOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -64,7 +64,8 @@ public partial class CollectionMatchOptions
 			}
 
 			_index++;
-			return _additionalItems.Count + _incorrectItems.Count + _missingItems.Count > 2 * CollectionFormatCount;
+			return _additionalItems.Count + _incorrectItems.Count + _missingItems.Count >
+			       2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems;
 		}
 
 		public bool VerifyComplete(string it, IOptionsEquality<T2> options, out string? error)
@@ -82,7 +83,8 @@ public partial class CollectionMatchOptions
 					_missingItems.Add(item);
 				}
 
-				if (_additionalItems.Count + _incorrectItems.Count + _missingItems.Count > 2 * CollectionFormatCount)
+				if (_additionalItems.Count + _incorrectItems.Count + _missingItems.Count >
+				    2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 				{
 					error = null;
 					return true;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -80,7 +80,7 @@ public static partial class ThatAsyncEnumerableShould
 			int count = 0;
 			await foreach (TItem item in materializedEnumerable)
 			{
-				if (count++ >= CollectionFormatCount)
+				if (count++ >= Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 				{
 					break;
 				}
@@ -91,7 +91,7 @@ public static partial class ThatAsyncEnumerableShould
 				sb.Append(",");
 			}
 
-			if (count > CollectionFormatCount)
+			if (count > Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 			{
 				sb.AppendLine();
 				sb.Append("  …,");
@@ -100,9 +100,9 @@ public static partial class ThatAsyncEnumerableShould
 			sb.Length--;
 			sb.AppendLine();
 			sb.Append("] had more than ");
-			sb.Append(2 * CollectionFormatCount);
+			sb.Append(2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems);
 			sb.Append(" deviations compared to ");
-			Formatter.Format(sb, expected.Take(CollectionFormatCount + 1), FormattingOptions.MultipleLines);
+			Formatter.Format(sb, expected.Take(Customization.Customize.Formatting.MaximumNumberOfCollectionItems + 1), FormattingOptions.MultipleLines);
 			return sb.ToString();
 		}
 

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
@@ -101,12 +101,12 @@ public static partial class ThatAsyncEnumerableShould
 		{
 			IAsyncEnumerable<TItem> materializedEnumerable =
 				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
-			List<TItem> items = new(CollectionFormatCount + 1);
+			List<TItem> items = new(Customization.Customize.Formatting.MaximumNumberOfCollectionItems + 1);
 			int count = 0;
 			bool isFailed = false;
 			await foreach (TItem item in materializedEnumerable.WithCancellation(cancellationToken))
 			{
-				if (items.Count <= CollectionFormatCount)
+				if (items.Count <= Customization.Customize.Formatting.MaximumNumberOfCollectionItems)
 				{
 					items.Add(item);
 				}
@@ -127,7 +127,7 @@ public static partial class ThatAsyncEnumerableShould
 					}
 				}
 
-				if (items.Count > CollectionFormatCount && isFailed)
+				if (items.Count > Customization.Customize.Formatting.MaximumNumberOfCollectionItems && isFailed)
 				{
 					return new ConstraintResult.Failure<IAsyncEnumerable<TItem>>(actual, ToString(),
 						$"{it} contained it at least {count} times in {Formatter.Format(items.ToArray())}");

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Be.cs
@@ -65,7 +65,7 @@ public static partial class ThatEnumerableShould
 		}
 
 		private string TooManyDeviationsError(IEnumerable<TItem> materializedEnumerable)
-			=> $"{it} was completely different: {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)} had more than {2 * CollectionFormatCount} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
+			=> $"{it} was completely different: {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)} had more than {2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
 
 		public override string ToString()
 			=> $"match collection {expectedExpression}{matchOptions}";

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.Contain.cs
@@ -107,7 +107,7 @@ public static partial class ThatEnumerableShould
 					if (check == false)
 					{
 						return new ConstraintResult.Failure<IEnumerable<TItem>>(actual, ToString(),
-							$"{it} contained it at least {count} times in {Formatter.Format(materializedEnumerable.Take(CollectionFormatCount + 1).ToArray())}");
+							$"{it} contained it at least {count} times in {Formatter.Format(materializedEnumerable)}");
 					}
 
 					if (check == true)
@@ -125,7 +125,7 @@ public static partial class ThatEnumerableShould
 			}
 
 			return new ConstraintResult.Failure<IEnumerable<TItem>>(actual, ToString(),
-				$"{it} contained it {count} times in {Formatter.Format(materializedEnumerable.Take(CollectionFormatCount + 1).ToArray())}");
+				$"{it} contained it {count} times in {Formatter.Format(materializedEnumerable)}");
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatStringEnumerableShould.Be.cs
@@ -64,7 +64,7 @@ public static partial class ThatStringEnumerableShould
 		}
 
 		private string TooManyDeviationsError(IEnumerable<string> materializedEnumerable)
-			=> $"{it} was completely different: {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)} had more than {2 * CollectionFormatCount} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
+			=> $"{it} was completely different: {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)} had more than {2 * Customization.Customize.Formatting.MaximumNumberOfCollectionItems} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
 
 		public override string ToString()
 			=> $"match collection {expectedExpression}{matchOptions}";

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -192,6 +192,25 @@ namespace aweXpect.Core.Sources
         public TValue Value { get; }
     }
 }
+namespace aweXpect.Customization
+{
+    public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeReflection
+    {
+        public static aweXpect.Customization.ICustomizeFormatting Formatting { get; }
+        public static aweXpect.Customization.Customize Instance { get; }
+        public static aweXpect.Customization.ICustomizeReflection Reflection { get; }
+    }
+    public interface ICustomizeFormatting
+    {
+        int MaximumNumberOfCollectionItems { get; }
+        System.IDisposable SetMaximumNumberOfCollectionItems(int value);
+    }
+    public interface ICustomizeReflection
+    {
+        string[] ExcludedAssemblyPrefixes { get; }
+        System.IDisposable ExcludeAssemblies(System.Action<System.Collections.Generic.List<string>> excludedAssemblyPrefixes);
+    }
+}
 namespace aweXpect
 {
     public static class Expect
@@ -251,7 +270,6 @@ namespace aweXpect.Formatting
 {
     public static class Format
     {
-        public static int CollectionFormatCount { get; }
         public static aweXpect.Formatting.ValueFormatter Formatter { get; }
     }
     public class FormattingOptions

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -197,7 +197,6 @@ namespace aweXpect.Customization
     public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeReflection
     {
         public static aweXpect.Customization.ICustomizeFormatting Formatting { get; }
-        public static aweXpect.Customization.Customize Instance { get; }
         public static aweXpect.Customization.ICustomizeReflection Reflection { get; }
     }
     public interface ICustomizeFormatting

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -192,6 +192,25 @@ namespace aweXpect.Core.Sources
         public TValue Value { get; }
     }
 }
+namespace aweXpect.Customization
+{
+    public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeReflection
+    {
+        public static aweXpect.Customization.ICustomizeFormatting Formatting { get; }
+        public static aweXpect.Customization.Customize Instance { get; }
+        public static aweXpect.Customization.ICustomizeReflection Reflection { get; }
+    }
+    public interface ICustomizeFormatting
+    {
+        int MaximumNumberOfCollectionItems { get; }
+        System.IDisposable SetMaximumNumberOfCollectionItems(int value);
+    }
+    public interface ICustomizeReflection
+    {
+        string[] ExcludedAssemblyPrefixes { get; }
+        System.IDisposable ExcludeAssemblies(System.Action<System.Collections.Generic.List<string>> excludedAssemblyPrefixes);
+    }
+}
 namespace aweXpect
 {
     public static class Expect
@@ -249,7 +268,6 @@ namespace aweXpect.Formatting
 {
     public static class Format
     {
-        public static int CollectionFormatCount { get; }
         public static aweXpect.Formatting.ValueFormatter Formatter { get; }
     }
     public class FormattingOptions

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -197,7 +197,6 @@ namespace aweXpect.Customization
     public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeReflection
     {
         public static aweXpect.Customization.ICustomizeFormatting Formatting { get; }
-        public static aweXpect.Customization.Customize Instance { get; }
         public static aweXpect.Customization.ICustomizeReflection Reflection { get; }
     }
     public interface ICustomizeFormatting

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeFormattingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeFormattingTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using aweXpect.Customization;
+
+namespace aweXpect.Core.Tests.Customization;
+
+public sealed class CustomizeFormattingTests
+{
+	[Fact]
+	public async Task MaximumNumberOfCollectionItems_ShouldBeUsedInFormatter()
+	{
+		int[] items = Enumerable.Range(1, 6).ToArray();
+		using (IDisposable _ = Customize.Formatting.SetMaximumNumberOfCollectionItems(3))
+		{
+			await That(Formatter.Format(items)).Should().Be("[1, 2, 3, …]");
+		}
+
+		using (IDisposable _ = Customize.Formatting.SetMaximumNumberOfCollectionItems(5))
+		{
+			await That(Formatter.Format(items)).Should().Be("[1, 2, 3, 4, 5, …]");
+		}
+
+		await That(Formatter.Format(items)).Should().Be("[1, 2, 3, 4, 5, 6]");
+	}
+}

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeReflectionTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeReflectionTests.cs
@@ -1,0 +1,24 @@
+﻿using aweXpect.Customization;
+
+namespace aweXpect.Core.Tests.Customization;
+
+public sealed class CustomizeReflectionTests
+{
+	[Fact]
+	public async Task ExcludeAssemblies_ShouldChangeTheExcludedAssemblyPrefixes()
+	{
+		string additionalExcludedAssemblyNamespace = "foo";
+
+		await That(Customize.Reflection.ExcludedAssemblyPrefixes).Should()
+			.NotContain(additionalExcludedAssemblyNamespace);
+
+		using (IDisposable _ = Customize.Reflection.ExcludeAssemblies(l => l.Add(additionalExcludedAssemblyNamespace)))
+		{
+			await That(Customize.Reflection.ExcludedAssemblyPrefixes).Should()
+				.Contain(additionalExcludedAssemblyNamespace);
+		}
+
+		await That(Customize.Reflection.ExcludedAssemblyPrefixes).Should()
+			.NotContain(additionalExcludedAssemblyNamespace);
+	}
+}


### PR DESCRIPTION
Support customization of
- the excluded assemblies from reflection
- the maximum number of displayed items in a collection

Changes to the customization return an `IDisposable` which resets the value to its default upon disposal.