### PR TITLE
fix: finalize release when at least one push succeeded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,9 +235,12 @@ jobs:
     
     finalize-release:
         name: "Finalize release"
-        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         needs: [ push_awexpect, push_core ]
+        if: |
+            always()
+            && contains(needs.*.result, 'success')
+            && !contains(needs.*.result, 'failure')
         permissions:
             contents: read
             issues: write


### PR DESCRIPTION
See https://stackoverflow.com/a/66358138/4003370:
> By default when using `needs`, any job in the dependency list that is skipped will trigger a skip of the current job. If you want to force the job to run you have to use the `always()` function which will tell your job to always run. Unfortunately this means that it will run event if a job fails or if all the previous jobs are skipped. `contains(needs.*.result, 'success')` will be true if at least one of the jobs succeeded. So if all your jobs are skipped it will be false. `!(contains(needs.*.result, 'failure'))` is false if any job failed