### PR TITLE
refactor: add missing assertion in ValueFormatters tests

### DIFF
--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.BoolTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.BoolTests.cs
@@ -50,6 +50,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.CollectionTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.CollectionTests.cs
@@ -49,9 +49,11 @@ public partial class ValueFormatters
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value!);
+			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value!);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateOnlyTests.cs
@@ -50,6 +50,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeOffsetTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeOffsetTests.cs
@@ -49,6 +49,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeTests.cs
@@ -49,6 +49,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.EnumTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.EnumTests.cs
@@ -50,6 +50,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
@@ -81,6 +81,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.HttpStatusCodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.HttpStatusCodeTests.cs
@@ -52,6 +52,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
@@ -162,6 +162,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -192,6 +193,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -222,6 +224,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -252,6 +255,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -283,6 +287,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -313,6 +318,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -375,6 +381,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -405,6 +412,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -435,6 +443,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -465,6 +474,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
@@ -495,6 +505,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.ObjectTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.ObjectTests.cs
@@ -165,6 +165,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.StringTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.StringTests.cs
@@ -70,6 +70,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeOnlyTests.cs
@@ -50,6 +50,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeSpanTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeSpanTests.cs
@@ -242,6 +242,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -115,6 +115,7 @@ public partial class ValueFormatters
 			Formatter.Format(sb, value);
 
 			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
 			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 


### PR DESCRIPTION
In the ValueFormatters the expectation for null formatting an `object` was missing.