### PR TITLE
refactor: temporarily disable NU5104

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -21,7 +21,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<NoWarn>1701;1702</NoWarn>
+		<NoWarn>$(NoWarn);1701;1702;NU5104</NoWarn>
 		<WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>


### PR DESCRIPTION
We need to create a release-version of Core first. https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104