### PR TITLE
docs: include package project url

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -9,6 +9,7 @@
 		<Copyright>Copyright (c) 2024 Valentin Breuß</Copyright>
 		<RepositoryUrl>https://github.com/aweXpect/aweXpect.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<PackageProjectUrl>https://awexpect.github.io/aweXpect/</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>


### PR DESCRIPTION
Include a project URL to https://awexpect.github.io/aweXpect/ in the nuget package