### PR TITLE
refactor: rename `Are(TItem)` to `AreEqualTo(TItem)`

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -26,7 +26,7 @@ await Expect.That(values).IsEqualTo([3, 3, 2, 2, 1, 1]).InAnyOrder().IgnoringDup
 You can verify, that all items in the collection are equal to the `expected` value
 
 ```csharp
-await Expect.That([1, 1, 1]).All().Are(1);
+await Expect.That([1, 1, 1]).All().AreEqualTo(1);
 ```
 
 You can also use a [custom comparer](/docs/expectations/object#custom-comparer) or
@@ -36,15 +36,15 @@ configure [equivalence](/docs/expectations/object#equivalence):
 IEnumerable<MyClass> values = //...
 MyClass expected = //...
 
-await Expect.That(values).All().Are(expected).Equivalent();
-await Expect.That(values).All().Are(expected).Using(new MyClassComparer());
+await Expect.That(values).All().AreEqualTo(expected).Equivalent();
+await Expect.That(values).All().AreEqualTo(expected).Using(new MyClassComparer());
 ```
 
 For strings, you can configure this expectation to ignore case, ignore newline style, ignoring leading or trailing
 white-space, or use a custom `IEqualityComparer<string>`:
 
 ```csharp
-await Expect.That(["foo", "FOO", "Foo"]).All().Are("foo").IgnoringCase();
+await Expect.That(["foo", "FOO", "Foo"]).All().AreEqualTo("foo").IgnoringCase();
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
@@ -10,49 +10,8 @@ namespace aweXpect;
 
 public static partial class ThatAsyncEnumerable
 {
-	public partial class Elements
-	{
-		/// <summary>
-		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>> Are(
-			string? expected)
-		{
-			StringEqualityOptions options = new();
-			return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
-					=> new CollectionConstraint<string?>(
-						it,
-						_quantifier,
-						() => $"equal to {Formatter.Format(expected)}",
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
-	}
-
 	public partial class Elements<TItem>
 	{
-		/// <summary>
-		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>
-			Are(TItem expected)
-		{
-			ObjectEqualityOptions options = new();
-			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
-					=> new CollectionConstraint<TItem>(
-						it,
-						_quantifier,
-						() => $"equal to {Formatter.Format(expected)}",
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
-
 		/// <summary>
 		///     Verifies that the items in the collection satisfy the <paramref name="expectations" />.
 		/// </summary>

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEqualTo.cs
@@ -1,0 +1,56 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatAsyncEnumerable
+{
+	public partial class Elements
+	{
+		/// <summary>
+		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>> AreEqualTo(
+			string? expected)
+		{
+			StringEqualityOptions options = new();
+			return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
+				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
+					=> new CollectionConstraint<string?>(
+						it,
+						_quantifier,
+						() => $"equal to {Formatter.Format(expected)}",
+						a => options.AreConsideredEqual(a, expected),
+						"were")),
+				_subject,
+				options);
+		}
+	}
+
+	public partial class Elements<TItem>
+	{
+		/// <summary>
+		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>
+			AreEqualTo(TItem expected)
+		{
+			ObjectEqualityOptions options = new();
+			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
+				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
+					=> new CollectionConstraint<TItem>(
+						it,
+						_quantifier,
+						() => $"equal to {Formatter.Format(expected)}",
+						a => options.AreConsideredEqual(a, expected),
+						"were")),
+				_subject,
+				options);
+		}
+	}
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -9,49 +9,8 @@ namespace aweXpect;
 
 public static partial class ThatEnumerable
 {
-	public partial class Elements
-	{
-		/// <summary>
-		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>> Are(
-			string? expected)
-		{
-			StringEqualityOptions options = new();
-			return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
-					=> new CollectionConstraint<string?>(
-						it,
-						_quantifier,
-						() => $"equal to {Formatter.Format(expected)}{options}",
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
-	}
-
 	public partial class Elements<TItem>
 	{
-		/// <summary>
-		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>
-			Are(TItem expected)
-		{
-			ObjectEqualityOptions options = new();
-			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
-					=> new CollectionConstraint<TItem>(
-						it,
-						_quantifier,
-						() => $"equal to {Formatter.Format(expected)}{options}",
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
-
 		/// <summary>
 		///     Verifies that the items in the collection satisfy the <paramref name="expectations" />.
 		/// </summary>

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatEnumerable
+{
+	public partial class Elements
+	{
+		/// <summary>
+		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>> AreEqualTo(
+			string? expected)
+		{
+			StringEqualityOptions options = new();
+			return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
+				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
+					=> new CollectionConstraint<string?>(
+						it,
+						_quantifier,
+						() => $"equal to {Formatter.Format(expected)}{options}",
+						a => options.AreConsideredEqual(a, expected),
+						"were")),
+				_subject,
+				options);
+		}
+	}
+
+	public partial class Elements<TItem>
+	{
+		/// <summary>
+		///     Verifies that the items in the collection are equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>
+			AreEqualTo(TItem expected)
+		{
+			ObjectEqualityOptions options = new();
+			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
+				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
+					=> new CollectionConstraint<TItem>(
+						it,
+						_quantifier,
+						() => $"equal to {Formatter.Format(expected)}{options}",
+						a => options.AreConsideredEqual(a, expected),
+						"were")),
+				_subject,
+				options);
+		}
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -87,15 +87,15 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public class Elements
         {
-            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> Are(string? expected) { }
+            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> AreEqualTo(string? expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> Satisfy(System.Func<string?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
         public class Elements<TItem>
         {
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are(System.Type type) { }
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are(TItem expected) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are<TType>() { }
+            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> AreEqualTo(TItem expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }
@@ -279,15 +279,15 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public class Elements
         {
-            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> Are(string? expected) { }
+            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreEqualTo(string? expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> Satisfy(System.Func<string?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
         public class Elements<TItem>
         {
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Type type) { }
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(TItem expected) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are<TType>() { }
+            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> AreEqualTo(TItem expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -182,15 +182,15 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public class Elements
         {
-            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> Are(string? expected) { }
+            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreEqualTo(string? expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> Satisfy(System.Func<string?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
         public class Elements<TItem>
         {
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Type type) { }
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(TItem expected) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are<TType>() { }
+            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> AreEqualTo(TItem expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Tests.cs
@@ -19,8 +19,8 @@ public sealed partial class ThatAsyncEnumerable
 					ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 					async Task Act()
-						=> await That(subject).All().Are(1)
-							.And.All().Are(1);
+						=> await That(subject).All().AreEqualTo(1)
+							.And.All().AreEqualTo(1);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 					async Task Act()
-						=> await That(subject).All().Are(1);
+						=> await That(subject).All().AreEqualTo(1);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -47,7 +47,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int?> subject = Factory.GetConstantValueAsyncEnumerable<int?>(null, 20);
 
 					async Task Act()
-						=> await That(subject).All().Are((int?)null);
+						=> await That(subject).All().AreEqualTo((int?)null);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -58,7 +58,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers(20);
 
 					async Task Act()
-						=> await That(subject).All().Are(5).Using(new AllEqualComparer());
+						=> await That(subject).All().AreEqualTo(5).Using(new AllEqualComparer());
 
 					await That(Act).DoesNotThrow();
 				}
@@ -69,7 +69,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers(20);
 
 					async Task Act()
-						=> await That(subject).All().Are(5);
+						=> await That(subject).All().AreEqualTo(5);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -86,7 +86,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int> subject = Factory.GetConstantValueAsyncEnumerable(constantValue, 20);
 
 					async Task Act()
-						=> await That(subject).All().Are(constantValue);
+						=> await That(subject).All().AreEqualTo(constantValue);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -98,7 +98,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int>? subject = null;
 
 					async Task Act()
-						=> await That(subject).All().Are(constantValue);
+						=> await That(subject).All().AreEqualTo(constantValue);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -117,7 +117,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string> subject = Factory.GetAsyncFibonacciNumbers(i => $"item-{i}");
 
 					async Task Act()
-						=> await That(subject).All().Are("item-1");
+						=> await That(subject).All().AreEqualTo("item-1");
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -133,7 +133,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string?> subject = Factory.GetConstantValueAsyncEnumerable<string?>(null, 20);
 
 					async Task Act()
-						=> await That(subject).All().Are(null);
+						=> await That(subject).All().AreEqualTo(null);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -144,7 +144,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string> subject = Factory.GetAsyncFibonacciNumbers(i => $"item-{i}", 20);
 
 					async Task Act()
-						=> await That(subject).All().Are("item-5").Using(new AllEqualComparer());
+						=> await That(subject).All().AreEqualTo("item-5").Using(new AllEqualComparer());
 
 					await That(Act).DoesNotThrow();
 				}
@@ -155,7 +155,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string> subject = Factory.GetAsyncFibonacciNumbers(i => $"item-{i}", 10);
 
 					async Task Act()
-						=> await That(subject).All().Are("item-5");
+						=> await That(subject).All().AreEqualTo("item-5");
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -173,7 +173,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO"]);
 
 					async Task Act()
-						=> await That(subject).All().Are("foo").IgnoringCase(ignoreCase);
+						=> await That(subject).All().AreEqualTo("foo").IgnoringCase(ignoreCase);
 
 					await That(Act).Throws<XunitException>().OnlyIf(!ignoreCase)
 						.WithMessage("""
@@ -190,7 +190,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string> subject = Factory.GetConstantValueAsyncEnumerable(constantValue, 20);
 
 					async Task Act()
-						=> await That(subject).All().Are(constantValue);
+						=> await That(subject).All().AreEqualTo(constantValue);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -202,7 +202,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<string>? subject = null;
 
 					async Task Act()
-						=> await That(subject).All().Are(constantValue);
+						=> await That(subject).All().AreEqualTo(constantValue);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtLeast.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtLeast.Tests.cs
@@ -33,8 +33,8 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).AtLeast(0).Are(1)
-						.And.AtLeast(0).Are(1);
+					=> await That(subject).AtLeast(0).AreEqualTo(1)
+						.And.AtLeast(0).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -45,7 +45,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).AtLeast(2).Are(1);
+					=> await That(subject).AtLeast(2).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -56,7 +56,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtLeast(3).Are(1);
+					=> await That(subject).AtLeast(3).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -67,7 +67,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtLeast(5).Are(1);
+					=> await That(subject).AtLeast(5).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -83,7 +83,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtLeast(5).Are(1);
+					=> await That(subject).AtLeast(5).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -99,7 +99,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).AtLeast(1).Are(0);
+					=> await That(subject).AtLeast(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtMost.Tests.cs
@@ -38,8 +38,8 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(1)
-						.And.AtMost(3).Are(1);
+					=> await That(subject).AtMost(3).AreEqualTo(1)
+						.And.AtMost(3).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -50,7 +50,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).AtMost(1).Are(1);
+					=> await That(subject).AtMost(1).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -66,7 +66,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(2);
+					=> await That(subject).AtMost(3).AreEqualTo(2);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -77,7 +77,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(1);
+					=> await That(subject).AtMost(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -93,7 +93,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).AtMost(1).Are(0);
+					=> await That(subject).AtMost(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Between.Tests.cs
@@ -38,8 +38,8 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).Between(0).And(2).Are(1)
-						.And.Between(0).And(1).Are(1);
+					=> await That(subject).Between(0).And(2).AreEqualTo(1)
+						.And.Between(0).And(1).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -50,7 +50,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).Between(0).And(1).Are(1);
+					=> await That(subject).Between(0).And(1).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -66,7 +66,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Between(3).And(4).Are(1);
+					=> await That(subject).Between(3).And(4).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -77,7 +77,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Between(3).And(4).Are(2);
+					=> await That(subject).Between(3).And(4).AreEqualTo(2);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -93,7 +93,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Between(1).And(3).Are(1);
+					=> await That(subject).Between(1).And(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -109,7 +109,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).Between(0).And(1).Are(0);
+					=> await That(subject).Between(0).And(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Exactly.Tests.cs
@@ -38,8 +38,8 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).Exactly(1).Are(1)
-						.And.Exactly(1).Are(1);
+					=> await That(subject).Exactly(1).AreEqualTo(1)
+						.And.Exactly(1).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -50,7 +50,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).Exactly(1).Are(1);
+					=> await That(subject).Exactly(1).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -66,7 +66,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Exactly(4).Are(1);
+					=> await That(subject).Exactly(4).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -77,7 +77,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Exactly(4).Are(2);
+					=> await That(subject).Exactly(4).AreEqualTo(2);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -93,7 +93,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Exactly(3).Are(1);
+					=> await That(subject).Exactly(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -109,7 +109,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).Exactly(1).Are(0);
+					=> await That(subject).Exactly(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Tests.cs
@@ -38,8 +38,8 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).None().Are(15)
-						.And.None().Are(81);
+					=> await That(subject).None().AreEqualTo(15)
+						.And.None().AreEqualTo(81);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -50,7 +50,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).None().Are(5);
+					=> await That(subject).None().AreEqualTo(5);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -66,7 +66,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).None().Are(1);
+					=> await That(subject).None().AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -82,7 +82,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).None().Are(42);
+					=> await That(subject).None().AreEqualTo(42);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -93,7 +93,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).None().Are(0);
+					=> await That(subject).None().AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Tests.cs
@@ -1,0 +1,358 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class All
+	{
+		public sealed class AreEqualTo
+		{
+			public sealed class ItemTests
+			{
+				[Fact]
+				public async Task DoesNotEnumerateTwice()
+				{
+					ThrowWhenIteratingTwiceEnumerable subject = new();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(1)
+							.And.All().AreEqualTo(1);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(1);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to 1,
+						             but not all were
+						             """);
+				}
+
+				[Fact]
+				public async Task ShouldSupportNullableValues()
+				{
+					IEnumerable<int?> subject = Factory.GetConstantValueEnumerable<int?>(null, 20);
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(null);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ShouldUseCustomComparer()
+				{
+					int[] subject = Factory.GetFibonacciNumbers(20).ToArray();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(5).Using(new AllEqualComparer());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldFailAndDisplayNotMatchingItems()
+				{
+					int[] subject = Factory.GetFibonacciNumbers(20).ToArray();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(5);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to 5,
+						             but only 1 of 20 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenNoItemsDiffer_ShouldSucceed()
+				{
+					int constantValue = 42;
+					int[] subject = Factory.GetConstantValueEnumerable(constantValue, 20).ToArray();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(constantValue);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					int constantValue = 42;
+					IEnumerable<int>? subject = null!;
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(constantValue);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to 42,
+						             but it was <null>
+						             """);
+				}
+			}
+
+			public sealed class StringItemTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<string> subject = Factory.GetFibonacciNumbers(i => $"item-{i}");
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("item-1");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "item-1",
+						             but not all were
+						             """);
+				}
+
+				[Fact]
+				public async Task ShouldSupportNullableValues()
+				{
+					IEnumerable<string?> subject = Factory.GetConstantValueEnumerable<string?>(null, 20);
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(null);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ShouldUseCustomComparer()
+				{
+					string[] subject = Factory.GetFibonacciNumbers(i => $"item-{i}", 20).ToArray();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("item-5").Using(new AllEqualComparer());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldFailAndDisplayNotMatchingItems()
+				{
+					string[] subject = Factory.GetFibonacciNumbers(i => $"item-{i}", 10).ToArray();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("item-5");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "item-5",
+						             but only 1 of 10 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowAllConfigurationsInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo")
+							.IgnoringCase()
+							.IgnoringNewlineStyle()
+							.IgnoringLeadingWhiteSpace()
+							.IgnoringTrailingWhiteSpace();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring case, white-space and newline style,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringCaseInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringCase();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring case,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringLeadingWhiteSpaceInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringLeadingWhiteSpace();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring leading white-space,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringNewlineStyleInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringNewlineStyle();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring newline style,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenItemsDiffer_ShouldShowIgnoringTrailingWhiteSpaceInMessage()
+				{
+					string[] subject = ["bar"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringTrailingWhiteSpace();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo" ignoring trailing white-space,
+						             but only 0 of 1 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInCase_ShouldSucceedWhenIgnoringCase(bool ignoreCase)
+				{
+					string[] subject = ["foo", "FOO"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringCase(ignoreCase);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreCase)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo",
+						             but only 1 of 2 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInLeadingWhiteSpace_ShouldSucceedWhenIgnoringLeadingWhiteSpace(
+					bool ignoreLeadingWhiteSpace)
+				{
+					string[] subject = [" foo", "foo", "\tfoo"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreLeadingWhiteSpace)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo",
+						             but only 1 of 3 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInNewlineStyle_ShouldSucceedWhenIgnoringNewlineStyle(
+					bool ignoreNewlineStyle)
+				{
+					string[] subject = ["foo\r\nbar", "foo\nbar", "foo\rbar"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo\nbar").IgnoringNewlineStyle(ignoreNewlineStyle);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreNewlineStyle)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo\nbar",
+						             but only 1 of 3 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WhenItemsDifferInTrailingWhiteSpace_ShouldSucceedWhenIgnoringTrailingWhiteSpace(
+					bool ignoreTrailingWhiteSpace)
+				{
+					string[] subject = ["foo ", "foo", "foo\t"];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo("foo").IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
+
+					await That(Act).Throws<XunitException>().OnlyIf(!ignoreTrailingWhiteSpace)
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo",
+						             but only 1 of 3 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenNoItemsDiffer_ShouldSucceed()
+				{
+					string constantValue = "foo";
+					string[] subject = Factory.GetConstantValueEnumerable(constantValue, 20).ToArray();
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(constantValue);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					string constantValue = "foo";
+					IEnumerable<string>? subject = null;
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(constantValue);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items equal to "foo",
+						             but it was <null>
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.Tests.cs
@@ -31,8 +31,8 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).AtLeast(0).Are(1)
-						.And.AtLeast(0).Are(1);
+					=> await That(subject).AtLeast(0).AreEqualTo(1)
+						.And.AtLeast(0).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -43,7 +43,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).AtLeast(2).Are(1);
+					=> await That(subject).AtLeast(2).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -54,7 +54,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtLeast(3).Are(1);
+					=> await That(subject).AtLeast(3).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -65,7 +65,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtLeast(5).Are(1);
+					=> await That(subject).AtLeast(5).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -81,7 +81,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).AtLeast(1).Are(0);
+					=> await That(subject).AtLeast(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
@@ -36,8 +36,8 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(1)
-						.And.AtMost(3).Are(1);
+					=> await That(subject).AtMost(3).AreEqualTo(1)
+						.And.AtMost(3).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -48,7 +48,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).AtMost(1).Are(1);
+					=> await That(subject).AtMost(1).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -64,7 +64,7 @@ public sealed partial class ThatEnumerable
 				int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(2);
+					=> await That(subject).AtMost(3).AreEqualTo(2);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -75,7 +75,7 @@ public sealed partial class ThatEnumerable
 				int[] subject = [1, 1, 1, 1, 2, 2, 3];
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(1);
+					=> await That(subject).AtMost(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -91,7 +91,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(2);
+					=> await That(subject).AtMost(3).AreEqualTo(2);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -102,7 +102,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).AtMost(3).Are(1);
+					=> await That(subject).AtMost(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -118,7 +118,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).AtMost(1).Are(0);
+					=> await That(subject).AtMost(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
@@ -36,8 +36,8 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).Between(0).And(2).Are(1)
-						.And.Between(0).And(1).Are(1);
+					=> await That(subject).Between(0).And(2).AreEqualTo(1)
+						.And.Between(0).And(1).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -48,7 +48,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).Between(0).And(1).Are(1);
+					=> await That(subject).Between(0).And(1).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -64,7 +64,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Between(3).And(4).Are(1);
+					=> await That(subject).Between(3).And(4).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -75,7 +75,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Between(3).And(4).Are(2);
+					=> await That(subject).Between(3).And(4).AreEqualTo(2);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -91,7 +91,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Between(1).And(3).Are(1);
+					=> await That(subject).Between(1).And(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -107,7 +107,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).Between(0).And(1).Are(0);
+					=> await That(subject).Between(0).And(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
@@ -37,8 +37,8 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).Exactly(1).Are(1)
-						.And.Exactly(1).Are(1);
+					=> await That(subject).Exactly(1).AreEqualTo(1)
+						.And.Exactly(1).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -49,7 +49,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).Exactly(1).Are(1);
+					=> await That(subject).Exactly(1).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -65,7 +65,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Exactly(4).Are(1);
+					=> await That(subject).Exactly(4).AreEqualTo(1);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -76,7 +76,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Exactly(4).Are(2);
+					=> await That(subject).Exactly(4).AreEqualTo(2);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -92,7 +92,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).Exactly(3).Are(1);
+					=> await That(subject).Exactly(3).AreEqualTo(1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -108,7 +108,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).Exactly(1).Are(0);
+					=> await That(subject).Exactly(1).AreEqualTo(0);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.Tests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
 
 					async Task Act()
-						=> await That(subject).None().Are(8)
+						=> await That(subject).None().AreEqualTo(8)
 							.WithCancellation(token);
 
 					await That(Act).Throws<XunitException>()
@@ -38,8 +38,8 @@ public sealed partial class ThatEnumerable
 					ThrowWhenIteratingTwiceEnumerable subject = new();
 
 					async Task Act()
-						=> await That(subject).None().Are(15)
-							.And.None().Are(81);
+						=> await That(subject).None().AreEqualTo(15)
+							.And.None().AreEqualTo(81);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -50,7 +50,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 					async Task Act()
-						=> await That(subject).None().Are(5);
+						=> await That(subject).None().AreEqualTo(5);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -66,7 +66,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 					async Task Act()
-						=> await That(subject).None().Are(1);
+						=> await That(subject).None().AreEqualTo(1);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -82,7 +82,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int> subject = ToEnumerable((int[]) []);
 
 					async Task Act()
-						=> await That(subject).None().Are(0);
+						=> await That(subject).None().AreEqualTo(0);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -93,7 +93,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 					async Task Act()
-						=> await That(subject).None().Are(42);
+						=> await That(subject).None().AreEqualTo(42);
 
 					await That(Act).DoesNotThrow();
 				}
@@ -104,7 +104,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int>? subject = null;
 
 					async Task Act()
-						=> await That(subject).None().Are(0);
+						=> await That(subject).None().AreEqualTo(0);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""


### PR DESCRIPTION
Fixes #285 

Rename `Are(TItem)` to `AreEqualTo(TItem)` for collection expectations to be consistent with the `Is`/`IsEqualTo` syntax for objects/strings.