### PR TITLE
feat: add `BeExactly`/`NotBeExactly` for objects

### DIFF
--- a/Docs/pages/docs/expectations/object.md
+++ b/Docs/pages/docs/expectations/object.md
@@ -76,6 +76,16 @@ await Expect.That(subject).Should().NotBe(typeof(OtherClass));
 ```
 This verifies, if the subject is of the given type or a derived type.
 
+You can also verify, that the `object` is only of the given type and not of a derived type:
+```csharp
+object subject = new MyClass(1);
+
+await Expect.That(subject).Should().BeExactly<MyClass>();
+await Expect.That(subject).Should().BeExactly(typeof(MyClass));
+await Expect.That(subject).Should().NotBeExactly<OtherClass>();
+await Expect.That(subject).Should().NotBeExactly(typeof(OtherClass));
+```
+
 
 ## Null
 

--- a/Source/aweXpect/That/Objects/ThatObjectShould.BeExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObjectShould.BeExactly.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatObjectShould
+{
+	/// <summary>
+	///     Verifies that the subject is excactly of type <typeparamref name="TType" />.
+	/// </summary>
+	public static AndOrWhichResult<TType, IThat<object?>> BeExactly<TType>(
+		this IThat<object?> source)
+		=> new(source.ExpectationBuilder.AddConstraint(it
+				=> new IsExactlyOfTypeConstraint<TType>(it)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is exactly of type <paramref name="type" />.
+	/// </summary>
+	public static AndOrWhichResult<object?, IThat<object?>> BeExactly(
+		this IThat<object?> source,
+		Type type)
+		=> new(source.ExpectationBuilder.AddConstraint(it
+				=> new IsExactlyOfTypeConstraint(it, type)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not exactly of type <typeparamref name="TType" />.
+	/// </summary>
+	public static AndOrWhichResult<object?, IThat<object?>> NotBeExactly<TType>(
+		this IThat<object?> source)
+		=> new(source.ExpectationBuilder.AddConstraint(it
+				=> new IsNotExactlyOfTypeConstraint<TType>(it)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not exactly of type <paramref name="type" />.
+	/// </summary>
+	public static AndOrWhichResult<object?, IThat<object?>> NotBeExactly(
+		this IThat<object?> source,
+		Type type)
+		=> new(source.ExpectationBuilder.AddConstraint(it
+				=> new IsNotExactlyOfTypeConstraint(it, type)),
+			source);
+
+	private readonly struct IsExactlyOfTypeConstraint<TType>(string it) : IValueConstraint<object?>
+	{
+		public ConstraintResult IsMetBy(object? actual)
+		{
+			if (actual is TType typedActual && actual.GetType() == typeof(TType))
+			{
+				return new ConstraintResult.Success<TType>(typedActual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"{it} was {Formatter.Format(actual, FormattingOptions.MultipleLines)}");
+		}
+
+		public override string ToString()
+			=> $"be exactly type {Formatter.Format(typeof(TType))}";
+	}
+
+	private readonly struct IsExactlyOfTypeConstraint(string it, Type type) : IValueConstraint<object?>
+	{
+		public ConstraintResult IsMetBy(object? actual)
+		{
+			if (actual?.GetType() == type)
+			{
+				return new ConstraintResult.Success<object?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"{it} was {Formatter.Format(actual, FormattingOptions.MultipleLines)}");
+		}
+
+		public override string ToString()
+			=> $"be exactly type {Formatter.Format(type)}";
+	}
+
+	private readonly struct IsNotExactlyOfTypeConstraint<TType>(string it) : IValueConstraint<object?>
+	{
+		public ConstraintResult IsMetBy(object? actual)
+		{
+			if (actual is TType typedActual && actual.GetType() == typeof(TType))
+			{
+				return new ConstraintResult.Failure(ToString(),
+					$"{it} was {Formatter.Format(typedActual, FormattingOptions.MultipleLines)}");
+			}
+
+			return new ConstraintResult.Success<object?>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> $"not be exactly type {Formatter.Format(typeof(TType))}";
+	}
+
+	private readonly struct IsNotExactlyOfTypeConstraint(string it, Type type) : IValueConstraint<object?>
+	{
+		public ConstraintResult IsMetBy(object? actual)
+		{
+			if (actual?.GetType() == type)
+			{
+				return new ConstraintResult.Failure(ToString(),
+					$"{it} was {Formatter.Format(actual, FormattingOptions.MultipleLines)}");
+			}
+
+			return new ConstraintResult.Success<object?>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> $"not be exactly type {Formatter.Format(type)}";
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -739,10 +739,14 @@ namespace aweXpect
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> Be(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> Be(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> Be<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> BeExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> BeExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeNull(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBe(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> NotBe(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBe<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBeExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBeExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object, aweXpect.Core.IThat<object?>> NotBeNull(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Core.IThat<object?> Should(this aweXpect.Core.IExpectSubject<object?> subject) { }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -639,10 +639,14 @@ namespace aweXpect
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> Be(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> Be(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> Be<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> BeExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> BeExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeNull(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBe(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> NotBe(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBe<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBeExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBeExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object, aweXpect.Core.IThat<object?>> NotBeNull(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Core.IThat<object?> Should(this aweXpect.Core.IExpectSubject<object?> subject) { }
     }

--- a/Tests/aweXpect.Tests/ThatTests/Objects/ObjectShould.BeExactlyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Objects/ObjectShould.BeExactlyTests.cs
@@ -1,0 +1,338 @@
+﻿namespace aweXpect.Tests.ThatTests.Objects;
+
+public sealed partial class ObjectShould
+{
+	public sealed class BeExactlyTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task ForGeneric_WhenAwaited_ShouldReturnTypedResult(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			MyClass result = await That(subject).Should().BeExactly<MyClass>();
+
+			await That(result).Should().BeSameAs(subject);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForGeneric_WhenTypeDoesNotMatch_ShouldFail(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly<OtherClass>()
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be exactly type OtherClass, because we want to test the failure,
+				               but it was MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForGeneric_WhenTypeIsSubtype_ShouldFail(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly<MyBaseClass>()
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be exactly type MyBaseClass, because we want to test the failure,
+				               but it was MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForGeneric_WhenTypeIsSupertype_ShouldFail(int value, string reason)
+		{
+			object subject = new MyBaseClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly<MyClass>()
+					.Because(reason);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be exactly type MyClass, because {{reason}},
+				               but it was MyBaseClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Fact]
+		public async Task ForGeneric_WhenTypeMatches_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly<MyClass>();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenAwaited_ShouldReturnTypedResult(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			object? result = await That(subject).Should().BeExactly(typeof(MyClass));
+
+			await That(result).Should().BeSameAs(subject);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenTypeDoesNotMatch_ShouldFail(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly(typeof(OtherClass))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be exactly type OtherClass, because we want to test the failure,
+				               but it was MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenTypeIsSubtype_ShouldSucceed(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly(typeof(MyBaseClass))
+					.Because("we want to test the failure");
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be exactly type MyBaseClass, because we want to test the failure,
+				               but it was MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenTypeIsSupertype_ShouldFail(int value, string reason)
+		{
+			object subject = new MyBaseClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly(typeof(MyClass))
+					.Because(reason);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               be exactly type MyClass, because {{reason}},
+				               but it was MyBaseClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Fact]
+		public async Task ForType_WhenTypeMatches_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().BeExactly(typeof(MyClass));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+
+	public sealed class NotBeExactlyTests
+	{
+		[Theory]
+		[AutoData]
+		public async Task ForGeneric_WhenAwaited_ShouldReturnObjectResult(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			object? result = await That(subject).Should().NotBeExactly<OtherClass>();
+
+			await That(result).Should().BeSameAs(subject);
+		}
+
+		[Fact]
+		public async Task ForGeneric_WhenTypeDoesNotMatch_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly<OtherClass>();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForGeneric_WhenTypeIsSubtype_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly<MyBaseClass>();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForGeneric_WhenTypeMatches_ShouldFail(int value, string reason)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly<MyClass>()
+					.Because(reason);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               not be exactly type MyClass, because {{reason}},
+				               but it was MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Fact]
+		public async Task ForGeneric_WhenTypeIsSupertype_ShouldSucceed()
+		{
+			object subject = new MyBaseClass();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly<MyClass>();
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenAwaited_ShouldReturnTypedResult(int value)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			object? result = await That(subject).Should().NotBeExactly(typeof(OtherClass));
+
+			await That(result).Should().BeSameAs(subject);
+		}
+
+		[Fact]
+		public async Task ForType_WhenTypeIsSubtype_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly(typeof(MyBaseClass));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Fact]
+		public async Task ForType_WhenTypeDoesNotMatch_ShouldSucceed()
+		{
+			object subject = new MyClass();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly(typeof(OtherClass));
+
+			await That(Act).Should().NotThrow();
+		}
+
+		[Theory]
+		[AutoData]
+		public async Task ForType_WhenTypeMatches_ShouldFail(int value, string reason)
+		{
+			object subject = new MyClass
+			{
+				Value = value
+			};
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly(typeof(MyClass))
+					.Because(reason);
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage($$"""
+				               Expected subject to
+				               not be exactly type MyClass, because {{reason}},
+				               but it was MyClass {
+				                 Value = {{value}}
+				               }
+				               """);
+		}
+
+		[Fact]
+		public async Task ForType_WhenTypeIsSupertype_ShouldSucceed()
+		{
+			object subject = new MyBaseClass();
+
+			async Task Act()
+				=> await That(subject).Should().NotBeExactly(typeof(MyClass));
+
+			await That(Act).Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
*From #55*

Add `BeExactly` and `NotBeExactly` expectations for `object`:
```csharp
record MyClass(int Value);
record OtherClass(int Value);

object subject = new MyClass(1);

await Expect.That(subject).Should().BeExactly<MyClass>();
await Expect.That(subject).Should().BeExactly(typeof(MyClass));
await Expect.That(subject).Should().NotBeExactly<OtherClass>();
await Expect.That(subject).Should().NotBeExactly(typeof(OtherClass));
```
This verifies, that the types match exactly (a sub-type will fail).