### PR TITLE
fix: failing nuget push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
     push_awexpect:
         name: "Push aweXpect"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         environment: production
         needs: [ pack ]
         permissions:
@@ -227,7 +227,7 @@ jobs:
     push_core:
         name: "Push aweXpect.Core"
         if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         environment: production
         needs: [ pack ]
         permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
     pack:
         name: "Pack"
         runs-on: ubuntu-latest
-        needs: [ publish-test-results, mutation-tests, benchmarks, static-code-analysis ]
+        needs: [ publish-test-results, benchmarks ]
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -193,7 +193,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack ]
+        needs: [ pack, mutation-tests, static-code-analysis ]
         permissions:
             contents: write
         steps:
@@ -229,7 +229,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack ]
+        needs: [ pack, mutation-tests, static-code-analysis ]
         permissions:
             contents: write
         steps:


### PR DESCRIPTION
use macos for nuget push, as it worked [here](https://github.com/aweXpect/aweXpect.Testably/pull/22)