### PR TITLE
feat: allow specifying the default timeout for the `SignalCounter`

### DIFF
--- a/Source/aweXpect.Core/Customization/Customize.Recording.cs
+++ b/Source/aweXpect.Core/Customization/Customize.Recording.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading;
+
+namespace aweXpect.Customization;
+
+public partial class Customize : ICustomizeRecording
+{
+	private static readonly int DefaultTimeoutSeconds = 30;
+
+	private readonly AsyncLocal<TimeSpan?> _defaultTimeout = new();
+
+	/// <summary>
+	///     Customizes the recording settings.
+	/// </summary>
+	public static ICustomizeRecording Recording => Instance;
+
+	/// <inheritdoc />
+	TimeSpan ICustomizeRecording.DefaultTimeout
+		=> _defaultTimeout.Value ?? TimeSpan.FromSeconds(DefaultTimeoutSeconds);
+
+	/// <inheritdoc />
+	IDisposable ICustomizeRecording.SetDefaultTimeout(TimeSpan timeout)
+	{
+		_defaultTimeout.Value = timeout;
+		return new ActionDisposable(() => _defaultTimeout.Value = null);
+	}
+}

--- a/Source/aweXpect.Core/Customization/ICustomizeRecording.cs
+++ b/Source/aweXpect.Core/Customization/ICustomizeRecording.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using aweXpect.Recording;
+
+namespace aweXpect.Customization;
+
+/// <summary>
+///     Customizes the recording settings.
+/// </summary>
+public interface ICustomizeRecording
+{
+	/// <summary>
+	///     The default timeout for the <see cref="SignalCounter" />.
+	/// </summary>
+	TimeSpan DefaultTimeout { get; }
+
+	/// <summary>
+	///     Specifies the default timeout for the <see cref="SignalCounter" />.
+	/// </summary>
+	/// <returns>
+	///     An object, that will revert the default timeout to 30 seconds upon disposal.
+	/// </returns>
+	IDisposable SetDefaultTimeout(TimeSpan timeout);
+}

--- a/Source/aweXpect.Core/Recording/SignalCounter.cs
+++ b/Source/aweXpect.Core/Recording/SignalCounter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using aweXpect.Customization;
 
 namespace aweXpect.Recording;
 
@@ -61,7 +62,7 @@ public class SignalCounter
 			}
 		}
 
-		timeout ??= TimeSpan.FromSeconds(30);
+		timeout ??= Customize.Recording.DefaultTimeout;
 		if (_resetEvent != null)
 		{
 			try
@@ -113,7 +114,7 @@ public class SignalCounter
 			_countdownEvent = new CountdownEvent(amount.Value - _counter);
 		}
 
-		timeout ??= TimeSpan.FromSeconds(30);
+		timeout ??= Customize.Recording.DefaultTimeout;
 		try
 		{
 			if (_countdownEvent.Wait(timeout.Value, cancellationToken))
@@ -200,7 +201,7 @@ public class SignalCounter<TParameter>
 			}
 		}
 
-		timeout ??= TimeSpan.FromSeconds(30);
+		timeout ??= Customize.Recording.DefaultTimeout;
 		if (_resetEvent != null)
 		{
 			try
@@ -261,7 +262,7 @@ public class SignalCounter<TParameter>
 			_countdownEvent = new CountdownEvent(amount.Value - actualCount);
 		}
 
-		timeout ??= TimeSpan.FromSeconds(30);
+		timeout ??= Customize.Recording.DefaultTimeout;
 		try
 		{
 			if (_countdownEvent.Wait(timeout.Value, cancellationToken))

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -196,15 +196,21 @@ namespace aweXpect.Core.Sources
 }
 namespace aweXpect.Customization
 {
-    public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeReflection
+    public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeRecording, aweXpect.Customization.ICustomizeReflection
     {
         public static aweXpect.Customization.ICustomizeFormatting Formatting { get; }
+        public static aweXpect.Customization.ICustomizeRecording Recording { get; }
         public static aweXpect.Customization.ICustomizeReflection Reflection { get; }
     }
     public interface ICustomizeFormatting
     {
         int MaximumNumberOfCollectionItems { get; }
         System.IDisposable SetMaximumNumberOfCollectionItems(int value);
+    }
+    public interface ICustomizeRecording
+    {
+        System.TimeSpan DefaultTimeout { get; }
+        System.IDisposable SetDefaultTimeout(System.TimeSpan timeout);
     }
     public interface ICustomizeReflection
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -196,15 +196,21 @@ namespace aweXpect.Core.Sources
 }
 namespace aweXpect.Customization
 {
-    public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeReflection
+    public class Customize : aweXpect.Customization.ICustomizeFormatting, aweXpect.Customization.ICustomizeRecording, aweXpect.Customization.ICustomizeReflection
     {
         public static aweXpect.Customization.ICustomizeFormatting Formatting { get; }
+        public static aweXpect.Customization.ICustomizeRecording Recording { get; }
         public static aweXpect.Customization.ICustomizeReflection Reflection { get; }
     }
     public interface ICustomizeFormatting
     {
         int MaximumNumberOfCollectionItems { get; }
         System.IDisposable SetMaximumNumberOfCollectionItems(int value);
+    }
+    public interface ICustomizeRecording
+    {
+        System.TimeSpan DefaultTimeout { get; }
+        System.IDisposable SetDefaultTimeout(System.TimeSpan timeout);
     }
     public interface ICustomizeReflection
     {

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeRecordingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeRecordingTests.cs
@@ -1,0 +1,29 @@
+﻿using aweXpect.Chronology;
+using aweXpect.Customization;
+using aweXpect.Recording;
+
+namespace aweXpect.Core.Tests.Customization;
+
+public sealed class CustomizeRecordingTests
+{
+	[Fact]
+	public async Task MaximumNumberOfCollectionItems_ShouldBeUsedInFormatter()
+	{
+		SignalCounter signalCounter = new();
+		await That(Customize.Recording.DefaultTimeout.TotalMilliseconds).Should().Be(30000);
+		using (IDisposable __ = Customize.Recording.SetDefaultTimeout(TimeSpan.FromMilliseconds(10)))
+		{
+			_ = Task.Delay(1000.Milliseconds()).ContinueWith(_ => signalCounter.Signal());
+			SignalCounterResult result = signalCounter.Wait();
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(Customize.Recording.DefaultTimeout.TotalMilliseconds).Should().Be(10);
+		}
+
+		{
+			_ = Task.Delay(200.Milliseconds()).ContinueWith(_ => signalCounter.Signal());
+			SignalCounterResult result = signalCounter.Wait();
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(Customize.Recording.DefaultTimeout.TotalMilliseconds).Should().Be(30000);
+		}
+	}
+}


### PR DESCRIPTION
Support specifying a default timeout that is used in the `SignalCounter` expectations, e.g.
```csharp
using (IDisposable __ = Customize.Recording.SetDefaultTimeout(TimeSpan.FromMilliseconds(10)))
{
    _ = Task.Delay(1000.Milliseconds()).ContinueWith(_ => signalCounter.Signal());
    SignalCounterResult result = signalCounter.Wait();
    await Expect.That(result.IsSuccess).Should().BeFalse();
    await Expect.That(Customize.Recording.DefaultTimeout.TotalMilliseconds).Should().Be(10);
}
```