### PR TITLE
refactor: require `.Should()` in recursive inner exceptions

### DIFF
--- a/Docs/pages/docs/expectations/delegates.md
+++ b/Docs/pages/docs/expectations/delegates.md
@@ -103,7 +103,7 @@ You can recursively verify the collection of inner exceptions of the thrown exce
 ```csharp
 void Act() => throw new AggregateException("outer", new CustomException("inner"));
 
-await Expect.That(Act).Should().ThrowException().WithRecursiveInnerExceptions(a => a.HaveAtLeast(1).Be<CustomException>());
+await Expect.That(Act).Should().ThrowException().WithRecursiveInnerExceptions(innerExceptions => innerExceptions.Should().HaveAtLeast(1).Be<CustomException>());
 ```
 
 ### Other members

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -18,12 +18,12 @@ public partial class ThatDelegateThrows<TException>
 	/// </remarks>
 	public AndOrResult<TException?, ThatDelegateThrows<TException>>
 		WithRecursiveInnerExceptions(
-			Action<IThat<IEnumerable<Exception>>> expectations)
+			Action<IExpectSubject<IEnumerable<Exception>>> expectations)
 		=> new(ExpectationBuilder
 				.ForMember(
 					MemberAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
 						e => e.GetInnerExpectations(), "recursive inner exceptions "),
-					(property, expectation) => $"with {property}which {expectation}")
+					(property, expectation) => $"with {property}which should {expectation}")
 				.AddExpectations(e
 					=> expectations(new That.Subject<IEnumerable<Exception>>(e))),
 			this);

--- a/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
+++ b/Source/aweXpect/That/Exceptions/ThatExceptionShould.HaveRecursiveInnerExceptions.cs
@@ -21,12 +21,12 @@ public partial class ThatExceptionShould<TException>
 	/// </remarks>
 	public AndOrResult<TException?, ThatExceptionShould<TException>>
 		HaveRecursiveInnerExceptions(
-			Action<IThat<IEnumerable<Exception>>> expectations)
+			Action<IExpectSubject<IEnumerable<Exception>>> expectations)
 		=> new(ExpectationBuilder
 				.ForMember(MemberAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
 						e => e.GetInnerExpectations(),
 						"recursive inner exceptions "),
-					(property, expectation) => $"have {property}which {expectation}",
+					(property, expectation) => $"have {property}which should {expectation}",
 					false)
 				.AddExpectations(e => expectations(
 					new That.Subject<IEnumerable<Exception>>(e))),

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -204,7 +204,7 @@ namespace aweXpect
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException() { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
         public aweXpect.Results.StringEqualityTypeResult<TException, aweXpect.ThatDelegateThrows<TException>> WithMessage(string expected) { }
-        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
+        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<aweXpect.Core.IExpectSubject<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatDictionaryShould
     {
@@ -344,7 +344,7 @@ namespace aweXpect
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveInnerException() { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
         public aweXpect.Results.StringEqualityTypeResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveMessage(string expected) { }
-        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
+        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<aweXpect.Core.IExpectSubject<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatGeneric
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -124,7 +124,7 @@ namespace aweXpect
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException() { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatDelegateThrows<TException>> WithInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
         public aweXpect.Results.StringEqualityTypeResult<TException, aweXpect.ThatDelegateThrows<TException>> WithMessage(string expected) { }
-        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
+        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions(System.Action<aweXpect.Core.IExpectSubject<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatDictionaryShould
     {
@@ -264,7 +264,7 @@ namespace aweXpect
         public aweXpect.Results.AndOrResult<TException, aweXpect.ThatExceptionShould<TException>> HaveInnerException() { }
         public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveInnerException(System.Action<aweXpect.ThatExceptionShould<System.Exception?>> expectations) { }
         public aweXpect.Results.StringEqualityTypeResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveMessage(string expected) { }
-        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
+        public aweXpect.Results.AndOrResult<TException?, aweXpect.ThatExceptionShould<TException>> HaveRecursiveInnerExceptions(System.Action<aweXpect.Core.IExpectSubject<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }
     public static class ThatGeneric
     {

--- a/Tests/aweXpect.Tests/Delegates/DelegateShould.ThrowExceptionTests.WithRecursiveInnerExceptions.cs
+++ b/Tests/aweXpect.Tests/Delegates/DelegateShould.ThrowExceptionTests.WithRecursiveInnerExceptions.cs
@@ -21,12 +21,12 @@ public sealed partial class DelegateShould
 
 				async Task Act()
 					=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(
-						e => e.HaveAtLeast(minimum, x => x.Be<CustomException>()));
+						e => e.Should().HaveAtLeast(minimum, x => x.Be<CustomException>()));
 
 				await That(Act).Should().Throw<XunitException>().OnlyIf(shouldThrow)
 					.WithMessage($"""
 					              Expected action to
-					              throw an exception with recursive inner exceptions which have at least {minimum} items be type CustomException,
+					              throw an exception with recursive inner exceptions which should have at least {minimum} items be type CustomException,
 					              but only 1 of 5 were
 					              """);
 			}
@@ -39,7 +39,7 @@ public sealed partial class DelegateShould
 
 				Exception? result = await That(Delegate)
 					.Should().ThrowException().WithRecursiveInnerExceptions(
-						e => e.HaveNone(x => x.Satisfy(_ => false)));
+						e => e.Should().HaveNone(x => x.Satisfy(_ => false)));
 
 				await That(result).Should().BeSameAs(exception);
 			}
@@ -51,12 +51,12 @@ public sealed partial class DelegateShould
 
 				async Task Act()
 					=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(
-						e => e.HaveAll(x => x.Satisfy(_ => false)));
+						e => e.Should().HaveAll(x => x.Satisfy(_ => false)));
 
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage("""
 					             Expected action to
-					             throw an exception with recursive inner exceptions which have all items satisfy _ => false,
+					             throw an exception with recursive inner exceptions which should have all items satisfy _ => false,
 					             but not all were
 					             """);
 			}
@@ -68,7 +68,7 @@ public sealed partial class DelegateShould
 
 				async Task Act()
 					=> await That(action).Should().ThrowException().WithRecursiveInnerExceptions(
-						e => e.HaveAll(x => x.Satisfy(_ => false)));
+						e => e.Should().HaveAll(x => x.Satisfy(_ => false)));
 
 				await That(Act).Should().NotThrow();
 			}

