### PR TITLE
refactor: compiler directive should check for NET8_0_OR_GREATER

### DIFF
--- a/Source/aweXpect.Core/Core/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+﻿#if !NET8_0_OR_GREATER
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/Source/aweXpect.Core/Core/Polyfills/StackTraceHiddenAttribute.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/StackTraceHiddenAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+﻿#if !NET8_0_OR_GREATER
 // ReSharper disable once CheckNamespace
 namespace System.Diagnostics;
 

--- a/Source/aweXpect.Core/Expect.cs
+++ b/Source/aweXpect.Core/Expect.cs
@@ -38,7 +38,7 @@ public static class Expect
 		=> new ThatSubject<T>(new ExpectationBuilder<T>(
 			new AsyncValueSource<T>(subject), doNotPopulateThisValue));
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Specify expectations for the current asynchronous <paramref name="subject" />.
 	/// </summary>
@@ -85,7 +85,7 @@ public static class Expect
 			new ExpectationBuilder<DelegateValue>(
 				new DelegateAsyncSource(@delegate), doNotPopulateThisValue));
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{ValueTask}" /> <paramref name="delegate" />.
 	/// </summary>
@@ -96,7 +96,7 @@ public static class Expect
 				new DelegateAsyncSource(_ => @delegate().AsTask()), doNotPopulateThisValue));
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{CancellationToken, ValueTask}" /> <paramref name="delegate" />
 	///     .
@@ -147,7 +147,7 @@ public static class Expect
 			new ExpectationBuilder<DelegateValue<TValue>>(
 				new DelegateAsyncValueSource<TValue>(@delegate), doNotPopulateThisValue));
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{T}" /> of <see cref="ValueTask{TValue}" />
 	///     <paramref name="delegate" />.
@@ -159,7 +159,7 @@ public static class Expect
 				new DelegateAsyncValueSource<TValue>(_ => @delegate().AsTask()), doNotPopulateThisValue));
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Specify expectations for the current <see cref="Func{CancellationToken, T}" /> of <see cref="ValueTask{TValue}" />
 	///     <paramref name="delegate" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateOnly.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateOnly.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System;
 using System.Text;
 

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.TimeOnly.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.TimeOnly.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System;
 using System.Text;
 

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -75,7 +75,7 @@ public static partial class ValueFormatters
 		{
 			formatter.Format(stringBuilder, timeSpanValue, options);
 		}
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		else if (value is DateOnly dateOnlyValue)
 		{
 			formatter.Format(stringBuilder, dateOnlyValue, options);

--- a/Source/aweXpect/Helpers/EvaluationContextExtensions.cs
+++ b/Source/aweXpect/Helpers/EvaluationContextExtensions.cs
@@ -31,7 +31,7 @@ internal static class EvaluationContextExtensions
 		return materializedEnumerable;
 	}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	private const string MaterializedAsyncEnumerableKey = nameof(MaterializedAsyncEnumerableKey);
 
 	/// <summary>

--- a/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 

