### PR TITLE
fix: finalize release executed only after aweXpect push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,12 +235,9 @@ jobs:
     
     finalize-release:
         name: "Finalize release"
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
-        needs: [ push_awexpect, push_core ]
-        if: |
-            always()
-            && contains(needs.*.result, 'success')
-            && !contains(needs.*.result, 'failure')
+        needs: [ push_awexpect ]
         permissions:
             contents: read
             issues: write


### PR DESCRIPTION
With #223 the finalize release action was triggered `always`, but this leads to many unnecessary/misleading PR comments.
We consider a release only finished, after the "aweXpect" main package is released and that's the new release version, therefore the finalize release action should only be triggered on a `v{x}.{y}.{z}` tag after a successful push of the "aweXpect" package.