### PR TITLE
coverage: add missing tests in aweXpect.Core (2)

### DIFF
--- a/Pipeline/Build.FrameworkTest.cs
+++ b/Pipeline/Build.FrameworkTest.cs
@@ -11,9 +11,19 @@ namespace Build;
 
 partial class Build
 {
+	Project[] FrameworkUnitTestProjects =>
+	[
+		Solution.Tests.Frameworks.aweXpect_Frameworks_Fallback_Tests,
+		Solution.Tests.Frameworks.aweXpect_Frameworks_MsTest_Tests,
+		Solution.Tests.Frameworks.aweXpect_Frameworks_NUnit4_Tests,
+		Solution.Tests.Frameworks.aweXpect_Frameworks_NUnit3_Tests,
+		Solution.Tests.Frameworks.aweXpect_Frameworks_XUnit2_Tests,
+		Solution.Tests.Frameworks.aweXpect_Frameworks_XUnit3_Core_Tests
+	];
+	
 	Target TestFrameworks => _ => _
 		.DependsOn(VsTestFrameworks)
-		.DependsOn(TunitTestingPlatformFrameworks)
+		.DependsOn(TestingPlatformFrameworks)
 		.DependsOn(XunitTestingPlatformFrameworks);
 
 	Target VsTestFrameworks => _ => _
@@ -21,18 +31,8 @@ partial class Build
 		.DependsOn(Compile)
 		.Executes(() =>
 		{
-			Project[] projects =
-			[
-				Solution.Tests.Frameworks.aweXpect_Frameworks_Fallback_Tests,
-				Solution.Tests.Frameworks.aweXpect_Frameworks_MsTest_Tests,
-				Solution.Tests.Frameworks.aweXpect_Frameworks_NUnit4_Tests,
-				Solution.Tests.Frameworks.aweXpect_Frameworks_NUnit3_Tests,
-				Solution.Tests.Frameworks.aweXpect_Frameworks_XUnit2_Tests,
-				Solution.Tests.Frameworks.aweXpect_Frameworks_XUnit3_Core_Tests
-			];
-
 			var testCombinations =
-				from project in projects
+				from project in FrameworkUnitTestProjects
 				let frameworks = project.GetTargetFrameworks()
 				let supportedFrameworks = EnvironmentInfo.IsWin ? frameworks : frameworks.Except(["net48"])
 				from framework in supportedFrameworks
@@ -59,7 +59,7 @@ partial class Build
 						.AddLoggers($"trx;LogFileName={v.project.Name}_{v.framework}.trx")), completeOnFailure: true);
 		});
 
-	Target TunitTestingPlatformFrameworks => _ => _
+	Target TestingPlatformFrameworks => _ => _
 		.Unlisted()
 		.DependsOn(Compile)
 		.Executes(() =>

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -44,7 +44,7 @@ partial class Build
 					Solution.aweXpect, [Solution.Tests.aweXpect_Tests, Solution.Tests.aweXpect_Internal_Tests]
 				},
 				{
-					Solution.aweXpect_Core, [Solution.Tests.aweXpect_Core_Tests]
+					Solution.aweXpect_Core, [..FrameworkUnitTestProjects, Solution.Tests.aweXpect_Core_Tests]
 				}
 			};
 