--- a/Source/aweXpect/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+﻿#if !NET8_0_OR_GREATER
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AllBe.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AllBe.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AllBeUnique.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AllBeUnique.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AllSatisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.AllSatisfy.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeContainedIn.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeContainedIn.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeEmpty.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeInAscendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeInAscendingOrder.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeInDescendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.BeInDescendingOrder.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.Contain.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAll.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAll.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtLeast.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveAtMost.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveBetween.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveBetween.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveExactly.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveNone.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveNone.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using aweXpect.Core;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.HaveSingle.cs
@@ -8,7 +8,7 @@ using aweXpect.Helpers;
 using aweXpect.Results;
 // ReSharper disable PossibleMultipleEnumeration
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace aweXpect;
 
 public static partial class ThatAsyncEnumerableShould

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerableShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.Be.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeAfter.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeBefore.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.HaveDay.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.HaveDay.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.HaveMonth.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.HaveMonth.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.HaveYear.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.HaveYear.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.Be.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeAfter.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeBefore.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrAfter.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrBefore.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.HaveDay.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.HaveDay.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.HaveMonth.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.HaveMonth.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.HaveYear.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.HaveYear.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.BeRedirection.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.BeRedirection.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.BeSuccess.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.BeSuccess.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveClientError.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveClientError.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveContent.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveError.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveError.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveServerError.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveServerError.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveStatusCode.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.HaveStatusCode.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Net;
 using System.Net.Http;

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessageShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/aweXpect/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
+++ b/Source/aweXpect/That/Streams/ThatBufferedStreamShould.HaveBufferSize.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.IO;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Streams/ThatBufferedStreamShould.cs
+++ b/Source/aweXpect/That/Streams/ThatBufferedStreamShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using System.IO;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.Be.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeAfter.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeBefore.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveHour.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveHour.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveMillisecond.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveMillisecond.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveMinute.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveMinute.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveSecond.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.HaveSecond.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.Be.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.Be.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeAfter.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeBefore.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrAfter.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrAfter.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrBefore.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.BeOnOrBefore.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveHour.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveHour.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveMillisecond.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveMillisecond.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveMinute.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveMinute.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveSecond.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.HaveSecond.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Results;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Tests/aweXpect.Core.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Core.Tests/ExpectTests.cs
@@ -22,7 +22,7 @@ public class ExpectTests
 		await That(Act).Should().NotThrow();
 	}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	[Fact]
 	public async Task ShouldSupportValueTaskAsSubject()
 	{

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateOnlyTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Text;
 
 namespace aweXpect.Core.Tests.Formatting;

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.HttpStatusCodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.HttpStatusCodeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Text;
 

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeOnlyTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Text;
 
 namespace aweXpect.Core.Tests.Formatting;

--- a/Tests/aweXpect.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Tests/ExpectTests.cs
@@ -1,5 +1,5 @@
 ﻿using aweXpect.Tests.TestHelpers;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -377,7 +377,7 @@ public class ExpectTests
 		}
 	}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Returns an <see cref="IAsyncEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the
 	///     <paramref name="cancellationTokenSource" /> after <paramref name="cancelAfter" /> iteration.

--- a/Tests/aweXpect.Tests/TestHelpers/Factory.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Factory.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.CompilerServices;
 using System.Threading;
 #endif
@@ -8,7 +8,7 @@ namespace aweXpect.Tests.TestHelpers;
 
 internal static class Factory
 {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Returns an "infinite" <see cref="IAsyncEnumerable{T}" /> of fibonacci numbers.
 	/// </summary>
@@ -28,7 +28,7 @@ internal static class Factory
 	}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Returns an "infinite" <see cref="IAsyncEnumerable{T}" /> of mapped fibonacci numbers.
 	/// </summary>
@@ -49,7 +49,7 @@ internal static class Factory
 	}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 	/// <summary>
 	///     Returns an "infinite" <see cref="IAsyncEnumerable{T}" /> of <paramref name="value"/>.
 	/// </summary>

--- a/Tests/aweXpect.Tests/TestHelpers/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NET6_0_OR_GREATER
+﻿#if !NET8_0_OR_GREATER
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AllBeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AllBeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AllBeUniqueTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AllBeUniqueTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using aweXpect.Tests.TestHelpers;
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AllSatisfyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.AllSatisfyTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeContainedInTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeContainedInTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeEmptyTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeInAscendingOrderTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeInAscendingOrderTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 
 // ReSharper disable PossibleMultipleEnumeration

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeInDescendingOrderTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeInDescendingOrderTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 
 // ReSharper disable PossibleMultipleEnumeration

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.BeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.ContainTests.Collection.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.ContainTests.Collection.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.ContainTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.ContainTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAllTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAllTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtLeastTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtLeastTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtMostTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveAtMostTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveBetweenTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveBetweenTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveExactlyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveExactlyTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveNoneTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveNoneTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Threading;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveSingleTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.HaveSingleTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 
 // ReSharper disable PossibleMultipleEnumeration

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.NotBeEmptyTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.NotBeEmptyTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 
 // ReSharper disable PossibleMultipleEnumeration

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.NotContainTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.NotContainTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Tests.TestHelpers;

--- a/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Collections/AsyncEnumerableShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeOnOrBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.BeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.HaveDayTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.HaveDayTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.HaveMonthTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.HaveMonthTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.HaveYearTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.HaveYearTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/DateOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class DateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeOnOrBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.BeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.HaveDayTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.HaveDayTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.HaveMonthTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.HaveMonthTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.HaveYearTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.HaveYearTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/DateOnlys/NullableDateOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.DateOnlys;
 
 public sealed partial class NullableDateOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateShould.ExecuteWithinTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateShould.ExecuteWithinTests.cs
