### PR TITLE
feat: support multiple trigger expectations

### DIFF
--- a/Docs/pages/docs/expectations/events.md
+++ b/Docs/pages/docs/expectations/events.md
@@ -64,12 +64,12 @@ You can verify, that an event was triggered a specific number of times
 ```csharp
 await Expect.That(sut)
   .Triggers(nameof(MyClass.ThresholdReached))
+  .Between(1).And(2.Times()
   .While(subject =>
   {
     subject.OnThresholdReached(new ThresholdReachedEventArgs(5));
     subject.OnThresholdReached(new ThresholdReachedEventArgs(15));
-  })
-  .Between(1).And(2.Times());
+  }));
 ```
 You can use the same occurrence constraints as in the [contain](/docs/expectations/collections#contain) method:
 - `AtLeast(2.Times())`
@@ -88,6 +88,6 @@ MyClass sut = // ...implements INotifyPropertyChanged
 await Expect.That(sut)
   .TriggersPropertyChanged()
   .WithPropertyChangedEventArgs(e => e.PropertyName == "MyProperty")
-  .While(subject => subject.Execute())
-  .AtLeast(2.Times());
+  .AtLeast(2.Times())
+  .While(subject => subject.Execute());
 ```

--- a/Source/aweXpect.Core/Core/Events/EventConstraint.cs
+++ b/Source/aweXpect.Core/Core/Events/EventConstraint.cs
@@ -1,0 +1,10 @@
+using aweXpect.Options;
+
+namespace aweXpect.Core.Events;
+
+internal class EventConstraint(int index, TriggerEventFilter? filter, Quantifier quantifier)
+{
+	public int Index { get; } = index;
+	public TriggerEventFilter? Filter { get; } = filter;
+	public Quantifier Quantifier { get; } = quantifier;
+}

--- a/Source/aweXpect.Core/Core/Events/EventConstraints.cs
+++ b/Source/aweXpect.Core/Core/Events/EventConstraints.cs
@@ -193,12 +193,7 @@ internal class EventConstraints
 		if (hasMultipleGroups)
 		{
 			stringBuilder.Append("  [").Append(item.Index).Append(']');
-			stringBuilder.Append(eventCount switch
-			{
-				0 => " never recorded",
-				1 => " recorded once",
-				_ => $" recorded {eventCount} times"
-			});
+			stringBuilder.Append(GetRecordingDisplayString(eventCount));
 			stringBuilder.AppendLine(" and");
 		}
 		else
@@ -208,12 +203,14 @@ internal class EventConstraints
 				stringBuilder.Append("  [").Append(item.Index).Append(']');
 			}
 
-			stringBuilder.Append(eventCount switch
-			{
-				0 => " never recorded",
-				1 => " recorded once",
-				_ => $" recorded {eventCount} times"
-			});
+			stringBuilder.Append(GetRecordingDisplayString(eventCount));
 		}
 	}
+
+	private static string GetRecordingDisplayString(int eventCount) => eventCount switch
+	{
+		0 => " never recorded",
+		1 => " recorded once",
+		_ => $" recorded {eventCount} times"
+	};
 }

--- a/Source/aweXpect.Core/Core/Events/EventConstraints.cs
+++ b/Source/aweXpect.Core/Core/Events/EventConstraints.cs
@@ -176,8 +176,8 @@ internal class EventConstraints
 					stringBuilder.Append(eventCount switch
 					{
 						0 => " never recorded",
-						1 => " only recorded once",
-						_ => $" only recorded {eventCount} times"
+						1 => " recorded once",
+						_ => $" recorded {eventCount} times"
 					});
 					stringBuilder.AppendLine(" and");
 				}
@@ -191,8 +191,8 @@ internal class EventConstraints
 					stringBuilder.Append(eventCount switch
 					{
 						0 => " never recorded",
-						1 => " only recorded once",
-						_ => $" only recorded {eventCount} times"
+						1 => " recorded once",
+						_ => $" recorded {eventCount} times"
 					});
 				}
 			}

--- a/Source/aweXpect.Core/Core/Events/EventConstraints.cs
+++ b/Source/aweXpect.Core/Core/Events/EventConstraints.cs
@@ -12,26 +12,38 @@ internal class EventConstraints
 
 	private int _constraintCount;
 
-	public void Add(string name, TriggerEventFilter? filter, Quantifier quantifier)
+	/// <summary>
+	///     Add a new event constraint.
+	/// </summary>
+	public void Add(string eventName, TriggerEventFilter? filter, Quantifier quantifier)
 	{
 		int index = ++_constraintCount;
-		if (!_constraints.TryGetValue(name, out List<EventConstraint>? constraint))
+		if (!_constraints.TryGetValue(eventName, out List<EventConstraint>? constraint))
 		{
 			constraint = new List<EventConstraint>();
-			_constraints.Add(name, constraint);
+			_constraints.Add(eventName, constraint);
 		}
 
 		constraint!.Add(new EventConstraint(index, filter, quantifier));
 	}
 
+	/// <summary>
+	///     Start recording all registered events.
+	/// </summary>
+	/// <remarks>
+	///     To stop the recording, dispose of the returned <see cref="EventRecording{T}" />.
+	/// </remarks>
 	public EventRecording<T> StartRecordingEvents<T>(T actual)
 		=> new(actual, _constraints.Keys);
 
+	/// <summary>
+	///     Returns the expectation string.
+	/// </summary>
 	public override string ToString()
 	{
 		StringBuilder? sb = new();
-		bool hasMultipleGroups = _constraints.Count > 1;
 		bool hasMultipleConstraints = _constraintCount > 1;
+		bool hasMultipleGroups = _constraints.Count > 1;
 		foreach (KeyValuePair<string, List<EventConstraint>> group in _constraints)
 		{
 			if (hasMultipleGroups)
@@ -43,41 +55,12 @@ internal class EventConstraints
 			if (hasMultipleGroupConstraints)
 			{
 				sb.Append("trigger event ").Append(group.Key);
-				foreach (EventConstraint? item in group.Value)
-				{
-					sb.AppendLine();
-					if (hasMultipleGroups)
-					{
-						sb.Append("  ");
-					}
-
-					sb.Append("  [").Append(item.Index).Append("]");
-					if (item.Filter != null)
-					{
-						sb.Append(item.Filter);
-					}
-
-					sb.Append(' ').Append(item.Quantifier);
-					sb.Append(" and");
-				}
-
-				sb.Length -= 4;
+				AppendExpectationForGroupWithMultipleValues(sb, group.Value, hasMultipleGroups);
 			}
 			else
 			{
-				EventConstraint? item = group.Value.First();
-				if (hasMultipleConstraints)
-				{
-					sb.Append("[" + item.Index + "] ");
-				}
-
-				sb.Append("trigger event ").Append(group.Key);
-				if (item.Filter != null)
-				{
-					sb.Append(item.Filter);
-				}
-
-				sb.Append(' ').Append(item.Quantifier);
+				EventConstraint item = group.Value.First();
+				AppendExpectationForGroupWithSingleValue(sb, group.Key, item, hasMultipleConstraints);
 			}
 
 			sb.Append(" and");
@@ -89,71 +72,138 @@ internal class EventConstraints
 		return sb.ToString();
 	}
 
+	private static void AppendExpectationForGroupWithMultipleValues(
+		StringBuilder sb,
+		List<EventConstraint> groupConstraints,
+		bool hasMultipleGroups)
+	{
+		foreach (EventConstraint? item in groupConstraints)
+		{
+			sb.AppendLine();
+			if (hasMultipleGroups)
+			{
+				sb.Append("  ");
+			}
 
-	public bool HasErrors<T>(EventRecording<T> recording, StringBuilder sb)
+			sb.Append("  [").Append(item.Index).Append("]");
+			if (item.Filter != null)
+			{
+				sb.Append(item.Filter);
+			}
+
+			sb.Append(' ').Append(item.Quantifier);
+			sb.Append(" and");
+		}
+
+		sb.Length -= 4;
+	}
+
+	private static void AppendExpectationForGroupWithSingleValue(
+		StringBuilder sb,
+		string eventName,
+		EventConstraint item,
+		bool hasMultipleConstraints)
+	{
+		if (hasMultipleConstraints)
+		{
+			sb.Append("[" + item.Index + "] ");
+		}
+
+		sb.Append("trigger event ").Append(eventName);
+		if (item.Filter != null)
+		{
+			sb.Append(item.Filter);
+		}
+
+		sb.Append(' ').Append(item.Quantifier);
+	}
+
+	/// <summary>
+	///     Checks if any expectation is not satisfied by the recorded events in the <paramref name="recording" />.
+	/// </summary>
+	/// <remarks>
+	///     Appends all errors to the provided <paramref name="stringBuilder" />.
+	/// </remarks>
+	public bool HasErrors<T>(EventRecording<T> recording, StringBuilder stringBuilder)
 	{
 		bool hasErrors = false;
-
 		bool hasMultipleConstraints = _constraintCount > 1;
 		if (hasMultipleConstraints)
 		{
-			sb.AppendLine();
+			stringBuilder.AppendLine();
 		}
 
 		foreach (KeyValuePair<string, List<EventConstraint>> constraint in _constraints)
 		{
-			string? name = constraint.Key;
-			bool hasGroupError = false;
-			foreach (EventConstraint? item in constraint.Value)
-			{
-				int eventCount = recording.GetEventCount(name, item.Filter);
+			string eventName = constraint.Key;
+			List<EventConstraint> constraints = constraint.Value;
 
-				if (item.Quantifier.Check(eventCount, true) != true)
-				{
-					hasErrors = true;
-					hasGroupError = true;
-					if (constraint.Value.Count > 1)
-					{
-						sb.Append("  [").Append(item.Index).Append(']');
-						sb.Append(eventCount switch
-						{
-							0 => " never recorded",
-							1 => " only recorded once",
-							_ => $" only recorded {eventCount} times"
-						});
-						sb.AppendLine(" and");
-					}
-					else
-					{
-						if (hasMultipleConstraints)
-						{
-							sb.Append("  [").Append(item.Index).Append(']');
-						}
-
-						sb.Append(eventCount switch
-						{
-							0 => " never recorded",
-							1 => " only recorded once",
-							_ => $" only recorded {eventCount} times"
-						});
-					}
-				}
-			}
-
-			if (constraint.Value.Count > 1)
-			{
-				sb.Length -= 4;
-				sb.Length -= Environment.NewLine.Length;
-			}
+			bool hasGroupError =
+				HasGroupError(recording, stringBuilder, eventName, constraints, hasMultipleConstraints);
 
 			if (hasGroupError)
 			{
-				sb.Append(" in ");
-				sb.Append(recording.ToString(name, hasMultipleConstraints ? "      " : ""));
-				sb.AppendLine(" and");
+				hasErrors = true;
+				stringBuilder.Append(" in ");
+				stringBuilder.Append(recording.ToString(eventName, hasMultipleConstraints ? "      " : ""));
+				stringBuilder.AppendLine(" and");
 			}
 		}
 
+		stringBuilder.Length -= 4;
+		stringBuilder.Length -= Environment.NewLine.Length;
 		return hasErrors;
+	}
+
+	private static bool HasGroupError<T>(
+		EventRecording<T> recording,
+		StringBuilder stringBuilder,
+		string eventName,
+		List<EventConstraint> constraints,
+		bool hasMultipleConstraints)
+	{
+		bool hasGroupError = false;
+		foreach (EventConstraint? item in constraints)
+		{
+			int eventCount = recording.GetEventCount(eventName, item.Filter);
+
+			if (item.Quantifier.Check(eventCount, true) != true)
+			{
+				hasGroupError = true;
+				if (constraints.Count > 1)
+				{
+					stringBuilder.Append("  [").Append(item.Index).Append(']');
+					stringBuilder.Append(eventCount switch
+					{
+						0 => " never recorded",
+						1 => " only recorded once",
+						_ => $" only recorded {eventCount} times"
+					});
+					stringBuilder.AppendLine(" and");
+				}
+				else
+				{
+					if (hasMultipleConstraints)
+					{
+						stringBuilder.Append("  [").Append(item.Index).Append(']');
+					}
+
+					stringBuilder.Append(eventCount switch
+					{
+						0 => " never recorded",
+						1 => " only recorded once",
+						_ => $" only recorded {eventCount} times"
+					});
+				}
+			}
+		}
+
+		if (constraints.Count > 1)
+		{
+			stringBuilder.Length -= 4;
+			stringBuilder.Length -= Environment.NewLine.Length;
+		}
+
+		return hasGroupError;
 	}
 }

--- a/Source/aweXpect.Core/Core/Events/EventConstraints.cs
+++ b/Source/aweXpect.Core/Core/Events/EventConstraints.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Options;
+
+namespace aweXpect.Core.Events;
+
+internal class EventConstraints
+{
+	private int _index;
+	public int TotalCount => _index;
+	internal Dictionary<string, List<EventConstraint>> Constraints { get; } = new();
+
+	public void Add(string name, TriggerEventFilter? filter, Quantifier quantifier)
+	{
+		int index = ++_index;
+		if (!Constraints.TryGetValue(name, out List<EventConstraint>? constraint))
+		{
+			constraint = new List<EventConstraint>();
+			Constraints.Add(name, constraint);
+		}
+
+		constraint!.Add(new EventConstraint(index, filter, quantifier));
+	}
+
+	public EventRecording<T> StartRecordingEvents<T>(T actual) => new(this, actual);
+
+	public override string ToString()
+	{
+		StringBuilder? sb = new();
+		bool hasMultipleGroups = Constraints.Count > 1;
+		bool hasMultipleConstraints = _index > 1;
+		foreach (KeyValuePair<string, List<EventConstraint>> group in Constraints)
+		{
+			if (hasMultipleGroups)
+			{
+				sb.Append("  ");
+			}
+
+			bool hasMultipleGroupConstraints = group.Value.Count > 1;
+			if (hasMultipleGroupConstraints)
+			{
+				sb.Append("trigger event ").Append(group.Key);
+				foreach (EventConstraint? item in group.Value)
+				{
+					sb.AppendLine();
+					if (hasMultipleGroups)
+					{
+						sb.Append("  ");
+					}
+
+					sb.Append("  [").Append(item.Index).Append("]");
+					if (item.Filter != null)
+					{
+						sb.Append(item.Filter);
+					}
+
+					sb.Append(' ').Append(item.Quantifier);
+					sb.Append(" and");
+				}
+
+				sb.Length -= 4;
+			}
+			else
+			{
+				EventConstraint? item = group.Value.First();
+				if (hasMultipleConstraints)
+				{
+					sb.Append("[" + item.Index + "] ");
+				}
+
+				sb.Append("trigger event ").Append(group.Key);
+				if (item.Filter != null)
+				{
+					sb.Append(item.Filter);
+				}
+
+				sb.Append(' ').Append(item.Quantifier);
+			}
+
+			sb.Append(" and");
+			sb.AppendLine();
+		}
+
+		sb.Length -= 4;
+		sb.Length -= Environment.NewLine.Length;
+		return sb.ToString();
+	}
+
+	internal class EventConstraint(int index, TriggerEventFilter? filter, Quantifier quantifier)
+	{
+		public int Index { get; } = index;
+		public TriggerEventFilter? Filter { get; } = filter;
+		public Quantifier Quantifier { get; } = quantifier;
+	}
+}

--- a/Source/aweXpect.Core/Core/Events/EventRecorder.cs
+++ b/Source/aweXpect.Core/Core/Events/EventRecorder.cs
@@ -46,10 +46,7 @@ internal sealed class EventRecorder(string eventName) : IDisposable
 
 		_onDispose = () =>
 		{
-			if (subject.Target is not null)
-			{
-				eventInfo.RemoveEventHandler(subject.Target, handler);
-			}
+			eventInfo.RemoveEventHandler(subject.Target, handler);
 		};
 	}
 
@@ -72,14 +69,7 @@ internal sealed class EventRecorder(string eventName) : IDisposable
 	///     Returns a formatted string for all recorded events.
 	/// </summary>
 	public string ToString(string indent)
-	{
-		if (string.IsNullOrEmpty(indent))
-		{
-			return Formatter.Format(_eventQueue, FormattingOptions.MultipleLines);
-		}
-
-		return Formatter.Format(_eventQueue, FormattingOptions.MultipleLines).Indent(indent, false);
-	}
+		=> Formatter.Format(_eventQueue, FormattingOptions.MultipleLines).Indent(indent, false);
 
 	/// <summary>
 	///     Gets the number of recorded events that match the <paramref name="filter" />.

--- a/Source/aweXpect.Core/Core/Events/EventRecorder.cs
+++ b/Source/aweXpect.Core/Core/Events/EventRecorder.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core.Helpers;
+using aweXpect.Options;
+
+namespace aweXpect.Core.Events;
+
+internal sealed class EventRecorder(string eventName) : IDisposable
+{
+	private readonly ConcurrentQueue<RecordedEvent> _eventQueue = new();
+	private Action? _onDispose;
+
+	public void Dispose() => _onDispose?.Invoke();
+
+	public void Attach(WeakReference subject, EventInfo eventInfo)
+	{
+		MethodInfo handlerType = eventInfo.EventHandlerType!.GetMethod("Invoke")!;
+		Delegate? handler = null;
+		foreach (MethodInfo method in typeof(EventRecorder).GetMethods().Where(x => x.Name == nameof(RecordEvent)))
+		{
+			if (method.GetParameters().Length == handlerType.GetParameters().Length)
+			{
+				MethodInfo handlerMethod = method;
+				if (handlerType.GetParameters().Length > 0)
+				{
+					handlerMethod = method
+						.MakeGenericMethod(handlerType.GetParameters()
+							.Select(x => x.ParameterType)
+							.ToArray());
+				}
+
+				handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, handlerMethod);
+			}
+		}
+
+		if (handler == null)
+		{
+			throw new NotSupportedException(
+				$"The event {eventName} contains too many parameters ({handlerType.GetParameters().Length}): {Formatter.Format(handlerType.GetParameters().Select(x => x.ParameterType))}");
+		}
+
+		eventInfo.AddEventHandler(subject.Target, handler);
+
+		_onDispose = () =>
+		{
+			if (subject.Target is not null)
+			{
+				eventInfo.RemoveEventHandler(subject.Target, handler);
+			}
+		};
+	}
+
+	public void RecordEvent()
+		=> _eventQueue.Enqueue(new RecordedEvent(eventName));
+
+	public void RecordEvent<T1>(T1 parameter1)
+		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1));
+
+	public void RecordEvent<T1, T2>(T1 parameter1, T2 parameter2)
+		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2));
+
+	public void RecordEvent<T1, T2, T3>(T1 parameter1, T2 parameter2, T3 parameter3)
+		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2, parameter3));
+
+	public void RecordEvent<T1, T2, T3, T4>(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
+		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2, parameter3, parameter4));
+
+	/// <summary>
+	///     Returns a formatted string for all recorded events.
+	/// </summary>
+	public string ToString(string indent)
+	{
+		if (string.IsNullOrEmpty(indent))
+		{
+			return Formatter.Format(_eventQueue, FormattingOptions.MultipleLines);
+		}
+
+		return Formatter.Format(_eventQueue, FormattingOptions.MultipleLines).Indent(indent, false);
+	}
+
+	/// <summary>
+	///     Gets the number of recorded events that match the <paramref name="filter" />.
+	/// </summary>
+	public int GetEventCount(TriggerEventFilter? filter)
+	{
+		if (filter != null)
+		{
+			return _eventQueue.Count(x => filter.IsMatch(eventName, x.Parameters));
+		}
+
+		return _eventQueue.Count;
+	}
+
+	private readonly struct RecordedEvent(string name, params object?[] parameters)
+	{
+		public string Name { get; } = name;
+		public object?[] Parameters { get; } = parameters;
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			StringBuilder sb = new();
+			sb.Append(Name).Append('(');
+			if (Parameters.Length > 0)
+			{
+				foreach (object? parameter in Parameters)
+				{
+					Formatter.Format(sb, parameter);
+					sb.Append(", ");
+				}
+
+				sb.Length -= 2;
+			}
+
+			sb.Append(')');
+			return sb.ToString();
+		}
+	}
+}

--- a/Source/aweXpect.Core/Core/Events/EventRecording.cs
+++ b/Source/aweXpect.Core/Core/Events/EventRecording.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using aweXpect.Core.Helpers;
 using aweXpect.Options;
 
 namespace aweXpect.Core.Events;
@@ -13,7 +10,11 @@ internal class EventRecording<T> : IDisposable
 {
 	private readonly Dictionary<string, EventRecorder> _recorders = new();
 
-	public EventRecording(T actual, IEnumerable<string> eventNames)
+	/// <summary>
+	///     Creates a new recording the given <paramref name="eventNames" /> that are triggered on the
+	///     <paramref name="subject" />.
+	/// </summary>
+	public EventRecording(T subject, IEnumerable<string> eventNames)
 	{
 		EventInfo[] events = typeof(T).GetEvents();
 		foreach (string? eventName in eventNames)
@@ -23,13 +24,14 @@ internal class EventRecording<T> : IDisposable
 			EventInfo? @event = events.FirstOrDefault(x => x.Name == eventName);
 			if (@event == null)
 			{
-				throw new NotSupportedException($"Event {eventName} is not supported on {Formatter.Format(actual)}");
+				throw new NotSupportedException($"Event {eventName} is not supported on {Formatter.Format(subject)}");
 			}
 
-			recorder.Attach(new WeakReference(actual), @event);
+			recorder.Attach(new WeakReference(subject), @event);
 		}
 	}
 
+	/// <inheritdoc />
 	public void Dispose()
 	{
 		foreach (EventRecorder recorder in _recorders.Values)
@@ -38,111 +40,15 @@ internal class EventRecording<T> : IDisposable
 		}
 	}
 
-	public int GetEventCount(string name, TriggerEventFilter? filter)
-	{
-		if (filter != null)
-		{
-			return _recorders[name].EventQueue.Count(x => filter.IsMatch(name, x.Parameters));
-		}
+	/// <summary>
+	///     Gets the number of recorded events for <paramref name="eventName" /> that match the <paramref name="filter" />.
+	/// </summary>
+	public int GetEventCount(string eventName, TriggerEventFilter? filter)
+		=> _recorders[eventName].GetEventCount(filter);
 
-		return _recorders[name].EventQueue.Count;
-	}
-
-	public string ToString(string name, string indent)
-	{
-		ConcurrentQueue<OccurredEvent>? eventQueue = _recorders[name].EventQueue;
-		if (string.IsNullOrEmpty(indent))
-		{
-			return Formatter.Format(eventQueue, FormattingOptions.MultipleLines);
-		}
-
-		return Formatter.Format(eventQueue, FormattingOptions.MultipleLines).Indent(indent, false);
-	}
-
-	private sealed class EventRecorder(string name) : IDisposable
-	{
-		private Action? _onDispose;
-		public ConcurrentQueue<OccurredEvent> EventQueue { get; } = new();
-
-		public void Dispose() => _onDispose?.Invoke();
-
-		public void Attach(WeakReference subject, EventInfo eventInfo)
-		{
-			MethodInfo handlerType = eventInfo.EventHandlerType!.GetMethod("Invoke")!;
-			Delegate? handler = null;
-			foreach (MethodInfo method in typeof(EventRecorder).GetMethods().Where(x => x.Name == nameof(RecordEvent)))
-			{
-				if (method.GetParameters().Length == handlerType.GetParameters().Length)
-				{
-					MethodInfo handlerMethod = method;
-					if (handlerType.GetParameters().Length > 0)
-					{
-						handlerMethod = method
-							.MakeGenericMethod(handlerType.GetParameters()
-								.Select(x => x.ParameterType)
-								.ToArray());
-					}
-
-					handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, handlerMethod);
-				}
-			}
-
-			if (handler == null)
-			{
-				throw new NotSupportedException(
-					$"The event {name} contains too many parameters ({handlerType.GetParameters().Length}): {Formatter.Format(handlerType.GetParameters().Select(x => x.ParameterType))}");
-			}
-
-			eventInfo.AddEventHandler(subject.Target, handler);
-
-			_onDispose = () =>
-			{
-				if (subject.Target is not null)
-				{
-					eventInfo.RemoveEventHandler(subject.Target, handler);
-				}
-			};
-		}
-
-		public void RecordEvent()
-			=> EventQueue.Enqueue(new OccurredEvent(name));
-
-		public void RecordEvent<T1>(T1 parameter1)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1));
-
-		public void RecordEvent<T1, T2>(T1 parameter1, T2 parameter2)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2));
-
-		public void RecordEvent<T1, T2, T3>(T1 parameter1, T2 parameter2, T3 parameter3)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2, parameter3));
-
-		public void RecordEvent<T1, T2, T3, T4>(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2, parameter3, parameter4));
-	}
-
-	private readonly struct OccurredEvent(string name, params object?[] parameters)
-	{
-		public string Name { get; } = name;
-		public object?[] Parameters { get; } = parameters;
-
-		/// <inheritdoc />
-		public override string ToString()
-		{
-			StringBuilder sb = new();
-			sb.Append(Name).Append('(');
-			if (Parameters.Length > 0)
-			{
-				foreach (object? parameter in Parameters)
-				{
-					Formatter.Format(sb, parameter);
-					sb.Append(", ");
-				}
-
-				sb.Length -= 2;
-			}
-
-			sb.Append(')');
-			return sb.ToString();
-		}
-	}
+	/// <summary>
+	///     Returns a formatted string for the recorded events for <paramref name="eventName" />.
+	/// </summary>
+	public string ToString(string eventName, string indent)
+		=> _recorders[eventName].ToString(indent);
 }

--- a/Source/aweXpect.Core/Core/Events/EventRecording.cs
+++ b/Source/aweXpect.Core/Core/Events/EventRecording.cs
@@ -6,7 +6,7 @@ using aweXpect.Options;
 
 namespace aweXpect.Core.Events;
 
-internal class EventRecording<T> : IDisposable
+internal sealed class EventRecording<T> : IDisposable
 {
 	private readonly Dictionary<string, EventRecorder> _recorders = new();
 
@@ -19,7 +19,7 @@ internal class EventRecording<T> : IDisposable
 		EventInfo[] events = typeof(T).GetEvents();
 		foreach (string? eventName in eventNames)
 		{
-			EventRecorder? recorder = new(eventName);
+			EventRecorder recorder = new(eventName);
 			_recorders.Add(eventName, recorder);
 			EventInfo? @event = events.FirstOrDefault(x => x.Name == eventName);
 			if (@event == null)

--- a/Source/aweXpect.Core/Core/Events/EventRecording.cs
+++ b/Source/aweXpect.Core/Core/Events/EventRecording.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core.Helpers;
+using aweXpect.Options;
+
+namespace aweXpect.Core.Events;
+
+internal class EventRecording<T> : IDisposable
+{
+	private readonly EventConstraints _constraints;
+	private readonly Dictionary<string, EventRecorder> _recorders = new();
+
+	public EventRecording(EventConstraints constraints, T actual)
+	{
+		_constraints = constraints;
+		EventInfo[] events = typeof(T).GetEvents();
+		foreach (string? eventName in constraints.Constraints.Keys)
+		{
+			EventRecorder? recorder = new(eventName);
+			_recorders.Add(eventName, recorder);
+			EventInfo? @event = events.FirstOrDefault(x => x.Name == eventName);
+			if (@event == null)
+			{
+				throw new NotSupportedException($"Event {eventName} is not supported on {Formatter.Format(actual)}");
+			}
+
+			recorder.Attach(new WeakReference(actual), @event);
+		}
+	}
+
+	public void Dispose()
+	{
+		foreach (EventRecorder recorder in _recorders.Values)
+		{
+			recorder.Dispose();
+		}
+	}
+
+	public bool HasErrors(StringBuilder sb)
+	{
+		bool hasErrors = false;
+
+		bool hasMultipleConstraints = _constraints.TotalCount > 1;
+		if (hasMultipleConstraints)
+		{
+			sb.AppendLine();
+		}
+
+		foreach (var constraint in _constraints.Constraints)
+		{
+			string? name = constraint.Key;
+			ConcurrentQueue<OccurredEvent>? eventQueue = null;
+			bool hasGroupError = false;
+			foreach (var item in constraint.Value)
+			{
+				eventQueue = _recorders[name].EventQueue;
+				int eventCount = eventQueue.Count;
+				TriggerEventFilter? filter = item.Filter;
+				if (filter != null)
+				{
+					eventCount = eventQueue.Count(x => filter.IsMatch(name, x.Parameters));
+				}
+
+				if (item.Quantifier.Check(eventCount, true) != true)
+				{
+					hasErrors = true;
+					hasGroupError = true;
+					if (constraint.Value.Count > 1)
+					{
+						sb.Append("  [").Append(item.Index).Append(']');
+						sb.Append(eventCount switch
+						{
+							0 => " never recorded",
+							1 => " only recorded once",
+							_ => $" only recorded {eventCount} times"
+						});
+						sb.AppendLine(" and");
+					}
+					else
+					{
+						if (hasMultipleConstraints)
+						{
+							sb.Append("  [").Append(item.Index).Append(']');
+						}
+
+						sb.Append(eventCount switch
+						{
+							0 => " never recorded",
+							1 => " only recorded once",
+							_ => $" only recorded {eventCount} times"
+						});
+					}
+				}
+			}
+
+			if (constraint.Value.Count > 1)
+			{
+				sb.Length -= 4;
+				sb.Length -= Environment.NewLine.Length;
+			}
+
+			if (hasGroupError)
+			{
+				sb.Append(" in ");
+				sb.Append(Formatter.Format(eventQueue, FormattingOptions.MultipleLines)
+					.Indent(hasMultipleConstraints ? "      " : "", false));
+				sb.AppendLine(" and");
+			}
+		}
+
+		return hasErrors;
+	}
+
+	private sealed class EventRecorder(string name) : IDisposable
+	{
+		private Action? _onDispose;
+		public ConcurrentQueue<OccurredEvent> EventQueue { get; } = new();
+
+		public void Dispose() => _onDispose?.Invoke();
+
+		public void Attach(WeakReference subject, EventInfo eventInfo)
+		{
+			MethodInfo handlerType = eventInfo.EventHandlerType!.GetMethod("Invoke")!;
+			Delegate? handler = null;
+			foreach (MethodInfo method in typeof(EventRecorder).GetMethods().Where(x => x.Name == nameof(RecordEvent)))
+			{
+				if (method.GetParameters().Length == handlerType.GetParameters().Length)
+				{
+					MethodInfo handlerMethod = method;
+					if (handlerType.GetParameters().Length > 0)
+					{
+						handlerMethod = method
+							.MakeGenericMethod(handlerType.GetParameters()
+								.Select(x => x.ParameterType)
+								.ToArray());
+					}
+
+					handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, handlerMethod);
+				}
+			}
+
+			if (handler == null)
+			{
+				throw new NotSupportedException(
+					$"The event {name} contains too many parameters ({handlerType.GetParameters().Length}): {Formatter.Format(handlerType.GetParameters().Select(x => x.ParameterType))}");
+			}
+
+			eventInfo.AddEventHandler(subject.Target, handler);
+
+			_onDispose = () =>
+			{
+				if (subject.Target is not null)
+				{
+					eventInfo.RemoveEventHandler(subject.Target, handler);
+				}
+			};
+		}
+
+		public void RecordEvent()
+			=> EventQueue.Enqueue(new OccurredEvent(name));
+
+		public void RecordEvent<T1>(T1 parameter1)
+			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1));
+
+		public void RecordEvent<T1, T2>(T1 parameter1, T2 parameter2)
+			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2));
+
+		public void RecordEvent<T1, T2, T3>(T1 parameter1, T2 parameter2, T3 parameter3)
+			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2, parameter3));
+
+		public void RecordEvent<T1, T2, T3, T4>(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
+			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2, parameter3, parameter4));
+	}
+
+	private readonly struct OccurredEvent(string name, params object?[] parameters)
+	{
+		public string Name { get; } = name;
+		public object?[] Parameters { get; } = parameters;
+
+		/// <inheritdoc />
+		public override string ToString()
+		{
+			StringBuilder sb = new();
+			sb.Append(Name).Append('(');
+			if (Parameters.Length > 0)
+			{
+				foreach (object? parameter in Parameters)
+				{
+					Formatter.Format(sb, parameter);
+					sb.Append(", ");
+				}
+
+				sb.Length -= 2;
+			}
+
+			sb.Append(')');
+			return sb.ToString();
+		}
+	}
+}

--- a/Source/aweXpect.Core/Core/Helpers/StringExtensions.cs
+++ b/Source/aweXpect.Core/Core/Helpers/StringExtensions.cs
@@ -13,9 +13,9 @@ internal static class StringExtensions
 	public static string? Indent(this string? value, string indentation = "  ",
 		bool indentFirstLine = true)
 	{
-		if (value == null)
+		if (value == null || string.IsNullOrEmpty(indentation))
 		{
-			return null;
+			return value;
 		}
 
 		return (indentFirstLine ? indentation : "")

--- a/Source/aweXpect.Core/Results/TriggerParameterResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerParameterResult.cs
@@ -30,7 +30,7 @@ public class TriggerParameterResult<T>(ExpectationBuilder expectationBuilder, IE
 	}
 
 	/// <summary>
-	///     Adds a parameter predicate on the parameter at the given <paramref name="position" /> of type
+	///     Adds a parameter predicate on the parameter at the given zero-based <paramref name="position" /> of type
 	///     <typeparamref name="TParameter" />.
 	/// </summary>
 	/// <remarks>

--- a/Source/aweXpect.Core/Results/TriggerParameterResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerParameterResult.cs
@@ -9,8 +9,8 @@ namespace aweXpect.Results;
 /// <summary>
 ///     A trigger result that also allows specifying parameter filters.
 /// </summary>
-public class TriggerParameterResult<T>(IThat<T> returnValue, string eventName, Quantifier quantifier)
-	: TriggerResult<T>(returnValue, eventName, quantifier)
+public class TriggerParameterResult<T>(ExpectationBuilder expectationBuilder, IExpectSubject<T> returnValue, string eventName, Quantifier quantifier)
+	: TriggerResult<T, TriggerParameterResult<T>>(expectationBuilder, returnValue, eventName, quantifier)
 {
 	private TriggerEventFilter? _filter;
 
@@ -49,4 +49,7 @@ public class TriggerParameterResult<T>(IThat<T> returnValue, string eventName, Q
 
 	/// <inheritdoc />
 	protected override TriggerEventFilter? GetFilter() => _filter;
+
+	protected override void ResetFilter() =>
+		_filter = null;
 }

--- a/Source/aweXpect.Core/Results/TriggerParameterResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerParameterResult.cs
@@ -50,6 +50,7 @@ public class TriggerParameterResult<T>(ExpectationBuilder expectationBuilder, IE
 	/// <inheritdoc />
 	protected override TriggerEventFilter? GetFilter() => _filter;
 
+	/// <inheritdoc />
 	protected override void ResetFilter() =>
 		_filter = null;
 }

--- a/Source/aweXpect.Core/Results/TriggerParameterResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerParameterResult.cs
@@ -9,8 +9,8 @@ namespace aweXpect.Results;
 /// <summary>
 ///     A trigger result that also allows specifying parameter filters.
 /// </summary>
-public class TriggerParameterResult<T>(IThat<T> returnValue, string eventName)
-	: TriggerResult<T>(returnValue, eventName)
+public class TriggerParameterResult<T>(IThat<T> returnValue, string eventName, Quantifier quantifier)
+	: TriggerResult<T>(returnValue, eventName, quantifier)
 {
 	private TriggerEventFilter? _filter;
 

--- a/Source/aweXpect.Core/Results/TriggerResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -7,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
+using aweXpect.Core.Helpers;
 using aweXpect.Options;
 
 namespace aweXpect.Results;
@@ -14,16 +16,90 @@ namespace aweXpect.Results;
 /// <summary>
 ///     The result for a <see cref="TriggersExtensions.Triggers{T}" /> expectation.
 /// </summary>
-public class TriggerResult<T>(IThat<T> returnValue, string eventName, Quantifier quantifier)
-	: CountResult<T, IThat<T>, TriggerResult<T>>(returnValue.ExpectationBuilder, returnValue, quantifier)
+public abstract class TriggerResult<T, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	IExpectSubject<T> returnValue,
+	string eventName,
+	Quantifier quantifier)
+	where TSelf : TriggerResult<T, TSelf>
 {
-	private readonly IThat<T> _returnValue = returnValue;
-	private readonly Quantifier _quantifier = quantifier;
+	private readonly List<EventConstraint> _eventConstraints = new();
+	private string _eventName = eventName;
+	private Quantifier _quantifier = quantifier;
+
+	/// <summary>
+	///     Add additional trigger expectations.
+	/// </summary>
+	public TriggerAndResult<TSelf> And => new(s =>
+	{
+		_eventConstraints.Add(new EventConstraint(_eventConstraints.Count + 1, _eventName, GetFilter(), _quantifier));
+		_eventName = s;
+		_quantifier = new Quantifier();
+		ResetFilter();
+
+		return (TSelf)this;
+	});
+
+	/// <summary>
+	///     Verifies, that it occurs at least <paramref name="minimum" /> times.
+	/// </summary>
+	public TSelf AtLeast(Times minimum)
+	{
+		_quantifier.AtLeast(minimum.Value);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs at most <paramref name="maximum" /> times.
+	/// </summary>
+	public TSelf AtMost(Times maximum)
+	{
+		_quantifier.AtMost(maximum.Value);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs between <paramref name="minimum" />...
+	/// </summary>
+	public BetweenResult<TSelf> Between(int minimum)
+		=> new(maximum =>
+		{
+			_quantifier.Between(minimum, maximum);
+			return (TSelf)this;
+		});
+
+	/// <summary>
+	///     Verifies, that it occurs exactly <paramref name="expected" /> times.
+	/// </summary>
+	public TSelf Exactly(Times expected)
+	{
+		_quantifier.Exactly(expected.Value);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs never.
+	/// </summary>
+	public TSelf Never()
+	{
+		_quantifier.Exactly(0);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Verifies, that it occurs exactly once.
+	/// </summary>
+	public TSelf Once()
+	{
+		_quantifier.Exactly(1);
+		return (TSelf)this;
+	}
+
 
 	/// <summary>
 	///     Executes the <paramref name="callback" /> while monitoring the triggered events.
 	/// </summary>
-	public AndOrResult<T, IThat<T>> While(Action<T> callback)
+	public AndOrResult<T, IExpectSubject<T>> While(Action<T> callback)
 		=> While((t, _) =>
 		{
 			callback(t);
@@ -33,22 +109,21 @@ public class TriggerResult<T>(IThat<T> returnValue, string eventName, Quantifier
 	/// <summary>
 	///     Executes the asynchronous <paramref name="callback" /> while monitoring the triggered events.
 	/// </summary>
-	public AndOrResult<T, IThat<T>> While(Func<T, Task> callback)
+	public AndOrResult<T, IExpectSubject<T>> While(Func<T, Task> callback)
 		=> While((t, _) => callback(t));
 
 	/// <summary>
 	///     Executes the asynchronous <paramref name="callback" /> with cancellation support
 	///     while monitoring the triggered events.
 	/// </summary>
-	public AndOrResult<T, IThat<T>> While(Func<T, CancellationToken, Task> callback)
+	public AndOrResult<T, IExpectSubject<T>> While(Func<T, CancellationToken, Task> callback)
 	{
-		_returnValue.ExpectationBuilder.AddConstraint(it
-			=> new EventConstraint(it,
-				eventName,
-				callback,
-				GetFilter(),
-				_quantifier));
-		return new AndOrResult<T, IThat<T>>(_returnValue.ExpectationBuilder, _returnValue);
+		_eventConstraints.Add(new EventConstraint(_eventConstraints.Count + 1, _eventName, GetFilter(), _quantifier));
+		expectationBuilder.AddConstraint(it
+			=> new EventTriggerConstraint(it,
+				_eventConstraints,
+				callback));
+		return new AndOrResult<T, IExpectSubject<T>>(expectationBuilder, returnValue);
 	}
 
 	/// <summary>
@@ -56,53 +131,208 @@ public class TriggerResult<T>(IThat<T> returnValue, string eventName, Quantifier
 	/// </summary>
 	protected virtual TriggerEventFilter? GetFilter() => null;
 
-	private readonly struct EventConstraint(
+	/// <summary>
+	///     Resets the event filter.
+	/// </summary>
+	protected abstract void ResetFilter();
+
+	/// <summary>
+	///     Result for combining multiple trigger filters.
+	/// </summary>
+	public class TriggerAndResult<TResult>(Func<string, TResult> callback)
+	{
+		/// <summary>
+		///     Verifies that the subject triggers an additional event with the given <paramref name="eventName" />.
+		/// </summary>
+		public TResult Triggers(string eventName) => callback(eventName);
+	}
+
+	private class EventConstraint(int index, string name, TriggerEventFilter? filter, Quantifier quantifier)
+	{
+		public int Index { get; } = index;
+		public string Name { get; } = name;
+		public TriggerEventFilter? Filter { get; } = filter;
+		public Quantifier Quantifier { get; } = quantifier;
+	}
+
+	private readonly struct EventTriggerConstraint(
 		string it,
-		string eventName,
-		Func<T, CancellationToken, Task> callback,
-		TriggerEventFilter? filter,
-		Quantifier quantifier)
+		List<EventConstraint> eventConstraints,
+		Func<T, CancellationToken, Task> callback)
 		: IAsyncConstraint<T>
 	{
 		public async Task<ConstraintResult> IsMetBy(T actual, CancellationToken cancellationToken)
 		{
 			EventInfo[] events = typeof(T).GetEvents();
-			string name = eventName;
-			using EventRecorder recorder = new(name);
-
-			EventInfo? @event = events.FirstOrDefault(x => x.Name == name);
-			if (@event == null)
+			EventRecorder[] recorders = new EventRecorder[eventConstraints.Count];
+			for (int i = 0; i < eventConstraints.Count; i++)
 			{
-				throw new NotSupportedException($"Event {name} is not supported on {Formatter.Format(actual)}");
+				string? name = eventConstraints[i].Name;
+				recorders[i] = new EventRecorder(name);
+				EventInfo? @event = events.FirstOrDefault(x => x.Name == name);
+				if (@event == null)
+				{
+					throw new NotSupportedException($"Event {name} is not supported on {Formatter.Format(actual)}");
+				}
+
+				recorders[i].Attach(new WeakReference(actual), @event);
 			}
 
-			recorder.Attach(new WeakReference(actual), @event);
-			await callback(actual, cancellationToken);
-			int eventCount = recorder.EventQueue.Count;
-			if (filter != null)
+			StringBuilder sb = new();
+			bool hasErrors = false;
+			try
 			{
-				TriggerEventFilter f = filter;
-				eventCount = recorder.EventQueue.Count(x => f.IsMatch(name, x.Parameters));
+				await callback(actual, cancellationToken);
+
+				sb.Append(it).Append(" was");
+				bool hasMultipleConstraints = eventConstraints.Count > 1;
+				if (hasMultipleConstraints)
+				{
+					sb.AppendLine();
+				}
+
+				foreach (IGrouping<string, EventConstraint> group in eventConstraints.GroupBy(x => x.Name))
+				{
+					string? name = group.Key;
+					ConcurrentQueue<OccurredEvent>? eventQueue = null;
+					bool hasGroupError = false;
+					foreach (EventConstraint? item in group)
+					{
+						eventQueue = recorders[item.Index - 1].EventQueue;
+						int eventCount = eventQueue.Count;
+						TriggerEventFilter? filter = item.Filter;
+						if (filter != null)
+						{
+							eventCount = eventQueue.Count(x => filter.IsMatch(name, x.Parameters));
+						}
+
+						if (item.Quantifier.Check(eventCount, true) != true)
+						{
+							hasErrors = true;
+							hasGroupError = true;
+							if (group.Count() > 1)
+							{
+								sb.Append("  [").Append(item.Index).Append(']');
+								sb.Append(eventCount switch
+								{
+									0 => " never recorded",
+									1 => " only recorded once",
+									_ => $" only recorded {eventCount} times"
+								});
+								sb.AppendLine(" and");
+							}
+							else
+							{
+								if (hasMultipleConstraints)
+								{
+									sb.Append("  [").Append(item.Index).Append(']');
+								}
+
+								sb.Append(eventCount switch
+								{
+									0 => " never recorded",
+									1 => " only recorded once",
+									_ => $" only recorded {eventCount} times"
+								});
+							}
+						}
+					}
+
+					if (group.Count() > 1)
+					{
+						sb.Length -= 4;
+						sb.Length -= Environment.NewLine.Length;
+					}
+
+					if (hasGroupError)
+					{
+						sb.Append(" in ");
+						sb.Append(Formatter.Format(eventQueue, FormattingOptions.MultipleLines)
+							.Indent(hasMultipleConstraints ? "      " : "", false));
+						sb.AppendLine(" and");
+					}
+				}
+			}
+			finally
+			{
+				for (int i = 0; i < eventConstraints.Count; i++)
+				{
+					recorders[i].Dispose();
+				}
 			}
 
-			if (quantifier.Check(eventCount, true) == true)
+			if (!hasErrors)
 			{
 				return new ConstraintResult.Success<T>(actual, ToString());
 			}
 
-			return new ConstraintResult.Failure<T>(actual, ToString(),
-				eventCount switch
-				{
-					0 =>
-						$"{it} was never recorded in {Formatter.Format(recorder.EventQueue, FormattingOptions.MultipleLines)}",
-					1 =>
-						$"{it} was only recorded once in {Formatter.Format(recorder.EventQueue, FormattingOptions.MultipleLines)}",
-					_ =>
-						$"{it} was only recorded {eventCount} times in {Formatter.Format(recorder.EventQueue, FormattingOptions.MultipleLines)}"
-				});
+			sb.Length -= 4;
+			sb.Length -= Environment.NewLine.Length;
+			return new ConstraintResult.Failure<T>(actual, ToString(), sb.ToString());
 		}
 
-		public override string ToString() => $"trigger event {eventName}{filter?.ToString() ?? ""} {quantifier}";
+		public override string ToString()
+		{
+			StringBuilder? sb = new();
+			bool hasMultipleConstraints = eventConstraints.Count > 1;
+			List<IGrouping<string, EventConstraint>>? groups = eventConstraints.GroupBy(x => x.Name).ToList();
+			bool hasMultipleGroups = groups.Count > 1;
+			foreach (IGrouping<string, EventConstraint> group in groups)
+			{
+				if (hasMultipleGroups)
+				{
+					sb.Append("  ");
+				}
+
+				bool hasMultipleGroupConstraints = group.Count() > 1;
+				if (hasMultipleGroupConstraints)
+				{
+					sb.Append("trigger event ").Append(group.Key);
+					foreach (EventConstraint? item in group)
+					{
+						sb.AppendLine();
+						if (hasMultipleGroups)
+						{
+							sb.Append("  ");
+						}
+
+						sb.Append("  [").Append(item.Index).Append("]");
+						if (item.Filter != null)
+						{
+							sb.Append(item.Filter);
+						}
+
+						sb.Append(' ').Append(item.Quantifier);
+						sb.Append(" and");
+					}
+
+					sb.Length -= 4;
+				}
+				else
+				{
+					EventConstraint? item = group.First();
+					if (hasMultipleConstraints)
+					{
+						sb.Append("[" + item.Index + "] ");
+					}
+
+					sb.Append("trigger event ").Append(group.Key);
+					if (item.Filter != null)
+					{
+						sb.Append(item.Filter);
+					}
+
+					sb.Append(' ').Append(item.Quantifier);
+				}
+
+				sb.Append(" and");
+				sb.AppendLine();
+			}
+
+			sb.Length -= 4;
+			sb.Length -= Environment.NewLine.Length;
+			return sb.ToString();
+		}
 	}
 
 	private sealed class EventRecorder(string name) : IDisposable

--- a/Source/aweXpect.Core/Results/TriggerResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerResult.cs
@@ -163,8 +163,6 @@ public abstract class TriggerResult<T, TSelf>(
 				return new ConstraintResult.Success<T>(actual, ToString());
 			}
 
-			sb.Length -= 4;
-			sb.Length -= Environment.NewLine.Length;
 			return new ConstraintResult.Failure<T>(actual, ToString(), sb.ToString());
 		}
 

--- a/Source/aweXpect.Core/Results/TriggerResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerResult.cs
@@ -157,7 +157,7 @@ public abstract class TriggerResult<T, TSelf>(
 
 			StringBuilder sb = new();
 			sb.Append(it).Append(" was");
-			bool hasErrors = recording.HasErrors(sb);
+			bool hasErrors = eventConstraints.HasErrors(recording, sb);
 			if (!hasErrors)
 			{
 				return new ConstraintResult.Success<T>(actual, ToString());

--- a/Source/aweXpect.Core/Results/TriggerResult.cs
+++ b/Source/aweXpect.Core/Results/TriggerResult.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
-using aweXpect.Core.Helpers;
+using aweXpect.Core.Events;
 using aweXpect.Options;
 
 namespace aweXpect.Results;
@@ -23,7 +19,7 @@ public abstract class TriggerResult<T, TSelf>(
 	Quantifier quantifier)
 	where TSelf : TriggerResult<T, TSelf>
 {
-	private readonly List<EventConstraint> _eventConstraints = new();
+	private readonly EventConstraints _eventConstraints = new();
 	private string _eventName = eventName;
 	private Quantifier _quantifier = quantifier;
 
@@ -32,7 +28,7 @@ public abstract class TriggerResult<T, TSelf>(
 	/// </summary>
 	public TriggerAndResult<TSelf> And => new(s =>
 	{
-		_eventConstraints.Add(new EventConstraint(_eventConstraints.Count + 1, _eventName, GetFilter(), _quantifier));
+		_eventConstraints.Add(_eventName, GetFilter(), _quantifier);
 		_eventName = s;
 		_quantifier = new Quantifier();
 		ResetFilter();
@@ -118,7 +114,7 @@ public abstract class TriggerResult<T, TSelf>(
 	/// </summary>
 	public AndOrResult<T, IExpectSubject<T>> While(Func<T, CancellationToken, Task> callback)
 	{
-		_eventConstraints.Add(new EventConstraint(_eventConstraints.Count + 1, _eventName, GetFilter(), _quantifier));
+		_eventConstraints.Add(_eventName, GetFilter(), _quantifier);
 		expectationBuilder.AddConstraint(it
 			=> new EventTriggerConstraint(it,
 				_eventConstraints,
@@ -147,120 +143,21 @@ public abstract class TriggerResult<T, TSelf>(
 		public TResult Triggers(string eventName) => callback(eventName);
 	}
 
-	private class EventConstraint(int index, string name, TriggerEventFilter? filter, Quantifier quantifier)
-	{
-		public int Index { get; } = index;
-		public string Name { get; } = name;
-		public TriggerEventFilter? Filter { get; } = filter;
-		public Quantifier Quantifier { get; } = quantifier;
-	}
-
 	private readonly struct EventTriggerConstraint(
 		string it,
-		List<EventConstraint> eventConstraints,
+		EventConstraints eventConstraints,
 		Func<T, CancellationToken, Task> callback)
 		: IAsyncConstraint<T>
 	{
 		public async Task<ConstraintResult> IsMetBy(T actual, CancellationToken cancellationToken)
 		{
-			EventInfo[] events = typeof(T).GetEvents();
-			EventRecorder[] recorders = new EventRecorder[eventConstraints.Count];
-			for (int i = 0; i < eventConstraints.Count; i++)
-			{
-				string? name = eventConstraints[i].Name;
-				recorders[i] = new EventRecorder(name);
-				EventInfo? @event = events.FirstOrDefault(x => x.Name == name);
-				if (@event == null)
-				{
-					throw new NotSupportedException($"Event {name} is not supported on {Formatter.Format(actual)}");
-				}
+			using EventRecording<T> recording = eventConstraints.StartRecordingEvents(actual);
 
-				recorders[i].Attach(new WeakReference(actual), @event);
-			}
+			await callback(actual, cancellationToken);
 
 			StringBuilder sb = new();
-			bool hasErrors = false;
-			try
-			{
-				await callback(actual, cancellationToken);
-
-				sb.Append(it).Append(" was");
-				bool hasMultipleConstraints = eventConstraints.Count > 1;
-				if (hasMultipleConstraints)
-				{
-					sb.AppendLine();
-				}
-
-				foreach (IGrouping<string, EventConstraint> group in eventConstraints.GroupBy(x => x.Name))
-				{
-					string? name = group.Key;
-					ConcurrentQueue<OccurredEvent>? eventQueue = null;
-					bool hasGroupError = false;
-					foreach (EventConstraint? item in group)
-					{
-						eventQueue = recorders[item.Index - 1].EventQueue;
-						int eventCount = eventQueue.Count;
-						TriggerEventFilter? filter = item.Filter;
-						if (filter != null)
-						{
-							eventCount = eventQueue.Count(x => filter.IsMatch(name, x.Parameters));
-						}
-
-						if (item.Quantifier.Check(eventCount, true) != true)
-						{
-							hasErrors = true;
-							hasGroupError = true;
-							if (group.Count() > 1)
-							{
-								sb.Append("  [").Append(item.Index).Append(']');
-								sb.Append(eventCount switch
-								{
-									0 => " never recorded",
-									1 => " only recorded once",
-									_ => $" only recorded {eventCount} times"
-								});
-								sb.AppendLine(" and");
-							}
-							else
-							{
-								if (hasMultipleConstraints)
-								{
-									sb.Append("  [").Append(item.Index).Append(']');
-								}
-
-								sb.Append(eventCount switch
-								{
-									0 => " never recorded",
-									1 => " only recorded once",
-									_ => $" only recorded {eventCount} times"
-								});
-							}
-						}
-					}
-
-					if (group.Count() > 1)
-					{
-						sb.Length -= 4;
-						sb.Length -= Environment.NewLine.Length;
-					}
-
-					if (hasGroupError)
-					{
-						sb.Append(" in ");
-						sb.Append(Formatter.Format(eventQueue, FormattingOptions.MultipleLines)
-							.Indent(hasMultipleConstraints ? "      " : "", false));
-						sb.AppendLine(" and");
-					}
-				}
-			}
-			finally
-			{
-				for (int i = 0; i < eventConstraints.Count; i++)
-				{
-					recorders[i].Dispose();
-				}
-			}
-
+			sb.Append(it).Append(" was");
+			bool hasErrors = recording.HasErrors(sb);
 			if (!hasErrors)
 			{
 				return new ConstraintResult.Success<T>(actual, ToString());
@@ -272,153 +169,6 @@ public abstract class TriggerResult<T, TSelf>(
 		}
 
 		public override string ToString()
-		{
-			StringBuilder? sb = new();
-			bool hasMultipleConstraints = eventConstraints.Count > 1;
-			List<IGrouping<string, EventConstraint>>? groups = eventConstraints.GroupBy(x => x.Name).ToList();
-			bool hasMultipleGroups = groups.Count > 1;
-			foreach (IGrouping<string, EventConstraint> group in groups)
-			{
-				if (hasMultipleGroups)
-				{
-					sb.Append("  ");
-				}
-
-				bool hasMultipleGroupConstraints = group.Count() > 1;
-				if (hasMultipleGroupConstraints)
-				{
-					sb.Append("trigger event ").Append(group.Key);
-					foreach (EventConstraint? item in group)
-					{
-						sb.AppendLine();
-						if (hasMultipleGroups)
-						{
-							sb.Append("  ");
-						}
-
-						sb.Append("  [").Append(item.Index).Append("]");
-						if (item.Filter != null)
-						{
-							sb.Append(item.Filter);
-						}
-
-						sb.Append(' ').Append(item.Quantifier);
-						sb.Append(" and");
-					}
-
-					sb.Length -= 4;
-				}
-				else
-				{
-					EventConstraint? item = group.First();
-					if (hasMultipleConstraints)
-					{
-						sb.Append("[" + item.Index + "] ");
-					}
-
-					sb.Append("trigger event ").Append(group.Key);
-					if (item.Filter != null)
-					{
-						sb.Append(item.Filter);
-					}
-
-					sb.Append(' ').Append(item.Quantifier);
-				}
-
-				sb.Append(" and");
-				sb.AppendLine();
-			}
-
-			sb.Length -= 4;
-			sb.Length -= Environment.NewLine.Length;
-			return sb.ToString();
-		}
-	}
-
-	private sealed class EventRecorder(string name) : IDisposable
-	{
-		private Action? _onDispose;
-		public ConcurrentQueue<OccurredEvent> EventQueue { get; } = new();
-
-		public void Dispose() => _onDispose?.Invoke();
-
-		public void Attach(WeakReference subject, EventInfo eventInfo)
-		{
-			MethodInfo handlerType = eventInfo.EventHandlerType!.GetMethod("Invoke")!;
-			Delegate? handler = null;
-			foreach (MethodInfo method in typeof(EventRecorder).GetMethods().Where(x => x.Name == nameof(RecordEvent)))
-			{
-				if (method.GetParameters().Length == handlerType.GetParameters().Length)
-				{
-					MethodInfo handlerMethod = method;
-					if (handlerType.GetParameters().Length > 0)
-					{
-						handlerMethod = method
-							.MakeGenericMethod(handlerType.GetParameters()
-								.Select(x => x.ParameterType)
-								.ToArray());
-					}
-
-					handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, handlerMethod);
-				}
-			}
-
-			if (handler == null)
-			{
-				throw new NotSupportedException(
-					$"The event {name} contains too many parameters ({handlerType.GetParameters().Length}): {Formatter.Format(handlerType.GetParameters().Select(x => x.ParameterType))}");
-			}
-
-			eventInfo.AddEventHandler(subject.Target, handler);
-
-			_onDispose = () =>
-			{
-				if (subject.Target is not null)
-				{
-					eventInfo.RemoveEventHandler(subject.Target, handler);
-				}
-			};
-		}
-
-		public void RecordEvent()
-			=> EventQueue.Enqueue(new OccurredEvent(name));
-
-		public void RecordEvent<T1>(T1 parameter1)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1));
-
-		public void RecordEvent<T1, T2>(T1 parameter1, T2 parameter2)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2));
-
-		public void RecordEvent<T1, T2, T3>(T1 parameter1, T2 parameter2, T3 parameter3)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2, parameter3));
-
-		public void RecordEvent<T1, T2, T3, T4>(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
-			=> EventQueue.Enqueue(new OccurredEvent(name, parameter1, parameter2, parameter3, parameter4));
-	}
-
-	private readonly struct OccurredEvent(string name, params object?[] parameters)
-	{
-		public string Name { get; } = name;
-		public object?[] Parameters { get; } = parameters;
-
-		/// <inheritdoc />
-		public override string ToString()
-		{
-			StringBuilder sb = new();
-			sb.Append(Name).Append('(');
-			if (Parameters.Length > 0)
-			{
-				foreach (object? parameter in Parameters)
-				{
-					Formatter.Format(sb, parameter);
-					sb.Append(", ");
-				}
-
-				sb.Length -= 2;
-			}
-
-			sb.Append(')');
-			return sb.ToString();
-		}
+			=> eventConstraints.ToString();
 	}
 }

--- a/Source/aweXpect.Core/TriggersExtensions.cs
+++ b/Source/aweXpect.Core/TriggersExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using aweXpect.Core;
+using aweXpect.Options;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -14,7 +15,8 @@ public static class TriggersExtensions
 	public static TriggerParameterResult<T> Triggers<T>(
 		this IExpectSubject<T> subject, string eventName)
 	{
+		Quantifier quantifier = new();
 		IThat<T> should = subject.Should(_ => { });
-		return new TriggerParameterResult<T>(should, eventName);
+		return new TriggerParameterResult<T>(should, eventName, quantifier);
 	}
 }

--- a/Source/aweXpect.Core/TriggersExtensions.cs
+++ b/Source/aweXpect.Core/TriggersExtensions.cs
@@ -17,6 +17,6 @@ public static class TriggersExtensions
 	{
 		Quantifier quantifier = new();
 		IThat<T> should = subject.Should(_ => { });
-		return new TriggerParameterResult<T>(should, eventName, quantifier);
+		return new TriggerParameterResult<T>(should.ExpectationBuilder, subject, eventName, quantifier);
 	}
 }

--- a/Source/aweXpect/Results/TriggerPropertyChangedParameterResult.cs
+++ b/Source/aweXpect/Results/TriggerPropertyChangedParameterResult.cs
@@ -10,8 +10,8 @@ namespace aweXpect.Results;
 /// <summary>
 ///     Result for a <see cref="INotifyPropertyChanged.PropertyChanged" /> event.
 /// </summary>
-public class TriggerPropertyChangedParameterResult<T>(IThat<T> returnValue, string eventName)
-	: TriggerParameterResult<T>(returnValue, eventName)
+public class TriggerPropertyChangedParameterResult<T>(IThat<T> returnValue, string eventName, Quantifier quantifier)
+	: TriggerParameterResult<T>(returnValue, eventName, quantifier)
 {
 	private TriggerEventFilter? _filter;
 

--- a/Source/aweXpect/Results/TriggerPropertyChangedParameterResult.cs
+++ b/Source/aweXpect/Results/TriggerPropertyChangedParameterResult.cs
@@ -10,15 +10,15 @@ namespace aweXpect.Results;
 /// <summary>
 ///     Result for a <see cref="INotifyPropertyChanged.PropertyChanged" /> event.
 /// </summary>
-public class TriggerPropertyChangedParameterResult<T>(IThat<T> returnValue, string eventName, Quantifier quantifier)
-	: TriggerParameterResult<T>(returnValue, eventName, quantifier)
+public class TriggerPropertyChangedParameterResult<T>(ExpectationBuilder expectationBuilder, IExpectSubject<T> returnValue, string eventName, Quantifier quantifier)
+	: TriggerParameterResult<T>(expectationBuilder, returnValue, eventName, quantifier)
 {
 	private TriggerEventFilter? _filter;
 
 	/// <summary>
 	///     Predicate to filter for the <see cref="PropertyChangedEventArgs" /> parameter.
 	/// </summary>
-	public TriggerResult<T> WithPropertyChangedEventArgs(Func<PropertyChangedEventArgs, bool> predicate,
+	public TriggerParameterResult<T> WithPropertyChangedEventArgs(Func<PropertyChangedEventArgs, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{

--- a/Source/aweXpect/That/TriggerExtensions.cs
+++ b/Source/aweXpect/That/TriggerExtensions.cs
@@ -18,6 +18,6 @@ public static class TriggerExtensions
 	{
 		Quantifier quantifier = new();
 		IThat<T> should = subject.Should(_ => { });
-		return new TriggerPropertyChangedParameterResult<T>(should, nameof(INotifyPropertyChanged.PropertyChanged), quantifier);
+		return new TriggerPropertyChangedParameterResult<T>(should.ExpectationBuilder, subject, nameof(INotifyPropertyChanged.PropertyChanged), quantifier);
 	}
 }

--- a/Source/aweXpect/That/TriggerExtensions.cs
+++ b/Source/aweXpect/That/TriggerExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using aweXpect.Core;
+using aweXpect.Options;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -15,7 +16,8 @@ public static class TriggerExtensions
 	public static TriggerPropertyChangedParameterResult<T> TriggersPropertyChanged<T>(this IExpectSubject<T> subject)
 		where T : INotifyPropertyChanged
 	{
+		Quantifier quantifier = new();
 		IThat<T> should = subject.Should(_ => { });
-		return new TriggerPropertyChangedParameterResult<T>(should, nameof(INotifyPropertyChanged.PropertyChanged));
+		return new TriggerPropertyChangedParameterResult<T>(should, nameof(INotifyPropertyChanged.PropertyChanged), quantifier);
 	}
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -677,19 +677,34 @@ namespace aweXpect.Results
         public TimeToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.TimeTolerance options) { }
         public TSelf Within(System.TimeSpan tolerance) { }
     }
-    public class TriggerParameterResult<T> : aweXpect.Results.TriggerResult<T>
+    public class TriggerParameterResult<T> : aweXpect.Results.TriggerResult<T, aweXpect.Results.TriggerParameterResult<T>>
     {
-        public TriggerParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        public TriggerParameterResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IExpectSubject<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
+        protected override void ResetFilter() { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
-    public class TriggerResult<T> : aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>, aweXpect.Results.TriggerResult<T>>
+    public abstract class TriggerResult<T, TSelf>
+        where TSelf : aweXpect.Results.TriggerResult<T, TSelf>
     {
-        public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        protected TriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IExpectSubject<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        public aweXpect.Results.TriggerResult<T, TSelf>.TriggerAndResult<TSelf> And { get; }
+        public TSelf AtLeast(aweXpect.Times minimum) { }
+        public TSelf AtMost(aweXpect.Times maximum) { }
+        public aweXpect.Results.BetweenResult<TSelf> Between(int minimum) { }
+        public TSelf Exactly(aweXpect.Times expected) { }
         protected virtual aweXpect.Options.TriggerEventFilter? GetFilter() { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        public TSelf Never() { }
+        public TSelf Once() { }
+        protected abstract void ResetFilter();
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IExpectSubject<T>> While(System.Action<T> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IExpectSubject<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IExpectSubject<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        public class TriggerAndResult<TResult>
+        {
+            public TriggerAndResult(System.Func<string, TResult> callback) { }
+            public TResult Triggers(string eventName) { }
+        }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -679,17 +679,17 @@ namespace aweXpect.Results
     }
     public class TriggerParameterResult<T> : aweXpect.Results.TriggerResult<T>
     {
-        public TriggerParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
+        public TriggerParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
-    public class TriggerResult<T>
+    public class TriggerResult<T> : aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>, aweXpect.Results.TriggerResult<T>>
     {
-        public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
+        public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected virtual aweXpect.Options.TriggerEventFilter? GetFilter() { }
-        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
-        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
-        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -667,19 +667,34 @@ namespace aweXpect.Results
         public TimeToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.TimeTolerance options) { }
         public TSelf Within(System.TimeSpan tolerance) { }
     }
-    public class TriggerParameterResult<T> : aweXpect.Results.TriggerResult<T>
+    public class TriggerParameterResult<T> : aweXpect.Results.TriggerResult<T, aweXpect.Results.TriggerParameterResult<T>>
     {
-        public TriggerParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        public TriggerParameterResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IExpectSubject<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
+        protected override void ResetFilter() { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
-    public class TriggerResult<T> : aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>, aweXpect.Results.TriggerResult<T>>
+    public abstract class TriggerResult<T, TSelf>
+        where TSelf : aweXpect.Results.TriggerResult<T, TSelf>
     {
-        public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        protected TriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IExpectSubject<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        public aweXpect.Results.TriggerResult<T, TSelf>.TriggerAndResult<TSelf> And { get; }
+        public TSelf AtLeast(aweXpect.Times minimum) { }
+        public TSelf AtMost(aweXpect.Times maximum) { }
+        public aweXpect.Results.BetweenResult<TSelf> Between(int minimum) { }
+        public TSelf Exactly(aweXpect.Times expected) { }
         protected virtual aweXpect.Options.TriggerEventFilter? GetFilter() { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        public TSelf Never() { }
+        public TSelf Once() { }
+        protected abstract void ResetFilter();
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IExpectSubject<T>> While(System.Action<T> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IExpectSubject<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IExpectSubject<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        public class TriggerAndResult<TResult>
+        {
+            public TriggerAndResult(System.Func<string, TResult> callback) { }
+            public TResult Triggers(string eventName) { }
+        }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -669,17 +669,17 @@ namespace aweXpect.Results
     }
     public class TriggerParameterResult<T> : aweXpect.Results.TriggerResult<T>
     {
-        public TriggerParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
+        public TriggerParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.TriggerParameterResult<T> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
-    public class TriggerResult<T>
+    public class TriggerResult<T> : aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>, aweXpect.Results.TriggerResult<T>>
     {
-        public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
+        public TriggerResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected virtual aweXpect.Options.TriggerEventFilter? GetFilter() { }
-        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
-        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
-        public aweXpect.Results.CountResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Action<T> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.Tasks.Task> callback) { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> While(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task> callback) { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -975,8 +975,8 @@ namespace aweXpect.Results
     }
     public class TriggerPropertyChangedParameterResult<T> : aweXpect.Results.TriggerParameterResult<T>
     {
-        public TriggerPropertyChangedParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        public TriggerPropertyChangedParameterResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IExpectSubject<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
-        public aweXpect.Results.TriggerResult<T> WithPropertyChangedEventArgs(System.Func<System.ComponentModel.PropertyChangedEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.TriggerParameterResult<T> WithPropertyChangedEventArgs(System.Func<System.ComponentModel.PropertyChangedEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -975,7 +975,7 @@ namespace aweXpect.Results
     }
     public class TriggerPropertyChangedParameterResult<T> : aweXpect.Results.TriggerParameterResult<T>
     {
-        public TriggerPropertyChangedParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
+        public TriggerPropertyChangedParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
         public aweXpect.Results.TriggerResult<T> WithPropertyChangedEventArgs(System.Func<System.ComponentModel.PropertyChangedEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -839,8 +839,8 @@ namespace aweXpect.Results
     }
     public class TriggerPropertyChangedParameterResult<T> : aweXpect.Results.TriggerParameterResult<T>
     {
-        public TriggerPropertyChangedParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
+        public TriggerPropertyChangedParameterResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IExpectSubject<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
-        public aweXpect.Results.TriggerResult<T> WithPropertyChangedEventArgs(System.Func<System.ComponentModel.PropertyChangedEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.TriggerParameterResult<T> WithPropertyChangedEventArgs(System.Func<System.ComponentModel.PropertyChangedEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -839,7 +839,7 @@ namespace aweXpect.Results
     }
     public class TriggerPropertyChangedParameterResult<T> : aweXpect.Results.TriggerParameterResult<T>
     {
-        public TriggerPropertyChangedParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName) { }
+        public TriggerPropertyChangedParameterResult(aweXpect.Core.IThat<T> returnValue, string eventName, aweXpect.Options.Quantifier quantifier) { }
         protected override aweXpect.Options.TriggerEventFilter? GetFilter() { }
         public aweXpect.Results.TriggerResult<T> WithPropertyChangedEventArgs(System.Func<System.ComponentModel.PropertyChangedEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }

--- a/Tests/aweXpect.Core.Tests/Core/Events/EventRecordingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Events/EventRecordingTests.cs
@@ -18,7 +18,7 @@ public sealed class EventRecordingTests
 				});
 
 		await That(Act).Should().Throw<NotSupportedException>()
-			.WithMessage("Event someMissingEventName is not supported on CustomEventWithoutParametersClass { }");
+			.WithMessage("Event someMissingEventName is not supported on CustomEventClass { }");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Events/EventRecordingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Events/EventRecordingTests.cs
@@ -1,0 +1,47 @@
+﻿using aweXpect.Core.Events;
+
+namespace aweXpect.Core.Tests.Core.Events;
+
+public sealed class EventRecordingTests
+{
+	[Fact]
+	public async Task MissingEventName_ShouldThrowNotSupportedException()
+	{
+		CustomEventClass sut = new();
+
+		async Task Act() =>
+			await That(sut)
+				.Triggers("someMissingEventName")
+				.While(t =>
+				{
+					t.NotifyCustomEvent(1);
+				});
+
+		await That(Act).Should().Throw<NotSupportedException>()
+			.WithMessage("Event someMissingEventName is not supported on CustomEventWithoutParametersClass { }");
+	}
+
+	[Fact]
+	public async Task ShouldStopListeningOnDispose()
+	{
+		CustomEventClass subject = new();
+		EventRecording<CustomEventClass> sut = new(subject, [nameof(CustomEventClass.CustomEvent)]);
+		subject.NotifyCustomEvent(1);
+		subject.NotifyCustomEvent(2);
+
+		sut.Dispose();
+
+		subject.NotifyCustomEvent(3);
+		await That(sut.GetEventCount(nameof(CustomEventClass.CustomEvent), null)).Should().Be(2);
+	}
+
+	private sealed class CustomEventClass
+	{
+		public delegate void CustomEventDelegate(int arg1);
+
+		public event CustomEventDelegate? CustomEvent;
+
+		public void NotifyCustomEvent(int arg1)
+			=> CustomEvent?.Invoke(arg1);
+	}
+}

--- a/Tests/aweXpect.Core.Tests/TriggersTests.CountTests.cs
+++ b/Tests/aweXpect.Core.Tests/TriggersTests.CountTests.cs
@@ -1,0 +1,154 @@
+﻿// ReSharper disable MemberCanBePrivate.Local
+
+namespace aweXpect.Core.Tests;
+
+public sealed partial class TriggerTests
+{
+	public sealed class CountTests
+	{
+		[Theory]
+		[InlineData(1, 1, true)]
+		[InlineData(2, 1, false)]
+		[InlineData(1, 2, true)]
+		[InlineData(2, 2, true)]
+		[InlineData(8, 2, false)]
+		[InlineData(2, 8, true)]
+		public async Task ShouldSupportAtLeast(int minimum, int count, bool expectSuccess)
+		{
+			CustomEventWithoutParametersClass sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+					.AtLeast(minimum.Times())
+					.While(t => t.NotifyCustomEvents(count));
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected sut to
+				              trigger event CustomEvent at least {(minimum == 1 ? "once" : $"{minimum} times")},
+				              but it was recorded {(count == 1 ? "once" : $"{count} times")} in *
+				              """).AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(1, 1, true)]
+		[InlineData(2, 1, true)]
+		[InlineData(1, 2, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(8, 2, true)]
+		[InlineData(2, 8, false)]
+		public async Task ShouldSupportAtMost(int maximum, int count, bool expectSuccess)
+		{
+			CustomEventWithoutParametersClass sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+					.AtMost(maximum.Times())
+					.While(t => t.NotifyCustomEvents(count));
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected sut to
+				              trigger event CustomEvent at most {(maximum == 1 ? "once" : $"{maximum} times")},
+				              but it was recorded {(count == 1 ? "once" : $"{count} times")} in *
+				              """).AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(0, 1, 3, false)]
+		[InlineData(6, 8, 4, false)]
+		[InlineData(6, 8, 5, false)]
+		[InlineData(6, 8, 6, true)]
+		[InlineData(6, 8, 7, true)]
+		[InlineData(6, 8, 8, true)]
+		[InlineData(6, 8, 9, false)]
+		[InlineData(6, 8, 10, false)]
+		public async Task ShouldSupportBetween(int minimum, int maximum, int count, bool expectSuccess)
+		{
+			CustomEventWithoutParametersClass sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+					.Between(minimum).And(maximum.Times())
+					.While(t => t.NotifyCustomEvents(count));
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected sut to
+				              trigger event CustomEvent between {minimum} and {maximum} times,
+				              but it was recorded {(count == 1 ? "once" : $"{count} times")} in *
+				              """).AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(1, 1, true)]
+		[InlineData(2, 1, false)]
+		[InlineData(1, 2, false)]
+		[InlineData(2, 2, true)]
+		[InlineData(8, 2, false)]
+		[InlineData(2, 8, false)]
+		public async Task ShouldSupportExactly(int expected, int count, bool expectSuccess)
+		{
+			CustomEventWithoutParametersClass sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+					.Exactly(expected.Times())
+					.While(t => t.NotifyCustomEvents(count));
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected sut to
+				              trigger event CustomEvent exactly {(expected == 1 ? "once" : $"{expected} times")},
+				              but it was recorded {(count == 1 ? "once" : $"{count} times")} in *
+				              """).AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(0, true)]
+		[InlineData(1, false)]
+		public async Task ShouldSupportNever(int count, bool expectSuccess)
+		{
+			CustomEventWithoutParametersClass sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+					.Never()
+					.While(t => t.NotifyCustomEvents(count));
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage("""
+				             Expected sut to
+				             trigger event CustomEvent never,
+				             but it was recorded once in *
+				             """).AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(0, false)]
+		[InlineData(1, true)]
+		[InlineData(2, false)]
+		public async Task ShouldSupportOnce(int count, bool expectSuccess)
+		{
+			CustomEventWithoutParametersClass sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+					.Once()
+					.While(t => t.NotifyCustomEvents(count));
+
+			await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected sut to
+				              trigger event CustomEvent exactly once,
+				              but it was {(count == 0 ? "never recorded" : $"recorded {count} times")} in *
+				              """).AsWildcard();
+		}
+	}
+}

--- a/Tests/aweXpect.Core.Tests/TriggersTests.MultipleEventTests.cs
+++ b/Tests/aweXpect.Core.Tests/TriggersTests.MultipleEventTests.cs
@@ -93,7 +93,7 @@ public sealed partial class TriggerTests
 				await That(sut)
 					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
 					.WithParameter<string>(s => s == "foo")
-					.AtLeast(2.Times())
+					.Never()
 					.And
 					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
 					.WithParameter<int>(s => s == 3)
@@ -106,7 +106,7 @@ public sealed partial class TriggerTests
 			await That(Act).Should().Throw<XunitException>()
 				.WithMessage("""
 				             Expected sut to
-				               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
+				               [1] trigger event CustomEventA with string parameter s => s == "foo" never and
 				               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
 				             but it was
 				               [1] recorded once in [

--- a/Tests/aweXpect.Core.Tests/TriggersTests.MultipleEventTests.cs
+++ b/Tests/aweXpect.Core.Tests/TriggersTests.MultipleEventTests.cs
@@ -1,0 +1,168 @@
+﻿// ReSharper disable MemberCanBePrivate.Local
+
+namespace aweXpect.Core.Tests;
+
+public sealed partial class TriggerTests
+{
+	public sealed class MultipleEventTests
+	{
+		[Fact]
+		public async Task ShouldSupportCombinationOfOneAndMultipleEvents()
+		{
+			MultipleEventsClass<string, int> sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+					.WithParameter<string>(s => s == "foo")
+					.AtLeast(2.Times())
+					.And
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+					.WithParameter<string>(s => s == "bar")
+					.AtMost(1.Times())
+					.And
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
+					.WithParameter<int>(s => s == 3)
+					.While(t =>
+					{
+						t.NotifyCustomEventA("foo");
+						t.NotifyCustomEventA("bar");
+						t.NotifyCustomEventB(2);
+					});
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected sut to
+				               trigger event CustomEventA
+				                 [1] with string parameter s => s == "foo" at least 2 times and
+				                 [2] with string parameter s => s == "bar" at most once and
+				               [3] trigger event CustomEventB with int parameter s => s == 3 at least once,
+				             but it was
+				               [1] recorded once in [
+				                     CustomEventA("foo"),
+				                     CustomEventA("bar")
+				                   ] and
+				               [3] never recorded in [
+				                     CustomEventB(2)
+				                   ]
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenListeningMultipleTimesToSameEvent_ShouldGroupEventsInFailureMessage()
+		{
+			MultipleEventsClass<string, int> sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+					.WithParameter<string>(s => s == "foo")
+					.AtLeast(2.Times())
+					.And
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+					.WithParameter<string>(s => s == "bar")
+					.AtLeast(3.Times())
+					.While(t =>
+					{
+						t.NotifyCustomEventA("foo");
+						t.NotifyCustomEventA("bar");
+					});
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected sut to
+				             trigger event CustomEventA
+				               [1] with string parameter s => s == "foo" at least 2 times and
+				               [2] with string parameter s => s == "bar" at least 3 times,
+				             but it was
+				               [1] recorded once and
+				               [2] recorded once in [
+				                     CustomEventA("foo"),
+				                     CustomEventA("bar")
+				                   ]
+				             """);
+		}
+
+		[Fact]
+		public async Task
+			WhenListeningOnceToMultipleDifferentEvents_AndOnlySomeAreSatisfied_ShouldDisplayAllFailedEventQueues()
+		{
+			MultipleEventsClass<string, int> sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+					.WithParameter<string>(s => s == "foo")
+					.AtLeast(2.Times())
+					.And
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
+					.WithParameter<int>(s => s == 3)
+					.While(t =>
+					{
+						t.NotifyCustomEventA("foo");
+						t.NotifyCustomEventB(3);
+					});
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected sut to
+				               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
+				               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
+				             but it was
+				               [1] recorded once in [
+				                     CustomEventA("foo")
+				                   ]
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenListeningOnceToMultipleDifferentEvents_ShouldDisplayAllEventQueues()
+		{
+			MultipleEventsClass<string, int> sut = new();
+
+			async Task Act() =>
+				await That(sut)
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+					.WithParameter<string>(s => s == "foo")
+					.AtLeast(2.Times())
+					.And
+					.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
+					.WithParameter<int>(s => s == 3)
+					.While(t =>
+					{
+						t.NotifyCustomEventA("foo");
+						t.NotifyCustomEventB(2);
+					});
+
+			await That(Act).Should().Throw<XunitException>()
+				.WithMessage("""
+				             Expected sut to
+				               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
+				               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
+				             but it was
+				               [1] recorded once in [
+				                     CustomEventA("foo")
+				                   ] and
+				               [2] never recorded in [
+				                     CustomEventB(2)
+				                   ]
+				             """);
+		}
+
+		private sealed class MultipleEventsClass<T1, T2>
+		{
+			public delegate void CustomEventDelegateA(T1 arg1);
+
+			public delegate void CustomEventDelegateB(T2 arg1);
+
+			public event CustomEventDelegateA? CustomEventA;
+			public event CustomEventDelegateB? CustomEventB;
+
+			public void NotifyCustomEventA(T1 arg1)
+				=> CustomEventA?.Invoke(arg1);
+
+			public void NotifyCustomEventB(T2 arg1)
+				=> CustomEventB?.Invoke(arg1);
+		}
+	}
+}

--- a/Tests/aweXpect.Core.Tests/TriggersTests.cs
+++ b/Tests/aweXpect.Core.Tests/TriggersTests.cs
@@ -17,8 +17,8 @@ public sealed class TriggerTests
 		async Task Act() =>
 			await That(sut)
 				.Triggers(nameof(AsyncCustomEventClass.CustomEvent))
-				.While((t, c) => t.NotifyCustomEventAsync(c))
 				.AtLeast(2.Times())
+				.While((t, c) => t.NotifyCustomEventAsync(c))
 				.WithCancellation(token);
 
 		await That(Act).Should().Throw<XunitException>()
@@ -38,11 +38,11 @@ public sealed class TriggerTests
 		async Task Act() =>
 			await That(sut)
 				.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+				.AtLeast(2.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent();
-				})
-				.AtLeast(2.Times());
+				});
 
 		sut.NotifyCustomEvent();
 		await That(Act).Should().Throw<XunitException>()
@@ -63,8 +63,8 @@ public sealed class TriggerTests
 		async Task Act() =>
 			await That(sut)
 				.Triggers(nameof(AsyncCustomEventClass.CustomEvent))
-				.While(t => t.NotifyCustomEventAsync())
-				.AtLeast(2.Times());
+				.AtLeast(2.Times())
+				.While(t => t.NotifyCustomEventAsync());
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""
@@ -105,12 +105,12 @@ public sealed class TriggerTests
 			await That(sut)
 				.Triggers(nameof(CustomEventWithParametersClass<string, string, string>.CustomEvent))
 				.WithParameter<string>(position, s => s == "p1")
+				.AtLeast(2.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent("p0", "p1", "p2");
 					t.NotifyCustomEvent("p0", "p1", "p2");
-				})
-				.AtLeast(2.Times());
+				});
 
 		await That(Act).Should().Throw<XunitException>().OnlyIf(!expectSuccess)
 			.WithMessage($"""
@@ -131,13 +131,13 @@ public sealed class TriggerTests
 		async Task Act() =>
 			await That(sut)
 				.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+				.AtLeast(3.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent();
 					t.NotifyCustomEvent();
 					t.NotifyCustomEvent();
-				})
-				.AtLeast(3.Times());
+				});
 
 		await That(Act).Should().NotThrow();
 	}
@@ -150,11 +150,11 @@ public sealed class TriggerTests
 		async Task Act() =>
 			await That(sut)
 				.Triggers(nameof(CustomEventWithoutParametersClass.CustomEvent))
+				.AtLeast(3.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent();
-				})
-				.AtLeast(3.Times());
+				});
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""
@@ -175,12 +175,39 @@ public sealed class TriggerTests
 			await That(sut)
 				.Triggers(nameof(CustomEventWithParametersClass<string>.CustomEvent))
 				.WithParameter<string>(s => s == "foo")
+				.AtLeast(2.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent("foo");
 					t.NotifyCustomEvent("bar");
-				})
-				.AtLeast(2.Times());
+				});
+
+		await That(Act).Should().Throw<XunitException>()
+			.WithMessage("""
+			             Expected sut to
+			             trigger event CustomEvent with string parameter s => s == "foo" at least 2 times,
+			             but it was only recorded once in [
+			               CustomEvent("foo"),
+			               CustomEvent("bar")
+			             ]
+			             """);
+	}
+
+	[Fact]
+	public async Task WhenCustomEventWithParameters2222_WhenFilterResultsInTooFewRecordings_ShouldFail()
+	{
+		CustomEventWithParametersClass<string> sut = new();
+
+		async Task Act() =>
+			await That(sut)
+				.Triggers(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+				.WithParameter<string>(s => s == "foo")
+				.AtLeast(2.Times())
+				.While(t =>
+				{
+					t.NotifyCustomEvent("foo");
+					t.NotifyCustomEvent("bar");
+				});
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""
@@ -202,13 +229,13 @@ public sealed class TriggerTests
 			await That(sut)
 				.Triggers(nameof(CustomEventWithParametersClass<string>.CustomEvent))
 				.WithParameter<string>(s => s == "foo")
+				.AtLeast(3.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent("foo");
 					t.NotifyCustomEvent("foo");
 					t.NotifyCustomEvent("foo");
-				})
-				.AtLeast(3.Times());
+				});
 
 		await That(Act).Should().NotThrow();
 	}
@@ -221,12 +248,12 @@ public sealed class TriggerTests
 		async Task Act() =>
 			await That(sut)
 				.Triggers(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+				.AtLeast(3.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent("foo");
 					t.NotifyCustomEvent("bar");
-				})
-				.AtLeast(3.Times());
+				});
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""
@@ -249,12 +276,12 @@ public sealed class TriggerTests
 				.Triggers(nameof(CustomEventWithParametersClass<string, int>.CustomEvent))
 				.WithParameter<string>(s => s == "foo")
 				.WithParameter<int>(i => i > 1)
+				.AtLeast(1.Times())
 				.While(t =>
 				{
 					t.NotifyCustomEvent("foo", 1);
 					t.NotifyCustomEvent("bar", 2);
-				})
-				.AtLeast(1.Times());
+				});
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""

--- a/Tests/aweXpect.Core.Tests/TriggersTests.cs
+++ b/Tests/aweXpect.Core.Tests/TriggersTests.cs
@@ -4,151 +4,8 @@
 
 namespace aweXpect.Core.Tests;
 
-public sealed class TriggerTests
+public sealed partial class TriggerTests
 {
-	[Fact]
-	public async Task MultipleEvents_WhenCombination()
-	{
-		MultipleEventsClass<string, int> sut = new();
-
-		async Task Act() =>
-			await That(sut)
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
-				.WithParameter<string>(s => s == "foo")
-				.AtLeast(2.Times())
-				.And
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
-				.WithParameter<string>(s => s == "bar")
-				.AtMost(1.Times())
-				.And
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
-				.WithParameter<int>(s => s == 3)
-				.While(t =>
-				{
-					t.NotifyCustomEventA("foo");
-					t.NotifyCustomEventA("bar");
-					t.NotifyCustomEventB(2);
-				});
-
-		await That(Act).Should().Throw<XunitException>()
-			.WithMessage("""
-			             Expected sut to
-			               trigger event CustomEventA
-			                 [1] with string parameter s => s == "foo" at least 2 times and
-			                 [2] with string parameter s => s == "bar" at most once and
-			               [3] trigger event CustomEventB with int parameter s => s == 3 at least once,
-			             but it was
-			               [1] only recorded once in [
-			                     CustomEventA("foo"),
-			                     CustomEventA("bar")
-			                   ] and
-			               [3] never recorded in [
-			                     CustomEventB(2)
-			                   ]
-			             """);
-	}
-
-	[Fact]
-	public async Task MultipleEvents_WhenListeningMultipleTimesToDifferentEvent_ShouldDisplayAllEventQueues()
-	{
-		MultipleEventsClass<string, int> sut = new();
-
-		async Task Act() =>
-			await That(sut)
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
-				.WithParameter<string>(s => s == "foo")
-				.AtLeast(2.Times())
-				.And
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
-				.WithParameter<int>(s => s == 3)
-				.While(t =>
-				{
-					t.NotifyCustomEventA("foo");
-					t.NotifyCustomEventB(2);
-				});
-
-		await That(Act).Should().Throw<XunitException>()
-			.WithMessage("""
-			             Expected sut to
-			               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
-			               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
-			             but it was
-			               [1] only recorded once in [
-			                     CustomEventA("foo")
-			                   ] and
-			               [2] never recorded in [
-			                     CustomEventB(2)
-			                   ]
-			             """);
-	}
-
-	[Fact]
-	public async Task
-		MultipleEvents_WhenListeningMultipleTimesToDifferentEventAndOnlySomeAreSatisfied_ShouldDisplayAllFailedEventQueues()
-	{
-		MultipleEventsClass<string, int> sut = new();
-
-		async Task Act() =>
-			await That(sut)
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
-				.WithParameter<string>(s => s == "foo")
-				.AtLeast(2.Times())
-				.And
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
-				.WithParameter<int>(s => s == 3)
-				.While(t =>
-				{
-					t.NotifyCustomEventA("foo");
-					t.NotifyCustomEventB(3);
-				});
-
-		await That(Act).Should().Throw<XunitException>()
-			.WithMessage("""
-			             Expected sut to
-			               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
-			               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
-			             but it was
-			               [1] only recorded once in [
-			                     CustomEventA("foo")
-			                   ]
-			             """);
-	}
-
-	[Fact]
-	public async Task MultipleEvents_WhenListeningMultipleTimesToSameEvent_ShouldGroupEventsInFailureMessage()
-	{
-		MultipleEventsClass<string, int> sut = new();
-
-		async Task Act() =>
-			await That(sut)
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
-				.WithParameter<string>(s => s == "foo")
-				.AtLeast(2.Times())
-				.And
-				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
-				.WithParameter<string>(s => s == "bar")
-				.AtLeast(3.Times())
-				.While(t =>
-				{
-					t.NotifyCustomEventA("foo");
-					t.NotifyCustomEventA("bar");
-				});
-
-		await That(Act).Should().Throw<XunitException>()
-			.WithMessage("""
-			             Expected sut to
-			             trigger event CustomEventA
-			               [1] with string parameter s => s == "foo" at least 2 times and
-			               [2] with string parameter s => s == "bar" at least 3 times,
-			             but it was
-			               [1] only recorded once and
-			               [2] only recorded once in [
-			                     CustomEventA("foo"),
-			                     CustomEventA("bar")
-			                   ]
-			             """);
-	}
-
 	[Fact]
 	public async Task ShouldConsiderCancellationTokenInAsyncCallback()
 	{
@@ -193,7 +50,7 @@ public sealed class TriggerTests
 			.WithMessage("""
 			             Expected sut to
 			             trigger event CustomEvent at least 2 times,
-			             but it was only recorded once in [
+			             but it was recorded once in [
 			               CustomEvent()
 			             ]
 			             """);
@@ -214,7 +71,7 @@ public sealed class TriggerTests
 			.WithMessage("""
 			             Expected sut to
 			             trigger event CustomEvent at least 2 times,
-			             but it was only recorded once in [
+			             but it was recorded once in [
 			               CustomEvent()
 			             ]
 			             """);
@@ -304,7 +161,7 @@ public sealed class TriggerTests
 			.WithMessage("""
 			             Expected sut to
 			             trigger event CustomEvent at least 3 times,
-			             but it was only recorded once in [
+			             but it was recorded once in [
 			               CustomEvent()
 			             ]
 			             """);
@@ -330,7 +187,7 @@ public sealed class TriggerTests
 			.WithMessage("""
 			             Expected sut to
 			             trigger event CustomEvent with string parameter s => s == "foo" at least 2 times,
-			             but it was only recorded once in [
+			             but it was recorded once in [
 			               CustomEvent("foo"),
 			               CustomEvent("bar")
 			             ]
@@ -376,7 +233,7 @@ public sealed class TriggerTests
 			.WithMessage("""
 			             Expected sut to
 			             trigger event CustomEvent at least 3 times,
-			             but it was only recorded 2 times in [
+			             but it was recorded 2 times in [
 			               CustomEvent("foo"),
 			               CustomEvent("bar")
 			             ]
@@ -458,6 +315,14 @@ public sealed class TriggerTests
 
 		public void NotifyCustomEvent()
 			=> CustomEvent?.Invoke();
+
+		public void NotifyCustomEvents(int notificationCount)
+		{
+			for (int i = 0; i < notificationCount; i++)
+			{
+				CustomEvent?.Invoke();
+			}
+		}
 	}
 
 	private sealed class CustomEventWithParametersClass<T1>
@@ -468,22 +333,6 @@ public sealed class TriggerTests
 
 		public void NotifyCustomEvent(T1 arg1)
 			=> CustomEvent?.Invoke(arg1);
-	}
-
-	private sealed class MultipleEventsClass<T1, T2>
-	{
-		public delegate void CustomEventDelegateA(T1 arg1);
-
-		public delegate void CustomEventDelegateB(T2 arg1);
-
-		public event CustomEventDelegateA? CustomEventA;
-		public event CustomEventDelegateB? CustomEventB;
-
-		public void NotifyCustomEventA(T1 arg1)
-			=> CustomEventA?.Invoke(arg1);
-
-		public void NotifyCustomEventB(T2 arg1)
-			=> CustomEventB?.Invoke(arg1);
 	}
 
 	private sealed class CustomEventWithParametersClass<T1, T2>

--- a/Tests/aweXpect.Core.Tests/TriggersTests.cs
+++ b/Tests/aweXpect.Core.Tests/TriggersTests.cs
@@ -1,10 +1,154 @@
 ﻿using System.Threading;
+
 // ReSharper disable MemberCanBePrivate.Local
 
 namespace aweXpect.Core.Tests;
 
 public sealed class TriggerTests
 {
+	[Fact]
+	public async Task MultipleEvents_WhenCombination()
+	{
+		MultipleEventsClass<string, int> sut = new();
+
+		async Task Act() =>
+			await That(sut)
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+				.WithParameter<string>(s => s == "foo")
+				.AtLeast(2.Times())
+				.And
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+				.WithParameter<string>(s => s == "bar")
+				.AtMost(1.Times())
+				.And
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
+				.WithParameter<int>(s => s == 3)
+				.While(t =>
+				{
+					t.NotifyCustomEventA("foo");
+					t.NotifyCustomEventA("bar");
+					t.NotifyCustomEventB(2);
+				});
+
+		await That(Act).Should().Throw<XunitException>()
+			.WithMessage("""
+			             Expected sut to
+			               trigger event CustomEventA
+			                 [1] with string parameter s => s == "foo" at least 2 times and
+			                 [2] with string parameter s => s == "bar" at most once and
+			               [3] trigger event CustomEventB with int parameter s => s == 3 at least once,
+			             but it was
+			               [1] only recorded once in [
+			                     CustomEventA("foo"),
+			                     CustomEventA("bar")
+			                   ] and
+			               [3] never recorded in [
+			                     CustomEventB(2)
+			                   ]
+			             """);
+	}
+
+	[Fact]
+	public async Task MultipleEvents_WhenListeningMultipleTimesToDifferentEvent_ShouldDisplayAllEventQueues()
+	{
+		MultipleEventsClass<string, int> sut = new();
+
+		async Task Act() =>
+			await That(sut)
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+				.WithParameter<string>(s => s == "foo")
+				.AtLeast(2.Times())
+				.And
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
+				.WithParameter<int>(s => s == 3)
+				.While(t =>
+				{
+					t.NotifyCustomEventA("foo");
+					t.NotifyCustomEventB(2);
+				});
+
+		await That(Act).Should().Throw<XunitException>()
+			.WithMessage("""
+			             Expected sut to
+			               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
+			               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
+			             but it was
+			               [1] only recorded once in [
+			                     CustomEventA("foo")
+			                   ] and
+			               [2] never recorded in [
+			                     CustomEventB(2)
+			                   ]
+			             """);
+	}
+
+	[Fact]
+	public async Task
+		MultipleEvents_WhenListeningMultipleTimesToDifferentEventAndOnlySomeAreSatisfied_ShouldDisplayAllFailedEventQueues()
+	{
+		MultipleEventsClass<string, int> sut = new();
+
+		async Task Act() =>
+			await That(sut)
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+				.WithParameter<string>(s => s == "foo")
+				.AtLeast(2.Times())
+				.And
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventB))
+				.WithParameter<int>(s => s == 3)
+				.While(t =>
+				{
+					t.NotifyCustomEventA("foo");
+					t.NotifyCustomEventB(3);
+				});
+
+		await That(Act).Should().Throw<XunitException>()
+			.WithMessage("""
+			             Expected sut to
+			               [1] trigger event CustomEventA with string parameter s => s == "foo" at least 2 times and
+			               [2] trigger event CustomEventB with int parameter s => s == 3 at least once,
+			             but it was
+			               [1] only recorded once in [
+			                     CustomEventA("foo")
+			                   ]
+			             """);
+	}
+
+	[Fact]
+	public async Task MultipleEvents_WhenListeningMultipleTimesToSameEvent_ShouldGroupEventsInFailureMessage()
+	{
+		MultipleEventsClass<string, int> sut = new();
+
+		async Task Act() =>
+			await That(sut)
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+				.WithParameter<string>(s => s == "foo")
+				.AtLeast(2.Times())
+				.And
+				.Triggers(nameof(MultipleEventsClass<string, int>.CustomEventA))
+				.WithParameter<string>(s => s == "bar")
+				.AtLeast(3.Times())
+				.While(t =>
+				{
+					t.NotifyCustomEventA("foo");
+					t.NotifyCustomEventA("bar");
+				});
+
+		await That(Act).Should().Throw<XunitException>()
+			.WithMessage("""
+			             Expected sut to
+			             trigger event CustomEventA
+			               [1] with string parameter s => s == "foo" at least 2 times and
+			               [2] with string parameter s => s == "bar" at least 3 times,
+			             but it was
+			               [1] only recorded once and
+			               [2] only recorded once in [
+			                     CustomEventA("foo"),
+			                     CustomEventA("bar")
+			                   ]
+			             """);
+	}
+
 	[Fact]
 	public async Task ShouldConsiderCancellationTokenInAsyncCallback()
 	{
@@ -194,33 +338,6 @@ public sealed class TriggerTests
 	}
 
 	[Fact]
-	public async Task WhenCustomEventWithParameters2222_WhenFilterResultsInTooFewRecordings_ShouldFail()
-	{
-		CustomEventWithParametersClass<string> sut = new();
-
-		async Task Act() =>
-			await That(sut)
-				.Triggers(nameof(CustomEventWithParametersClass<string>.CustomEvent))
-				.WithParameter<string>(s => s == "foo")
-				.AtLeast(2.Times())
-				.While(t =>
-				{
-					t.NotifyCustomEvent("foo");
-					t.NotifyCustomEvent("bar");
-				});
-
-		await That(Act).Should().Throw<XunitException>()
-			.WithMessage("""
-			             Expected sut to
-			             trigger event CustomEvent with string parameter s => s == "foo" at least 2 times,
-			             but it was only recorded once in [
-			               CustomEvent("foo"),
-			               CustomEvent("bar")
-			             ]
-			             """);
-	}
-
-	[Fact]
 	public async Task WhenCustomEventWithParametersIsTriggeredOftenEnough_ShouldSucceed()
 	{
 		CustomEventWithParametersClass<string> sut = new();
@@ -351,6 +468,22 @@ public sealed class TriggerTests
 
 		public void NotifyCustomEvent(T1 arg1)
 			=> CustomEvent?.Invoke(arg1);
+	}
+
+	private sealed class MultipleEventsClass<T1, T2>
+	{
+		public delegate void CustomEventDelegateA(T1 arg1);
+
+		public delegate void CustomEventDelegateB(T2 arg1);
+
+		public event CustomEventDelegateA? CustomEventA;
+		public event CustomEventDelegateB? CustomEventB;
+
+		public void NotifyCustomEventA(T1 arg1)
+			=> CustomEventA?.Invoke(arg1);
+
+		public void NotifyCustomEventB(T2 arg1)
+			=> CustomEventB?.Invoke(arg1);
 	}
 
 	private sealed class CustomEventWithParametersClass<T1, T2>

--- a/Tests/aweXpect.Tests/ThatTests/TriggerExtensionsTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TriggerExtensionsTests.cs
@@ -44,7 +44,7 @@ public sealed class TriggerExtensionsTests
 			.WithMessage("""
 			             Expected sut to
 			             trigger event PropertyChanged with PropertyChangedEventArgs parameter e => e.PropertyName == "foo" at least 2 times,
-			             but it was only recorded once in [
+			             but it was recorded once in [
 			               PropertyChanged(PropertyChangedClass { }, PropertyChangedEventArgs {
 			                   PropertyName = "foo"
 			                 }),

--- a/Tests/aweXpect.Tests/ThatTests/TriggerExtensionsTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TriggerExtensionsTests.cs
@@ -13,13 +13,13 @@ public sealed class TriggerExtensionsTests
 			await That(sut)
 				.TriggersPropertyChanged()
 				.WithPropertyChangedEventArgs(e => e.PropertyName == "foo")
+				.AtLeast(3.Times())
 				.While(t =>
 				{
 					t.NotifyPropertyChanged("foo");
 					t.NotifyPropertyChanged("foo");
 					t.NotifyPropertyChanged("foo");
-				})
-				.AtLeast(3.Times());
+				});
 
 		await That(Act).Should().NotThrow();
 	}
@@ -33,12 +33,12 @@ public sealed class TriggerExtensionsTests
 			await That(sut)
 				.TriggersPropertyChanged()
 				.WithPropertyChangedEventArgs(e => e.PropertyName == "foo")
+				.AtLeast(2.Times())
 				.While(t =>
 				{
 					t.NotifyPropertyChanged("foo");
 					t.NotifyPropertyChanged("bar");
-				})
-				.AtLeast(2.Times());
+				});
 
 		await That(Act).Should().Throw<XunitException>()
 			.WithMessage("""


### PR DESCRIPTION
From #133:
> Multiple expectations for one callback:
> ```csharp
> await Expect.That(sut)
>   .TriggersPropertyChangedFor(x => x.Property1).And
>   .TriggersPropertyChangedFor(x => x.Property2)
> ```
> This will require changing the order, so that the While is always last and the "AtLeast" etc. is before

Adjust the results to specify the count before the while loop and allow for multiple triggers to be expected.