### PR TITLE
feat: support `.Is()` with struct types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="0.18.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="0.19.0"/>
+		<PackageVersion Include="aweXpect" Version="0.19.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="0.19.1"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="0.3.0"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -36,6 +36,40 @@ public static partial class ThatObject
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
+	public static ObjectEqualityResult<T?, IThat<T?>> Is<T>(
+		this IThat<T?> source,
+		T? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		where T : struct
+	{
+		ObjectEqualityOptions options = new();
+		return new ObjectEqualityResult<T?, IThat<T?>>(
+			source.ThatIs().ExpectationBuilder.AddConstraint(it
+				=> new IsNullableEqualToConstraint<T>(it, expected, doNotPopulateThisValue, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ObjectEqualityResult<T, IThat<T>> Is<T>(
+		this IThat<T> source,
+		T? expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+		where T : struct
+	{
+		ObjectEqualityOptions options = new();
+		return new ObjectEqualityResult<T, IThat<T>>(
+			source.ThatIs().ExpectationBuilder.AddConstraint(it
+				=> new IsEqualToConstraint<T>(it, expected, doNotPopulateThisValue, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
 	public static ObjectEqualityResult<Type?, IThat<Type?>> Is(
 		this IThat<Type?> source,
 		Type? expected,
@@ -81,6 +115,42 @@ public static partial class ThatObject
 		return new ObjectEqualityResult<object?, IThat<object?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new IsNotEqualToConstraint(it, unexpected, doNotPopulateThisValue, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static ObjectEqualityResult<T?, IThat<T?>> IsNot<T>(
+		this IThat<T?> source,
+		T? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		where T : struct
+	{
+		ObjectEqualityOptions options = new();
+		return new ObjectEqualityResult<T?, IThat<T?>>(
+			source.ThatIs().ExpectationBuilder.AddConstraint(it
+				=> new IsNullableNotEqualToConstraint<T>(it, unexpected, doNotPopulateThisValue, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static ObjectEqualityResult<T, IThat<T>> IsNot<T>(
+		this IThat<T> source,
+		T? unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+		where T : struct
+	{
+		ObjectEqualityOptions options = new();
+		return new ObjectEqualityResult<T, IThat<T>>(
+			source.ThatIs().ExpectationBuilder.AddConstraint(it
+				=> new IsNotEqualToConstraint<T>(it, unexpected, doNotPopulateThisValue, options)),
 			source,
 			options);
 	}
@@ -142,6 +212,50 @@ public static partial class ThatObject
 			=> options.GetExpectation(expectedExpression);
 	}
 
+	private readonly struct IsEqualToConstraint<T>(
+		string it,
+		T? expected,
+		string expectedExpression,
+		ObjectEqualityOptions options)
+		: IValueConstraint<T>
+		where T : struct
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			if (options.AreConsideredEqual(actual, expected))
+			{
+				return new ConstraintResult.Success<T>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), options.GetExtendedFailure(it, actual, expected));
+		}
+
+		public override string ToString()
+			=> options.GetExpectation(expectedExpression);
+	}
+
+	private readonly struct IsNullableEqualToConstraint<T>(
+		string it,
+		T? expected,
+		string expectedExpression,
+		ObjectEqualityOptions options)
+		: IValueConstraint<T?>
+		where T : struct
+	{
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			if (options.AreConsideredEqual(actual, expected))
+			{
+				return new ConstraintResult.Success<T?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(), options.GetExtendedFailure(it, actual, expected));
+		}
+
+		public override string ToString()
+			=> options.GetExpectation(expectedExpression);
+	}
+
 	private readonly struct IsNotEqualToConstraint(
 		string it,
 		object? unexpected,
@@ -157,6 +271,50 @@ public static partial class ThatObject
 			}
 
 			return new ConstraintResult.Success<object?>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> "not " + options.GetExpectation(unexpectedExpression);
+	}
+
+	private readonly struct IsNotEqualToConstraint<T>(
+		string it,
+		T? unexpected,
+		string unexpectedExpression,
+		ObjectEqualityOptions options)
+		: IValueConstraint<T>
+		where T : struct
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			if (options.AreConsideredEqual(actual, unexpected))
+			{
+				return new ConstraintResult.Failure(ToString(), $"{it} was {Formatter.Format(actual)}");
+			}
+
+			return new ConstraintResult.Success<T>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> "not " + options.GetExpectation(unexpectedExpression);
+	}
+
+	private readonly struct IsNullableNotEqualToConstraint<T>(
+		string it,
+		T? unexpected,
+		string unexpectedExpression,
+		ObjectEqualityOptions options)
+		: IValueConstraint<T?>
+		where T : struct
+	{
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			if (options.AreConsideredEqual(actual, unexpected))
+			{
+				return new ConstraintResult.Failure(ToString(), $"{it} was {Formatter.Format(actual)}");
+			}
+
+			return new ConstraintResult.Success<T?>(actual, ToString());
 		}
 
 		public override string ToString()

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -830,12 +830,20 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Is(this aweXpect.Core.IThat<System.Type?> source, System.Type? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> Is(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>> Is<T>(this aweXpect.Core.IThat<T> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNot(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNot(this aweXpect.Core.IThat<System.Type?> source, System.Type? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> IsNot(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>> IsNot<T>(this aweXpect.Core.IThat<T> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object, aweXpect.Core.IThat<object?>> IsNotNull(this aweXpect.Core.IThat<object?> source) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -656,12 +656,20 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Is(this aweXpect.Core.IThat<System.Type?> source, System.Type? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> Is(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>> Is<T>(this aweXpect.Core.IThat<T> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNot(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNot(this aweXpect.Core.IThat<System.Type?> source, System.Type? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>> IsNot(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>> IsNot<T>(this aweXpect.Core.IThat<T> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+            where T :  struct { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object, aweXpect.Core.IThat<object?>> IsNotNull(this aweXpect.Core.IThat<object?> source) { }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.EquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.EquivalentTo.Tests.cs
@@ -207,8 +207,8 @@ public sealed partial class ThatObject
 						.WithMessage("""
 						             Expected subject to
 						             be equivalent to expected,
-						             but it was*
-						             """).AsWildcard();
+						             but it was 'z'
+						             """);
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
@@ -4,68 +4,157 @@ public sealed partial class ThatObject
 {
 	public sealed partial class Is
 	{
-		public sealed partial class EqualTo
+		public sealed class Tests
 		{
-			public sealed class Tests
+			[Fact]
+			public async Task SubjectToItself_ShouldSucceed()
 			{
-				[Fact]
-				public async Task SubjectToItself_ShouldSucceed()
-				{
-					object subject = new MyClass();
+				object subject = new MyClass();
 
-					async Task Act()
-						=> await That(subject).Is(subject);
+				async Task Act()
+					=> await That(subject).Is(subject);
 
-					await That(Act).DoesNotThrow();
-				}
+				await That(Act).DoesNotThrow();
+			}
 
-				[Fact]
-				public async Task SubjectToSomeOtherValue_ShouldFail()
-				{
-					object subject = new MyClass();
-					object expected = new MyClass();
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldFail()
+			{
+				object subject = new MyClass();
+				object expected = new MyClass();
 
-					async Task Act()
-						=> await That(subject).Is(expected)
-							.Because("we want to test the failure");
+				async Task Act()
+					=> await That(subject).Is(expected)
+						.Because("we want to test the failure");
 
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected subject to
-						             be equal to expected, because we want to test the failure,
-						             but it was MyClass {
-						               Value = 0
-						             }
-						             """);
-				}
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to expected, because we want to test the failure,
+					             but it was MyClass {
+					               Value = 0
+					             }
+					             """);
+			}
 
-				[Fact]
-				public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
-				{
-					MyClass? subject = null;
-					MyClass? expected = null;
+			[Fact]
+			public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+			{
+				MyClass? subject = null;
+				MyClass? expected = null;
 
-					async Task Act()
-						=> await That(subject).Is(expected);
+				async Task Act()
+					=> await That(subject).Is(expected);
 
-					await That(Act).DoesNotThrow();
-				}
+				await That(Act).DoesNotThrow();
+			}
 
-				[Fact]
-				public async Task WhenSubjectIsNull_ShouldFail()
-				{
-					MyClass? subject = null;
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				MyClass? subject = null;
 
-					async Task Act()
-						=> await That(subject).Is(new MyClass());
+				async Task Act()
+					=> await That(subject).Is(new MyClass());
 
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected subject to
-						             be equal to new MyClass(),
-						             but it was <null>
-						             """);
-				}
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to new MyClass(),
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StructTests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldSucceed()
+			{
+				char subject = 'c';
+
+				async Task Act()
+					=> await That(subject).Is(subject);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldFail()
+			{
+				char subject = 'x';
+				char expected = 'y';
+
+				async Task Act()
+					=> await That(subject).Is(expected)
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to expected, because we want to test the failure,
+					             but it was 'x'
+					             """);
+			}
+		}
+
+		public sealed class NullableStructTests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldSucceed()
+			{
+				char? subject = 'c';
+
+				async Task Act()
+					=> await That(subject).Is(subject);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldFail()
+			{
+				char? subject = 'x';
+				char? expected = 'y';
+
+				async Task Act()
+					=> await That(subject).Is(expected)
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to expected, because we want to test the failure,
+					             but it was 'x'
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+			{
+				char? subject = null;
+				char? expected = null;
+
+				async Task Act()
+					=> await That(subject).Is(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				char? subject = null;
+
+				async Task Act()
+					=> await That(subject).Is('c');
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to 'c',
+					             but it was <null>
+					             """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
@@ -1,0 +1,163 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatObject
+{
+	public sealed partial class IsNot
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldFail()
+			{
+				object subject = new MyClass();
+
+				async Task Act()
+					=> await That(subject).IsNot(subject)
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be equal to subject, because we want to test the failure,
+					             but it was MyClass {
+					               Value = 0
+					             }
+					             """);
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldSucceed()
+			{
+				object subject = new MyClass();
+				object expected = new MyClass();
+
+				async Task Act()
+					=> await That(subject).IsNot(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
+			{
+				MyClass? subject = null;
+				MyClass? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsNot(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be equal to expected,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldSucceed()
+			{
+				MyClass? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNot(new MyClass());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class StructTests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldFail()
+			{
+				char subject = 'c';
+				char unexpected = 'c';
+
+				async Task Act()
+					=> await That(subject).IsNot(unexpected)
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be equal to unexpected, because we want to test the failure,
+					             but it was 'c'
+					             """);
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldSucceed()
+			{
+				char subject = 'x';
+				char expected = 'y';
+
+				async Task Act()
+					=> await That(subject).IsNot(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NullableStructTests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldFail()
+			{
+				char? subject = 'c';
+				char? unexpected = 'c';
+
+				async Task Act()
+					=> await That(subject).IsNot(unexpected)
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be equal to unexpected, because we want to test the failure,
+					             but it was 'c'
+					             """);
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldSucceed()
+			{
+				char? subject = 'x';
+				char? expected = 'y';
+
+				async Task Act()
+					=> await That(subject).IsNot(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
+			{
+				char? subject = null;
+				char? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsNot(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             not be equal to expected,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				char? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNot('c');
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.TypeTests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.TypeTests.cs
@@ -2,7 +2,7 @@
 
 public sealed partial class ThatObject
 {
-	public sealed class IsNot
+	public sealed partial class IsNot
 	{
 		public sealed class GenericTests
 		{


### PR DESCRIPTION
Add support for struct type equality comparison (e.g. `char`).