### PR TITLE
docs: update URL to awexpect.com

### DIFF
--- a/Docs/pages/docusaurus.config.ts
+++ b/Docs/pages/docusaurus.config.ts
@@ -10,10 +10,10 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://aweXpect.github.io',
+  url: 'https://aweXpect.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/aweXpect/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Assert unit tests in natural language using awesome expectations.
    This brings the static `Expect` class and lots of extension methods into scope.
 
 
-3. See the [documentation](https://awexpect.github.io/aweXpect/docs/getting-started#write-your-first-expectation) for
+3. See the [documentation](https://awexpect.com/docs/getting-started#write-your-first-expectation) for
    usage scenarios.
 
 ## Features
@@ -47,10 +47,10 @@ We added lots of extensibility points to allow you to build custom extensions.
 The [aweXpect.Core](https://www.nuget.org/packages/aweXpect.Core/) package is intended to be a stable source for extensions, so that the risk of version conflicts between different extensions can be reduced.
 
 You can extend the functionality for any types, by adding extension methods on `IThat<TType>`.
-More information can be found in the [extensibility guide](https://awexpect.github.io/aweXpect/docs/category/extensibility).
+More information can be found in the [extensibility guide](https://awexpect.com/docs/category/extensibility).
 
 ### Performant
 
 A focus on performance allows you to execute your tests as fast as possible.  
 Special care is taken for the happy case (succeeding tests) to be as performant as possible. See
-the [benchmarks](https://awexpect.github.io/aweXpect/benchmarks) for more details.
+the [benchmarks](https://awexpect.com/benchmarks) for more details.

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -9,7 +9,7 @@
 		<Copyright>Copyright (c) 2024 Valentin Breuß</Copyright>
 		<RepositoryUrl>https://github.com/aweXpect/aweXpect.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<PackageProjectUrl>https://aweXpect.github.io/aweXpect/</PackageProjectUrl>
+		<PackageProjectUrl>https://aweXpect.com</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>


### PR DESCRIPTION
After aquiring [awexpect.com](https://awexpect.com/), set it up for use in Github Pages.