### PR TITLE
coverage: add missing tests in aweXpect.Core (1)

### DIFF
--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -24,19 +24,6 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
-	/// </summary>
-	public static string Format(
-		this ValueFormatter formatter,
-		IEnumerable? value,
-		FormattingOptions? options = null)
-	{
-		StringBuilder stringBuilder = new();
-		Format(formatter, stringBuilder, value, options);
-		return stringBuilder.ToString();
-	}
-
-	/// <summary>
 	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Enum.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Enum.cs
@@ -34,9 +34,10 @@ public static partial class ValueFormatters
 		if (value == null)
 		{
 			stringBuilder.Append(ValueFormatter.NullString);
-			return;
 		}
-
-		stringBuilder.Append(value);
+		else
+		{
+			stringBuilder.Append(value);
+		}
 	}
 }

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -19,11 +19,6 @@ public static partial class ValueFormatters
 		FormattingOptions? options = null,
 		FormattingContext? context = null)
 	{
-		if (value is null)
-		{
-			return ValueFormatter.NullString;
-		}
-
 		StringBuilder stringBuilder = new();
 		Format(formatter, stringBuilder, value, options, context);
 		return stringBuilder.ToString();

--- a/Source/aweXpect.Core/Signaling/SignalerResult.cs
+++ b/Source/aweXpect.Core/Signaling/SignalerResult.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Signaling;
 /// <summary>
 ///     The result when waiting in a <see cref="Signaler" />.
 /// </summary>
-public class SignalerResult(bool wasTriggered, int counter)
+public class SignalerResult(bool isSuccess, int counter)
 {
 	/// <summary>
 	///     The number of times the callback was triggered.
@@ -20,14 +20,14 @@ public class SignalerResult(bool wasTriggered, int counter)
 	///     or the <see cref="CancellationToken" /> was cancelled prior to enough triggered callbacks;
 	///     otherwise <see langword="true" />.
 	/// </remarks>
-	public bool IsSuccess { get; } = wasTriggered;
+	public bool IsSuccess { get; } = isSuccess;
 }
 
 /// <summary>
 ///     The result when waiting in a <see cref="Signaler{TParameter}" />.
 /// </summary>
-public class SignalerResult<TParameter>(bool wasTriggered, TParameter[] parameters)
-	: SignalerResult(wasTriggered, parameters.Length)
+public class SignalerResult<TParameter>(bool isSuccess, TParameter[] parameters)
+	: SignalerResult(isSuccess, parameters.Length)
 {
 	/// <summary>
 	///     The parameters provided while triggering the callback.

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -320,7 +320,6 @@ namespace aweXpect.Formatting
         public static string Format(this aweXpect.Formatting.ValueFormatter _, ulong value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, System.UIntPtr value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, string? value, aweXpect.Formatting.FormattingOptions? options = null) { }
-        public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.Collections.IEnumerable? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.DateOnly? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.DateTime? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.DateTimeOffset? value, aweXpect.Formatting.FormattingOptions? options = null) { }
@@ -736,13 +735,13 @@ namespace aweXpect.Signaling
     }
     public class SignalerResult
     {
-        public SignalerResult(bool wasTriggered, int counter) { }
+        public SignalerResult(bool isSuccess, int counter) { }
         public int Count { get; }
         public bool IsSuccess { get; }
     }
     public class SignalerResult<TParameter> : aweXpect.Signaling.SignalerResult
     {
-        public SignalerResult(bool wasTriggered, TParameter[] parameters) { }
+        public SignalerResult(bool isSuccess, TParameter[] parameters) { }
         public TParameter[] Parameters { get; }
     }
     public class Signaler<TParameter>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -313,7 +313,6 @@ namespace aweXpect.Formatting
         public static string Format(this aweXpect.Formatting.ValueFormatter _, ulong value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, System.UIntPtr value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, string? value, aweXpect.Formatting.FormattingOptions? options = null) { }
