### PR TITLE
fix: readme links in generated nuget packages

### DIFF
--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Object.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Object.cs
@@ -53,14 +53,6 @@ public static partial class ValueFormatters
 		return str is null || str == value.GetType().ToString();
 	}
 
-	/// <summary>
-	///     Selects the name to display for <paramref name="type" />.
-	/// </summary>
-	/// <param name="type">The <see cref="Type" /> of the object being formatted.</param>
-	/// <returns>The name to be displayed for <paramref name="type" />.</returns>
-	/// <remarks>The default is <see cref="Type.FullName" />.</remarks>
-	private static string TypeDisplayName(Type type) => type.Name;
-
 	private static void WriteMemberValues(
 		object obj,
 		MemberInfo[] members,

--- a/Tests/aweXpect.Core.Tests/Core/StringDifferenceTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/StringDifferenceTests.cs
@@ -287,6 +287,6 @@ public class StringDifferenceTests
 			throw new NotSupportedException("Comparer was executed more than once");
 		}
 
-		public int GetHashCode([DisallowNull] string obj) => obj.GetHashCode();
+		public int GetHashCode(string obj) => obj.GetHashCode();
 	}
 }


### PR DESCRIPTION
Use the correct links to the `core/v{x}.{y}.{z}` tag in the generated README included in the published nuget packages.
In the "aweXpect.Core" package display the badge to the "aweXpect.Core" package instead of the "aweXpect" package.

*Also fix two minor sonar issues*