### PR TITLE
refactor: speedup counting items for `ICollection`

### DIFF
--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Collection.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Collection.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using FluentAssertions;
+using FluentAssertions.Collections;
+
+namespace aweXpect.Benchmarks;
+
+public partial class HappyCaseBenchmarks
+{
+	private readonly int _enumerableCount = 1000;
+	private readonly IEnumerable<int> _enumerableSubject = Enumerable.Range(1, 1000);
+
+	[Benchmark]
+	public async Task ItemsCount_AtLeast_aweXpect()
+		=> await Expect.That(_enumerableSubject).Should().HaveAtLeast(_enumerableCount).Items();
+
+	[Benchmark]
+	public AndConstraint<GenericCollectionAssertions<int>> ItemsCount_AtLeast_FluentAssertions()
+		=> _enumerableSubject.Should().HaveCountGreaterThanOrEqualTo(_enumerableCount);
+
+	[Benchmark]
+	public async Task ItemsCount_AtLeast_TUnit()
+		=> await Assert.That(_enumerableSubject).HasCount().GreaterThanOrEqualTo(_enumerableCount);
+}

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Int.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Int.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using FluentAssertions;
+using FluentAssertions.Numeric;
+
+namespace aweXpect.Benchmarks;
+
+public partial class HappyCaseBenchmarks
+{
+	private readonly int _intSubject = 42;
+	private readonly int _intMinimum = 20;
+
+	[Benchmark]
+	public async Task<int> Int_GreaterThan_aweXpect()
+		=> await Expect.That(_intSubject).Should().BeGreaterThan(_intMinimum);
+
+	[Benchmark]
+	public AndConstraint<NumericAssertions<int>> Int_GreaterThan_FluentAssertions()
+		=> _intSubject.Should().BeGreaterThan(_intMinimum);
+
+	[Benchmark]
+	public async Task<int> Int_GreaterThan_TUnit()
+		=> await Assert.That(_intSubject).IsGreaterThan(_intMinimum);
+}

--- a/Source/aweXpect/That/Collections/ThatEnumerableShould.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerableShould.cs
@@ -96,11 +96,20 @@ public static partial class ThatEnumerableShould
 			IEvaluationContext context,
 			CancellationToken cancellationToken)
 		{
-			IEnumerable<TItem> materialized =
-				context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
 			int matchingCount = 0;
 			int notMatchingCount = 0;
 			int? totalCount = null;
+
+			if (actual is ICollection<TItem> collectionOfT)
+			{
+				matchingCount = collectionOfT.Count;
+				totalCount = matchingCount;
+				return Task.FromResult(_quantifier.GetResult(
+					actual, _it, null, matchingCount, notMatchingCount, totalCount));
+			}
+			
+			IEnumerable<TItem> materialized =
+				context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
 
 			foreach (TItem _ in materialized)
 			{
@@ -120,8 +129,9 @@ public static partial class ThatEnumerableShould
 				}
 			}
 
+			totalCount = matchingCount + notMatchingCount;
 			return Task.FromResult(_quantifier.GetResult(actual, _it, null, matchingCount, notMatchingCount,
-				matchingCount + notMatchingCount));
+				totalCount));
 		}
 	}
 }


### PR DESCRIPTION
Speedup counting items for a collection.
Add benchmarks for integer comparison and counting items.