-        public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.Collections.IEnumerable? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.DateTime? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.DateTimeOffset? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.Enum? value, aweXpect.Formatting.FormattingOptions? options = null) { }
@@ -723,13 +722,13 @@ namespace aweXpect.Signaling
     }
     public class SignalerResult
     {
-        public SignalerResult(bool wasTriggered, int counter) { }
+        public SignalerResult(bool isSuccess, int counter) { }
         public int Count { get; }
         public bool IsSuccess { get; }
     }
     public class SignalerResult<TParameter> : aweXpect.Signaling.SignalerResult
     {
-        public SignalerResult(bool wasTriggered, TParameter[] parameters) { }
+        public SignalerResult(bool isSuccess, TParameter[] parameters) { }
         public TParameter[] Parameters { get; }
     }
     public class Signaler<TParameter>

--- a/Tests/aweXpect.Core.Tests/Formatting/FormattingOptionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/FormattingOptionsTests.cs
@@ -1,0 +1,20 @@
+﻿namespace aweXpect.Core.Tests.Formatting;
+
+public class FormattingOptionsTests
+{
+	[Fact]
+	public async Task MultipleLines_ShouldUseLineBreaks()
+	{
+		FormattingOptions? multipleLines = FormattingOptions.MultipleLines;
+
+		await That(multipleLines.UseLineBreaks).Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task SingleLine_ShouldNotUseLineBreaks()
+	{
+		FormattingOptions? multipleLines = FormattingOptions.SingleLine;
+
+		await That(multipleLines.UseLineBreaks).Should().BeFalse();
+	}
+}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
@@ -70,7 +70,6 @@ public partial class ValueFormatters
 			await That(sb.ToString()).Should().Be(expectedResult);
 		}
 
-
 		[Fact]
 		public async Task Numbers_Int32_ShouldReturnExpectedValue()
 		{
@@ -339,6 +338,21 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task Numbers_NullableNint_WhenNull_ShouldUseDefaultNullString()
+		{
+			nint? value = null;
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
+			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
+		}
+
+		[Fact]
 		public async Task Numbers_NullableNuint_ShouldReturnExpectedValue()
 		{
 			nuint? value = 123;
@@ -352,6 +366,21 @@ public partial class ValueFormatters
 			await That(result).Should().Be(expectedResult);
 			await That(objectResult).Should().Be(expectedResult);
 			await That(sb.ToString()).Should().Be(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_NullableNuint_WhenNull_ShouldUseDefaultNullString()
+		{
+			nuint? value = null;
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).Should().Be(ValueFormatter.NullString);
+			await That(objectResult).Should().Be(ValueFormatter.NullString);
+			await That(sb.ToString()).Should().Be(ValueFormatter.NullString);
 		}
 
 		[Fact]

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeSpanTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeSpanTests.cs
@@ -232,6 +232,22 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task ShouldSupportTenAsHoursOrMinutes()
+		{
+			TimeSpan value = 10.Days(10.Hours(10.Minutes(10.Seconds())));
+			string expectedResult = "10.10:10:10";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).Should().Be(expectedResult);
+			await That(objectResult).Should().Be(expectedResult);
+			await That(sb.ToString()).Should().Be(expectedResult);
+		}
+
+		[Fact]
 		public async Task WhenNull_ShouldUseDefaultNullString()
 		{
 			TimeSpan? value = null;

--- a/Tests/aweXpect.Core.Tests/Signaling/SignalerTests.cs
+++ b/Tests/aweXpect.Core.Tests/Signaling/SignalerTests.cs
@@ -137,7 +137,7 @@ public class SignalerTests
 			Signaler signaler = new();
 			using ManualResetEventSlim ms = new();
 
-			_ = Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				for (int i = 10; i < 1000; i++)
 				{
@@ -147,7 +147,7 @@ public class SignalerTests
 						break;
 					}
 
-					Thread.Sleep(i.Milliseconds());
+					await Task.Delay(i.Milliseconds());
 					signaler.Signal();
 				}
 			});
