### PR TITLE
refactor: include exception message when constraint fails

### DIFF
--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -89,7 +89,7 @@ internal class ExpectationNode : Node
 		}
 		catch (Exception e) when (_constraint is not null)
 		{
-			throw new InvalidOperationException($"Error evaluating {Formatter.Format(_constraint.GetType())} constraint with value {Formatter.Format(value)}", e);
+			throw new InvalidOperationException($"Error evaluating {Formatter.Format(_constraint.GetType())} constraint with value {Formatter.Format(value)}: {e.Message}", e);
 		}
 
 		if (_inner != null)

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
@@ -20,7 +20,7 @@ public class ExpectationNodeTests
 
 		await That(Act).Should().Throw<InvalidOperationException>()
 			.WithMessage("""
-			             Error evaluating DummyAsyncConstraint<int> constraint with value 44
+			             Error evaluating DummyAsyncConstraint<int> constraint with value 44: WhenAsyncConstraintThrowsException_ShouldThrowInvalidOperationException
 			             """).And
 			.WithInner<MyException>(x => x.HaveMessage(exception.Message));
 	}
@@ -37,7 +37,7 @@ public class ExpectationNodeTests
 
 		await That(Act).Should().Throw<InvalidOperationException>()
 			.WithMessage("""
-			             Error evaluating DummyAsyncContextConstraint<int> constraint with value 45
+			             Error evaluating DummyAsyncContextConstraint<int> constraint with value 45: WhenAsyncContextConstraintThrowsException_ShouldThrowInvalidOperationException
 			             """).And
 			.WithInner<MyException>(x => x.HaveMessage(exception.Message));
 	}
@@ -54,7 +54,7 @@ public class ExpectationNodeTests
 
 		await That(Act).Should().Throw<InvalidOperationException>()
 			.WithMessage("""
-			             Error evaluating DummyContextConstraint<int> constraint with value 43
+			             Error evaluating DummyContextConstraint<int> constraint with value 43: WhenContextConstraintThrowsException_ShouldThrowInvalidOperationException
 			             """).And
 			.WithInner<MyException>(x => x.HaveMessage(exception.Message));
 	}
@@ -71,7 +71,7 @@ public class ExpectationNodeTests
 
 		await That(Act).Should().Throw<InvalidOperationException>()
 			.WithMessage("""
-			             Error evaluating DummyValueConstraint<string> constraint with value "42"
+			             Error evaluating DummyValueConstraint<string> constraint with value "42": WhenValueConstraintThrowsException_ShouldThrowInvalidOperationException
 			             """).And
 			.WithInner<MyException>(x => x.HaveMessage(exception.Message));
 	}


### PR DESCRIPTION
Building on top of #178, include the exception message in the `InvalidOperationException` that wraps exceptions thrown in a constraint.