### PR TITLE
feat: support chaining delegate expectations in any order

### DIFF
--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithHResult.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithHResult.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using aweXpect.Core;
+using aweXpect.Delegates;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -9,8 +9,8 @@ public static partial class ThatDelegateThrows
 	/// <summary>
 	///     Verifies that the actual <see cref="Exception" /> has an <paramref name="expected" /> HResult.
 	/// </summary>
-	public static AndOrResult<TException, IThatDelegateThrows<TException>> WithHResult<TException>(
-		this IThatDelegateThrows<TException> source,
+	public static AndOrResult<TException, ThatDelegateThrows<TException>> WithHResult<TException>(
+		this ThatDelegateThrows<TException> source,
 		int expected)
 		where TException : Exception?
 		=> new(source.ExpectationBuilder.AddConstraint(it

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithParamName.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithParamName.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using aweXpect.Core;
+using aweXpect.Delegates;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -9,8 +9,8 @@ public static partial class ThatDelegateThrows
 	/// <summary>
 	///     Verifies that the actual <see cref="ArgumentException" /> has an <paramref name="expected" /> param name.
 	/// </summary>
-	public static AndOrResult<TException, IThatDelegateThrows<TException>> WithParamName<TException>(
-			this IThatDelegateThrows<TException> source,
+	public static AndOrResult<TException, ThatDelegateThrows<TException>> WithParamName<TException>(
+			this ThatDelegateThrows<TException> source,
 			string expected)
 		where TException : ArgumentException?
 		=> new(source.ExpectationBuilder.AddConstraint(it

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using aweXpect.Core;
+using aweXpect.Delegates;
 using aweXpect.Helpers;
 using aweXpect.Results;
 
@@ -16,8 +17,8 @@ public static partial class ThatDelegateThrows
 	///     Recursively applies the expectations on the <see cref="Exception.InnerException" /> (if not <see langword="null" />
 	///     and for <see cref="AggregateException" /> also on the <see cref="AggregateException.InnerExceptions" />.
 	/// </remarks>
-	public static AndOrResult<TException?, IThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(
-		this IThatDelegateThrows<TException> source,
+	public static AndOrResult<TException?, ThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(
+		this ThatDelegateThrows<TException> source,
 		Action<IThat<IEnumerable<Exception>>> expectations)
 		where TException : Exception?
 		=> new(source.ExpectationBuilder

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -198,11 +198,11 @@ namespace aweXpect
     }
     public static class ThatDelegateThrows
     {
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThatDelegateThrows<TException>> WithHResult<TException>(this aweXpect.Core.IThatDelegateThrows<TException> source, int expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithHResult<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, int expected)
             where TException : System.Exception? { }
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Core.IThatDelegateThrows<TException> source, string expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string expected)
             where TException : System.ArgumentException? { }
-        public static aweXpect.Results.AndOrResult<TException?, aweXpect.Core.IThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(this aweXpect.Core.IThatDelegateThrows<TException> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations)
+        public static aweXpect.Results.AndOrResult<TException?, aweXpect.Delegates.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations)
             where TException : System.Exception? { }
     }
     public static class ThatDictionary

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -97,11 +97,11 @@ namespace aweXpect
     }
     public static class ThatDelegateThrows
     {
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThatDelegateThrows<TException>> WithHResult<TException>(this aweXpect.Core.IThatDelegateThrows<TException> source, int expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithHResult<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, int expected)
             where TException : System.Exception? { }
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Core.IThatDelegateThrows<TException> source, string expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string expected)
             where TException : System.ArgumentException? { }
-        public static aweXpect.Results.AndOrResult<TException?, aweXpect.Core.IThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(this aweXpect.Core.IThatDelegateThrows<TException> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations)
+        public static aweXpect.Results.AndOrResult<TException?, aweXpect.Delegates.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations)
             where TException : System.Exception? { }
     }
     public static class ThatDictionary


### PR DESCRIPTION
Make it possible to write expectations on delegates in any order, so now you can write both:
```csharp
await That(action).ThrowsException()
  .WithMessage("foo").And
  .WithHResult(42);

await That(action).ThrowsException()
  .WithHResult(42).And
  .WithMessage("foo");
```