### PR TITLE
docs: fix name of suggested alternative in warnings

### DIFF
--- a/Source/aweXpect.Core/Core/IThat.cs
+++ b/Source/aweXpect.Core/Core/IThat.cs
@@ -14,7 +14,7 @@ public interface IThat<out T>
 {
 	/// <summary>
 	///     <i>Not supported!</i><br />
-	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Be</c> instead?
+	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Is</c> instead?
 	/// </summary>
 	/// <remarks>
 	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.

--- a/Source/aweXpect.Core/Core/IThatVerb.cs
+++ b/Source/aweXpect.Core/Core/IThatVerb.cs
@@ -22,7 +22,7 @@ public interface IThatVerb<out T>
 
 	/// <summary>
 	///     <i>Not supported!</i><br />
-	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Be</c> instead?
+	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Is</c> instead?
 	/// </summary>
 	/// <remarks>
 	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.

--- a/Source/aweXpect.Core/Results/Expectation.cs
+++ b/Source/aweXpect.Core/Results/Expectation.cs
@@ -21,14 +21,14 @@ public abstract class Expectation
 {
 	/// <summary>
 	///     <i>Not supported!</i><br />
-	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Be</c> instead?
+	///     <see cref="object.Equals(object?)" /> is not supported. Did you mean <c>Is</c> instead?
 	/// </summary>
 	/// <remarks>
 	///     Consider adding support for <see cref="EditorBrowsableAttribute" /> to hide this method from code suggestions.
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public override bool Equals(object? obj)
-		=> throw new NotSupportedException("Equals is not supported. Did you mean Be() instead?");
+		=> throw new NotSupportedException("Equals is not supported. Did you mean Is() instead?");
 
 	/// <summary>
 	///     <i>Not supported!</i><br />

--- a/Tests/aweXpect.Core.Tests/Results/ExpectationTests.cs
+++ b/Tests/aweXpect.Core.Tests/Results/ExpectationTests.cs
@@ -14,7 +14,7 @@ public class ExpectationTests
 #pragma warning restore aweXpect0001
 
 		await That(Act).Throws<NotSupportedException>()
-			.WithMessage("Equals is not supported. Did you mean Be() instead?");
+			.WithMessage("Equals is not supported. Did you mean Is() instead?");
 	}
 
 	[Fact]


### PR DESCRIPTION
Correct the suggested alternative in warnings when using the `Equals` method.