### PR TITLE
feat: make `IsNull()` generic

### DIFF
--- a/Source/aweXpect/That/Objects/ThatObject.IsNull.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsNull.cs
@@ -9,10 +9,11 @@ public static partial class ThatObject
 	/// <summary>
 	///     Verifies that the subject is <see langword="null" />.
 	/// </summary>
-	public static AndOrResult<object?, IThat<object?>> IsNull(
-		this IThat<object?> source)
+	public static AndOrResult<T?, IThat<T?>> IsNull<T>(
+		this IThat<T?> source)
+		where T : class
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint(it
-				=> new GenericConstraint<object?>(
+				=> new GenericConstraint<T?>(
 					it,
 					null,
 					"be null",
@@ -38,10 +39,11 @@ public static partial class ThatObject
 	/// <summary>
 	///     Verifies that the subject is not <see langword="null" />.
 	/// </summary>
-	public static AndOrResult<object, IThat<object?>> IsNotNull(
-		this IThat<object?> source)
+	public static AndOrResult<T, IThat<T?>> IsNotNull<T>(
+		this IThat<T?> source)
+		where T : class
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint(it
-				=> new GenericConstraint<object?>(
+				=> new GenericConstraint<T?>(
 					it,
 					null,
 					"not be null",
@@ -54,10 +56,11 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<T, IThat<T?>> IsNotNull<T>(
 		this IThat<T?> source)
+		where T : struct
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new GenericConstraint<T?>(
 					it,
-					default,
+					null,
 					"not be null",
 					(a, _) => a is not null,
 					(_, _, i) => $"{i} was")),

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -844,11 +844,14 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<object, aweXpect.Core.IThat<object?>> IsNotNull(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source) { }
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
+            where T :  class { }
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
+            where T :  struct { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNotSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNull(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
+            where T :  class { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -670,11 +670,14 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhichResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<object, aweXpect.Core.IThat<object?>> IsNotNull(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source) { }
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
+            where T :  class { }
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
+            where T :  struct { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNotSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNull(this aweXpect.Core.IThat<object?> source) { }
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
+            where T :  class { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")


### PR DESCRIPTION
Make `IsNull()` and `IsNotNull()` generic, so that it can be better chained.