--- a/Source/aweXpect.Core/Core/Ambient/Initialization.cs
+++ b/Source/aweXpect.Core/Core/Ambient/Initialization.cs
@@ -20,11 +20,6 @@ internal static class Initialization
 			         .Where(x => x is { IsClass: true, IsAbstract: false })
 			         .Where(frameworkInterface.IsAssignableFrom))
 		{
-			if (frameworkType == typeof(FallbackTestFramework))
-			{
-				continue;
-			}
-
 			try
 			{
 				ITestFrameworkAdapter? testFramework =

--- a/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
@@ -3,11 +3,11 @@ using aweXpect.Core.Constraints;
 
 namespace aweXpect.Core.Helpers;
 
-internal struct BecauseReason(string reason)
+internal readonly struct BecauseReason(string reason)
 {
-	private string? _message;
+	private readonly Lazy<string> _message = new(() => CreateMessage(reason));
 
-	private string CreateMessage()
+	private static string CreateMessage(string reason)
 	{
 		const string prefix = "because";
 		string message = reason.Trim();
@@ -18,14 +18,11 @@ internal struct BecauseReason(string reason)
 	}
 
 	public override string ToString()
-	{
-		_message ??= CreateMessage();
-		return _message;
-	}
+		=> _message.Value;
 
 	public ConstraintResult ApplyTo(ConstraintResult result)
 	{
-		string message = CreateMessage();
+		string message = _message.Value;
 		return result.UpdateExpectationText(e => e.ExpectationText + message);
 	}
 }

--- a/Source/aweXpect.Core/Core/Helpers/StringExtensions.cs
+++ b/Source/aweXpect.Core/Core/Helpers/StringExtensions.cs
@@ -46,7 +46,8 @@ internal static class StringExtensions
 	}
 
 	[return: NotNullIfNotNull(nameof(value))]
-	public static string? ToSingleLine(this string? value) => value?.Replace("\n", "\\n").Replace("\r", "\\r");
+	public static string? ToSingleLine(this string? value)
+		=> value?.Replace("\n", "\\n").Replace("\r", "\\r");
 
 	[return: NotNullIfNotNull(nameof(value))]
 	public static string? TruncateWithEllipsis(this string? value, int maxLength)

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
@@ -1,0 +1,39 @@
+﻿using aweXpect.Core.Constraints;
+
+namespace aweXpect.Core.Tests.Core.Constraints;
+
+public class ConstraintResultTests
+{
+	[Fact]
+	public async Task Success_T_TryGetValue_WhenTypeDoesNotMatch_ShouldReturnFalse()
+	{
+		ConstraintResult.Success<int> sut = new(1, "foo");
+
+		bool result = sut.TryGetValue(out string? value);
+
+		await That(result).Should().BeFalse();
+		await That(value).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Success_T_TryGetValue_WhenTypeMatches_ShouldReturnTrue()
+	{
+		ConstraintResult.Success<string> sut = new("bar", "foo");
+
+		bool result = sut.TryGetValue(out string? value);
+
+		await That(result).Should().BeTrue();
+		await That(value).Should().Be("bar");
+	}
+
+	[Fact]
+	public async Task Success_TryGetValue_ShouldReturnFalse()
+	{
+		ConstraintResult.Success sut = new("foo");
+
+		bool result = sut.TryGetValue(out string? value);
+
+		await That(result).Should().BeFalse();
+		await That(value).Should().BeNull();
+	}
+}

--- a/Tests/aweXpect.Core.Tests/Core/Helpers/BecauseReasonTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Helpers/BecauseReasonTests.cs
@@ -1,0 +1,30 @@
+﻿using aweXpect.Core.Helpers;
+
+namespace aweXpect.Core.Tests.Core.Helpers;
+
+public class BecauseReasonTests
+{
+	[Fact]
+	public async Task WhenReasonDoesNotStartWithBecause_ShouldPrefixCommaAndBecause()
+	{
+		string reason = "something";
+		string expected = ", because something";
+		BecauseReason sut = new(reason);
+
+		string result = sut.ToString();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task WhenReasonStartsWithBecause_ShouldPrefixComma()
+	{
+		string reason = "because something";
+		string expected = ", because something";
+		BecauseReason sut = new(reason);
+
+		string result = sut.ToString();
+
+		await That(result).Should().Be(expected);
+	}
+}

--- a/Tests/aweXpect.Core.Tests/Core/Helpers/StringExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Helpers/StringExtensionsTests.cs
@@ -5,6 +5,103 @@ namespace aweXpect.Core.Tests.Core.Helpers;
 public class StringExtensionsTests
 {
 	[Fact]
+	public async Task DisplayWhitespace_ShouldEscapeNewlines()
+	{
+		string input = "\r,\n;\t ";
+		string expected = @"\r,\n;\t ";
+
+		string result = input.DisplayWhitespace();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task DisplayWhitespace_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.DisplayWhitespace();
+
+		await That(result).Should().BeNull();
+	}
+
+
+	[Fact]
+	public async Task Indent_WhenIndentationIsEmpty_ShouldReturnInput()
+	{
+		string input = "foo\nbar";
+
+		string result = input.Indent("");
+
+		await That(result).Should().Be(input);
+	}
+
+	[Fact]
+	public async Task Indent_WhenIndentationIsNotEmpty_ShouldReturnIndentedInput()
+	{
+		string input = "foo\nbar";
+		string expected = "   foo\n   bar";
+
+		string result = input.Indent("   ");
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task Indent_WhenIndentFirstLineIsFalse_ShouldOnlyIndentSubsequentLines()
+	{
+		string input = "foo\nbar";
+		string expected = "foo\n   bar";
+
+		string result = input.Indent("   ", false);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task Indent_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.Indent();
+
+		await That(result).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task RemoveNewlineStyle_ShouldReplaceNewlinesWithSlashN()
+	{
+		string input = "\ra\r\nb\nc";
+		string expected = "\na\nb\nc";
+
+		string result = input.RemoveNewlineStyle();
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Fact]
+	public async Task RemoveNewlineStyle_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.Indent();
+
+		await That(result).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task SubstringUntilFirst_WhenFirstCharacter_ShouldReturnEmptyString()
+	{
+		string input = "a,b,c";
+
+		string result = input.SubstringUntilFirst('a');
+
+		await That(result).Should().Be("");
+	}
+
+
+	[Fact]
 	public async Task SubstringUntilFirst_WhenNotPresent_ShouldReturnString()
 	{
 		string input = "foo";
@@ -22,5 +119,112 @@ public class StringExtensionsTests
 		string result = input.SubstringUntilFirst(',');
 
 		await That(result).Should().Be("a");
+	}
+
+
+	[Fact]
+	public async Task ToSingleLine_ShouldEscapeNewlines()
+	{
+		string input = "\r,\n;\t ";
+		string expected = "\\r,\\n;\t ";
+
+		string result = input.ToSingleLine();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task ToSingleLine_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.ToSingleLine();
+
+		await That(result).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task TruncateWithEllipsis_WhenLonger_ShouldTruncateWithEllipsis()
+	{
+		string input = "12345678910";
+		string expected = "1234567891…";
+
+		string result = input.TruncateWithEllipsis(10);
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Fact]
+	public async Task TruncateWithEllipsis_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.TruncateWithEllipsis(10);
+
+		await That(result).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task TruncateWithEllipsis_WhenShorter_ShouldReturnInput()
+	{
+		string input = "1234567890";
+
+		string result = input.TruncateWithEllipsis(10);
+
+		await That(result).Should().Be(input);
+	}
+
+	[Fact]
+	public async Task TruncateWithEllipsisOnWord_WhenLongerWithoutWordBoundary_ShouldTruncateOnWordWithEllipsis()
+	{
+		string input = "some word boundary";
+		string expected = "some word…";
+
+		string result = input.TruncateWithEllipsisOnWord(11);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task TruncateWithEllipsisOnWord_WhenLongerWithoutWordBoundary_ShouldTruncateWithEllipsis()
+	{
+		string input = "12345678910";
+		string expected = "1234567891…";
+
+		string result = input.TruncateWithEllipsisOnWord(10);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task TruncateWithEllipsisOnWord_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.TruncateWithEllipsisOnWord(10);
+
+		await That(result).Should().BeNull();
+	}
+
+	[Fact]
+	public async Task TruncateWithEllipsisOnWord_WhenShorter_ShouldReturnInput()
+	{
+		string input = "1234567890";
+
+		string result = input.TruncateWithEllipsisOnWord(10);
+
+		await That(result).Should().Be(input);
+	}
+
+	[Theory]
+	[InlineData("another word-boundary", "another wo…")]
+	[InlineData("_another word-boundary", "_another…")]
+	public async Task TruncateWithEllipsisOnWord_WhenWordBoundaryIsBelow80Percent_ShouldTruncateWithEllipsis(
+		string input, string expected)
+	{
+		string result = input.TruncateWithEllipsisOnWord(10);
+
+		await That(result).Should().Be(expected);
 	}
 }

--- a/Tests/aweXpect.Tests/Delegates/DelegateShould.ExecuteWithinTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/DelegateShould.ExecuteWithinTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Tests.TestHelpers;
+﻿using System.Threading;
+using aweXpect.Tests.TestHelpers;
 
 namespace aweXpect.Tests.Delegates;
 
@@ -197,6 +198,57 @@ public sealed partial class DelegateShould
 #endif
 
 #if NET8_0_OR_GREATER
+		public sealed class FuncCancellationTokenValueTaskTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.CompletedTask);
+
+				async Task Act()
+					=> await That(Delegate).Should().ExecuteWithin(5000.Milliseconds());
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage()
+			{
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.FromException(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).Should().ExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage($"""
+					              Expected Delegate to
+					              execute within 0:00.500,
+					              but it did throw a MyException:
+					                {nameof(WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<CancellationToken, ValueTask>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).Should().ExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             execute within 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
 		public sealed class FuncValueTaskValueTests
 		{
 			[Fact]
@@ -231,6 +283,57 @@ public sealed partial class DelegateShould
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				Func<ValueTask<int>>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).Should().ExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             execute within 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
+		public sealed class FuncCancellationTokenValueTaskValueTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromResult(1));
+
+				async Task Act()
+					=> await That(Delegate).Should().ExecuteWithin(5000.Milliseconds());
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage()
+			{
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromException<int>(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).Should().ExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage($"""
+					              Expected Delegate to
+					              execute within 0:00.500,
+					              but it did throw a MyException:
+					                {nameof(WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<CancellationToken, ValueTask<int>>? subject = null;
 
 				async Task Act()
 					=> await That(subject!).Should().ExecuteWithin(500.Milliseconds());

--- a/Tests/aweXpect.Tests/Delegates/DelegateShould.NotExecuteWithinTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/DelegateShould.NotExecuteWithinTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Tests.TestHelpers;
+﻿using System.Threading;
+using aweXpect.Tests.TestHelpers;
 
 namespace aweXpect.Tests.Delegates;
 
@@ -178,6 +179,107 @@ public sealed partial class DelegateShould
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				Func<ValueTask>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).Should().NotExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not execute within 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
+		public sealed class FuncCancellationTokenValueTaskTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldFail()
+			{
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.CompletedTask);
+
+				async Task Act()
+					=> await That(Delegate).Should().NotExecuteWithin(5000.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected Delegate to
+					             not execute within 0:05,
+					             but it took only *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.FromException(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).Should().NotExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<CancellationToken, ValueTask>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).Should().NotExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not execute within 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
+
+		public sealed class FuncCancellationTokenValueTaskValueTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldFail()
+			{
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromResult(1));
+
+				async Task Act()
+					=> await That(Delegate).Should().NotExecuteWithin(5000.Milliseconds());
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected Delegate to
+					             not execute within 0:05,
+					             but it took only *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromException<int>(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).Should().NotExecuteWithin(500.Milliseconds());
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<CancellationToken, ValueTask<int>>? subject = null;
 
 				async Task Act()
 					=> await That(subject!).Should().NotExecuteWithin(500.Milliseconds());


### PR DESCRIPTION
See #1 (and continuing #182):

Improve test coverage in aweXpect.Core:

- Add missing tests for `Expect`
- Improve `Signaler` coverage
- Add tests for `ConstraintResult`
- Use "FrameworkTests" for mutation testing to improve coverage in `Initialization`
- Improve coverage for `BecauseReason`
- Add missing tests for `StringExtensions`
