### PR TITLE
feat: add support for collection expressions

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -56,9 +56,7 @@ To check for a proper superset, use `AndMore` instead (which would fail for equa
 
 You can verify, that all items in the collection are equal to the `expected` value
 ```csharp
-int[] values = [1, 1, 1]
-
-await Expect.That(values).Should().AllBe(1);
+await Expect.That([1, 1, 1]).Should().AllBe(1);
 ```
 
 You can also use a [custom comparer](/docs/expectations/object#custom-comparer) or configure [equivalence](/docs/expectations/object#equivalence):
@@ -72,9 +70,7 @@ await Expect.That(values).Should().AllBe(expected).Using(new MyClassComparer());
 
 For strings, you can configure this expectation to ignore case, ignore newline style, ignoring leading or trailing white-space, or use a custom `IEqualityComparer<string>`:
 ```csharp
-string[] values = ["foo", "FOO", "Foo"];
-
-await Expect.That(values).Should().AllBe("foo").IgnoringCase();
+await Expect.That(["foo", "FOO", "Foo"]).Should().AllBe("foo").IgnoringCase();
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
@@ -84,9 +80,7 @@ await Expect.That(values).Should().AllBe("foo").IgnoringCase();
 
 You can verify, that all items in a collection are unique.
 ```csharp
-IEnumerable<int> values = [1, 2, 3];
-
-await Expect.That(values).Should().AllBeUnique();
+await Expect.That([1, 2, 3]).Should().AllBeUnique();
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
@@ -96,9 +90,7 @@ await Expect.That(values).Should().AllBeUnique();
 
 You can verify, that all items in a collection satisfy a condition:
 ```csharp
-int[] values = [1, 2, 3];
-
-await Expect.That(values).Should().AllSatisfy(x => x < 4);
+await Expect.That([1, 2, 3]).Should().AllSatisfy(x => x < 4);
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
@@ -237,6 +229,7 @@ await Expect.That(values).Should().HaveAtMost(11).Items();
 You can verify, that between `minimum` and `maximum` items in the collection, satisfy an expectation:
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
+
 await Expect.That(values).Should().HaveBetween(1).And(2, x => x.Satisfy(i => i < 2));
 ```
 

--- a/Source/aweXpect.Core/Expect.cs
+++ b/Source/aweXpect.Core/Expect.cs
@@ -19,8 +19,16 @@ public static class Expect
 	/// </summary>
 	public static IExpectSubject<T> That<T>(T? subject,
 		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
-		=> new ThatSubject<T>(new ExpectationBuilder<T?>(new ValueSource<T?>(subject),
-			doNotPopulateThisValue));
+		=> new ThatSubject<T>(new ExpectationBuilder<T?>(
+			new ValueSource<T?>(subject), doNotPopulateThisValue));
+
+	/// <summary>
+	///     Specify expectations for the current <paramref name="subject" />.
+	/// </summary>
+	public static IExpectSubject<T[]> That<T>(T[] subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new ThatSubject<T[]>(new ExpectationBuilder<T[]>(
+			new ValueSource<T[]>(subject), doNotPopulateThisValue));
 
 	/// <summary>
 	///     Specify expectations for the current <see cref="Action" /> <paramref name="delegate" />.
@@ -53,8 +61,7 @@ public static class Expect
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{CancellationToken, Task}" /> <paramref name="delegate" />.
 	/// </summary>
-	public static IExpectSubject<ThatDelegate.WithoutValue> That(
-		Func<CancellationToken, Task> @delegate,
+	public static IExpectSubject<ThatDelegate.WithoutValue> That(Func<CancellationToken, Task> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithoutValue>(
 			new ExpectationBuilder<DelegateValue>(
@@ -83,8 +90,7 @@ public static class Expect
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{TValue}" /> <paramref name="delegate" />.
 	/// </summary>
-	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(
-		Func<TValue> @delegate,
+	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(Func<TValue> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithValue<TValue>>(
 			new ExpectationBuilder<DelegateValue<TValue>>(
@@ -93,8 +99,7 @@ public static class Expect
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{CancellationToken, TValue}" /> <paramref name="delegate" />.
 	/// </summary>
-	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(
-		Func<CancellationToken, TValue> @delegate,
+	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(Func<CancellationToken, TValue> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithValue<TValue>>(
 			new ExpectationBuilder<DelegateValue<TValue>>(
@@ -104,13 +109,11 @@ public static class Expect
 	///     Specify expectations for the current <see cref="Func{T}" /> of <see cref="Task{TValue}" />
 	///     <paramref name="delegate" />.
 	/// </summary>
-	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(
-		Func<Task<TValue>> @delegate,
+	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(Func<Task<TValue>> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithValue<TValue>>(
 			new ExpectationBuilder<DelegateValue<TValue>>(
-				new DelegateAsyncValueSource<TValue>(_ => @delegate()),
-				doNotPopulateThisValue));
+				new DelegateAsyncValueSource<TValue>(_ => @delegate()), doNotPopulateThisValue));
 
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{CancellationToken, T}" /> of <see cref="Task{TValue}" />
@@ -121,14 +124,12 @@ public static class Expect
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithValue<TValue>>(
 			new ExpectationBuilder<DelegateValue<TValue>>(
-				new DelegateAsyncValueSource<TValue>(@delegate),
-				doNotPopulateThisValue));
+				new DelegateAsyncValueSource<TValue>(@delegate), doNotPopulateThisValue));
 
 	/// <summary>
 	///     Specify expectations for the current <see cref="Task{TValue}" /> <paramref name="delegate" />.
 	/// </summary>
-	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(
-		Task<TValue> @delegate,
+	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(Task<TValue> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithValue<TValue>>(
 			new ExpectationBuilder<DelegateValue<TValue>>(
@@ -138,14 +139,11 @@ public static class Expect
 	/// <summary>
 	///     Specify expectations for the current <see cref="ValueTask{TValue}" /> <paramref name="delegate" />.
 	/// </summary>
-	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(
-		ValueTask<TValue> @delegate,
+	public static IExpectSubject<ThatDelegate.WithValue<TValue>> That<TValue>(ValueTask<TValue> @delegate,
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new ThatSubject<ThatDelegate.WithValue<TValue>>(
 			new ExpectationBuilder<DelegateValue<TValue>>(
-				new DelegateAsyncValueSource<TValue>(
-					async _ => await @delegate),
-				doNotPopulateThisValue));
+				new DelegateAsyncValueSource<TValue>(async _ => await @delegate), doNotPopulateThisValue));
 #endif
 
 	/// <summary>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -227,6 +227,7 @@ namespace aweXpect
         public static aweXpect.Core.IExpectSubject<aweXpect.Core.ThatDelegate.WithValue<TValue>> That<TValue>(System.Func<System.Threading.CancellationToken, TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IExpectSubject<aweXpect.Core.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.Task<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IExpectSubject<aweXpect.Core.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.ValueTask<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Core.IExpectSubject<T[]> That<T>(T[] subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IExpectSubject<T> That<T>(T? subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.Expectation.Combination.All ThatAll(params aweXpect.Results.Expectation[] expectations) { }
         public static aweXpect.Results.Expectation.Combination.Any ThatAny(params aweXpect.Results.Expectation[] expectations) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -225,6 +225,7 @@ namespace aweXpect
         public static aweXpect.Core.IExpectSubject<aweXpect.Core.ThatDelegate.WithValue<TValue>> That<TValue>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TValue>> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IExpectSubject<aweXpect.Core.ThatDelegate.WithValue<TValue>> That<TValue>(System.Func<System.Threading.CancellationToken, TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IExpectSubject<aweXpect.Core.ThatDelegate.WithValue<TValue>> That<TValue>(System.Threading.Tasks.Task<TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Core.IExpectSubject<T[]> That<T>(T[] subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IExpectSubject<T> That<T>(T? subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.Expectation.Combination.All ThatAll(params aweXpect.Results.Expectation[] expectations) { }
         public static aweXpect.Results.Expectation.Combination.Any ThatAny(params aweXpect.Results.Expectation[] expectations) { }

--- a/Tests/aweXpect.Core.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Core.Tests/ExpectTests.cs
@@ -1,0 +1,13 @@
+﻿namespace aweXpect.Core.Tests;
+
+public class ExpectTests
+{
+	[Fact]
+	public async Task ShouldSupportCollectionExpressionsAsSubject()
+	{
+		async Task Act()
+			=> await That([1, 2, 3]).Should().BeInAscendingOrder();
+
+		await That(Act).Should().NotThrow();
+	}
+}


### PR DESCRIPTION
Support providing collection expressions as subject, e.g.
```csharp
await Expect.That([1, 2, 3]).Should().BeInAscendingOrder();
```