### PR TITLE
fix: execute benchmark report in main build

### DIFF
--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -92,7 +92,7 @@ partial class Build
 
 	Target BenchmarkReport => _ => _
 		.After(BenchmarkDotNet)
-		.OnlyWhenDynamic(() => BranchName == "main")
+		.OnlyWhenDynamic(() => GitHubActions?.IsPullRequest == false)
 		.Executes(async () =>
 		{
 			BenchmarkFile currentFile = await DownloadBenchmarkFile();


### PR DESCRIPTION
The condition for executing the benchmark report is incorrect.