### PR TITLE
refactor: separate version for "aweXpect.Core"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
     push:
         branches: [ main ]
-        tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
+        tags: [ 'v[0-9]+.[0-9]+.[0-9]+', 'core/v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
     unit-tests:
@@ -188,8 +188,8 @@ jobs:
                     path: Artifacts/Packages
                     name: Packages
     
-    push:
-        name: "Push"
+    push_awexpect:
+        name: "Push aweXpect"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: ubuntu-latest
         environment: production
@@ -206,11 +206,47 @@ jobs:
                 run: |
                     echo "Found the following packages to push:"
                     search_dir=Artifacts/Packages
-                    for entry in Artifacts/Packages/*.nupkg
+                    for entry in Artifacts/Packages/aweXpect/*.nupkg
                     do
                       echo "- $entry"
                     done
-                    for entry in Artifacts/Packages/*.nupkg
+                    for entry in Artifacts/Packages/aweXpect/*.nupkg
+                    do
+                      nuget push $entry -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
+                    done
+            -   name: Create GitHub release
+                if: ${{ !startsWith(github.ref, 'refs/tags/core/v') }}
+                continue-on-error: true
+                uses: softprops/action-gh-release@v2
+                with:
+                    name: ${{ steps.tag.outputs.release_version }}
+                    tag_name: ${{ steps.tag.outputs.release_version }}
+                    token: ${{ secrets.GITHUB_TOKEN }}
+                    generate_release_notes: true
+    
+    push_core:
+        name: "Push aweXpect.Core"
+        if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
+        runs-on: ubuntu-latest
+        environment: production
+        needs: [ pack ]
+        permissions:
+            contents: write
+        steps:
+            -   name: Download packages
+                uses: actions/download-artifact@v4
+                with:
+                    name: Packages
+                    path: Artifacts/Packages
+            -   name: Publish
+                run: |
+                    echo "Found the following packages to push:"
+                    search_dir=Artifacts/Packages
+                    for entry in Artifacts/Packages/aweXpect.Core/*.nupkg
+                    do
+                      echo "- $entry"
+                    done
+                    for entry in Artifacts/Packages/aweXpect.Core/*.nupkg
                     do
                       nuget push $entry -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
                     done

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -44,7 +44,7 @@
         "Pack",
         "Restore",
         "TestFrameworks",
-        "TunitTestingPlatformFrameworks",
+        "TestingPlatformFrameworks",
         "UnitTests",
         "UpdateReadme",
         "VsTestFrameworks",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="MinVer" Version="6.0.0"/>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.ApiChecks.cs
+++ b/Pipeline/Build.ApiChecks.cs
@@ -3,6 +3,8 @@ using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
+
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -9,6 +9,7 @@ using Octokit;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -1,6 +1,7 @@
 using Nuke.Common;
 using Nuke.Common.Tools.SonarScanner;
 
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;
@@ -20,8 +21,8 @@ partial class Build
 				.SetProjectKey("aweXpect_aweXpect")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
-				.SetPullRequestOrBranchName(GitHubActions, GitVersion)
-				.SetVersion(GitVersion.SemVer)
+				.SetPullRequestOrBranchName(GitHubActions, BranchName)
+				.SetVersion(SemVer)
 				.SetToken(SonarToken));
 		});
 

--- a/Pipeline/Build.CodeCoverage.cs
+++ b/Pipeline/Build.CodeCoverage.cs
@@ -3,6 +3,7 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.ReportGenerator;
 using static Nuke.Common.Tools.ReportGenerator.ReportGeneratorTasks;
 
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;

--- a/Pipeline/Build.Compile.cs
+++ b/Pipeline/Build.Compile.cs
@@ -94,12 +94,7 @@ partial class Build
 				.WhenNotNull(CoreVersion, (summary, version) => summary
 					.AddPair("Core", version.FileVersion)));
 
-			foreach (string package in Directory
-				         .EnumerateFiles(Solution.aweXpect.Directory / "bin", "*nupkg",
-					         SearchOption.AllDirectories))
-			{
-				File.Delete(package);
-			}
+			ClearNugetPackages(Solution.aweXpect.Directory / "bin");
 
 			DotNetBuild(s => s
 				.SetProjectFile(Solution)
@@ -111,12 +106,7 @@ partial class Build
 				.SetFileVersion(MainVersion.FileVersion)
 				.SetInformationalVersion(MainVersion.InformationalVersion));
 
-			foreach (string package in Directory
-				         .EnumerateFiles(Solution.aweXpect_Core.Directory / "bin", "*nupkg",
-					         SearchOption.AllDirectories))
-			{
-				File.Delete(package);
-			}
+			ClearNugetPackages(Solution.aweXpect_Core.Directory / "bin");
 
 			DotNetBuild(s => s
 				.SetProjectFile(Solution.aweXpect_Core)
@@ -140,6 +130,17 @@ partial class Build
 			}
 
 			return new AssemblyVersion(gitVersion.AssemblySemVer, gitVersion.InformationalVersion);
+		}
+	}
+
+	private static void ClearNugetPackages(string binPath)
+	{
+		if (Directory.Exists(binPath))
+		{
+			foreach (string package in Directory.EnumerateFiles(binPath, "*nupkg", SearchOption.AllDirectories))
+			{
+				File.Delete(package);
+			}
 		}
 	}
 }

--- a/Pipeline/Build.FrameworkTest.cs
+++ b/Pipeline/Build.FrameworkTest.cs
@@ -5,6 +5,7 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -12,6 +12,7 @@ using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using Project = Nuke.Common.ProjectModel.Project;
 
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;
@@ -50,7 +51,7 @@ partial class Build
 
 			foreach (KeyValuePair<Project, Project[]> project in projects)
 			{
-				string branchName = GitVersion.BranchName;
+				string branchName = BranchName;
 				if (GitHubActions?.Ref.StartsWith("refs/tags/", StringComparison.OrdinalIgnoreCase) == true)
 				{
 					string version = GitHubActions.Ref.Substring("refs/tags/".Length);
@@ -73,7 +74,7 @@ partial class Build
 				                      		"target-framework": "net8.0",
 				                      		"since": {
 				                      			"target": "main",
-				                      			"enabled": {{(GitVersion.BranchName != "main").ToString().ToLowerInvariant()}},
+				                      			"enabled": {{(BranchName != "main").ToString().ToLowerInvariant()}},
 				                      			"ignore-changes-in": [
 				                      				"**/.github/**/*.*"
 				                      			]

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using static Nuke.Common.Tools.Xunit.XunitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
+// ReSharper disable UnusedMember.Local
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -2,7 +2,6 @@ using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
-using Nuke.Common.Tools.GitVersion;
 
 namespace Build;
 
