### PR TITLE
feat: add `BeJsonSerializable` for objects

### DIFF
--- a/Docs/pages/docs/expectations/json.md
+++ b/Docs/pages/docs/expectations/json.md
@@ -169,3 +169,32 @@ await Expect.That(subject).Should().BeArray(a => a
 		i => i.With(2).Properties()
 	));
 ```
+
+## JSON serializable
+
+You can verify that an `object` is JSON serializable:
+
+```csharp
+MyClass subject = new MyClass();
+
+await Expect.That(subject).Should().BeJsonSerializable();
+```
+This validates, that the `MyClass` can be serialized and deserialized to/from JSON and that the result is equivalent to the original subject.
+
+You can specify both, the [`JsonSerializerOptions`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions) and the equivalency options:
+```csharp
+MyClass subject = new MyClass();
+
+await Expect.That(subject).Should().BeJsonSerializable(
+    new JsonSerializerOptions { IncludeFields = true },
+    e => e.IgnoringMember("Foo"));
+```
+
+You can also specify an expected generic type that the subject should have:
+```csharp
+object subject = //...
+
+await Expect.That(subject).Should().BeJsonSerializable<MyClass>(
+    new JsonSerializerOptions { IncludeFields = true },
+    e => e.IgnoringMember("Foo"));
+```

--- a/Source/aweXpect.Core/Options/EquivalencyOptions.cs
+++ b/Source/aweXpect.Core/Options/EquivalencyOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace aweXpect.Options;
 
@@ -22,4 +23,15 @@ public class EquivalencyOptions
 		_membersToIgnore.Add(memberToIgnore);
 		return this;
 	}
+
+	/// <summary>
+	///     Creates a new <see cref="EquivalencyOptions" /> instance from the provided <paramref name="callback" />.
+	/// </summary>
+	/// <remarks>
+	///     Uses the default instance, when no <paramref name="callback" /> is given.
+	/// </remarks>
+	public static EquivalencyOptions FromCallback(Func<EquivalencyOptions, EquivalencyOptions>? callback)
+		=> callback is null
+			? new EquivalencyOptions()
+			: callback(new EquivalencyOptions());
 }

--- a/Source/aweXpect/Equivalency/EquivalencyComparer.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyComparer.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Equivalency;
+
+internal sealed class EquivalencyComparer(EquivalencyOptions equivalencyOptions)
+	: IObjectMatchType
+{
+	private ComparisonFailure? _firstFailure;
+
+	/// <inheritdoc cref="IObjectMatchType.AreConsideredEqual(object?, object?)" />
+	public bool AreConsideredEqual(object? actual, object? expected)
+	{
+		if (HandleSpecialCases(actual, expected, out bool? specialCaseResult))
+		{
+			return specialCaseResult.Value;
+		}
+
+		List<ComparisonFailure> failures = Compare.CheckEquivalent(actual, expected,
+			new CompareOptions
+			{
+				MembersToIgnore = [.. equivalencyOptions.MembersToIgnore]
+			}).ToList();
+
+		if (failures.FirstOrDefault() is { } firstFailure)
+		{
+			_firstFailure = firstFailure;
+			if (firstFailure.Type == MemberType.Value)
+			{
+				return false;
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/// <inheritdoc cref="IObjectMatchType.GetExpectation(string)" />
+	public string GetExpectation(string expected) => $"be equivalent to {expected}";
+
+	/// <inheritdoc cref="IObjectMatchType.GetExtendedFailure(string, object?, object?)" />
+	public string GetExtendedFailure(string it, object? actual, object? expected)
+	{
+		if (_firstFailure == null)
+		{
+			return $"{it} was {Formatter.Format(actual, FormattingOptions.MultipleLines)}";
+		}
+
+		if (_firstFailure.Type == MemberType.Value)
+		{
+			return $"{it} was {Formatter.Format(_firstFailure.Actual, FormattingOptions.SingleLine)}";
+		}
+
+		StringBuilder sb = new();
+		sb.Append(_firstFailure.Type).Append(' ')
+			.Append(string.Join(".", _firstFailure.NestedMemberNames))
+			.AppendLine(" did not match:");
+
+		sb.Append("  Expected: ");
+		Formatter.Format(sb, _firstFailure.Expected);
+		sb.AppendLine();
+
+		sb.Append("  Received: ");
+		Formatter.Format(sb, _firstFailure.Actual);
+		return sb.ToString();
+	}
+
+	private static bool HandleSpecialCases(object? a, object? b,
+		[NotNullWhen(true)] out bool? isConsideredEqual)
+	{
+		if (a is IEqualityComparer basicEqualityComparer)
+		{
+			isConsideredEqual = basicEqualityComparer.Equals(a, b);
+			return true;
+		}
+
+		if (b is IEqualityComparer expectedBasicEqualityComparer)
+		{
+			isConsideredEqual = expectedBasicEqualityComparer.Equals(a, b);
+			return true;
+		}
+
+		if (a is IEnumerable enumerable && b is IEnumerable enumerable2)
+		{
+			isConsideredEqual =
+				enumerable.Cast<object>().SequenceEqual(enumerable2.Cast<object>());
+			return true;
+		}
+
+		isConsideredEqual = null;
+		return false;
+	}
+
+	public override string ToString() => " equivalent";
+}

--- a/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using aweXpect.Core;
 using aweXpect.Equivalency;
 using aweXpect.Options;
@@ -21,13 +16,11 @@ public static class EquivalencyExtensions
 	///     Use equivalency to compare objects.
 	/// </summary>
 	public static TSelf Equivalent<TType, TThat, TSelf>(this ObjectEqualityResult<TType, TThat, TSelf> result,
-		Func<EquivalencyOptions, EquivalencyOptions>? optionsCallback = null)
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
 		where TSelf : ObjectEqualityResult<TType, TThat, TSelf>
 	{
-		EquivalencyOptions equivalencyOptions =
-			optionsCallback?.Invoke(new EquivalencyOptions()) ?? new EquivalencyOptions();
 		((IOptionsProvider<ObjectEqualityOptions>)result).Options.SetMatchType(
-			new EquivalencyComparer(equivalencyOptions));
+			new EquivalencyComparer(EquivalencyOptions.FromCallback(equivalencyOptions)));
 		return (TSelf)result;
 	}
 
@@ -39,97 +32,5 @@ public static class EquivalencyExtensions
 	{
 		options.SetMatchType(new EquivalencyComparer(equivalencyOptions));
 		return options;
-	}
-
-	private sealed class EquivalencyComparer(EquivalencyOptions equivalencyOptions)
-		: IObjectMatchType
-	{
-		private ComparisonFailure? _firstFailure;
-
-		/// <inheritdoc cref="IObjectMatchType.AreConsideredEqual(object?, object?)" />
-		public bool AreConsideredEqual(object? actual, object? expected)
-		{
-			if (HandleSpecialCases(actual, expected, out bool? specialCaseResult))
-			{
-				return specialCaseResult.Value;
-			}
-
-			List<ComparisonFailure> failures = Compare.CheckEquivalent(actual, expected,
-				new CompareOptions
-				{
-					MembersToIgnore = [.. equivalencyOptions.MembersToIgnore]
-				}).ToList();
-
-			if (failures.FirstOrDefault() is { } firstFailure)
-			{
-				_firstFailure = firstFailure;
-				if (firstFailure.Type == MemberType.Value)
-				{
-					return false;
-				}
-
-				return false;
-			}
-
-			return true;
-		}
-
-		/// <inheritdoc cref="IObjectMatchType.GetExpectation(string)" />
-		public string GetExpectation(string expected) => $"be equivalent to {expected}";
-
-		/// <inheritdoc cref="IObjectMatchType.GetExtendedFailure(string, object?, object?)" />
-		public string GetExtendedFailure(string it, object? actual, object? expected)
-		{
-			if (_firstFailure == null)
-			{
-				return $"{it} was {Formatter.Format(actual, FormattingOptions.MultipleLines)}";
-			}
-
-			if (_firstFailure.Type == MemberType.Value)
-			{
-				return $"{it} was {Formatter.Format(_firstFailure.Actual, FormattingOptions.SingleLine)}";
-			}
-
-			StringBuilder sb = new();
-			sb.Append(_firstFailure.Type).Append(' ')
-				.Append(string.Join(".", _firstFailure.NestedMemberNames))
-				.AppendLine(" did not match:");
-
-			sb.Append("  Expected: ");
-			Formatter.Format(sb, _firstFailure.Expected);
-			sb.AppendLine();
-
-			sb.Append("  Received: ");
-			Formatter.Format(sb, _firstFailure.Actual);
-			return sb.ToString();
-		}
-
-		private static bool HandleSpecialCases(object? a, object? b,
-			[NotNullWhen(true)] out bool? isConsideredEqual)
-		{
-			if (a is IEqualityComparer basicEqualityComparer)
-			{
-				isConsideredEqual = basicEqualityComparer.Equals(a, b);
-				return true;
-			}
-
-			if (b is IEqualityComparer expectedBasicEqualityComparer)
-			{
-				isConsideredEqual = expectedBasicEqualityComparer.Equals(a, b);
-				return true;
-			}
-
-			if (a is IEnumerable enumerable && b is IEnumerable enumerable2)
-			{
-				isConsideredEqual =
-					enumerable.Cast<object>().SequenceEqual(enumerable2.Cast<object>());
-				return true;
-			}
-
-			isConsideredEqual = null;
-			return false;
-		}
-
-		public override string ToString() => " equivalent";
 	}
 }

--- a/Source/aweXpect/That/Objects/ThatObjectShould.BeJsonSerializable.cs
+++ b/Source/aweXpect/That/Objects/ThatObjectShould.BeJsonSerializable.cs
@@ -1,0 +1,113 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Text.Json;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Equivalency;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatObjectShould
+{
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> BeJsonSerializable(
+		this IThat<object?> source,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new BeJsonSerializableConstraint<object>(it, new JsonSerializerOptions(),
+					EquivalencyOptions.FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> BeJsonSerializable(
+		this IThat<object?> source,
+		JsonSerializerOptions serializerOptions,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new BeJsonSerializableConstraint<object>(it, serializerOptions,
+					EquivalencyOptions.FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON of type <typeparamref name="T" />.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> BeJsonSerializable<T>(
+		this IThat<object?> source,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new BeJsonSerializableConstraint<T>(it, new JsonSerializerOptions(),
+					EquivalencyOptions.FromCallback(equivalencyOptions))),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject can be serialized as JSON of type <typeparamref name="T" />.
+	/// </summary>
+	public static AndOrResult<object?, IThat<object?>> BeJsonSerializable<T>(
+		this IThat<object?> source,
+		JsonSerializerOptions serializerOptions,
+		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		=> new(
+			source.ExpectationBuilder.AddConstraint(it
+				=> new BeJsonSerializableConstraint<T>(it, serializerOptions,
+					EquivalencyOptions.FromCallback(equivalencyOptions))),
+			source);
+
+	private readonly struct BeJsonSerializableConstraint<T>(
+		string it,
+		JsonSerializerOptions serializerOptions,
+		EquivalencyOptions options)
+		: IValueConstraint<object?>
+	{
+		public ConstraintResult IsMetBy(object? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<T?>(default, ToString(), $"{it} was <null>");
+			}
+
+			if (actual is not T typedSubject)
+			{
+				return new ConstraintResult.Failure<T?>(default, ToString(),
+					$"{it} was not assignable to {Formatter.Format(typeof(T))}");
+			}
+
+			object? deserializedObject;
+			try
+			{
+				string serializedObject = JsonSerializer.Serialize(actual, serializerOptions);
+				deserializedObject = JsonSerializer.Deserialize(serializedObject, actual.GetType(), serializerOptions);
+			}
+			catch (Exception e)
+			{
+				return new ConstraintResult.Failure<T?>(typedSubject, ToString(),
+					$"{it} could not be deserialized: {e.Message}");
+			}
+
+			EquivalencyComparer equivalencyComparer = new(options);
+			if (equivalencyComparer.AreConsideredEqual(deserializedObject, actual))
+			{
+				return new ConstraintResult.Success<T?>(typedSubject, ToString());
+			}
+
+			return new ConstraintResult.Failure<T?>(typedSubject, ToString(),
+				equivalencyComparer.GetExtendedFailure(it, actual, deserializedObject));
+		}
+
+		public override string ToString()
+			=> (typeof(T) == typeof(object)) switch
+			{
+				true => "be serializable as JSON",
+				false => $"be serializable as {Formatter.Format(typeof(T))} JSON"
+			};
+	}
+}
+#endif

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -444,6 +444,7 @@ namespace aweXpect.Options
         public EquivalencyOptions() { }
         public System.Collections.Generic.IReadOnlyList<string> MembersToIgnore { get; }
         public aweXpect.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
+        public static aweXpect.Options.EquivalencyOptions FromCallback(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? callback) { }
     }
     public class NumberTolerance<TNumber>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -425,6 +425,7 @@ namespace aweXpect.Options
         public EquivalencyOptions() { }
         public System.Collections.Generic.IReadOnlyList<string> MembersToIgnore { get; }
         public aweXpect.Options.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
+        public static aweXpect.Options.EquivalencyOptions FromCallback(System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? callback) { }
     }
     public class NumberTolerance<TNumber>
         where TNumber :  struct, System.IComparable<TNumber>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -19,7 +19,7 @@ namespace aweXpect
     public static class EquivalencyExtensions
     {
         public static aweXpect.Options.ObjectEqualityOptions Equivalent(this aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.EquivalencyOptions equivalencyOptions) { }
-        public static TSelf Equivalent<TType, TThat, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> result, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null)
+        public static TSelf Equivalent<TType, TThat, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> result, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? equivalencyOptions = null)
             where TSelf : aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> { }
     }
     public static class JsonExtensions
@@ -874,6 +874,10 @@ namespace aweXpect
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> Be<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> BeExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> BeExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeJsonSerializable(this aweXpect.Core.IThat<object?> source, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeJsonSerializable(this aweXpect.Core.IThat<object?> source, System.Text.Json.JsonSerializerOptions serializerOptions, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeJsonSerializable<T>(this aweXpect.Core.IThat<object?> source, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? equivalencyOptions = null) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeJsonSerializable<T>(this aweXpect.Core.IThat<object?> source, System.Text.Json.JsonSerializerOptions serializerOptions, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? equivalencyOptions = null) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> BeNull(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> NotBe(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> NotBe(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -19,7 +19,7 @@ namespace aweXpect
     public static class EquivalencyExtensions
     {
         public static aweXpect.Options.ObjectEqualityOptions Equivalent(this aweXpect.Options.ObjectEqualityOptions options, aweXpect.Options.EquivalencyOptions equivalencyOptions) { }
-        public static TSelf Equivalent<TType, TThat, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> result, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? optionsCallback = null)
+        public static TSelf Equivalent<TType, TThat, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> result, System.Func<aweXpect.Options.EquivalencyOptions, aweXpect.Options.EquivalencyOptions>? equivalencyOptions = null)
             where TSelf : aweXpect.Results.ObjectEqualityResult<TType, TThat, TSelf> { }
     }
     public static class ThatBoolShould

--- a/Tests/aweXpect.Tests/Objects/ObjectShould.BeJsonSerializableTests.cs
+++ b/Tests/aweXpect.Tests/Objects/ObjectShould.BeJsonSerializableTests.cs
@@ -1,0 +1,333 @@
+﻿#if NET8_0_OR_GREATER
+using System.Text.Json;
+using aweXpect.Tests.TestHelpers.Models;
+
+namespace aweXpect.Tests.Objects;
+
+public sealed partial class ObjectShould
+{
+	public sealed class BeJsonSerializable
+	{
+		public sealed class ObjectTests
+		{
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_ShouldFail()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo"
+				};
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as JSON,
+					             but Property Name did not match:
+					               Expected: "foo"
+					               Received: <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_WhenPropertyIsIgnored_ShouldSucceed()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo"
+				};
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable(o => o.IgnoringMember("Name"));
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructor_ShouldFail()
+			{
+				PocoWithPrivateConstructor subject = PocoWithPrivateConstructor.Create(42);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as JSON,
+					             but it could not be deserialized: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'aweXpect.Tests.TestHelpers.Models.PocoWithPrivateConstructor'*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructorWithJsonConstructorAttribute_ShouldSucceed()
+			{
+				PocoWithPrivateConstructorWithJsonConstructorAttribute subject =
+					PocoWithPrivateConstructorWithJsonConstructorAttribute.Create(42);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasNoDefaultConstructor_ShouldFail()
+			{
+				PocoWithoutDefaultConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Tests.TestHelpers.Models.PocoWithoutDefaultConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object*
+					             """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(true)]
+			[InlineData(false)]
+			public async Task WhenSubjectHasNoDefaultFieldConstructor_ShouldFailUnlessIncludeFieldsIsSet(
+				bool includeFields)
+			{
+				PocoWithoutDefaultFieldConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable(new JsonSerializerOptions
+					{
+						IncludeFields = includeFields
+					});
+
+				await That(Act).Should().Throw<XunitException>().OnlyIf(!includeFields)
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Tests.TestHelpers.Models.PocoWithoutDefaultFieldConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. Fields are only considered when 'JsonSerializerOptions.IncludeFields' is enabled*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				object? subject = null;
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as JSON,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsPoco_ShouldSucceed()
+			{
+				SimplePocoWithPrimitiveTypes subject = new()
+				{
+					Id = 1,
+					GlobalId = Guid.NewGuid(),
+					Name = "foo",
+					DateOfBirth = DateTime.Today,
+					Height = new decimal(4.3),
+					Weight = 5.6,
+					ShoeSize = 7.8f,
+					IsActive = true,
+					Image = [8, 9, 10, 11],
+					Category = 'a'
+				};
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_ShouldFail()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo"
+				};
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<PocoWithIgnoredProperty>();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as PocoWithIgnoredProperty JSON,
+					             but Property Name did not match:
+					               Expected: "foo"
+					               Received: <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAnIgnoredProperty_WhenPropertyIsIgnored_ShouldSucceed()
+			{
+				PocoWithIgnoredProperty subject = new()
+				{
+					Id = 2,
+					Name = "foo"
+				};
+
+				async Task Act()
+					=> await That(subject).Should()
+						.BeJsonSerializable<PocoWithIgnoredProperty>(o => o.IgnoringMember("Name"));
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructor_ShouldFail()
+			{
+				PocoWithPrivateConstructor subject = PocoWithPrivateConstructor.Create(42);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<PocoWithPrivateConstructor>();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as PocoWithPrivateConstructor JSON,
+					             but it could not be deserialized: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'aweXpect.Tests.TestHelpers.Models.PocoWithPrivateConstructor'*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAPrivateConstructorWithJsonConstructorAttribute_ShouldSucceed()
+			{
+				PocoWithPrivateConstructorWithJsonConstructorAttribute subject =
+					PocoWithPrivateConstructorWithJsonConstructorAttribute.Create(42);
+
+				async Task Act()
+					=> await That(subject).Should()
+						.BeJsonSerializable<PocoWithPrivateConstructorWithJsonConstructorAttribute>();
+
+				await That(Act).Should().NotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasNoDefaultConstructor_ShouldFail()
+			{
+				PocoWithoutDefaultConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<PocoWithoutDefaultConstructor>();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as PocoWithoutDefaultConstructor JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Tests.TestHelpers.Models.PocoWithoutDefaultConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object*
+					             """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(true)]
+			[InlineData(false)]
+			public async Task WhenSubjectHasNoDefaultFieldConstructor_ShouldFailUnlessIncludeFieldsIsSet(
+				bool includeFields)
+			{
+				PocoWithoutDefaultFieldConstructor subject = new(12);
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<PocoWithoutDefaultFieldConstructor>(
+						new JsonSerializerOptions
+						{
+							IncludeFields = includeFields
+						});
+
+				await That(Act).Should().Throw<XunitException>().OnlyIf(!includeFields)
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as PocoWithoutDefaultFieldConstructor JSON,
+					             but it could not be deserialized: Each parameter in the deserialization constructor on type 'aweXpect.Tests.TestHelpers.Models.PocoWithoutDefaultFieldConstructor' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. Fields are only considered when 'JsonSerializerOptions.IncludeFields' is enabled*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				object? subject = null;
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<SimplePocoWithPrimitiveTypes>();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as SimplePocoWithPrimitiveTypes JSON,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeDoesNotMatch_ShouldFail()
+			{
+				SimplePocoWithPrimitiveTypes subject = new()
+				{
+					Id = 1,
+					GlobalId = Guid.NewGuid(),
+					Name = "foo",
+					DateOfBirth = DateTime.Today,
+					Height = new decimal(4.3),
+					Weight = 5.6,
+					ShoeSize = 7.8f,
+					IsActive = true,
+					Image = [8, 9, 10, 11],
+					Category = 'a'
+				};
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<PocoWithIgnoredProperty>();
+
+				await That(Act).Should().Throw<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be serializable as PocoWithIgnoredProperty JSON,
+					             but it was not assignable to PocoWithIgnoredProperty
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeMatches_ShouldSucceed()
+			{
+				SimplePocoWithPrimitiveTypes subject = new()
+				{
+					Id = 1,
+					GlobalId = Guid.NewGuid(),
+					Name = "foo",
+					DateOfBirth = DateTime.Today,
+					Height = new decimal(4.3),
+					Weight = 5.6,
+					ShoeSize = 7.8f,
+					IsActive = true,
+					Image = [8, 9, 10, 11],
+					Category = 'a'
+				};
+
+				async Task Act()
+					=> await That(subject).Should().BeJsonSerializable<SimplePocoWithPrimitiveTypes>();
+
+				await That(Act).Should().NotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithIgnoredProperty.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithIgnoredProperty.cs
@@ -1,0 +1,12 @@
+﻿#if NET8_0_OR_GREATER
+using System.Text.Json.Serialization;
+
+namespace aweXpect.Tests.TestHelpers.Models;
+
+public class PocoWithIgnoredProperty
+{
+	public int Id { get; set; }
+
+	[JsonIgnore] public string? Name { get; set; }
+}
+#endif

--- a/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithPrivateConstructor.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithPrivateConstructor.cs
@@ -1,0 +1,13 @@
+﻿namespace aweXpect.Tests.TestHelpers.Models;
+
+public class PocoWithPrivateConstructor
+{
+	private PocoWithPrivateConstructor() { }
+
+	public int Id { get; set; }
+
+	public static PocoWithPrivateConstructor Create(int id) => new()
+	{
+		Id = id
+	};
+}

--- a/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithPrivateConstructorWithJsonConstructorAttribute.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithPrivateConstructorWithJsonConstructorAttribute.cs
@@ -1,0 +1,19 @@
+﻿#if NET8_0_OR_GREATER
+using System.Text.Json.Serialization;
+
+namespace aweXpect.Tests.TestHelpers.Models;
+
+public class PocoWithPrivateConstructorWithJsonConstructorAttribute
+{
+	[JsonConstructor]
+	private PocoWithPrivateConstructorWithJsonConstructorAttribute() { }
+
+	public int Id { get; init; }
+
+	public static PocoWithPrivateConstructorWithJsonConstructorAttribute Create(int id) => new()
+	{
+		Id = id
+	};
+}
+
+#endif

--- a/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithoutDefaultConstructor.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithoutDefaultConstructor.cs
@@ -1,0 +1,6 @@
+﻿namespace aweXpect.Tests.TestHelpers.Models;
+
+public class PocoWithoutDefaultConstructor(int value)
+{
+	public int Id { get; } = value;
+}

--- a/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithoutDefaultFieldConstructor.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Models/PocoWithoutDefaultFieldConstructor.cs
@@ -1,0 +1,6 @@
+﻿namespace aweXpect.Tests.TestHelpers.Models;
+
+public class PocoWithoutDefaultFieldConstructor(int value)
+{
+	public int Value = value;
+}

--- a/Tests/aweXpect.Tests/TestHelpers/Models/SimplePocoWithPrimitiveTypes.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/Models/SimplePocoWithPrimitiveTypes.cs
@@ -1,0 +1,24 @@
+﻿namespace aweXpect.Tests.TestHelpers.Models;
+
+public class SimplePocoWithPrimitiveTypes
+{
+	public int Id { get; set; }
+
+	public Guid GlobalId { get; set; }
+
+	public string Name { get; set; } = "";
+
+	public DateTime DateOfBirth { get; set; }
+
+	public decimal Height { get; set; }
+
+	public double Weight { get; set; }
+
+	public float ShoeSize { get; set; }
+
+	public bool IsActive { get; set; }
+
+	public byte[] Image { get; set; } = [];
+
+	public char Category { get; set; }
+}


### PR DESCRIPTION
## JSON serializable

You can verify that an `object` is JSON serializable:

```csharp
MyClass subject = new MyClass();

await Expect.That(subject).Should().BeJsonSerializable();
```
This validates, that the `MyClass` can be serialized and deserialized to/from JSON and that the result is equivalent to the original subject.

You can specify both, the [`JsonSerializerOptions`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions) and the equivalency options:
```csharp
MyClass subject = new MyClass();

await Expect.That(subject).Should().BeJsonSerializable(
    new JsonSerializerOptions { IncludeFields = true },
    e => e.IgnoringMember("Foo"));
```

You can also specify an expected generic type that the subject should have:
```csharp
object subject = //...
await Expect.That(subject).Should().BeJsonSerializable<MyClass>(
    new JsonSerializerOptions { IncludeFields = true },
    e => e.IgnoringMember("Foo"));
```

*Fixes remaining issue from #188*