### PR TITLE
docs: add link to benchmark definition

### DIFF
--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Bool.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Bool.cs
@@ -4,6 +4,9 @@ using FluentAssertions.Primitives;
 
 namespace aweXpect.Benchmarks;
 
+/// <summary>
+///     In this benchmark we verify that the subject is equal to <see langword="true" />.<br />
+/// </summary>
 public partial class HappyCaseBenchmarks
 {
 	private readonly bool _boolSubject = true;

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Int_GreaterThan.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Int_GreaterThan.cs
@@ -4,6 +4,9 @@ using FluentAssertions.Numeric;
 
 namespace aweXpect.Benchmarks;
 
+/// <summary>
+///     In this benchmark we verify that the subject is greater than the expected minimum.<br />
+/// </summary>
 public partial class HappyCaseBenchmarks
 {
 	private readonly int _intMinimum = 20;

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.ItemsCount_AtLeast.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.ItemsCount_AtLeast.cs
@@ -4,6 +4,9 @@ using FluentAssertions.Collections;
 
 namespace aweXpect.Benchmarks;
 
+/// <summary>
+///     In this benchmark we verify that a collection has at least the expected number of items.<br />
+/// </summary>
 public partial class HappyCaseBenchmarks
 {
 	private readonly int _enumerableCount = 1000;

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.String.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.String.cs
@@ -4,6 +4,9 @@ using FluentAssertions.Primitives;
 
 namespace aweXpect.Benchmarks;
 
+/// <summary>
+///     In this benchmark we verify that a <see cref="string" /> is equal to another one.<br />
+/// </summary>
 public partial class HappyCaseBenchmarks
 {
 	private readonly string _stringExpectation = "foo";

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.StringArray.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.StringArray.cs
@@ -2,15 +2,15 @@
 using BenchmarkDotNet.Engines;
 using FluentAssertions;
 using FluentAssertions.Collections;
-using TUnit.Assertions.Enums;
 
 namespace aweXpect.Benchmarks;
 
-public partial class
-	HappyCaseBenchmarks
+/// <summary>
+///     In this benchmark we verify that a <see cref="string" /> array has the same values than another one.<br />
+/// </summary>
+public partial class HappyCaseBenchmarks
 {
 	private readonly string[] _stringArrayExpectation = ["foo", "bar", "baz"];
-	private readonly string[] _stringArrayOtherOrderExpectation = ["foo", "baz", "bar"];
 	private readonly string[] _stringArraySubject = ["foo", "bar", "baz"];
 
 	[Benchmark]
@@ -24,18 +24,4 @@ public partial class
 	[Benchmark]
 	public async Task StringArray_TUnit()
 		=> (await Assert.That(_stringArraySubject).IsEquivalentTo(_stringArrayExpectation))?.Consume(_consumer);
-
-	[Benchmark]
-	public async Task StringArrayInAnyOrder_aweXpect()
-		=> (await Expect.That(_stringArraySubject).Is(_stringArrayOtherOrderExpectation).InAnyOrder())
-			.Consume(_consumer);
-
-	[Benchmark]
-	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArrayInAnyOrder_FluentAssertions()
-		=> _stringArraySubject.Should().BeEquivalentTo(_stringArrayOtherOrderExpectation);
-
-	[Benchmark]
-	public async Task StringArrayInAnyOrder_TUnit()
-		=> (await Assert.That(_stringArraySubject)
-			.IsEquivalentTo(_stringArrayOtherOrderExpectation, CollectionOrdering.Any))?.Consume(_consumer);
 }

--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.StringArrayInAnyOrder.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.StringArrayInAnyOrder.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using FluentAssertions;
+using FluentAssertions.Collections;
+using TUnit.Assertions.Enums;
+
+namespace aweXpect.Benchmarks;
+
+/// <summary>
+///     In this benchmark we verify that a <see cref="string" /> array has the same values in a different order than
+///     another one.<br />
+/// </summary>
+public partial class HappyCaseBenchmarks
+{
+	private readonly string[] _stringArrayAnyOrderExpectation = ["foo", "baz", "bar"];
+	private readonly string[] _stringArrayAnyOrderSubject = ["foo", "bar", "baz"];
+
+	[Benchmark]
+	public async Task StringArrayInAnyOrder_aweXpect()
+		=> (await Expect.That(_stringArrayAnyOrderSubject).Is(_stringArrayAnyOrderExpectation).InAnyOrder())
+			.Consume(_consumer);
+
+	[Benchmark]
+	public AndConstraint<StringCollectionAssertions<IEnumerable<string>>> StringArrayInAnyOrder_FluentAssertions()
+		=> _stringArrayAnyOrderSubject.Should().BeEquivalentTo(_stringArrayAnyOrderExpectation);
+
+	[Benchmark]
+	public async Task StringArrayInAnyOrder_TUnit()
+		=> (await Assert.That(_stringArrayAnyOrderSubject)
+			.IsEquivalentTo(_stringArrayAnyOrderExpectation, CollectionOrdering.Any))?.Consume(_consumer);
+}

--- a/Docs/pages/static/js/benchmarks.js
+++ b/Docs/pages/static/js/benchmarks.js
@@ -12,8 +12,12 @@
 	function renderChart(main, name, data) {
 		const div = document.createElement("div");
 		const h = document.createElement("h3");
+		const l = document.createElement("a");
+		l.setAttribute("href", "https://github.com/aweXpect/aweXpect/blob/main/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks." + name + ".cs");
+		l.setAttribute("target", "_blank");
 		const t = document.createTextNode(name);
-		h.appendChild(t);
+		l.appendChild(t);
+		h.appendChild(l);
 		div.appendChild(h);
 		const canvas = document.createElement('canvas');
 		canvas.className = 'benchmark-chart';


### PR DESCRIPTION
Add a link from the website to the definition of the benchmarks.