@@ -19,8 +18,6 @@ partial class Build : NukeBuild
 
 	[Parameter("Github Token")] readonly string GithubToken;
 
-	[Required] [GitVersion(Framework = "net8.0", NoCache = true, NoFetch = true)] readonly GitVersion GitVersion;
-
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 
 	AbsolutePath ArtifactsDirectory => RootDirectory / "Artifacts";
@@ -28,8 +25,8 @@ partial class Build : NukeBuild
 	GitHubActions GitHubActions => GitHubActions.Instance;
 
 	public static int Main() => Execute<Build>([
-		x => x.ApiChecks,
-		x => x.Benchmarks,
-		x => x.CodeAnalysis,
+		x => x.Pack,
+		//x => x.Benchmarks,
+		//x => x.CodeAnalysis,
 	]);
 }

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -26,7 +26,8 @@ partial class Build : NukeBuild
 
 	public static int Main() => Execute<Build>([
 		x => x.Pack,
-		//x => x.Benchmarks,
-		//x => x.CodeAnalysis,
+		x => x.ApiChecks,
+		x => x.Benchmarks,
+		x => x.CodeAnalysis,
 	]);
 }

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Nuke.Common.CI.GitHubActions;
-using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Tools.SonarScanner;
 using Serilog;
 using System;
@@ -11,7 +10,7 @@ public static class BuildExtensions
 	public static SonarScannerBeginSettings SetPullRequestOrBranchName(
 		this SonarScannerBeginSettings settings,
 		GitHubActions gitHubActions,
-		GitVersion gitVersion)
+		string branchName)
 	{
 		if (gitHubActions?.IsPullRequest == true)
 		{
@@ -25,12 +24,12 @@ public static class BuildExtensions
 		if (gitHubActions?.Ref.StartsWith("refs/tags/", StringComparison.OrdinalIgnoreCase) == true)
 		{
 			string version = gitHubActions.Ref.Substring("refs/tags/".Length);
-			string branchName = "release/" + version;
+			branchName = "release/" + version;
 			Log.Information("Use release branch analysis for '{BranchName}'", branchName);
 			return settings.SetBranchName(branchName);
 		}
 
-		Log.Information("Use branch analysis for '{BranchName}'", gitVersion.BranchName);
-		return settings.SetBranchName(gitVersion.BranchName);
+		Log.Information("Use branch analysis for '{BranchName}'", branchName);
+		return settings.SetBranchName(branchName);
 	}
 }

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -39,10 +39,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MinVer">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="Nullable">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes #99 by setting the version for "aweXpect.Core" differently from the main version.
In order to update the core version, add a tag `core/v{major}.{minor}.{patch}` which will build and release a core version update. Afterwards, after updating the core version in "Directory.Packages.props", create a normal release that uses the core version.