### PR TITLE
feat: include options in expectation message of string collections

### DIFF
--- a/Source/aweXpect.Core/Options/StringEqualityOptions.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Helpers;
 
@@ -115,7 +116,57 @@ public partial class StringEqualityOptions : IOptionsEquality<string?>
 
 	/// <inheritdoc />
 	public override string ToString()
-		=> _matchType.ToString(_ignoreCase, _comparer);
+	{
+		if (!_ignoreLeadingWhiteSpace && !_ignoreTrailingWhiteSpace && !_ignoreNewlineStyle)
+		{
+			return _matchType.ToString(_ignoreCase, _comparer);
+		}
+
+		string? whiteSpaceToken = (_ignoreLeadingWhiteSpace, _ignoreTrailingWhiteSpace) switch
+		{
+			(true, true) => " white-space",
+			(true, false) => " leading white-space",
+			(false, true) => " trailing white-space",
+			(false, false) => null
+		};
+
+		string? newlineStyleToken = _ignoreNewlineStyle
+			? " newline style"
+			: null;
+
+		StringBuilder sb = new();
+		string? initialString = _matchType.ToString(_ignoreCase, _comparer);
+		sb.Append(initialString);
+		if (initialString.Contains("ignoring"))
+		{
+			sb.Append(whiteSpaceToken == null || newlineStyleToken == null ? " and" : ",");
+		}
+		else
+		{
+			if (sb.Length > 0)
+			{
+				sb.Append(' ');
+			}
+
+			sb.Append(" ignoring");
+		}
+
+		if (whiteSpaceToken != null)
+		{
+			sb.Append(whiteSpaceToken);
+			if (newlineStyleToken != null)
+			{
+				sb.Append(" and");
+			}
+		}
+
+		if (newlineStyleToken != null)
+		{
+			sb.Append(newlineStyleToken);
+		}
+
+		return sb.ToString();
+	}
 
 	/// <summary>
 	///     Specifies a specific <see cref="IEqualityComparer{T}" /> to use for comparing <see langword="string" />s.

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -23,7 +23,7 @@ public static partial class ThatEnumerable
 					=> new CollectionConstraint<string?>(
 						it,
 						_quantifier,
-						() => $"equal to {Formatter.Format(expected)}",
+						() => $"equal to {Formatter.Format(expected)}{options}",
 						a => options.AreConsideredEqual(a, expected),
 						"were")),
 				_subject,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -45,7 +45,7 @@ public static partial class ThatEnumerable
 					=> new CollectionConstraint<TItem>(
 						it,
 						_quantifier,
-						() => $"equal to {Formatter.Format(expected)}",
+						() => $"equal to {Formatter.Format(expected)}{options}",
 						a => options.AreConsideredEqual(a, expected),
 						"were")),
 				_subject,
@@ -79,7 +79,7 @@ public static partial class ThatEnumerable
 						it,
 						_quantifier,
 						() => $"be of type {Formatter.Format(typeof(TType))}",
-						a => typeof(TType).IsAssignableFrom(a?.GetType()),
+						a => a is TType,
 						"were")),
 				_subject,
 				options);
@@ -98,7 +98,7 @@ public static partial class ThatEnumerable
 						it,
 						_quantifier,
 						() => $"be of type {Formatter.Format(type)}",
-						a => type.IsAssignableFrom(a?.GetType()),
+						a => type.IsInstanceOfType(a),
 						"were")),
 				_subject,
 				options);

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
@@ -165,7 +165,7 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Requires Core Update")]
 				public async Task WhenItemsDiffer_ShouldShowAllConfigurationsInMessage()
 				{
 					string[] subject = ["bar"];
@@ -185,7 +185,7 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Requires Core Update")]
 				public async Task WhenItemsDiffer_ShouldShowIgnoringCaseInMessage()
 				{
 					string[] subject = ["bar"];
@@ -201,7 +201,7 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Requires Core Update")]
 				public async Task WhenItemsDiffer_ShouldShowIgnoringLeadingWhiteSpaceInMessage()
 				{
 					string[] subject = ["bar"];
@@ -217,7 +217,7 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Requires Core Update")]
 				public async Task WhenItemsDiffer_ShouldShowIgnoringNewlineStyleInMessage()
 				{
 					string[] subject = ["bar"];
@@ -233,7 +233,7 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Requires Core Update")]
 				public async Task WhenItemsDiffer_ShouldShowIgnoringTrailingWhiteSpaceInMessage()
 				{
 					string[] subject = ["bar"];

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
@@ -165,6 +165,90 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowAllConfigurationsInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo")
+							.IgnoringCase()
+							.IgnoringNewlineStyle()
+							.IgnoringLeadingWhiteSpace()
+							.IgnoringTrailingWhiteSpace();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring case, white-space and newline style,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringCaseInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo").IgnoringCase();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring case,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringLeadingWhiteSpaceInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo").IgnoringLeadingWhiteSpace();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring leading white-space,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringNewlineStyleInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo").IgnoringNewlineStyle();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring newline style,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringTrailingWhiteSpaceInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo").IgnoringTrailingWhiteSpace();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring trailing white-space,
+						             but only 0 of 1 were
+						             """);
+				}
+
 				[Theory]
 				[InlineData(true)]
 				[InlineData(false)]
@@ -180,6 +264,63 @@ public sealed partial class ThatEnumerable
 						             Expected subject to
 						             have all items equal to "foo",
 						             but only 1 of 2 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInLeadingWhiteSpace_ShouldSucceedWhenIgnoringLeadingWhiteSpace(
+					bool ignoreLeadingWhiteSpace)
+				{
+					string[] subject = [" foo", "foo", "\tfoo"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo").IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreLeadingWhiteSpace)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo",
+						             but only 1 of 3 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInNewlineStyle_ShouldSucceedWhenIgnoringNewlineStyle(
+					bool ignoreNewlineStyle)
+				{
+					string[] subject = ["foo\r\nbar", "foo\nbar", "foo\rbar"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo\nbar").IgnoringNewlineStyle(ignoreNewlineStyle);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreNewlineStyle)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo\nbar",
+						             but only 1 of 3 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInTrailingWhiteSpace_ShouldSucceedWhenIgnoringTrailingWhiteSpace(
+					bool ignoreTrailingWhiteSpace)
+				{
+					string[] subject = ["foo ", "foo", "foo\t"];
+
+					async Task Act()
+						=> await That(subject).All().Are("foo").IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreTrailingWhiteSpace)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo",
+						             but only 1 of 3 were
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Strings/ThatString.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.Is.Tests.cs
@@ -38,6 +38,22 @@ public sealed partial class ThatString
 			}
 
 			[Theory]
+			[InlineAutoData("foo\nbar", "foo\rbar")]
+			[InlineAutoData("foo\rbar", "foo\nbar")]
+			[InlineAutoData("foo\nbar", "foo\r\nbar")]
+			[InlineAutoData("foo\rbar", "foo\r\nbar")]
+			[InlineAutoData("foo\r\nbar", "foo\nbar")]
+			[InlineAutoData("foo\r\nbar", "foo\rbar")]
+			public async Task IgnoringNewlineStyle_WhenStringsDifferOnlyInNewlineStyle_ShouldSucceed(
+				string subject, string expected)
+			{
+				async Task Act()
+					=> await That(subject).Is(expected).IgnoringNewlineStyle();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
 			[InlineAutoData("foo ", "foo")]
 			[InlineAutoData("foo", "foo ")]
 			[InlineAutoData("foo\t", "foo\n")]


### PR DESCRIPTION
Include information about the applied string options (ignore white-space or ignore newline style) in the expectation message of string collections.