@@ -297,7 +297,7 @@ public class SignalerTests
 			Signaler<int> signaler = new();
 			using ManualResetEventSlim ms = new();
 
-			_ = Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				for (int i = 10; i < 1000; i++)
 				{
@@ -308,7 +308,7 @@ public class SignalerTests
 					}
 
 					int value = i;
-					Thread.Sleep(i.Milliseconds());
+					await Task.Delay(i.Milliseconds());
 					signaler.Signal(value);
 				}
 			});
@@ -392,7 +392,7 @@ public class SignalerTests
 			Signaler<int> signaler = new();
 			using ManualResetEventSlim ms = new();
 
-			_ = Task.Run(() =>
+			_ = Task.Run(async () =>
 			{
 				for (int i = 10; i < 1000; i++)
 				{
@@ -403,7 +403,7 @@ public class SignalerTests
 					}
 
 					int value = i;
-					Thread.Sleep(i.Milliseconds());
+					await Task.Delay(i.Milliseconds());
 					signaler.Signal(value);
 				}
 			});

--- a/Tests/aweXpect.Core.Tests/Signaling/SignalerTests.cs
+++ b/Tests/aweXpect.Core.Tests/Signaling/SignalerTests.cs
@@ -1,0 +1,422 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using aweXpect.Chronology;
+using aweXpect.Signaling;
+
+namespace aweXpect.Core.Tests.Signaling;
+
+public class SignalerTests
+{
+	public sealed class Tests
+	{
+		[Theory]
+		[InlineData(0, 0, true)]
+		[InlineData(0, 1, false)]
+		[InlineData(2, 0, true)]
+		[InlineData(2, 1, true)]
+		[InlineData(2, 2, true)]
+		[InlineData(2, 3, false)]
+		[InlineData(2, 5, false)]
+		public async Task IsSignaled_ShouldCompareToSignalCount(int signalCount, int amount, bool expectedResult)
+		{
+			Signaler signaler = new();
+
+			for (int i = 0; i < signalCount; i++)
+			{
+				signaler.Signal();
+			}
+
+			bool result = signaler.IsSignaled(amount.Times());
+
+			await That(result).Should().Be(expectedResult);
+		}
+
+		[Fact]
+		public async Task Wait_EnoughSignals_ShouldSucceed()
+		{
+			Signaler signaler = new();
+
+			signaler.Signal();
+			signaler.Signal();
+			signaler.Signal();
+
+			SignalerResult result = signaler.Wait(2);
+
+			await That(result.IsSuccess).Should().BeTrue();
+		}
+
+		[Fact]
+		public async Task Wait_NegativeAmount_ShouldThrowArgumentOutOfRangeException()
+		{
+			Signaler signaler = new();
+
+			void Act()
+				=> signaler.Wait(-1);
+
+			await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+				.WithMessage("The amount must be greater than zero*").AsWildcard().And
+				.WithParamName("amount");
+		}
+
+		[Fact]
+		public async Task Wait_ShouldCatchOperationCanceledException()
+		{
+			Signaler signaler = new();
+			using CancellationTokenSource cts = new(30.Milliseconds());
+			CancellationToken token = cts.Token;
+
+			for (int i = 0; i < 99; i++)
+			{
+				_ = Task.Run(() => signaler.Signal(), token);
+			}
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(100.Times(), cancellationToken: token);
+			sw.Stop();
+
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_ShouldReturnAsSoonAsEnoughSignalsWereRecorded()
+		{
+			Signaler signaler = new();
+
+			List<Task> tasks = new();
+			for (int i = 0; i < 100; i++)
+			{
+				tasks.Add(Task.Run(() => signaler.Signal()));
+			}
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(100.Times());
+			sw.Stop();
+
+			await That(tasks).Should().HaveAll(x => x.Satisfy(t => t.IsCompleted));
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_Single_AlreadySignaled_ShouldSucceed()
+		{
+			Signaler signaler = new();
+
+			signaler.Signal();
+			signaler.Signal();
+
+			SignalerResult result = signaler.Wait();
+
+			await That(result.IsSuccess).Should().BeTrue();
+		}
+
+		[Fact]
+		public async Task Wait_Single_ShouldCatchOperationCanceledException()
+		{
+			Signaler signaler = new();
+			using CancellationTokenSource cts = new(30.Milliseconds());
+			CancellationToken token = cts.Token;
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(cancellationToken: token);
+			sw.Stop();
+
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_Single_ShouldReturnAsSoonAsSignalWasRecorded()
+		{
+			Signaler signaler = new();
+			using ManualResetEventSlim ms = new();
+
+			_ = Task.Run(() =>
+			{
+				for (int i = 10; i < 1000; i++)
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					if (ms.IsSet)
+					{
+						break;
+					}
+
+					Thread.Sleep(i.Milliseconds());
+					signaler.Signal();
+				}
+			});
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait();
+			sw.Stop();
+
+			ms.Set();
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+	}
+
+	public sealed class WithParameterTests
+	{
+		[Theory]
+		[InlineData(0, 0, true)]
+		[InlineData(0, 1, false)]
+		[InlineData(2, 0, true)]
+		[InlineData(2, 1, true)]
+		[InlineData(2, 2, true)]
+		[InlineData(2, 3, false)]
+		[InlineData(2, 5, false)]
+		public async Task IsSignaled_ShouldCompareToSignalCount(int signalCount, int amount, bool expectedResult)
+		{
+			Signaler<int> signaler = new();
+
+			for (int i = 0; i < signalCount; i++)
+			{
+				signaler.Signal(i);
+			}
+
+			bool result = signaler.IsSignaled(amount.Times());
+
+			await That(result).Should().Be(expectedResult);
+		}
+
+		[Fact]
+		public async Task Wait_EnoughSignals_ShouldSucceed()
+		{
+			Signaler<int> signaler = new();
+
+			signaler.Signal(4);
+			signaler.Signal(5);
+			signaler.Signal(6);
+
+			SignalerResult<int> result = signaler.Wait(2);
+
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(result.Parameters).Should().Be([4, 5, 6]).InAnyOrder();
+		}
+
+		[Fact]
+		public async Task Wait_NegativeAmount_ShouldThrowArgumentOutOfRangeException()
+		{
+			Signaler<int> signaler = new();
+
+			void Act()
+				=> signaler.Wait(-1);
+
+			await That(Act).Should().Throw<ArgumentOutOfRangeException>()
+				.WithMessage("The amount must be greater than zero*").AsWildcard().And
+				.WithParamName("amount");
+		}
+
+		[Fact]
+		public async Task Wait_ShouldCatchOperationCanceledException()
+		{
+			Signaler<int> signaler = new();
+			using CancellationTokenSource cts = new(30.Milliseconds());
+			CancellationToken token = cts.Token;
+
+			for (int i = 0; i < 99; i++)
+			{
+				int value = i;
+				_ = Task.Run(() => signaler.Signal(value), token);
+			}
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(100.Times(), cancellationToken: token);
+			sw.Stop();
+
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_ShouldReturnAsSoonAsEnoughSignalsWereRecorded()
+		{
+			Signaler<int> signaler = new();
+
+			List<Task> tasks = new();
+			for (int i = 0; i < 100; i++)
+			{
+				int value = i;
+				tasks.Add(Task.Run(() => signaler.Signal(value)));
+			}
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult<int> result = signaler.Wait(100.Times());
+			sw.Stop();
+
+			await That(tasks).Should().HaveAll(x => x.Satisfy(t => t.IsCompleted));
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(result.Parameters).Should().Be(Enumerable.Range(0, 100)).InAnyOrder();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_Single_AlreadySignaled_ShouldSucceed()
+		{
+			Signaler<int> signaler = new();
+
+			signaler.Signal(4);
+			signaler.Signal(5);
+			signaler.Signal(6);
+
+			SignalerResult<int> result = signaler.Wait();
+
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(result.Parameters).Should().Be([4, 5, 6]).InAnyOrder();
+		}
+
+		[Fact]
+		public async Task Wait_Single_ShouldCatchOperationCanceledException()
+		{
+			Signaler<int> signaler = new();
+			using CancellationTokenSource cts = new(30.Milliseconds());
+			CancellationToken token = cts.Token;
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(cancellationToken: token);
+			sw.Stop();
+
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_Single_ShouldReturnAsSoonAsSignalWasRecorded()
+		{
+			Signaler<int> signaler = new();
+			using ManualResetEventSlim ms = new();
+
+			_ = Task.Run(() =>
+			{
+				for (int i = 10; i < 1000; i++)
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					if (ms.IsSet)
+					{
+						break;
+					}
+
+					int value = i;
+					Thread.Sleep(i.Milliseconds());
+					signaler.Signal(value);
+				}
+			});
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait();
+			sw.Stop();
+
+			ms.Set();
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_WithPredicate_ShouldCatchOperationCanceledException()
+		{
+			Signaler<int> signaler = new();
+			using CancellationTokenSource cts = new(30.Milliseconds());
+			CancellationToken token = cts.Token;
+
+			for (int i = 0; i < 100; i++)
+			{
+				int value = i;
+				_ = Task.Run(() => signaler.Signal(value), token);
+			}
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(100.Times(), x => x != 50, cancellationToken: token);
+			sw.Stop();
+
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_WithPredicate_ShouldReturnAsSoonAsEnoughSignalsWereRecorded()
+		{
+			Signaler<int> signaler = new();
+
+			List<Task> tasks = new();
+			for (int i = 0; i < 110; i++)
+			{
+				int value = i;
+				tasks.Add(Task.Run(() => signaler.Signal(value)));
+			}
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult<int> result = signaler.Wait(100.Times(), x => x >= 10);
+			sw.Stop();
+
+			await That(tasks.Skip(10)).Should().HaveAll(x => x.Satisfy(t => t.IsCompleted));
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(result.Parameters).Should().Contain(Enumerable.Range(10, 100)).InAnyOrder();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_WithPredicate_Single_ShouldCatchOperationCanceledException()
+		{
+			Signaler<int> signaler = new();
+			using CancellationTokenSource cts = new(30.Milliseconds());
+			CancellationToken token = cts.Token;
+
+			signaler.Signal(50);
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(x => x != 50, cancellationToken: token);
+			sw.Stop();
+
+			await That(result.IsSuccess).Should().BeFalse();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds());
+		}
+
+		[Fact]
+		public async Task Wait_WithPredicate_Single_ShouldReturnAsSoonAsSignalWasRecorded()
+		{
+			Signaler<int> signaler = new();
+			using ManualResetEventSlim ms = new();
+
+			_ = Task.Run(() =>
+			{
+				for (int i = 10; i < 1000; i++)
+				{
+					// ReSharper disable once AccessToDisposedClosure
+					if (ms.IsSet)
+					{
+						break;
+					}
+
+					int value = i;
+					Thread.Sleep(i.Milliseconds());
+					signaler.Signal(value);
+				}
+			});
+
+			Stopwatch sw = new();
+			sw.Start();
+			SignalerResult result = signaler.Wait(x => x > 10);
+			sw.Stop();
+
+			ms.Set();
+			await That(result.IsSuccess).Should().BeTrue();
+			await That(sw.Elapsed).Should().BeLessThan(5000.Milliseconds())
+				.And.BeGreaterThanOrEqualTo(10.Milliseconds());
+		}
+	}
+}


### PR DESCRIPTION
Improve test coverage in aweXpect.Core:
- Add tests for `Signaler`
- Add missing formatter tests