@@ -58,7 +58,7 @@ public sealed partial class DelegateShould
 				              """);
 		}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task WhenFuncValueTaskThrowsAnException_ShouldFailWithDescriptiveMessage()
 		{
@@ -78,7 +78,7 @@ public sealed partial class DelegateShould
 
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task WhenFuncValueTaskValueThrowsAnException_ShouldFailWithDescriptiveMessage()
 		{
@@ -150,7 +150,7 @@ public sealed partial class DelegateShould
 			await That(Act).Should().NotThrow();
 		}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task WhenFuncValueTaskThrowsAnException_ShouldSucceed()
 		{
@@ -164,7 +164,7 @@ public sealed partial class DelegateShould
 
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task WhenFuncValueTaskValueThrowsAnException_ShouldSucceed()
 		{

--- a/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Delegates/DelegateShould.cs
@@ -30,7 +30,7 @@ public sealed partial class DelegateShould
 			await That(result).Should().Be(value);
 		}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Theory]
 		[AutoData]
 		public async Task ShouldReturnValue_FuncValueTaskValue(int value)
@@ -43,7 +43,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Theory]
 		[AutoData]
 		public async Task ShouldReturnValue_FuncValueTaskValue_WithCancellationToken(int value)
@@ -384,7 +384,7 @@ public sealed partial class DelegateShould
 				              """);
 		}
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_FuncValueTask_WhenSuccess()
 		{
@@ -403,7 +403,7 @@ public sealed partial class DelegateShould
 #endif
 
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_FuncValueTask_WithCancellationToken_WhenSuccess()
 		{
@@ -421,7 +421,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_ValueTask_WhenThrown()
 		{
@@ -440,7 +440,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_ValueTask_WithCancellationToken_WhenThrown()
 		{
@@ -459,7 +459,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_ValueTaskValue_WhenSuccess()
 		{
@@ -477,7 +477,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_ValueTaskValue_WhenThrown()
 		{
@@ -496,7 +496,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_ValueTaskValue_WithCancellationToken_WhenSuccess()
 		{
@@ -514,7 +514,7 @@ public sealed partial class DelegateShould
 		}
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		[Fact]
 		public async Task ShouldSupportDelegate_ValueTaskValue_WithCancellationToken_WhenThrown()
 		{

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.BeRedirectionTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.BeRedirectionTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.BeSuccessTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.BeSuccessTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveClientErrorTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveClientErrorTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveContentTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveContentTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net.Http;
 
 namespace aweXpect.Tests.ThatTests.Http;

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveErrorTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveErrorTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveServerErrorTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveServerErrorTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveStatusCodeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.HaveStatusCodeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Http/HttpResponseMessageShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 

--- a/Tests/aweXpect.Tests/ThatTests/Streams/BufferedStreamShould.HaveBufferSizeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Streams/BufferedStreamShould.HaveBufferSizeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.IO;
 
 namespace aweXpect.Tests.ThatTests.Streams;

--- a/Tests/aweXpect.Tests/ThatTests/Streams/BufferedStreamShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/Streams/BufferedStreamShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.IO;
 
 namespace aweXpect.Tests.ThatTests.Streams;

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeOnOrBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.BeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveHourTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveHourTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveMillisecondTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveMillisecondTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveMinuteTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveMinuteTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveSecondTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.HaveSecondTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/NullableTimeOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class NullableTimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrAfterTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrAfterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrBeforeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeOnOrBeforeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.BeTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveHourTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveHourTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveMillisecondTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveMillisecondTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveMinuteTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveMinuteTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveSecondTests.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.HaveSecondTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould

--- a/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.cs
+++ b/Tests/aweXpect.Tests/ThatTests/TimeOnlys/TimeOnlyShould.cs
@@ -1,4 +1,4 @@
-﻿#if NET6_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 namespace aweXpect.Tests.ThatTests.TimeOnlys;
 
 public sealed partial class TimeOnlyShould


### PR DESCRIPTION
Replace `#if NET6_0_OR_GREATER` with `#if NET8_0_OR_GREATER` as we only target net8.0