### PR TITLE
docs: set minimum of benchmark y-axes to zero

### DIFF
--- a/Docs/pages/static/js/benchmarks.js
+++ b/Docs/pages/static/js/benchmarks.js
@@ -46,12 +46,14 @@
 					display: true,
 					title: { display: true, text: 'time [ns]' },
 					position: 'left',
+					min: 0
 				},
 				y1: {
 					type: 'linear',
 					display: true,
 					title: { display: true, text: 'memory [bytes]' },
 					position: 'right',
+					min: 0,
 					grid: {
 						drawOnChartArea: false,
 					},


### PR DESCRIPTION
Set the `min` property on the [Chart.js Axes](https://www.chartjs.org/docs/latest/axes/#common-options-to-all-axes) to 0 (zero).