### PR TITLE
chore: fix fluentassertions to v7, as no benchmarks are allowed after the license change

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
 		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.3"/>
-		<PackageVersion Include="FluentAssertions" Version="7.0.0"/>
+		<PackageVersion Include="FluentAssertions" Version="[7.0.0,8.0.0)"/>
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.5.0"/>
 		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.3.0"/>


### PR DESCRIPTION
According to the license in https://github.com/fluentassertions/fluentassertions/pull/2943, it is not allowed to "publish results from benchmarks or performance comparison tests (with other products) without advance written permission by Xceed", therefore, fix the version to the latest v7!