### PR TITLE
feat: support async event trigger callbacks

### DIFF
--- a/Docs/pages/docs/expectations/events.md
+++ b/Docs/pages/docs/expectations/events.md
@@ -25,10 +25,23 @@ MyClass sut = new MyClass();
 
 await Expect.That(sut)
   .Triggers(nameof(MyClass.ThresholdReached))
-  .While(t => t.OnThresholdReached(new ThresholdReachedEventArgs()));
+  .While(subject => subject.OnThresholdReached(new ThresholdReachedEventArgs()));
 ```
 
 This will register a recording of all events named "ThresholdReached" that are triggered during the execution of the callback.
+
+The callback in `While()` can also be asynchronous. In this case, you can also get the cancellation token as second parameter:
+```csharp
+await Expect.That(sut)
+  .Triggers(nameof(MyClass.ThresholdReached))
+  .While(subject => subject.OnThresholdReachedAsync(new ThresholdReachedEventArgs()))
+  .Because("we support asynchronous callbacks");
+
+await Expect.That(sut)
+  .Triggers(nameof(MyClass.ThresholdReached))
+  .While((subject, token) => subject.OnThresholdReachedAsync(new ThresholdReachedEventArgs(), token))
+  .Because("we also support cancellation");
+```
 
 
 ## Filtering
@@ -38,10 +51,10 @@ You can filter triggered events based on their parameters.
 await Expect.That(sut)
   .Triggers(nameof(MyClass.ThresholdReached))
   .WithParameter<ThresholdReachedEventArgs>(e => e.Threshold > 10)
-  .While(t =>
+  .While(subject =>
   {
-    t.OnThresholdReached(new ThresholdReachedEventArgs(5));
-    t.OnThresholdReached(new ThresholdReachedEventArgs(15));
+    subject.OnThresholdReached(new ThresholdReachedEventArgs(5));
+    subject.OnThresholdReached(new ThresholdReachedEventArgs(15));
   });
 ```
 
@@ -51,10 +64,10 @@ You can verify, that an event was triggered a specific number of times
 ```csharp
 await Expect.That(sut)
   .Triggers(nameof(MyClass.ThresholdReached))
-  .While(t =>
+  .While(subject =>
   {
-    t.OnThresholdReached(new ThresholdReachedEventArgs(5));
-    t.OnThresholdReached(new ThresholdReachedEventArgs(15));
+    subject.OnThresholdReached(new ThresholdReachedEventArgs(5));
+    subject.OnThresholdReached(new ThresholdReachedEventArgs(15));
   })
   .Between(1).And(2.Times());
 ```
@@ -75,6 +88,6 @@ MyClass sut = // ...implements INotifyPropertyChanged
 await Expect.That(sut)
   .TriggersPropertyChanged()
   .WithPropertyChangedEventArgs(e => e.PropertyName == "MyProperty")
-  .While(t => t.Execute())
+  .While(subject => subject.Execute())
   .AtLeast(2.Times());
 ```

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -689,5 +689,7 @@ namespace aweXpect.Results
         public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
         protected virtual aweXpect.Options.TriggerEventFilter? GetFilter() { }
         public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
+        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -679,5 +679,7 @@ namespace aweXpect.Results
         public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
         protected virtual aweXpect.Options.TriggerEventFilter? GetFilter() { }
         public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
+        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
     }
 }


### PR DESCRIPTION
From #133
> async while callback (with optional cancellationtoken parameter)

The callback in `While()` can now also be asynchronous. In this case, you can also get the cancellation token as second parameter:
```csharp
await Expect.That(sut)
  .Triggers(nameof(MyClass.ThresholdReached))
  .While(subject => subject.OnThresholdReachedAsync(new ThresholdReachedEventArgs()))
  .Because("we support asynchronous callbacks");

await Expect.That(sut)
  .Triggers(nameof(MyClass.ThresholdReached))
  .While((subject, token) => subject.OnThresholdReachedAsync(new ThresholdReachedEventArgs(), token))
  .Because("we also support cancellation");
```