### PR TITLE
docs: reset benchmarks on main branch

### DIFF
--- a/Docs/pages/static/js/data.js
+++ b/Docs/pages/static/js/data.js
@@ -1,2 +1,578 @@
 window.BENCHMARK_DATA = {
+  "Bool": {
+    "commits": [
+      {
+        "sha": "198447f7ad33650ea18d7239d6579cda44f17f2f",
+        "author": "Valentin Breu\u00DF",
+        "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
+        "message": "fix: execute benchmark report in main build (#219)"
+      }
+    ],
+    "labels": [
+      "198447f7"
+    ],
+    "datasets": [
+      {
+        "label": "aweXpect time",
+        "unit": "ns",
+        "data": [
+          150.75262652910672
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "aweXpect memory",
+        "unit": "b",
+        "data": [
+          496
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "FluentAssertions time",
+        "unit": "ns",
+        "data": [
+          200.27242479721704
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "FluentAssertions memory",
+        "unit": "b",
+        "data": [
+          776
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "TUnit time",
+        "unit": "ns",
+        "data": [
+          539.4753929138184
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "TUnit memory",
+        "unit": "b",
+        "data": [
+          1712
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      }
+    ]
+  },
+  "ItemsCount_AtLeast": {
+    "commits": [
+      {
+        "sha": "198447f7ad33650ea18d7239d6579cda44f17f2f",
+        "author": "Valentin Breu\u00DF",
+        "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
+        "message": "fix: execute benchmark report in main build (#219)"
+      }
+    ],
+    "labels": [
+      "198447f7"
+    ],
+    "datasets": [
+      {
+        "label": "aweXpect time",
+        "unit": "ns",
+        "data": [
+          329.63557247320813
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "aweXpect memory",
+        "unit": "b",
+        "data": [
+          888
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "FluentAssertions time",
+        "unit": "ns",
+        "data": [
+          417.0791400029109
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "FluentAssertions memory",
+        "unit": "b",
+        "data": [
+          1816
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "TUnit time",
+        "unit": "ns",
+        "data": [
+          14911.549033610027
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "TUnit memory",
+        "unit": "b",
+        "data": [
+          26616
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      }
+    ]
+  },
+  "Int_GreaterThan": {
+    "commits": [
+      {
+        "sha": "198447f7ad33650ea18d7239d6579cda44f17f2f",
+        "author": "Valentin Breu\u00DF",
+        "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
+        "message": "fix: execute benchmark report in main build (#219)"
+      }
+    ],
+    "labels": [
+      "198447f7"
+    ],
+    "datasets": [
+      {
+        "label": "aweXpect time",
+        "unit": "ns",
+        "data": [
+          204.06733180681866
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "aweXpect memory",
+        "unit": "b",
+        "data": [
+          848
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "FluentAssertions time",
+        "unit": "ns",
+        "data": [
+          250.96880504063196
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "FluentAssertions memory",
+        "unit": "b",
+        "data": [
+          1048
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "TUnit time",
+        "unit": "ns",
+        "data": [
+          766.1536415735881
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "TUnit memory",
+        "unit": "b",
+        "data": [
+          2352
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      }
+    ]
+  },
+  "String": {
+    "commits": [
+      {
+        "sha": "198447f7ad33650ea18d7239d6579cda44f17f2f",
+        "author": "Valentin Breu\u00DF",
+        "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
+        "message": "fix: execute benchmark report in main build (#219)"
+      }
+    ],
+    "labels": [
+      "198447f7"
+    ],
+    "datasets": [
+      {
+        "label": "aweXpect time",
+        "unit": "ns",
+        "data": [
+          304.53645614477307
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "aweXpect memory",
+        "unit": "b",
+        "data": [
+          928
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "FluentAssertions time",
+        "unit": "ns",
+        "data": [
+          351.26639202662875
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "FluentAssertions memory",
+        "unit": "b",
+        "data": [
+          1832
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "TUnit time",
+        "unit": "ns",
+        "data": [
+          814.6544300715128
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "TUnit memory",
+        "unit": "b",
+        "data": [
+          2328
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      }
+    ]
+  },
+  "StringArray": {
+    "commits": [
+      {
+        "sha": "198447f7ad33650ea18d7239d6579cda44f17f2f",
+        "author": "Valentin Breu\u00DF",
+        "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
+        "message": "fix: execute benchmark report in main build (#219)"
+      }
+    ],
+    "labels": [
+      "198447f7"
+    ],
+    "datasets": [
+      {
+        "label": "aweXpect time",
+        "unit": "ns",
+        "data": [
+          1069.4012530190605
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "aweXpect memory",
+        "unit": "b",
+        "data": [
+          2384
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "FluentAssertions time",
+        "unit": "ns",
+        "data": [
+          1175.168862915039
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "FluentAssertions memory",
+        "unit": "b",
+        "data": [
+          3760
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "TUnit time",
+        "unit": "ns",
+        "data": [
+          2060.838473510742
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "TUnit memory",
+        "unit": "b",
+        "data": [
+          3216
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      }
+    ]
+  },
+  "StringArrayInAnyOrder": {
+    "commits": [
+      {
+        "sha": "198447f7ad33650ea18d7239d6579cda44f17f2f",
+        "author": "Valentin Breu\u00DF",
+        "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
+        "message": "fix: execute benchmark report in main build (#219)"
+      }
+    ],
+    "labels": [
+      "198447f7"
+    ],
+    "datasets": [
+      {
+        "label": "aweXpect time",
+        "unit": "ns",
+        "data": [
+          1094.4609926768712
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "aweXpect memory",
+        "unit": "b",
+        "data": [
+          2408
+        ],
+        "borderColor": "#63A2AC",
+        "backgroundColor": "#63A2AC",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "FluentAssertions time",
+        "unit": "ns",
+        "data": [
+          76939.67994791667
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "FluentAssertions memory",
+        "unit": "b",
+        "data": [
+          50710
+        ],
+        "borderColor": "#ACA263",
+        "backgroundColor": "#ACA263",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      },
+      {
+        "label": "TUnit time",
+        "unit": "ns",
+        "data": [
+          3975.66723429362
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y",
+        "borderDash": [],
+        "pointStyle": "circle"
+      },
+      {
+        "label": "TUnit memory",
+        "unit": "b",
+        "data": [
+          5160
+        ],
+        "borderColor": "#AC6262",
+        "backgroundColor": "#AC6262",
+        "yAxisID": "y1",
+        "borderDash": [
+          5,
+          5
+        ],
+        "pointStyle": "triangle"
+      }
+    ]
+  }
 }

--- a/Docs/pages/static/js/data.js
+++ b/Docs/pages/static/js/data.js
@@ -6,17 +6,113 @@ window.BENCHMARK_DATA = {
         "author": "Valentin Breu\u00DF",
         "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
         "message": "fix: execute benchmark report in main build (#219)"
+      },
+      {
+        "sha": "e994b4ddac319ba1496d5d908adabef71217f6b5",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:06:43 2025 \u002B0100",
+        "message": "docs: avoid reporting benchmarks for the same commit twice (#221)"
+      },
+      {
+        "sha": "a6022c2c3716943fc039096336119983cf150e7e",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:17:07 2025 \u002B0100",
+        "message": "coverage: exclude polyfill files (#222)"
+      },
+      {
+        "sha": "ba348350c55bc5b042f1e6116e5f4ddb00a80a24",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:43:03 2025 \u002B0100",
+        "message": "fix: finalize release when at least one push succeeded (#223)"
+      },
+      {
+        "sha": "96f70d37e5bf44488ff777dab44333c47fbccfeb",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 11:28:18 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0 (#229)"
+      },
+      {
+        "sha": "a65ca3f33d06e0a712049c084956217791a1af8d",
+        "author": "Valentin",
+        "date": "Mon Jan 20 11:18:44 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0"
+      },
+      {
+        "sha": "b6626f8ea71062e77ed99d409fffa363faeeb86c",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:26 2025 \u002B0100",
+        "message": "build(deps): bump Microsoft.Testing.Extensions.TrxReport from 1.5.0 to 1.5.1 (#228)"
+      },
+      {
+        "sha": "08ef69d9676332d2cc040e885cf1d859ae9a0238",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:36 2025 \u002B0100",
+        "message": "build(deps): bump SharpCompress from 0.38.0 to 0.39.0 (#227)"
+      },
+      {
+        "sha": "8c5638ae5f225aa69698100f545da758885f3385",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:43 2025 \u002B0100",
+        "message": "build(deps): bump TUnit.Assertions from 0.6.137 to 0.6.151 in the tunit group (#226)"
+      },
+      {
+        "sha": "8111de1379be71399916ded9e459e43d9a746ca3",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:53 2025 \u002B0100",
+        "message": "build(deps): bump the mstest group with 2 updates (#225)"
+      },
+      {
+        "sha": "8881f80647f5e9da9bf8886db6ea6fec9537abc9",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:55:02 2025 \u002B0100",
+        "message": "build(deps): bump the nuke group with 2 updates (#224)"
+      },
+      {
+        "sha": "a7ed6bc73346bbd62c70d36a9a61536eb87ad8de",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 13:24:55 2025 \u002B0100",
+        "message": "fix: finalize release executed only after aweXpect push (#230)"
+      },
+      {
+        "sha": "46c2cd1d1828af4cc393c10457ea5ac986ee3cd2",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 14:17:39 2025 \u002B0100",
+        "message": "docs: set minimum of benchmark y-axes to zero (#231)"
       }
     ],
     "labels": [
-      "198447f7"
+      "198447f7",
+      "e994b4dd",
+      "a6022c2c",
+      "ba348350",
+      "96f70d37",
+      "a65ca3f3",
+      "b6626f8e",
+      "08ef69d9",
+      "8c5638ae",
+      "8111de13",
+      "8881f806",
+      "a7ed6bc7",
+      "46c2cd1d"
     ],
     "datasets": [
       {
         "label": "aweXpect time",
         "unit": "ns",
         "data": [
-          150.75262652910672
+          150.75262652910672,
+          170.8307419459025,
+          170.6940963904063,
+          158.4435460090637,
+          155.13557620048522,
+          165.76554095745087,
+          164.67326958974203,
+          160.11295573527997,
+          156.0363313992818,
+          151.6461879014969,
+          185.18310533251082,
+          151.3436605612437,
+          162.8321444829305
         ],
         "borderColor": "#63A2AC",
         "backgroundColor": "#63A2AC",
@@ -28,6 +124,18 @@ window.BENCHMARK_DATA = {
         "label": "aweXpect memory",
         "unit": "b",
         "data": [
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
+          496,
           496
         ],
         "borderColor": "#63A2AC",
@@ -43,7 +151,19 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions time",
         "unit": "ns",
         "data": [
-          200.27242479721704
+          200.27242479721704,
+          224.86235439777374,
+          222.18419427871703,
+          199.29969428135797,
+          207.76855233510335,
+          225.15658162434895,
+          208.41571418444315,
+          206.88912995656332,
+          202.32963379224142,
+          205.74112950052535,
+          206.35183811187744,
+          208.50420352128836,
+          216.60735592475305
         ],
         "borderColor": "#ACA263",
         "backgroundColor": "#ACA263",
@@ -55,6 +175,18 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions memory",
         "unit": "b",
         "data": [
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
+          776,
           776
         ],
         "borderColor": "#ACA263",
@@ -70,7 +202,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit time",
         "unit": "ns",
         "data": [
-          539.4753929138184
+          539.4753929138184,
+          595.9496761322022,
+          578.6159603754679,
+          524.8989543233599,
+          562.5271207491556,
+          567.452426846822,
+          550.8775363922119,
+          522.3786952836173,
+          549.5231369654338,
+          568.7060990651448,
+          576.34955736307,
+          588.3241058985392,
+          569.3761840820313
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -82,7 +226,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit memory",
         "unit": "b",
         "data": [
-          1712
+          1712,
+          1712,
+          1712,
+          1712,
+          1712,
+          1712,
+          1712,
+          1712,
+          1752,
+          1752,
+          1752,
+          1752,
+          1752
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -102,17 +258,113 @@ window.BENCHMARK_DATA = {
         "author": "Valentin Breu\u00DF",
         "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
         "message": "fix: execute benchmark report in main build (#219)"
+      },
+      {
+        "sha": "e994b4ddac319ba1496d5d908adabef71217f6b5",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:06:43 2025 \u002B0100",
+        "message": "docs: avoid reporting benchmarks for the same commit twice (#221)"
+      },
+      {
+        "sha": "a6022c2c3716943fc039096336119983cf150e7e",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:17:07 2025 \u002B0100",
+        "message": "coverage: exclude polyfill files (#222)"
+      },
+      {
+        "sha": "ba348350c55bc5b042f1e6116e5f4ddb00a80a24",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:43:03 2025 \u002B0100",
+        "message": "fix: finalize release when at least one push succeeded (#223)"
+      },
+      {
+        "sha": "96f70d37e5bf44488ff777dab44333c47fbccfeb",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 11:28:18 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0 (#229)"
+      },
+      {
+        "sha": "a65ca3f33d06e0a712049c084956217791a1af8d",
+        "author": "Valentin",
+        "date": "Mon Jan 20 11:18:44 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0"
+      },
+      {
+        "sha": "b6626f8ea71062e77ed99d409fffa363faeeb86c",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:26 2025 \u002B0100",
+        "message": "build(deps): bump Microsoft.Testing.Extensions.TrxReport from 1.5.0 to 1.5.1 (#228)"
+      },
+      {
+        "sha": "08ef69d9676332d2cc040e885cf1d859ae9a0238",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:36 2025 \u002B0100",
+        "message": "build(deps): bump SharpCompress from 0.38.0 to 0.39.0 (#227)"
+      },
+      {
+        "sha": "8c5638ae5f225aa69698100f545da758885f3385",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:43 2025 \u002B0100",
+        "message": "build(deps): bump TUnit.Assertions from 0.6.137 to 0.6.151 in the tunit group (#226)"
+      },
+      {
+        "sha": "8111de1379be71399916ded9e459e43d9a746ca3",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:53 2025 \u002B0100",
+        "message": "build(deps): bump the mstest group with 2 updates (#225)"
+      },
+      {
+        "sha": "8881f80647f5e9da9bf8886db6ea6fec9537abc9",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:55:02 2025 \u002B0100",
+        "message": "build(deps): bump the nuke group with 2 updates (#224)"
+      },
+      {
+        "sha": "a7ed6bc73346bbd62c70d36a9a61536eb87ad8de",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 13:24:55 2025 \u002B0100",
+        "message": "fix: finalize release executed only after aweXpect push (#230)"
+      },
+      {
+        "sha": "46c2cd1d1828af4cc393c10457ea5ac986ee3cd2",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 14:17:39 2025 \u002B0100",
+        "message": "docs: set minimum of benchmark y-axes to zero (#231)"
       }
     ],
     "labels": [
-      "198447f7"
+      "198447f7",
+      "e994b4dd",
+      "a6022c2c",
+      "ba348350",
+      "96f70d37",
+      "a65ca3f3",
+      "b6626f8e",
+      "08ef69d9",
+      "8c5638ae",
+      "8111de13",
+      "8881f806",
+      "a7ed6bc7",
+      "46c2cd1d"
     ],
     "datasets": [
       {
         "label": "aweXpect time",
         "unit": "ns",
         "data": [
-          329.63557247320813
+          329.63557247320813,
+          351.37352555592855,
+          374.3091664632162,
+          337.2535416603088,
+          352.39308126156146,
+          381.1330859502157,
+          336.44947052001953,
+          365.3181669371469,
+          345.05609801610314,
+          352.852764742715,
+          362.02392800649005,
+          361.74809068044027,
+          363.89608076640536
         ],
         "borderColor": "#63A2AC",
         "backgroundColor": "#63A2AC",
@@ -124,6 +376,18 @@ window.BENCHMARK_DATA = {
         "label": "aweXpect memory",
         "unit": "b",
         "data": [
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
+          888,
           888
         ],
         "borderColor": "#63A2AC",
@@ -139,7 +403,19 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions time",
         "unit": "ns",
         "data": [
-          417.0791400029109
+          417.0791400029109,
+          460.97408453623456,
+          456.0185529504503,
+          406.35335045594434,
+          436.15411609013876,
+          457.1187669436137,
+          424.73906723658246,
+          442.4963041305542,
+          412.4149733543396,
+          473.0607053756714,
+          428.04975872039796,
+          424.6540211995443,
+          461.3379871050517
         ],
         "borderColor": "#ACA263",
         "backgroundColor": "#ACA263",
@@ -151,6 +427,18 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions memory",
         "unit": "b",
         "data": [
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
+          1816,
           1816
         ],
         "borderColor": "#ACA263",
@@ -166,7 +454,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit time",
         "unit": "ns",
         "data": [
-          14911.549033610027
+          14911.549033610027,
+          15581.482432047525,
+          14722.414560953775,
+          14283.944193913387,
+          22458.590706380208,
+          14792.756424967449,
+          15938.436789879432,
+          20583.53896077474,
+          14059.436920166016,
+          17242.750053992637,
+          16893.544787597657,
+          14554.276959010533,
+          21124.68842163086
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -178,7 +478,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit memory",
         "unit": "b",
         "data": [
-          26616
+          26616,
+          26616,
+          26616,
+          26616,
+          26616,
+          26616,
+          26616,
+          26616,
+          26552,
+          26552,
+          26552,
+          26552,
+          26552
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -198,17 +510,113 @@ window.BENCHMARK_DATA = {
         "author": "Valentin Breu\u00DF",
         "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
         "message": "fix: execute benchmark report in main build (#219)"
+      },
+      {
+        "sha": "e994b4ddac319ba1496d5d908adabef71217f6b5",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:06:43 2025 \u002B0100",
+        "message": "docs: avoid reporting benchmarks for the same commit twice (#221)"
+      },
+      {
+        "sha": "a6022c2c3716943fc039096336119983cf150e7e",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:17:07 2025 \u002B0100",
+        "message": "coverage: exclude polyfill files (#222)"
+      },
+      {
+        "sha": "ba348350c55bc5b042f1e6116e5f4ddb00a80a24",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:43:03 2025 \u002B0100",
+        "message": "fix: finalize release when at least one push succeeded (#223)"
+      },
+      {
+        "sha": "96f70d37e5bf44488ff777dab44333c47fbccfeb",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 11:28:18 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0 (#229)"
+      },
+      {
+        "sha": "a65ca3f33d06e0a712049c084956217791a1af8d",
+        "author": "Valentin",
+        "date": "Mon Jan 20 11:18:44 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0"
+      },
+      {
+        "sha": "b6626f8ea71062e77ed99d409fffa363faeeb86c",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:26 2025 \u002B0100",
+        "message": "build(deps): bump Microsoft.Testing.Extensions.TrxReport from 1.5.0 to 1.5.1 (#228)"
+      },
+      {
+        "sha": "08ef69d9676332d2cc040e885cf1d859ae9a0238",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:36 2025 \u002B0100",
+        "message": "build(deps): bump SharpCompress from 0.38.0 to 0.39.0 (#227)"
+      },
+      {
+        "sha": "8c5638ae5f225aa69698100f545da758885f3385",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:43 2025 \u002B0100",
+        "message": "build(deps): bump TUnit.Assertions from 0.6.137 to 0.6.151 in the tunit group (#226)"
+      },
+      {
+        "sha": "8111de1379be71399916ded9e459e43d9a746ca3",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:53 2025 \u002B0100",
+        "message": "build(deps): bump the mstest group with 2 updates (#225)"
+      },
+      {
+        "sha": "8881f80647f5e9da9bf8886db6ea6fec9537abc9",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:55:02 2025 \u002B0100",
+        "message": "build(deps): bump the nuke group with 2 updates (#224)"
+      },
+      {
+        "sha": "a7ed6bc73346bbd62c70d36a9a61536eb87ad8de",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 13:24:55 2025 \u002B0100",
+        "message": "fix: finalize release executed only after aweXpect push (#230)"
+      },
+      {
+        "sha": "46c2cd1d1828af4cc393c10457ea5ac986ee3cd2",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 14:17:39 2025 \u002B0100",
+        "message": "docs: set minimum of benchmark y-axes to zero (#231)"
       }
     ],
     "labels": [
-      "198447f7"
+      "198447f7",
+      "e994b4dd",
+      "a6022c2c",
+      "ba348350",
+      "96f70d37",
+      "a65ca3f3",
+      "b6626f8e",
+      "08ef69d9",
+      "8c5638ae",
+      "8111de13",
+      "8881f806",
+      "a7ed6bc7",
+      "46c2cd1d"
     ],
     "datasets": [
       {
         "label": "aweXpect time",
         "unit": "ns",
         "data": [
-          204.06733180681866
+          204.06733180681866,
+          216.9594315801348,
+          206.10692450205485,
+          196.2139249581557,
+          206.1067977587382,
+          214.8942221959432,
+          199.87026483217875,
+          201.19402921994526,
+          192.24772651378925,
+          200.14843589918954,
+          196.2580615679423,
+          197.36898280779522,
+          210.5766167300088
         ],
         "borderColor": "#63A2AC",
         "backgroundColor": "#63A2AC",
@@ -220,6 +628,18 @@ window.BENCHMARK_DATA = {
         "label": "aweXpect memory",
         "unit": "b",
         "data": [
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
+          848,
           848
         ],
         "borderColor": "#63A2AC",
@@ -235,7 +655,19 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions time",
         "unit": "ns",
         "data": [
-          250.96880504063196
+          250.96880504063196,
+          278.63078991572064,
+          270.1289446512858,
+          242.58121951421103,
+          274.3820020675659,
+          270.8007615974971,
+          264.8141753514608,
+          270.9082823912303,
+          248.62949003492082,
+          267.79543792284454,
+          254.42266976038616,
+          258.39817374547323,
+          262.22281582014904
         ],
         "borderColor": "#ACA263",
         "backgroundColor": "#ACA263",
@@ -247,6 +679,18 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions memory",
         "unit": "b",
         "data": [
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
+          1048,
           1048
         ],
         "borderColor": "#ACA263",
@@ -262,7 +706,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit time",
         "unit": "ns",
         "data": [
-          766.1536415735881
+          766.1536415735881,
+          829.1234278996785,
+          821.9613706588746,
+          849.6050724983215,
+          797.4266170092991,
+          815.1987977981568,
+          817.5118516286215,
+          793.0287864685058,
+          813.043058013916,
+          841.1511103947958,
+          837.8089452107747,
+          823.1867488225301,
+          871.8636178970337
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -274,7 +730,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit memory",
         "unit": "b",
         "data": [
-          2352
+          2352,
+          2352,
+          2352,
+          2352,
+          2352,
+          2352,
+          2352,
+          2352,
+          2240,
+          2240,
+          2240,
+          2240,
+          2240
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -294,17 +762,113 @@ window.BENCHMARK_DATA = {
         "author": "Valentin Breu\u00DF",
         "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
         "message": "fix: execute benchmark report in main build (#219)"
+      },
+      {
+        "sha": "e994b4ddac319ba1496d5d908adabef71217f6b5",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:06:43 2025 \u002B0100",
+        "message": "docs: avoid reporting benchmarks for the same commit twice (#221)"
+      },
+      {
+        "sha": "a6022c2c3716943fc039096336119983cf150e7e",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:17:07 2025 \u002B0100",
+        "message": "coverage: exclude polyfill files (#222)"
+      },
+      {
+        "sha": "ba348350c55bc5b042f1e6116e5f4ddb00a80a24",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:43:03 2025 \u002B0100",
+        "message": "fix: finalize release when at least one push succeeded (#223)"
+      },
+      {
+        "sha": "96f70d37e5bf44488ff777dab44333c47fbccfeb",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 11:28:18 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0 (#229)"
+      },
+      {
+        "sha": "a65ca3f33d06e0a712049c084956217791a1af8d",
+        "author": "Valentin",
+        "date": "Mon Jan 20 11:18:44 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0"
+      },
+      {
+        "sha": "b6626f8ea71062e77ed99d409fffa363faeeb86c",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:26 2025 \u002B0100",
+        "message": "build(deps): bump Microsoft.Testing.Extensions.TrxReport from 1.5.0 to 1.5.1 (#228)"
+      },
+      {
+        "sha": "08ef69d9676332d2cc040e885cf1d859ae9a0238",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:36 2025 \u002B0100",
+        "message": "build(deps): bump SharpCompress from 0.38.0 to 0.39.0 (#227)"
+      },
+      {
+        "sha": "8c5638ae5f225aa69698100f545da758885f3385",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:43 2025 \u002B0100",
+        "message": "build(deps): bump TUnit.Assertions from 0.6.137 to 0.6.151 in the tunit group (#226)"
+      },
+      {
+        "sha": "8111de1379be71399916ded9e459e43d9a746ca3",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:53 2025 \u002B0100",
+        "message": "build(deps): bump the mstest group with 2 updates (#225)"
+      },
+      {
+        "sha": "8881f80647f5e9da9bf8886db6ea6fec9537abc9",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:55:02 2025 \u002B0100",
+        "message": "build(deps): bump the nuke group with 2 updates (#224)"
+      },
+      {
+        "sha": "a7ed6bc73346bbd62c70d36a9a61536eb87ad8de",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 13:24:55 2025 \u002B0100",
+        "message": "fix: finalize release executed only after aweXpect push (#230)"
+      },
+      {
+        "sha": "46c2cd1d1828af4cc393c10457ea5ac986ee3cd2",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 14:17:39 2025 \u002B0100",
+        "message": "docs: set minimum of benchmark y-axes to zero (#231)"
       }
     ],
     "labels": [
-      "198447f7"
+      "198447f7",
+      "e994b4dd",
+      "a6022c2c",
+      "ba348350",
+      "96f70d37",
+      "a65ca3f3",
+      "b6626f8e",
+      "08ef69d9",
+      "8c5638ae",
+      "8111de13",
+      "8881f806",
+      "a7ed6bc7",
+      "46c2cd1d"
     ],
     "datasets": [
       {
         "label": "aweXpect time",
         "unit": "ns",
         "data": [
-          304.53645614477307
+          304.53645614477307,
+          328.66932388714383,
+          306.69245314598083,
+          301.3085208960942,
+          315.39779373577665,
+          317.1949115753174,
+          301.54692827860515,
+          315.0062762260437,
+          307.0068321961623,
+          314.97997426986694,
+          304.8040408452352,
+          309.0778631766637,
+          336.5508539199829
         ],
         "borderColor": "#63A2AC",
         "backgroundColor": "#63A2AC",
@@ -316,6 +880,18 @@ window.BENCHMARK_DATA = {
         "label": "aweXpect memory",
         "unit": "b",
         "data": [
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
+          928,
           928
         ],
         "borderColor": "#63A2AC",
@@ -331,7 +907,19 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions time",
         "unit": "ns",
         "data": [
-          351.26639202662875
+          351.26639202662875,
+          409.45268201828003,
+          351.31532487869265,
+          354.7790416399638,
+          364.92660064697264,
+          375.06243960062665,
+          370.2074193954468,
+          360.54308700561523,
+          347.67961702346804,
+          368.80354767579297,
+          347.7576244990031,
+          370.4904707499913,
+          378.0701917330424
         ],
         "borderColor": "#ACA263",
         "backgroundColor": "#ACA263",
@@ -343,6 +931,18 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions memory",
         "unit": "b",
         "data": [
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
+          1832,
           1832
         ],
         "borderColor": "#ACA263",
@@ -358,7 +958,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit time",
         "unit": "ns",
         "data": [
-          814.6544300715128
+          814.6544300715128,
+          895.92631987163,
+          855.6375809351604,
+          903.2392115910848,
+          844.5590480804443,
+          825.1556023279826,
+          838.7160714956431,
+          807.5309039524624,
+          950.0381783167521,
+          942.2038411458333,
+          939.4553424199422,
+          980.3985696156819,
+          993.3785611561367
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -370,7 +982,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit memory",
         "unit": "b",
         "data": [
-          2328
+          2328,
+          2328,
+          2328,
+          2328,
+          2328,
+          2328,
+          2328,
+          2328,
+          2232,
+          2232,
+          2232,
+          2232,
+          2232
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -390,17 +1014,113 @@ window.BENCHMARK_DATA = {
         "author": "Valentin Breu\u00DF",
         "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
         "message": "fix: execute benchmark report in main build (#219)"
+      },
+      {
+        "sha": "e994b4ddac319ba1496d5d908adabef71217f6b5",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:06:43 2025 \u002B0100",
+        "message": "docs: avoid reporting benchmarks for the same commit twice (#221)"
+      },
+      {
+        "sha": "a6022c2c3716943fc039096336119983cf150e7e",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:17:07 2025 \u002B0100",
+        "message": "coverage: exclude polyfill files (#222)"
+      },
+      {
+        "sha": "ba348350c55bc5b042f1e6116e5f4ddb00a80a24",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:43:03 2025 \u002B0100",
+        "message": "fix: finalize release when at least one push succeeded (#223)"
+      },
+      {
+        "sha": "96f70d37e5bf44488ff777dab44333c47fbccfeb",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 11:28:18 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0 (#229)"
+      },
+      {
+        "sha": "a65ca3f33d06e0a712049c084956217791a1af8d",
+        "author": "Valentin",
+        "date": "Mon Jan 20 11:18:44 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0"
+      },
+      {
+        "sha": "b6626f8ea71062e77ed99d409fffa363faeeb86c",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:26 2025 \u002B0100",
+        "message": "build(deps): bump Microsoft.Testing.Extensions.TrxReport from 1.5.0 to 1.5.1 (#228)"
+      },
+      {
+        "sha": "08ef69d9676332d2cc040e885cf1d859ae9a0238",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:36 2025 \u002B0100",
+        "message": "build(deps): bump SharpCompress from 0.38.0 to 0.39.0 (#227)"
+      },
+      {
+        "sha": "8c5638ae5f225aa69698100f545da758885f3385",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:43 2025 \u002B0100",
+        "message": "build(deps): bump TUnit.Assertions from 0.6.137 to 0.6.151 in the tunit group (#226)"
+      },
+      {
+        "sha": "8111de1379be71399916ded9e459e43d9a746ca3",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:53 2025 \u002B0100",
+        "message": "build(deps): bump the mstest group with 2 updates (#225)"
+      },
+      {
+        "sha": "8881f80647f5e9da9bf8886db6ea6fec9537abc9",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:55:02 2025 \u002B0100",
+        "message": "build(deps): bump the nuke group with 2 updates (#224)"
+      },
+      {
+        "sha": "a7ed6bc73346bbd62c70d36a9a61536eb87ad8de",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 13:24:55 2025 \u002B0100",
+        "message": "fix: finalize release executed only after aweXpect push (#230)"
+      },
+      {
+        "sha": "46c2cd1d1828af4cc393c10457ea5ac986ee3cd2",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 14:17:39 2025 \u002B0100",
+        "message": "docs: set minimum of benchmark y-axes to zero (#231)"
       }
     ],
     "labels": [
-      "198447f7"
+      "198447f7",
+      "e994b4dd",
+      "a6022c2c",
+      "ba348350",
+      "96f70d37",
+      "a65ca3f3",
+      "b6626f8e",
+      "08ef69d9",
+      "8c5638ae",
+      "8111de13",
+      "8881f806",
+      "a7ed6bc7",
+      "46c2cd1d"
     ],
     "datasets": [
       {
         "label": "aweXpect time",
         "unit": "ns",
         "data": [
-          1069.4012530190605
+          1069.4012530190605,
+          1128.346786226545,
+          1098.832622391837,
+          1076.532111985343,
+          1181.8951923370362,
+          1101.8187058766682,
+          1068.2992315292358,
+          1067.380584335327,
+          1056.3488892873129,
+          1062.4824607031685,
+          1053.444019317627,
+          1080.6714853559222,
+          1138.7777727762857
         ],
         "borderColor": "#63A2AC",
         "backgroundColor": "#63A2AC",
@@ -412,6 +1132,18 @@ window.BENCHMARK_DATA = {
         "label": "aweXpect memory",
         "unit": "b",
         "data": [
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
+          2384,
           2384
         ],
         "borderColor": "#63A2AC",
@@ -427,7 +1159,19 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions time",
         "unit": "ns",
         "data": [
-          1175.168862915039
+          1175.168862915039,
+          1306.7912724812825,
+          1294.6244603474936,
+          1156.1905431111654,
+          1206.3019789377847,
+          1235.2764401753743,
+          1188.1393574305944,
+          1209.3633190155028,
+          1204.6632853190104,
+          1177.385548655192,
+          1161.8918017069498,
+          1170.215314102173,
+          1212.6018609364828
         ],
         "borderColor": "#ACA263",
         "backgroundColor": "#ACA263",
@@ -439,6 +1183,18 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions memory",
         "unit": "b",
         "data": [
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
+          3760,
           3760
         ],
         "borderColor": "#ACA263",
@@ -454,7 +1210,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit time",
         "unit": "ns",
         "data": [
-          2060.838473510742
+          2060.838473510742,
+          2126.9997182210286,
+          2178.2397992060733,
+          2115.8911359151202,
+          2086.3043131510417,
+          2090.007182820638,
+          2170.923581804548,
+          2082.4139742533366,
+          2234.402118174235,
+          2267.74205163809,
+          2184.4211016337076,
+          2220.696941630046,
+          2319.064328413743
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -466,7 +1234,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit memory",
         "unit": "b",
         "data": [
-          3216
+          3216,
+          3216,
+          3216,
+          3216,
+          3216,
+          3216,
+          3216,
+          3216,
+          3256,
+          3256,
+          3256,
+          3256,
+          3256
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -486,17 +1266,113 @@ window.BENCHMARK_DATA = {
         "author": "Valentin Breu\u00DF",
         "date": "Sun Jan 19 22:32:18 2025 \u002B0100",
         "message": "fix: execute benchmark report in main build (#219)"
+      },
+      {
+        "sha": "e994b4ddac319ba1496d5d908adabef71217f6b5",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:06:43 2025 \u002B0100",
+        "message": "docs: avoid reporting benchmarks for the same commit twice (#221)"
+      },
+      {
+        "sha": "a6022c2c3716943fc039096336119983cf150e7e",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:17:07 2025 \u002B0100",
+        "message": "coverage: exclude polyfill files (#222)"
+      },
+      {
+        "sha": "ba348350c55bc5b042f1e6116e5f4ddb00a80a24",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 08:43:03 2025 \u002B0100",
+        "message": "fix: finalize release when at least one push succeeded (#223)"
+      },
+      {
+        "sha": "96f70d37e5bf44488ff777dab44333c47fbccfeb",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 11:28:18 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0 (#229)"
+      },
+      {
+        "sha": "a65ca3f33d06e0a712049c084956217791a1af8d",
+        "author": "Valentin",
+        "date": "Mon Jan 20 11:18:44 2025 \u002B0100",
+        "message": "chore(deps): update aweXpect.Core to v0.18.0"
+      },
+      {
+        "sha": "b6626f8ea71062e77ed99d409fffa363faeeb86c",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:26 2025 \u002B0100",
+        "message": "build(deps): bump Microsoft.Testing.Extensions.TrxReport from 1.5.0 to 1.5.1 (#228)"
+      },
+      {
+        "sha": "08ef69d9676332d2cc040e885cf1d859ae9a0238",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:36 2025 \u002B0100",
+        "message": "build(deps): bump SharpCompress from 0.38.0 to 0.39.0 (#227)"
+      },
+      {
+        "sha": "8c5638ae5f225aa69698100f545da758885f3385",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:43 2025 \u002B0100",
+        "message": "build(deps): bump TUnit.Assertions from 0.6.137 to 0.6.151 in the tunit group (#226)"
+      },
+      {
+        "sha": "8111de1379be71399916ded9e459e43d9a746ca3",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:54:53 2025 \u002B0100",
+        "message": "build(deps): bump the mstest group with 2 updates (#225)"
+      },
+      {
+        "sha": "8881f80647f5e9da9bf8886db6ea6fec9537abc9",
+        "author": "dependabot[bot]",
+        "date": "Mon Jan 20 11:55:02 2025 \u002B0100",
+        "message": "build(deps): bump the nuke group with 2 updates (#224)"
+      },
+      {
+        "sha": "a7ed6bc73346bbd62c70d36a9a61536eb87ad8de",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 13:24:55 2025 \u002B0100",
+        "message": "fix: finalize release executed only after aweXpect push (#230)"
+      },
+      {
+        "sha": "46c2cd1d1828af4cc393c10457ea5ac986ee3cd2",
+        "author": "Valentin Breu\u00DF",
+        "date": "Mon Jan 20 14:17:39 2025 \u002B0100",
+        "message": "docs: set minimum of benchmark y-axes to zero (#231)"
       }
     ],
     "labels": [
-      "198447f7"
+      "198447f7",
+      "e994b4dd",
+      "a6022c2c",
+      "ba348350",
+      "96f70d37",
+      "a65ca3f3",
+      "b6626f8e",
+      "08ef69d9",
+      "8c5638ae",
+      "8111de13",
+      "8881f806",
+      "a7ed6bc7",
+      "46c2cd1d"
     ],
     "datasets": [
       {
         "label": "aweXpect time",
         "unit": "ns",
         "data": [
-          1094.4609926768712
+          1094.4609926768712,
+          1179.811538441976,
+          1194.3902856191,
+          1128.3401187016414,
+          1133.359532220023,
+          1140.0626906077066,
+          1114.837188584464,
+          1105.9909159342449,
+          1085.2066505432128,
+          1121.4894528706868,
+          1159.6692977632795,
+          1140.622148513794,
+          1146.810167312622
         ],
         "borderColor": "#63A2AC",
         "backgroundColor": "#63A2AC",
@@ -508,6 +1384,18 @@ window.BENCHMARK_DATA = {
         "label": "aweXpect memory",
         "unit": "b",
         "data": [
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
+          2408,
           2408
         ],
         "borderColor": "#63A2AC",
@@ -523,7 +1411,19 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions time",
         "unit": "ns",
         "data": [
-          76939.67994791667
+          76939.67994791667,
+          82148.39580829327,
+          82674.91611328124,
+          78198.26883370536,
+          79701.94614955357,
+          78199.53501674107,
+          79218.87158203125,
+          78894.54677734376,
+          77662.87524414062,
+          77152.24766322544,
+          77628.22822265625,
+          76892.178125,
+          80998.14617047991
         ],
         "borderColor": "#ACA263",
         "backgroundColor": "#ACA263",
@@ -535,6 +1435,18 @@ window.BENCHMARK_DATA = {
         "label": "FluentAssertions memory",
         "unit": "b",
         "data": [
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
+          50710,
           50710
         ],
         "borderColor": "#ACA263",
@@ -550,7 +1462,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit time",
         "unit": "ns",
         "data": [
-          3975.66723429362
+          3975.66723429362,
+          4182.777239118303,
+          4299.858325703939,
+          4055.510234069824,
+          4066.8915339152018,
+          4005.5797353108724,
+          4133.923426114596,
+          4168.885194905599,
+          4045.5662724812823,
+          4230.382392883301,
+          4082.37625579834,
+          4100.937807718913,
+          4319.206312997
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",
@@ -562,7 +1486,19 @@ window.BENCHMARK_DATA = {
         "label": "TUnit memory",
         "unit": "b",
         "data": [
-          5160
+          5160,
+          5160,
+          5160,
+          5160,
+          5160,
+          5160,
+          5160,
+          5160,
+          5128,
+          5128,
+          5128,
+          5128,
+          5128
         ],
         "borderColor": "#AC6262",
         "backgroundColor": "#AC6262",


### PR DESCRIPTION
Update the benchmark data file on the main branch, so that local tests of the docusaurus page show reasonable data.