### PR TITLE
chore: update aweXpect.Core to v0.19.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="0.22.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="0.19.3"/>
+		<PackageVersion Include="aweXpect.Core" Version="0.19.4"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="0.4.0"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Docs/pages/docs/expectations/datetime-offset.md
+++ b/Docs/pages/docs/expectations/datetime-offset.md
@@ -93,25 +93,25 @@ DateTime subject = new DateTime(2024, 12, 31, 15, 16, 17, 189, DateTimeKind.Utc)
 // or
 DateTimeOffset subject = new DateTimeOffset(2024, 12, 31, 15, 16, 17, 189, TimeSpan.FromMinutes(90));
 
-await Expect.That(subject).HasYear(2024);
-await Expect.That(subject).HasMonth(12);
-await Expect.That(subject).HasDay(31);
-await Expect.That(subject).HasHour(15);
-await Expect.That(subject).HasMinute(16);
-await Expect.That(subject).HasSecond(17);
-await Expect.That(subject).HasMillisecond(189);
+await Expect.That(subject).HasYear().EqualTo(2024);
+await Expect.That(subject).HasMonth().EqualTo(12);
+await Expect.That(subject).HasDay().EqualTo(31);
+await Expect.That(subject).HasHour().EqualTo(15);
+await Expect.That(subject).HasMinute().EqualTo(16);
+await Expect.That(subject).HasSecond().EqualTo(17);
+await Expect.That(subject).HasMillisecond().EqualTo(189);
 ```
 
 For `DateTime` you can also verify the `Kind` property:
 
 ```csharp
-await Expect.That(subject).HasKind(DateTimeKind.Utc);
+await Expect.That(subject).HasKind().EqualTo(DateTimeKind.Utc);
 ```
 
 For `DateTimeOffset` you can also verify the `Offset` property:
 
 ```csharp
-await Expect.That(subject).HasOffset(TimeSpan.FromMinutes(90));
+await Expect.That(subject).HasOffset().EqualTo(TimeSpan.FromMinutes(90));
 ```
 
 ## Default Tolerance

--- a/Docs/pages/docs/expectations/ref-struct.md
+++ b/Docs/pages/docs/expectations/ref-struct.md
@@ -2,13 +2,14 @@
 sidebar_position: 18
 ---
 
-# `ref struct`
+# Ref struct types
 
-Describes how to work with `ref struct`
+Describes how you can work with `ref` structure types
 
 [ref struct types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct) can't be
-used in an `async` context. In order to allow using aweXpect on properties of `ref struct` types, there is a built-in workaround to verify the
-expectation synchronously:
+used in an `async` context.  
+In order to allow using aweXpect on properties of `ref struct` types, there is a built-in workaround to verify the
+expectation synchronously, so that the test method itself can remain synchronous:
 
 ```csharp
 ReadOnlySpan<char> subject = @"foo".AsSpan();
@@ -17,3 +18,5 @@ Synchronously.Verify(Expect.That(subject.Length).IsEqualTo(3));
 // or alternatively:
 Expect.That(subject.Length).IsEqualTo(3).Verify();
 ```
+
+*Note: These methods are in the namespace `aweXpect.Synchronous`.*

--- a/Docs/pages/docs/expectations/ref-struct.md
+++ b/Docs/pages/docs/expectations/ref-struct.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 18
+---
+
+# `ref struct`
+
+Describes how to work with `ref struct`
+
+[ref struct types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct) can't be
+used in an `async` context. In order to allow using aweXpect on properties of `ref struct` types, there is a built-in workaround to verify the
+expectation synchronously:
+
+```csharp
+ReadOnlySpan<char> subject = @"foo".AsSpan();
+
+Synchronously.Verify(Expect.That(subject.Length).IsEqualTo(3));
+// or alternatively:
+Expect.That(subject.Length).IsEqualTo(3).Verify();
+```

--- a/Docs/pages/docs/expectations/stream.md
+++ b/Docs/pages/docs/expectations/stream.md
@@ -29,8 +29,8 @@ You can verify, the length of the `Stream`:
 ```csharp
 Stream subject = new MemoryStream("foo"u8.ToArray());
 
-await Expect.That(subject).HasLength(3);
-await Expect.That(subject).DoesNotHaveLength(4);
+await Expect.That(subject).HasLength().EqualTo(3);
+await Expect.That(subject).HasLength().NotEqualTo(4);
 ```
 
 ## Position
@@ -41,8 +41,8 @@ You can verify, the position of the `Stream`:
 Stream subject = new MemoryStream("foo"u8.ToArray());
 subject.Seek(2, SeekOrigin.Current);
 
-await Expect.That(subject).HasPosition(2);
-await Expect.That(subject).DoesNotHavePosition(0);
+await Expect.That(subject).HasPosition().EqualTo(2);
+await Expect.That(subject).HasPosition().NotEqualTo(0);
 ```
 
 ## Buffer size
@@ -52,6 +52,6 @@ You can verify, the buffer size of the `BufferedStream`:
 ```csharp
 BufferedStream subject = new(new MemoryStream("foo"u8.ToArray()), 2);
 
-await Expect.That(subject).HasBufferSize(2);
-await Expect.That(subject).DoesNotHaveBufferSize(3);
+await Expect.That(subject).HasBufferSize().EqualTo(2);
+await Expect.That(subject).HasBufferSize().NotEqualTo(3);
 ```

--- a/Docs/pages/docs/expectations/string.md
+++ b/Docs/pages/docs/expectations/string.md
@@ -99,6 +99,17 @@ await Expect.That(subject).IsNullOrWhiteSpace();
 await Expect.That("foo").IsNotNullOrWhiteSpace();
 ```
 
+## Length
+
+You can verify, that the `string` has the expected length:
+
+```csharp
+string subject = "some value";
+
+await Expect.That(subject).HasLength().EqualTo(10);
+await Expect.That(subject).HasLength().NotEqualTo(9);
+```
+
 ## String start / end
 
 You can verify, that the `string` starts or ends with a given string.  


### PR DESCRIPTION
Also fix minor issues in the documentation and add information about handling [`ref struct` types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct).