### PR TITLE
feat: support static synchronous `Verify`

### DIFF
--- a/Source/aweXpect.Analyzers/AwaitExpectationAnalyzer.cs
+++ b/Source/aweXpect.Analyzers/AwaitExpectationAnalyzer.cs
@@ -94,15 +94,20 @@ public class AwaitExpectationAnalyzer : DiagnosticAnalyzer
 				return;
 			}
 
-			if (node is IdentifierNameSyntax nameSyntax &&
-			    semanticModel.GetSymbolInfo(nameSyntax).Symbol is IMethodSymbol methodSymbol &&
-			    methodSymbol.MatchesFullName("aweXpect", "Synchronous", "SynchronousTestExecution", "Verify") &&
-			    methodSymbol.Parameters.Length == 0)
+			if (IsVerifyMatch(semanticModel, node, 0) ||
+			    (node is MemberAccessExpressionSyntax memberAccessExpressionSyntax &&
+			     IsVerifyMatch(semanticModel, memberAccessExpressionSyntax.Name, 1)))
 			{
 				IsVerifyCalled = true;
 			}
 
 			base.Visit(node);
+
+			static bool IsVerifyMatch(SemanticModel semanticModel, SyntaxNode syntaxNode, int parameterCount)
+				=> syntaxNode is IdentifierNameSyntax nameSyntax &&
+				   semanticModel.GetSymbolInfo(nameSyntax).Symbol is IMethodSymbol methodSymbol &&
+				   methodSymbol.MatchesFullName("aweXpect", "Synchronous", "Synchronously", "Verify") &&
+				   methodSymbol.Parameters.Length == parameterCount;
 		}
 	}
 }

--- a/Source/aweXpect.Core/Synchronous/Synchronously.cs
+++ b/Source/aweXpect.Core/Synchronous/Synchronously.cs
@@ -9,7 +9,7 @@ namespace aweXpect.Synchronous;
 ///     <b>WARNING!</b><br />
 ///     The only intended use case is to support synchronous evaluation for <c>ref struct</c>.
 /// </remarks>
-public static class SynchronousTestExecution
+public static class Synchronously
 {
 	/// <summary>
 	///     Verifies synchronously that the expectation is satisfied.

--- a/Tests/aweXpect.Analyzers.Tests/AwaitExpectationAnalyzerTests.cs
+++ b/Tests/aweXpect.Analyzers.Tests/AwaitExpectationAnalyzerTests.cs
@@ -115,4 +115,41 @@ public class AwaitExpectationAnalyzerTests
 			}
 			"""
 		);
+
+	[Fact]
+	public async Task WhenVerifiedStatically_ShouldNotBeFlagged() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using System.Threading.Tasks;
+			using aweXpect;
+			using aweXpect.Synchronous;
+
+			public class MyClass
+			{
+			    public async Task MyTest()
+			    {
+			        var subject = true;
+			        Synchronously.Verify({|#0:Expect.That(subject)|}.IsTrue());
+			    }
+			}
+			"""
+		);
+
+	[Fact]
+	public async Task WhenVerifiedStatically_WithoutReturnValue_ShouldNotBeFlagged() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using System.Threading.Tasks;
+			using aweXpect;
+			using aweXpect.Synchronous;
+
+			public class MyClass
+			{
+			    public async Task MyTest()
+			    {
+			        Synchronously.Verify({|#0:Expect.That(() => {})|}.DoesNotThrow());
+			    }
+			}
+			"""
+		);
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -853,7 +853,7 @@ namespace aweXpect.Signaling
 }
 namespace aweXpect.Synchronous
 {
-    public static class SynchronousTestExecution
+    public static class Synchronously
     {
         public static void Verify(this aweXpect.Results.ExpectationResult result) { }
         public static TType Verify<TType, TSelf>(this aweXpect.Results.ExpectationResult<TType, TSelf> result)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -840,7 +840,7 @@ namespace aweXpect.Signaling
 }
 namespace aweXpect.Synchronous
 {
-    public static class SynchronousTestExecution
+    public static class Synchronously
     {
         public static void Verify(this aweXpect.Results.ExpectationResult result) { }
         public static TType Verify<TType, TSelf>(this aweXpect.Results.ExpectationResult<TType, TSelf> result)

--- a/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyTests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Runtime.CompilerServices;
 using aweXpect.Core.Tests.TestHelpers;
 using aweXpect.Synchronous;
+// ReSharper disable InvokeAsExtensionMethod
 
 namespace aweXpect.Core.Tests.Synchronous;
 
-public class SynchronousTestExecutionTests
+public class SynchronouslyTests
 {
 	[Fact]
 	public void WhenActionDoesNotThrow_ShouldSucceed()
@@ -15,7 +16,7 @@ public class SynchronousTestExecutionTests
 		};
 
 		int value = subject.Bar;
-		That(() => ThrowIf(value != 3)).DoesNotThrow().Verify();
+		Synchronously.Verify(That(() => ThrowIf(value != 3)).DoesNotThrow());
 	}
 
 	[Fact]
@@ -26,15 +27,15 @@ public class SynchronousTestExecutionTests
 			Bar = 3
 		};
 		int value = subject.Bar;
-		void Act() => That(() => ThrowIf(value == 3)).DoesNotThrow().Verify();
+		void Act() => Synchronously.Verify(That(() => ThrowIf(value == 3)).DoesNotThrow());
 
-		That(Act).Throws<XunitException>()
+		Synchronously.Verify(That(Act).Throws<XunitException>()
 			.WithMessage("""
 			             Expected () => ThrowIf(value == 3) to
 			             not throw any exception,
 			             but it did throw a MyException:
 			               WhenActionThrows_ShouldFail
-			             """).Verify();
+			             """));
 	}
 
 	[Fact]
@@ -45,14 +46,14 @@ public class SynchronousTestExecutionTests
 			Bar = 3
 		};
 		int value = subject.Bar;
-		void Act() => That(value).IsEqualTo(2).Verify();
+		void Act() => Synchronously.Verify(That(value).IsEqualTo(2));
 
-		That(Act).Throws<XunitException>()
+		Synchronously.Verify(That(Act).Throws<XunitException>()
 			.WithMessage("""
 			             Expected value to
 			             be equal to 2,
 			             but it was 3
-			             """).Verify();
+			             """));
 	}
 
 	[Fact]
@@ -63,9 +64,9 @@ public class SynchronousTestExecutionTests
 			Bar = 3
 		};
 
-		int value = That(subject.Bar).IsEqualTo(3).Verify();
+		int value = Synchronously.Verify(That(subject.Bar).IsEqualTo(3));
 
-		That(value).IsEqualTo(3).Verify();
+		Synchronously.Verify(That(value).IsEqualTo(3));
 	}
 
 	private static void ThrowIf(bool condition, [CallerMemberName] string message = "")


### PR DESCRIPTION
Support calling the `Verify` method also statically (without an extension method), e.g.:
```csharp
Synchronously.Verify(That(value).IsEqualTo(2));
```

Fixes #271 