### PR TITLE
docs: add CNAME file

### DIFF
--- a/Docs/pages/static/CNAME
+++ b/Docs/pages/static/CNAME
@@ -1,0 +1,1 @@
+awexpect.com


### PR DESCRIPTION
Add the CNAME file to Docusaurus (see [here](https://docusaurus.io/docs/deployment#deploying-to-github-pages)):
> In case you want to use your custom domain for GitHub Pages, create a `CNAME` file in the `static` directory. Anything within the `static` directory will be copied to the root of the `build` directory for deployment. When using a custom domain, you should be able to move back from `baseUrl: '/projectName/'` to `baseUrl: '/'`, and also set your url to your custom domain.