### PR TITLE
coverage: exclude polyfill files

### DIFF
--- a/Source/aweXpect.Core/Core/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,6 @@
 ﻿#if !NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -9,6 +11,7 @@ namespace System.Runtime.CompilerServices
 	///     Indicates that a parameter captures the expression passed for another parameter as a string.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Parameter)]
+	[ExcludeFromCodeCoverage]
 	internal sealed class CallerArgumentExpressionAttribute : Attribute
 	{
 		/// <summary>

--- a/Source/aweXpect.Core/Core/Polyfills/Index.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/Index.cs
@@ -1,10 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
+// ReSharper disable once CheckNamespace
 namespace System;
 
 /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
@@ -15,6 +16,7 @@ namespace System;
 /// int lastElement = someArray[^1]; // lastElement = 5
 /// </code>
 /// </remarks>
+[ExcludeFromCodeCoverage]
 public readonly struct Index : IEquatable<Index>
 {
 	private readonly int _value;

--- a/Source/aweXpect.Core/Core/Polyfills/Range.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/Range.cs
@@ -1,10 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #if NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
+// ReSharper disable once CheckNamespace
 namespace System;
 
 /// <summary>Represent a range has start and end indexes.</summary>
@@ -16,6 +17,7 @@ namespace System;
 /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
 /// </code>
 /// </remarks>
+[ExcludeFromCodeCoverage]
 public readonly struct Range : IEquatable<Range>
 {
 	/// <summary>Represent the inclusive start index of the Range.</summary>

--- a/Source/aweXpect.Core/Core/Polyfills/StackTraceHiddenAttribute.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/StackTraceHiddenAttribute.cs
@@ -1,4 +1,6 @@
 ﻿#if !NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+
 // ReSharper disable once CheckNamespace
 namespace System.Diagnostics;
 
@@ -11,5 +13,6 @@ namespace System.Diagnostics;
                 AttributeTargets.Constructor |
                 AttributeTargets.Struct,
 	Inherited = false)]
+[ExcludeFromCodeCoverage]
 public sealed class StackTraceHiddenAttribute : Attribute;
 #endif

--- a/Source/aweXpect.Core/Core/Polyfills/StringExtensions.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/StringExtensions.cs
@@ -3,7 +3,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace aweXpect.Polyfills;
+namespace aweXpect.Core.Polyfills;
 
 /// <summary>
 ///     Provides extension methods to simplify writing platform independent tests.

--- a/Source/aweXpect.Core/Usings.cs
+++ b/Source/aweXpect.Core/Usings.cs
@@ -1,5 +1,5 @@
 ﻿#if NETSTANDARD2_0 || NETSTANDARD2_1
-global using aweXpect.Polyfills;
+global using aweXpect.Core.Polyfills;
 #endif
 
 global using aweXpect.Formatting;

--- a/Source/aweXpect/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,6 @@
-﻿#if !NET8_0_OR_GREATER
+﻿using System.Diagnostics.CodeAnalysis;
+
+#if !NET8_0_OR_GREATER
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -9,6 +11,7 @@ namespace System.Runtime.CompilerServices
 	///     Indicates that a parameter captures the expression passed for another parameter as a string.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Parameter)]
+	[ExcludeFromCodeCoverage]
 	internal sealed class CallerArgumentExpressionAttribute : Attribute
 	{
 		/// <summary>


### PR DESCRIPTION
Add the [`ExcludeFromCodeCoverage` attribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.excludefromcodecoverageattribute) to polyfill classes, as we don't want to write unit tests for them.