### PR TITLE
refactor: use "aweXpect" for API tests

### DIFF
--- a/Tests/aweXpect.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Api.Tests/ApiAcceptance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace aweXpect.Api.Tests;
@@ -10,7 +11,7 @@ public sealed class ApiAcceptance
 	/// </summary>
 	[TestCase]
 	[Explicit]
-	public void AcceptApiChanges()
+	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =
 		[
@@ -28,6 +29,6 @@ public sealed class ApiAcceptance
 			}
 		}
 
-		Assert.That(assemblyNames, Is.Not.Empty);
+		await Expect.That(assemblyNames).Should().NotBeEmpty();
 	}
 }

--- a/Tests/aweXpect.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Api.Tests/ApiApprovalTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace aweXpect.Api.Tests;
@@ -11,25 +12,25 @@ namespace aweXpect.Api.Tests;
 public sealed class ApiApprovalTests
 {
 	[TestCaseSource(typeof(TargetFrameworksTheoryData))]
-	public void VerifyPublicApiForAweXpect(string framework)
+	public async Task VerifyPublicApiForAweXpect(string framework)
 	{
 		const string assemblyName = "aweXpect";
 
 		string publicApi = Helper.CreatePublicApi(framework, assemblyName);
 		string expectedApi = Helper.GetExpectedApi(framework, assemblyName);
 
-		Assert.That(publicApi, Is.EqualTo(expectedApi));
+		await Expect.That(publicApi).Should().Be(expectedApi);
 	}
 
 	[TestCaseSource(typeof(TargetFrameworksTheoryData))]
-	public void VerifyPublicApiForAweXpectCore(string framework)
+	public async Task VerifyPublicApiForAweXpectCore(string framework)
 	{
 		const string assemblyName = "aweXpect.Core";
 
 		string publicApi = Helper.CreatePublicApi(framework, assemblyName);
 		string expectedApi = Helper.GetExpectedApi(framework, assemblyName);
 
-		Assert.That(publicApi, Is.EqualTo(expectedApi));
+		await Expect.That(publicApi).Should().Be(expectedApi);
 	}
 
 	private sealed class TargetFrameworksTheoryData : IEnumerable

--- a/Tests/aweXpect.Api.Tests/Helper.cs
+++ b/Tests/aweXpect.Api.Tests/Helper.cs
@@ -9,7 +9,7 @@ using PublicApiGenerator;
 
 namespace aweXpect.Api.Tests;
 
-public static class Helper
+internal static class Helper
 {
 	public static string CreatePublicApi(string framework, string assemblyName)
 	{


### PR DESCRIPTION
Improve the error message when the API test fails by using "aweXpect".