### PR TITLE
docs: use fluentassertions 8 in benchmarks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1"/>
 		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.3"/>
-		<PackageVersion Include="FluentAssertions" Version="[7.0.0,8.0.0)"/>
+		<PackageVersion Include="FluentAssertions" Version="8.0.1"/>
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.5.1"/>
 		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.3.0"/>

--- a/Pipeline/PageBenchmarkReportGenerator.cs
+++ b/Pipeline/PageBenchmarkReportGenerator.cs
@@ -141,8 +141,8 @@ public class PageBenchmarkReportGenerator
 			=> type switch
 			{
 				"aweXpect" => "#63A2AC",
-				"FluentAssertions" => "#ACA263",
-				"TUnit" => "#AC6262",
+				"FluentAssertions" => "#FF671B",
+				"TUnit" => "#1A6029",
 				_ => "#e84393"
 			};
 


### PR DESCRIPTION
I asked xceed, that I would like to continue making and publishing Benchmarks between different assertion libraries. According to the new license terms I have to get a written permission from you.

They answered:
> At the moment we do not see an issue with you to continue to do so, so we authorize.
> If ever we see an issue, we will make sure to reach out to you.