--- a/Tests/aweXpect.Tests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ExceptionShould.HaveRecursiveInnerExceptionsTests.cs
@@ -17,7 +17,7 @@ public sealed partial class ExceptionShould
 
 				async Task Act()
 					=> await That(subject).Should().HaveRecursiveInnerExceptions(c
-						=> c.HaveAll(x => x.Satisfy(e => e.Message.StartsWith("inner"))));
+						=> c.Should().HaveAll(x => x.Satisfy(e => e.Message.StartsWith("inner"))));
 
 				await That(Act).Should().NotThrow();
 			}
@@ -33,12 +33,12 @@ public sealed partial class ExceptionShould
 
 				async Task Act()
 					=> await That(subject).Should().HaveRecursiveInnerExceptions(
-						c => c.HaveAll(x => x.Satisfy(e => e.Message != "inner3A")));
+						c => c.Should().HaveAll(x => x.Satisfy(e => e.Message != "inner3A")));
 
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage("""
 					             Expected subject to
-					             have recursive inner exceptions which have all items satisfy e => e.Message != "inner3A",
+					             have recursive inner exceptions which should have all items satisfy e => e.Message != "inner3A",
 					             but not all were
 					             """);
 			}
@@ -54,12 +54,12 @@ public sealed partial class ExceptionShould
 
 				async Task Act()
 					=> await That(subject).Should().HaveRecursiveInnerExceptions(
-						c => c.HaveNone(x => x.Satisfy(e => e.Message != "inner3A")));
+						c => c.Should().HaveNone(x => x.Satisfy(e => e.Message != "inner3A")));
 
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage("""
 					             Expected subject to
-					             have recursive inner exceptions which have no items satisfy e => e.Message != "inner3A",
+					             have recursive inner exceptions which should have no items satisfy e => e.Message != "inner3A",
 					             but at least one was
 					             """);
 			}
@@ -70,12 +70,12 @@ public sealed partial class ExceptionShould
 				Exception? subject = null;
 
 				async Task Act()
-					=> await That(subject).Should().HaveRecursiveInnerExceptions(c => c.BeEmpty());
+					=> await That(subject).Should().HaveRecursiveInnerExceptions(c => c.Should().BeEmpty());
 
 				await That(Act).Should().Throw<XunitException>()
 					.WithMessage("""
 					             Expected subject to
-					             have recursive inner exceptions which be empty,
+					             have recursive inner exceptions which should be empty,
 					             but it was <null>
 					             """);
 			}


### PR DESCRIPTION
Require a `.Should()` in the expectations on recursive inner exceptions to have a more consistent API.