### PR TITLE
refactor: avoid creating core release in Github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,14 +224,6 @@ jobs:
                     do
                       nuget push $entry -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
                     done
-            -   name: Create GitHub release
-                continue-on-error: true
-                uses: softprops/action-gh-release@v2
-                with:
-                    name: ${{ steps.tag.outputs.release_version }}
-                    tag_name: ${{ steps.tag.outputs.release_version }}
-                    token: ${{ secrets.GITHUB_TOKEN }}
-                    generate_release_notes: true
     
     finalize-release:
         name: "Finalize release"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,8 +204,6 @@ jobs:
         runs-on: macos-latest
         environment: production
         needs: [ pack, mutation-tests, static-code-analysis ]
-        permissions:
-            contents: write
         steps:
             -   name: Download packages
                 uses: actions/download-artifact@v4

--- a/Pipeline/Build.Compile.cs
+++ b/Pipeline/Build.Compile.cs
@@ -144,7 +144,7 @@ partial class Build
 		sb.AppendLine(lines.First());
 		sb.AppendLine(lines.Skip(1).First());
 		sb.AppendLine(
-			$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/aweXpect/aweXpect/releases/tag/{version})");
+			$"[![Changelog](https://img.shields.io/badge/Changelog-{version}-blue)](https://github.com/aweXpect/aweXpect/releases/tag/{version})");
 		foreach (string line in lines.Skip(2))
 		{
 			if (line.StartsWith("[![Build](https://github.com/aweXpect/aweXpect/actions/workflows/build.yml") ||


### PR DESCRIPTION
Only create a Github release for main versions, as the changelog is otherwise hard to follow.