### PR TITLE
feat: add `BeValidJson` extension on strings

### DIFF
--- a/Docs/pages/docs/expectations/json.md
+++ b/Docs/pages/docs/expectations/json.md
@@ -6,18 +6,6 @@ sidebar_position: 17
 
 Describes the possible expectations for working with [System.Text.Json](https://learn.microsoft.com/en-us/dotnet/api/system.text.json).
 
-## JsonElement
-
-You can verify, that the `JsonElement` has the expected number of items:
-```csharp
-JsonElement subject = JsonDocument.Parse("[1,2]").RootElement;
-
-await Expect.That(subject).Should().HaveCount(2);
-await Expect.That(subject).Should().NotHaveCount(3);
-```
-
-This works for both, arrays and objects, but fails for all other JSON types.
-
 
 ## String comparison as JSON
 
@@ -35,3 +23,41 @@ string expected = """
 
 await Expect.That(subject).Should().Be(expected).AsJson();
 ```
+
+
+## Validation
+
+You can verify, that a string is valid JSON.
+```csharp
+string subject = "{\"foo\": 2}";
+
+await Expect.That(subject).Should().BeValidJson();
+```
+This verifies that the string can be parsed by [`JsonDocument.Parse`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsondocument.parse) without exceptions.
+
+You can also specify the [`JsonDocumentOptions`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsondocumentoptions):
+```csharp
+string subject = "{\"foo\": 2}";
+
+await Expect.That(subject).Should().BeValidJson(o => o with {CommentHandling = JsonCommentHandling.Disallow});
+```
+
+You can also add additional expectations on the [`JsonElement`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonelement) created when parsing the subject:
+```csharp
+string subject = "{\"foo\": 2}";
+
+await Expect.That(subject).Should().BeValidJson().Which(j => j.Should().HaveCount(1));
+```
+
+
+## `JsonElement`
+
+You can verify, that the `JsonElement` has the expected number of items:
+```csharp
+JsonElement subject = JsonDocument.Parse("[1,2]").RootElement;
+
+await Expect.That(subject).Should().HaveCount(2);
+await Expect.That(subject).Should().NotHaveCount(3);
+```
+
+This works for both, arrays and objects, but fails for all other JSON types.

--- a/Source/aweXpect/Results/JsonWhichResult.cs
+++ b/Source/aweXpect/Results/JsonWhichResult.cs
@@ -1,0 +1,42 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Text.Json;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     An <see cref="AndOrResult{TType,TThat}" /> for JSON strings.
+/// </summary>
+public class JsonWhichResult(
+	ExpectationBuilder expectationBuilder,
+	IThat<string?> returnValue,
+	JsonDocumentOptions options) : AndOrResult<string?, IThat<string?>>(expectationBuilder, returnValue)
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+	private readonly IThat<string?> _returnValue = returnValue;
+
+	/// <summary>
+	///     Allows specifying <paramref name="expectations" /> on the <see cref="JsonElement" />
+	///     represented by the <see langword="string" />.
+	/// </summary>
+	public AndOrResult<string?, IThat<string?>> Which(Action<IExpectSubject<JsonElement?>> expectations)
+	{
+		_expectationBuilder
+			.ForMember(MemberAccessor<string?, JsonElement?>.FromFunc(s =>
+				{
+					if (s is null)
+					{
+						return null;
+					}
+
+					using JsonDocument jsonDocument = JsonDocument.Parse(s, options);
+					return jsonDocument.RootElement.Clone();
+				}, "it"),
+				(_, expectation) => $" which should {expectation}")
+			.AddExpectations(e => expectations(new That.Subject<JsonElement?>(e)));
+		return this;
+	}
+}
+#endif

--- a/Source/aweXpect/That/Json/JsonExtensions.cs
+++ b/Source/aweXpect/That/Json/JsonExtensions.cs
@@ -15,7 +15,8 @@ public static class JsonExtensions
 	/// <summary>
 	///     Interpret the <see cref="string" /> as JSON.
 	/// </summary>
-	public static TSelf AsJson<TType, TThat, TSelf>(this StringEqualityResult<TType, TThat, TSelf> result,
+	public static TSelf AsJson<TType, TThat, TSelf>(
+		this StringEqualityResult<TType, TThat, TSelf> result,
 		Func<JsonOptions, JsonOptions>? options = null)
 		where TSelf : StringEqualityResult<TType, TThat, TSelf>
 	{

--- a/Source/aweXpect/That/Strings/ThatStringShould.BeValidJson.cs
+++ b/Source/aweXpect/That/Strings/ThatStringShould.BeValidJson.cs
@@ -1,0 +1,57 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Text.Json;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatStringShould
+{
+	/// <summary>
+	///     Verifies that the subject is a valid JSON string.
+	/// </summary>
+	public static JsonWhichResult BeValidJson(
+		this IThat<string?> source,
+		Func<JsonDocumentOptions, JsonDocumentOptions>? options = null)
+	{
+		JsonDocumentOptions defaultOptions = Customize.Json.DefaultJsonDocumentOptions;
+		if (options != null)
+		{
+			defaultOptions = options(defaultOptions);
+		}
+
+		return new JsonWhichResult(source.ExpectationBuilder.AddConstraint(it
+				=> new BeValidJsonConstraint(it, defaultOptions)),
+			source, defaultOptions);
+	}
+
+	private readonly struct BeValidJsonConstraint(string it, JsonDocumentOptions options) : IValueConstraint<string?>
+	{
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(null, ToString(), $"{it} was <null>");
+			}
+
+			try
+			{
+				using JsonDocument jsonDocument = JsonDocument.Parse(actual, options);
+			}
+			catch (JsonException jsonException)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					$"{it} could not be parsed: {jsonException.Message}");
+			}
+
+			return new ConstraintResult.Success<string?>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> "be valid JSON";
+	}
+}
+#endif

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -913,6 +913,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> BeOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> BeUpperCased(this aweXpect.Core.IThat<string?> source) { }
+        public static aweXpect.Results.JsonWhichResult BeValidJson(this aweXpect.Core.IThat<string?> source, System.Func<System.Text.Json.JsonDocumentOptions, System.Text.Json.JsonDocumentOptions>? options = null) { }
         public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> Contain(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> EndWith(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> HaveLength(this aweXpect.Core.IThat<string?> source, int expected) { }
@@ -1005,6 +1006,11 @@ namespace aweXpect.Results
     {
         public ItemsResult(TReturn value) { }
         public TReturn Items() { }
+    }
+    public class JsonWhichResult : aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>>
+    {
+        public JsonWhichResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<string?> returnValue, System.Text.Json.JsonDocumentOptions options) { }
+        public aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> Which(System.Action<aweXpect.Core.IExpectSubject<System.Text.Json.JsonElement?>> expectations) { }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat>
     {

--- a/Tests/aweXpect.Core.Tests/Options/JsonOptionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/JsonOptionsTests.cs
@@ -1,0 +1,47 @@
+﻿#if NET8_0_OR_GREATER
+using System.Text.Json;
+using aweXpect.Json;
+
+namespace aweXpect.Core.Tests.Options;
+
+public class JsonOptionsTests
+{
+	[Fact]
+	public async Task DocumentOptions_ShouldDefaultToAllowTrailingCommas()
+	{
+		JsonOptions sut = new();
+
+		await That(sut.DocumentOptions.AllowTrailingCommas).Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task WithJsonOptions_ShouldSetDocumentOptions()
+	{
+		int maxDepth = new Random().Next(1, 10);
+		JsonOptions sut = new();
+
+		sut.WithJsonOptions(o => o with
+		{
+			MaxDepth = maxDepth
+		});
+
+		await That(sut.DocumentOptions.MaxDepth).Should().Be(maxDepth);
+	}
+
+	[Fact]
+	public async Task WithJsonOptions_ShouldSupportProvidingFixedOptions()
+	{
+		int maxDepth = new Random().Next(1, 10);
+		JsonDocumentOptions documentOptions = new()
+		{
+			MaxDepth = maxDepth
+		};
+
+		JsonOptions sut = new();
+
+		sut.WithJsonOptions(_ => documentOptions);
+
+		await That(sut.DocumentOptions.MaxDepth).Should().Be(maxDepth);
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Strings/StringShould.BeValidJsonTests.cs
+++ b/Tests/aweXpect.Tests/Strings/StringShould.BeValidJsonTests.cs
@@ -1,0 +1,131 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests.Strings;
+
+public sealed partial class StringShould
+{
+	public class BeValidJson
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData(true)]
+			[InlineData(false)]
+			public async Task ShouldUseProvidedOptions(bool allowTrailingCommas)
+			{
+				string subject = "[1, 2,]";
+
+				async Task Act()
+					=> await That(subject).Should().BeValidJson(o => o with
+					{
+						AllowTrailingCommas = allowTrailingCommas
+					});
+
+				await That(Act).Should().Throw<XunitException>().OnlyIf(!allowTrailingCommas);
+			}
+
+			[Fact]
+			public async Task WhenActualIsEmpty_ShouldFail()
+			{
+				string subject = "";
+
+				async Task Act()
+					=> await That(subject).Should().BeValidJson();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be valid JSON,
+					             but it could not be parsed: The input does not contain any JSON tokens.*
+					             """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData("True", "'T' is an invalid start of a value")]
+			[InlineData("False", "'F' is an invalid start of a value")]
+			[InlineData("Null", "'N' is an invalid start of a value")]
+			[InlineData("{\"foo\":1}}", "'}' is invalid after a single JSON value. Expected end of data")]
+			[InlineData("{}{\"foo\":1}", "'{' is invalid after a single JSON value. Expected end of data")]
+			[InlineData("[",
+				"Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed")]
+			public async Task WhenActualIsInvalidJson_ShouldFail(string subject, string errorMessage)
+			{
+				async Task Act()
+					=> await That(subject).Should().BeValidJson();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage($"""
+					              Expected subject to
+					              be valid JSON,
+					              but it could not be parsed: {errorMessage}*
+					              """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenActualIsNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).Should().BeValidJson();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be valid JSON,
+					             but it was <null>
+					             """);
+			}
+
+			[Theory]
+			[InlineData("42")]
+			[InlineData("\"foo\"")]
+			[InlineData("true")]
+			[InlineData("false")]
+			[InlineData("null")]
+			[InlineData("[]")]
+			[InlineData("[1]")]
+			[InlineData("[\"foo\", \"bar\"]")]
+			[InlineData("{}")]
+			[InlineData("{\"foo\": null}")]
+			[InlineData("{\"foo\": {\"bar\":[1,2,3], \"baz\": true,}}")]
+			public async Task WhenActualIsValidJson_ShouldSucceed(string subject)
+			{
+				async Task Act()
+					=> await That(subject).Should().BeValidJson();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+
+		public sealed class WhichTests
+		{
+			[Fact]
+			public async Task WhenExpectationInWhichFails_ShouldFail()
+			{
+				string subject = "[1, 2]";
+
+				async Task Act()
+					=> await That(subject).Should().BeValidJson().Which(d => d.Should().HaveCount(3));
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be valid JSON which should have 3 items,
+					             but it had 2
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectationInWhichIsSatisfied_ShouldSucceed()
+			{
+				string subject = "[1, 2]";
+
+				async Task Act()
+					=> await That(subject).Should().BeValidJson().Which(d => d.Should().HaveCount(2));
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
You can verify, that a string is valid JSON.
```csharp
string subject = "{\"foo\": 2}";

await Expect.That(subject).Should().BeValidJson();
```
This verifies that the string can be parsed by [`JsonDocument.Parse`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsondocument.parse) without exceptions.

You can also specify the [`JsonDocumentOptions`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsondocumentoptions):
```csharp
string subject = "{\"foo\": 2}";

await Expect.That(subject).Should().BeValidJson(o => o with {CommentHandling = JsonCommentHandling.Disallow});
```

You can also add additional expectations on the [`JsonElement`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonelement) created when parsing the subject:
```csharp
string subject = "{\"foo\": 2}";

await Expect.That(subject).Should().BeValidJson().Which(j => j.Should().HaveCount(1));
```

*(from #188)*