### PR TITLE
docs: add explicit package descriptions

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -5,7 +5,6 @@
 
 	<PropertyGroup>
 		<Authors>aweXpect</Authors>
-		<Description>Assert unit tests in natural language using awesome expectations.</Description>
 		<Copyright>Copyright (c) 2024 Valentin Breuß</Copyright>
 		<RepositoryUrl>https://github.com/aweXpect/aweXpect.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/Source/aweXpect.Analyzers.CodeFixers/aweXpect.Analyzers.CodeFixers.csproj
+++ b/Source/aweXpect.Analyzers.CodeFixers/aweXpect.Analyzers.CodeFixers.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
 	<PropertyGroup>
+		<Description>Code fix providers for aweXpect to help with the correct usage.</Description>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<IsRoslynComponent>true</IsRoslynComponent>
@@ -9,7 +11,9 @@
 		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
+
 	<ItemGroup>
+		<ProjectReference Include="..\aweXpect.Analyzers\aweXpect.Analyzers.csproj"/>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,14 +22,14 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common"/>
 	</ItemGroup>
+
 	<ItemGroup>
 		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
 	</ItemGroup>
+
 	<ItemGroup>
 		<AdditionalFiles Remove="AnalyzerReleases.Unshipped.md"/>
 		<AdditionalFiles Remove="AnalyzerReleases.Shipped.md"/>
 	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\aweXpect.Analyzers\aweXpect.Analyzers.csproj"/>
-	</ItemGroup>
+
 </Project>

--- a/Source/aweXpect.Analyzers/aweXpect.Analyzers.csproj
+++ b/Source/aweXpect.Analyzers/aweXpect.Analyzers.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
 	<PropertyGroup>
+		<Description>Analyzers for aweXpect to ensure correct usage.</Description>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<IsRoslynComponent>true</IsRoslynComponent>
@@ -9,6 +11,7 @@
 		<EnableTrimAnalyzer>false</EnableTrimAnalyzer>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>aweXpect.Analyzers.Tests</_Parameter1>
@@ -17,6 +20,7 @@
 			<_Parameter1>aweXpect.Analyzers.CodeFixers</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
 			<PrivateAssets>all</PrivateAssets>
@@ -25,12 +29,14 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.Common"/>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
 	</ItemGroup>
+
 	<ItemGroup>
 		<EmbeddedResource Update="Resources.resx">
 			<Generator>ResXFileCodeGenerator</Generator>
 			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
 		</EmbeddedResource>
 	</ItemGroup>
+
 	<ItemGroup>
 		<Compile Update="Resources.Designer.cs">
 			<DesignTime>True</DesignTime>
@@ -38,4 +44,5 @@
 			<DependentUpon>Resources.resx</DependentUpon>
 		</Compile>
 	</ItemGroup>
+	
 </Project>

--- a/Source/aweXpect.Core/aweXpect.Core.csproj
+++ b/Source/aweXpect.Core/aweXpect.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<Description>Core package for writing extensions for aweXpect.</Description>
 		<RootNamespace>aweXpect</RootNamespace>
 	</PropertyGroup>
 

--- a/Source/aweXpect/aweXpect.csproj
+++ b/Source/aweXpect/aweXpect.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<PropertyGroup>
+		<Description>Assert unit tests in natural language using awesome expectations.</Description>
+	</PropertyGroup>
+
 	<ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
 		<PackageReference Include="aweXpect.Core"/>
 	</ItemGroup>
@@ -14,10 +18,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\aweXpect.Analyzers\aweXpect.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-		<None Include="$(MSBuildProjectDirectory)\..\aweXpect.Analyzers\bin\$(Configuration)\netstandard2.0\aweXpect.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-		<ProjectReference Include="..\aweXpect.Analyzers.CodeFixers\aweXpect.Analyzers.CodeFixers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-		<None Include="$(MSBuildProjectDirectory)\..\aweXpect.Analyzers.CodeFixers\bin\$(Configuration)\netstandard2.0\aweXpect.Analyzers.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<ProjectReference Include="..\aweXpect.Analyzers\aweXpect.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+		<None Include="$(MSBuildProjectDirectory)\..\aweXpect.Analyzers\bin\$(Configuration)\netstandard2.0\aweXpect.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+		<ProjectReference Include="..\aweXpect.Analyzers.CodeFixers\aweXpect.Analyzers.CodeFixers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+		<None Include="$(MSBuildProjectDirectory)\..\aweXpect.Analyzers.CodeFixers\bin\$(Configuration)\netstandard2.0\aweXpect.Analyzers.CodeFixers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes the issue highlighted by @KiddyTCat:
> When installing awexpect via nuget package manager it is not clear which package to install as awexpect and awexpect.core have the exact same description.