### PR TITLE
docs: remove no longer used `MinVer` from documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,3 @@ using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect) 
 
 Additionally each push to the `main` branch checks the quality of the unit tests
 using [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/).
-
-## Versioning
-
-This project uses [MinVer](https://github.com/adamralph/minver) for versioning.  

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -13,7 +13,6 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>
-		<MinVerTagPrefix>v</MinVerTagPrefix>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
Remove [MinVer](https://github.com/adamralph/minver) from CONTRIBUTING.md and also the corresponding unused property in the `Directory.Build.props` file.