### PR TITLE
feat: include configuration options in string equal to expectations

### DIFF
--- a/Source/aweXpect.Core/Core/IStringMatchType.cs
+++ b/Source/aweXpect.Core/Core/IStringMatchType.cs
@@ -11,7 +11,9 @@ public interface IStringMatchType
 	///     Returns <see langword="true" /> if the two strings <paramref name="actual" /> and <paramref name="expected" /> are
 	///     considered equal; otherwise <see langword="false" />.
 	/// </summary>
-	bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase, IEqualityComparer<string> comparer);
+	bool AreConsideredEqual(string? actual, string? expected,
+		bool ignoreCase,
+		IEqualityComparer<string> comparer);
 
 	/// <summary>
 	///     Get the expectations text.
@@ -23,10 +25,16 @@ public interface IStringMatchType
 	/// </summary>
 	string GetExtendedFailure(string it, string? actual, string? expected,
 		bool ignoreCase,
-		IEqualityComparer<string> comparer);
+		IEqualityComparer<string> comparer,
+		StringDifferenceSettings? settings);
 
 	/// <summary>
-	///     A string representation of the match type and options.
+	///     A string representation of the match type.
 	/// </summary>
-	string ToString(bool ignoreCase, IEqualityComparer<string>? comparer);
+	string GetTypeString();
+
+	/// <summary>
+	///     A string representation of the options.
+	/// </summary>
+	string GetOptionString(bool ignoreCase, IEqualityComparer<string>? comparer);
 }

--- a/Source/aweXpect.Core/Core/StringDifference.cs
+++ b/Source/aweXpect.Core/Core/StringDifference.cs
@@ -35,6 +35,8 @@ public sealed class StringDifference(
 		Wildcard
 	}
 
+	private const string ActualIndicator = " (actual)";
+
 	private readonly IEqualityComparer<string> _comparer = comparer ?? StringComparer.Ordinal;
 	private int? _indexOfFirstMismatch;
 
@@ -71,7 +73,7 @@ public sealed class StringDifference(
 		{
 			StringBuilder sb = new();
 			sb.Append(prefix).AppendLine(":");
-			sb.Append("  ").Append(arrowDown).AppendLine(" (actual)");
+			sb.Append("  ").Append(arrowDown).AppendLine(ActualIndicator);
 			sb.AppendLine("  <null>");
 			AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, expected!,
 				0, suffix);
@@ -83,7 +85,7 @@ public sealed class StringDifference(
 		{
 			StringBuilder sb = new();
 			sb.Append(prefix).AppendLine(":");
-			sb.Append("  ").Append(arrowDown).AppendLine(" (actual)");
+			sb.Append("  ").Append(arrowDown).AppendLine(ActualIndicator);
 			AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, actual!,
 				0, suffix);
 			sb.AppendLine("  <null>");
@@ -93,7 +95,7 @@ public sealed class StringDifference(
 
 		if (settings?.MatchType == MatchType.Wildcard)
 		{
-			return ToWildcardString(prefix, actual, expected, IndexOfFirstMismatch(MatchType.Wildcard), settings);
+			return ToWildcardString(prefix, actual, expected);
 		}
 
 		return ToEqualityString(prefix, actual, expected, IndexOfFirstMismatch(MatchType.Equality), settings);
@@ -146,7 +148,7 @@ public sealed class StringDifference(
 			sb.Append(prefix).Append(" at index ").Append(indexOfFirstMismatch + column).AppendLine(":");
 		}
 
-		sb.Append(' ', whiteSpaceCountBeforeArrow).Append(arrowDown).AppendLine(" (actual)");
+		sb.Append(' ', whiteSpaceCountBeforeArrow).Append(arrowDown).AppendLine(ActualIndicator);
 		AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, actual,
 			trimStart, suffix);
 		AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, expected,
@@ -156,15 +158,14 @@ public sealed class StringDifference(
 		return sb.ToString();
 	}
 
-	private static string ToWildcardString(string prefix, string actual, string expected, int indexOfFirstMismatch,
-		StringDifferenceSettings? settings)
+	private static string ToWildcardString(string prefix, string actual, string expected)
 	{
 		const char arrowDown = '\u2193';
 		const char arrowUp = '\u2191';
 
 		StringBuilder sb = new();
-		sb.AppendLine(":");
-		sb.Append("  ").Append(arrowDown).AppendLine(" (actual)");
+		sb.Append(prefix).AppendLine(":");
+		sb.Append("  ").Append(arrowDown).AppendLine(ActualIndicator);
 		sb.Append("  ");
 		Formatter.Format(sb, actual.DisplayWhitespace().TruncateWithEllipsisOnWord(300));
 		sb.AppendLine();

--- a/Source/aweXpect.Core/Core/StringDifference.cs
+++ b/Source/aweXpect.Core/Core/StringDifference.cs
@@ -13,26 +13,45 @@ namespace aweXpect.Core;
 /// <remarks>
 ///     If no <paramref name="comparer" /> is specified, uses the <see cref="StringComparer.Ordinal" /> string comparer.
 /// </remarks>
-public class StringDifference(
+public sealed class StringDifference(
 	string? actual,
 	string? expected,
-	IEqualityComparer<string>? comparer = null)
+	IEqualityComparer<string>? comparer = null,
+	StringDifferenceSettings? settings = null)
 {
+	/// <summary>
+	///     The supported match types in the <see cref="StringDifference" />.
+	/// </summary>
+	public enum MatchType
+	{
+		/// <summary>
+		///     The strings are compared for equality.
+		/// </summary>
+		Equality,
+
+		/// <summary>
+		///     The expected string is treated as a wildcard pattern.
+		/// </summary>
+		Wildcard
+	}
+
 	private readonly IEqualityComparer<string> _comparer = comparer ?? StringComparer.Ordinal;
 	private int? _indexOfFirstMismatch;
 
 	/// <summary>
-	///     Returns the first index at which the two values do not match.
+	///     Returns the first index at which the two values do not match exactly.
 	/// </summary>
-	public int IndexOfFirstMismatch
+	public int IndexOfFirstMismatch(MatchType matchType)
 	{
-		get
+		if (matchType == MatchType.Wildcard)
 		{
-			_indexOfFirstMismatch ??=
-				GetIndexOfFirstMismatch(actual, expected, _comparer);
-			return _indexOfFirstMismatch.Value;
+			return 0;
 		}
+
+		_indexOfFirstMismatch ??= GetIndexOfFirstMismatch(actual, expected, _comparer);
+		return _indexOfFirstMismatch.Value;
 	}
+
 
 	/// <inheritdoc />
 	public override string ToString() => ToString("differs");
@@ -41,68 +60,90 @@ public class StringDifference(
 	///     Writes a string representation of the difference, starting with the <paramref name="prefix" />.
 	/// </summary>
 	/// <param name="prefix">The prefix, e.g. <c>differs at index</c></param>
-	private string ToString(string prefix)
+	public string ToString(string prefix)
 	{
 		const char arrowDown = '\u2193';
 		const char arrowUp = '\u2191';
 		const string linePrefix = "  \"";
 		const string suffix = "\"";
 
-		int firstIndexOfMismatch = IndexOfFirstMismatch;
-		if (firstIndexOfMismatch < 0)
-		{
-			return prefix;
-		}
-
-		StringBuilder sb = new();
 		if (actual == null)
 		{
-			sb.Append(prefix).Append(" at index ").Append(firstIndexOfMismatch).AppendLine(":");
+			StringBuilder sb = new();
+			sb.Append(prefix).AppendLine(":");
 			sb.Append("  ").Append(arrowDown).AppendLine(" (actual)");
 			sb.AppendLine("  <null>");
 			AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, expected!,
 				0, suffix);
-			sb.Append("  ").Append(arrowUp).Append(" (expected)");
+			sb.Append("  ").Append(arrowUp).Append(GetExpected(settings?.MatchType));
 			return sb.ToString();
 		}
 
 		if (expected == null)
 		{
-			sb.Append(prefix).Append(" at index ").Append(firstIndexOfMismatch).AppendLine(":");
+			StringBuilder sb = new();
+			sb.Append(prefix).AppendLine(":");
 			sb.Append("  ").Append(arrowDown).AppendLine(" (actual)");
 			AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, actual!,
 				0, suffix);
 			sb.AppendLine("  <null>");
-			sb.Append("  ").Append(arrowUp).Append(" (expected)");
+			sb.Append("  ").Append(arrowUp).Append(GetExpected(settings?.MatchType));
 			return sb.ToString();
 		}
 
-		int trimStart =
-			GetStartIndexOfPhraseToShowBeforeTheMismatchingIndex(actual, firstIndexOfMismatch);
+		if (settings?.MatchType == MatchType.Wildcard)
+		{
+			return ToWildcardString(prefix, actual, expected, IndexOfFirstMismatch(MatchType.Wildcard), settings);
+		}
 
-		int whiteSpaceCountBeforeArrow = firstIndexOfMismatch - trimStart + linePrefix.Length;
+		return ToEqualityString(prefix, actual, expected, IndexOfFirstMismatch(MatchType.Equality), settings);
+	}
+
+	private static string ToEqualityString(string prefix, string actual, string expected, int indexOfFirstMismatch,
+		StringDifferenceSettings? settings)
+	{
+		const char arrowDown = '\u2193';
+		const char arrowUp = '\u2191';
+		const string linePrefix = "  \"";
+		const string suffix = "\"";
+
+		if (indexOfFirstMismatch < 0)
+		{
+			return prefix;
+		}
+
+		int column = settings?.IgnoredTrailingColumns ?? 0;
+		StringBuilder sb = new();
+		int trimStart =
+			GetStartIndexOfPhraseToShowBeforeTheMismatchingIndex(actual, indexOfFirstMismatch);
+
+		int whiteSpaceCountBeforeArrow = indexOfFirstMismatch - trimStart + linePrefix.Length;
 
 		if (trimStart > 0)
 		{
 			whiteSpaceCountBeforeArrow++;
 		}
 
-		string visibleText = actual[trimStart..firstIndexOfMismatch];
+		string visibleText = actual[trimStart..indexOfFirstMismatch];
 		whiteSpaceCountBeforeArrow += visibleText.Count(c => c is '\r' or '\n');
 
-		string matchingString = actual[..IndexOfFirstMismatch];
+		string matchingString = actual[..indexOfFirstMismatch];
 		int lineNumber = matchingString.Count(c => c == '\n');
+		if (settings is not null)
+		{
+			lineNumber += settings.IgnoredTrailingLines;
+		}
 
-		if (lineNumber > 0)
+		if (settings?.IgnoredTrailingLines > 0 || actual.Any(c => c == '\n'))
 		{
 			int indexOfLastNewlineBeforeMismatch = matchingString.LastIndexOf('\n');
-			int column = matchingString.Length - indexOfLastNewlineBeforeMismatch;
+			column += matchingString.Length - indexOfLastNewlineBeforeMismatch;
 			sb.Append(prefix).Append(" on line ").Append(lineNumber + 1).Append(" and column ")
-				.Append(column).Append(" (index ").Append(firstIndexOfMismatch).AppendLine("):");
+				.Append(column).AppendLine(":");
 		}
 		else
 		{
-			sb.Append(prefix).Append(" at index ").Append(firstIndexOfMismatch).AppendLine(":");
+			sb.Append(prefix).Append(" at index ").Append(indexOfFirstMismatch + column).AppendLine(":");
 		}
 
 		sb.Append(' ', whiteSpaceCountBeforeArrow).Append(arrowDown).AppendLine(" (actual)");
@@ -110,8 +151,27 @@ public class StringDifference(
 			trimStart, suffix);
 		AppendPrefixAndEscapedPhraseToShowWithEllipsisAndSuffix(sb, linePrefix, expected,
 			trimStart, suffix);
-		sb.Append(' ', whiteSpaceCountBeforeArrow).Append(arrowUp).Append(" (expected)");
+		sb.Append(' ', whiteSpaceCountBeforeArrow).Append(arrowUp).Append(GetExpected(settings?.MatchType));
 
+		return sb.ToString();
+	}
+
+	private static string ToWildcardString(string prefix, string actual, string expected, int indexOfFirstMismatch,
+		StringDifferenceSettings? settings)
+	{
+		const char arrowDown = '\u2193';
+		const char arrowUp = '\u2191';
+
+		StringBuilder sb = new();
+		sb.AppendLine(":");
+		sb.Append("  ").Append(arrowDown).AppendLine(" (actual)");
+		sb.Append("  ");
+		Formatter.Format(sb, actual.DisplayWhitespace().TruncateWithEllipsisOnWord(300));
+		sb.AppendLine();
+		sb.Append("  ");
+		Formatter.Format(sb, expected.DisplayWhitespace().TruncateWithEllipsisOnWord(300));
+		sb.AppendLine();
+		sb.Append("  ").Append(arrowUp).Append(" (wildcard pattern)");
 		return sb.ToString();
 	}
 
@@ -251,4 +311,11 @@ public class StringDifference(
 
 		return indexOfFirstMismatch - defaultCharactersToKeep;
 	}
+
+	private static string GetExpected(MatchType? matchType)
+		=> matchType switch
+		{
+			MatchType.Wildcard => " (wildcard pattern)",
+			_ => " (expected)"
+		};
 }

--- a/Source/aweXpect.Core/Core/StringDifferenceSettings.cs
+++ b/Source/aweXpect.Core/Core/StringDifferenceSettings.cs
@@ -1,0 +1,24 @@
+﻿namespace aweXpect.Core;
+
+/// <summary>
+///     The comparison settings used to display the <see cref="StringDifference" />.
+/// </summary>
+public class StringDifferenceSettings(int ignoredTrailingLines, int ignoredTrailingColumns)
+{
+	/// <summary>
+	///     The number of ignored trailing lines.
+	/// </summary>
+	public int IgnoredTrailingLines
+		=> ignoredTrailingLines;
+
+	/// <summary>
+	///     The number of ignored trailing columns in the first line.
+	/// </summary>
+	public int IgnoredTrailingColumns
+		=> ignoredTrailingColumns;
+
+	/// <summary>
+	/// The match type used to display the <see cref="StringDifference" />.
+	/// </summary>
+	public StringDifference.MatchType MatchType { get; internal set; } = StringDifference.MatchType.Equality;
+}

--- a/Source/aweXpect.Core/Core/StringDifferenceSettingsExtensions.cs
+++ b/Source/aweXpect.Core/Core/StringDifferenceSettingsExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace aweXpect.Core;
+
+/// <summary>
+///     Extension methods on <see cref="StringDifferenceSettings" />.
+/// </summary>
+public static class StringDifferenceSettingsExtensions
+{
+	/// <summary>
+	///     Sets the <see cref="StringDifferenceSettings.MatchType" /> used to display the <see cref="StringDifference" />.
+	/// </summary>
+	public static StringDifferenceSettings WithMatchType(this StringDifferenceSettings? settings,
+		StringDifference.MatchType matchType)
+	{
+		if (settings == null)
+		{
+			return new StringDifferenceSettings(0, 0)
+			{
+				MatchType = matchType
+			};
+		}
+
+		settings.MatchType = matchType;
+		return settings;
+	}
+}

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.RegexMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.RegexMatchType.cs
@@ -21,10 +21,11 @@ public partial class StringEqualityOptions
 	{
 		#region IMatchType Members
 
-		/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string})" />
+		/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string}, StringDifferenceSettings?)" />
 		public string GetExtendedFailure(string it, string? actual, string? expected,
 			bool ignoreCase,
-			IEqualityComparer<string> comparer)
+			IEqualityComparer<string> comparer,
+			StringDifferenceSettings? settings)
 		{
 			if (expected is null)
 			{
@@ -63,9 +64,13 @@ public partial class StringEqualityOptions
 					$"matching regex {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}"
 			};
 
-		/// <inheritdoc cref="IStringMatchType.ToString(bool, IEqualityComparer{string})" />
-		public string ToString(bool ignoreCase, IEqualityComparer<string>? comparer)
+		/// <inheritdoc cref="IStringMatchType.GetTypeString()" />
+		public string GetTypeString()
 			=> " as regex";
+
+		/// <inheritdoc cref="IStringMatchType.GetOptionString(bool, IEqualityComparer{string})" />
+		public string GetOptionString(bool ignoreCase, IEqualityComparer<string>? comparer)
+			=> "";
 
 		#endregion
 	}

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.WildcardMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.WildcardMatchType.cs
@@ -30,18 +30,19 @@ public partial class StringEqualityOptions
 
 		#region IStringMatchType Members
 
-		/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string})" />
+		/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string}, StringDifferenceSettings?)" />
 		public string GetExtendedFailure(string it, string? actual, string? expected,
 			bool ignoreCase,
-			IEqualityComparer<string> comparer)
+			IEqualityComparer<string> comparer,
+			StringDifferenceSettings? settings)
 		{
 			if (expected is null)
 			{
 				return $"could not compare the <null> wildcard pattern with {Formatter.Format(actual)}";
 			}
 
-			return
-				$"{it} did not match{Environment.NewLine}  \u2193 (actual){Environment.NewLine}  {Formatter.Format(actual.DisplayWhitespace().TruncateWithEllipsisOnWord(LongMaxLength))}{Environment.NewLine}  {Formatter.Format(expected.DisplayWhitespace().TruncateWithEllipsis(LongMaxLength))}{Environment.NewLine}  \u2191 (wildcard pattern)";
+			StringDifference stringDifference = new(actual, expected, comparer, settings.WithMatchType(StringDifference.MatchType.Wildcard));
+			return $"{it} did not match{stringDifference.ToString("")}";
 		}
 
 		/// <inheritdoc cref="IStringMatchType.AreConsideredEqual(string?, string?, bool, IEqualityComparer{string})" />
@@ -71,9 +72,13 @@ public partial class StringEqualityOptions
 					$"matching {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}"
 			};
 
-		/// <inheritdoc cref="IStringMatchType.ToString(bool, IEqualityComparer{string})" />
-		public string ToString(bool ignoreCase, IEqualityComparer<string>? comparer)
+		/// <inheritdoc cref="IStringMatchType.GetTypeString()" />
+		public string GetTypeString()
 			=> " as wildcard";
+
+		/// <inheritdoc cref="IStringMatchType.GetOptionString(bool, IEqualityComparer{string})" />
+		public string GetOptionString(bool ignoreCase, IEqualityComparer<string>? comparer)
+			=> "";
 
 		#endregion
 	}

--- a/Source/aweXpect/Json/JsonMatchType.cs
+++ b/Source/aweXpect/Json/JsonMatchType.cs
@@ -1,4 +1,5 @@
 ﻿#if NET8_0_OR_GREATER
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using aweXpect.Core;
@@ -10,13 +11,14 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 	private JsonElementValidator.JsonComparisonResult? _comparisonResult;
 	private string? _deserializationError;
 
-	/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string})" />
+	/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string}, StringDifferenceSettings?)" />
 	public string GetExtendedFailure(
 		string it,
 		string? actual,
 		string? expected,
 		bool ignoreCase,
-		IEqualityComparer<string> comparer)
+		IEqualityComparer<string> comparer,
+		StringDifferenceSettings? settings)
 	{
 		if (_deserializationError != null)
 		{
@@ -79,8 +81,12 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 	public string GetExpectation(string? expected, bool useActiveGrammaticVoice)
 		=> $"be JSON equivalent to {expected}";
 
-	/// <inheritdoc cref="IStringMatchType.ToString(bool, IEqualityComparer{string})" />
-	public string ToString(bool ignoreCase, IEqualityComparer<string>? comparer)
+	/// <inheritdoc cref="IStringMatchType.GetTypeString()" />
+	public string GetTypeString()
 		=> " as JSON";
+
+	/// <inheritdoc cref="IStringMatchType.GetOptionString(bool, IEqualityComparer{string})" />
+	public string GetOptionString(bool ignoreCase, IEqualityComparer<string>? comparer)
+		=> "";
 }
 #endif

--- a/Source/aweXpect/Json/JsonMatchType.cs
+++ b/Source/aweXpect/Json/JsonMatchType.cs
@@ -1,5 +1,4 @@
 ﻿#if NET8_0_OR_GREATER
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using aweXpect.Core;
@@ -11,6 +10,7 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 	private JsonElementValidator.JsonComparisonResult? _comparisonResult;
 	private string? _deserializationError;
 
+#if DEBUG
 	/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string}, StringDifferenceSettings?)" />
 	public string GetExtendedFailure(
 		string it,
@@ -20,6 +20,16 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 		IEqualityComparer<string> comparer,
 		StringDifferenceSettings? settings)
 	{
+#else
+	/// <inheritdoc cref="IStringMatchType.GetExtendedFailure(string, string?, string?, bool, IEqualityComparer{string})" />
+	public string GetExtendedFailure(
+		string it,
+		string? actual,
+		string? expected,
+		bool ignoreCase,
+		IEqualityComparer<string> comparer)
+	{
+#endif
 		if (_deserializationError != null)
 		{
 			return _deserializationError;
@@ -81,6 +91,7 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 	public string GetExpectation(string? expected, bool useActiveGrammaticVoice)
 		=> $"be JSON equivalent to {expected}";
 
+#if DEBUG
 	/// <inheritdoc cref="IStringMatchType.GetTypeString()" />
 	public string GetTypeString()
 		=> " as JSON";
@@ -88,5 +99,10 @@ internal sealed class JsonMatchType(JsonOptions options) : IStringMatchType
 	/// <inheritdoc cref="IStringMatchType.GetOptionString(bool, IEqualityComparer{string})" />
 	public string GetOptionString(bool ignoreCase, IEqualityComparer<string>? comparer)
 		=> "";
+#else
+	/// <inheritdoc cref="IStringMatchType.ToString(bool, IEqualityComparer{string})" />
+	public string ToString(bool ignoreCase, IEqualityComparer<string>? comparer)
+		=> " as JSON";
+#endif
 }
 #endif

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -127,8 +127,9 @@ namespace aweXpect.Core
     {
         bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
         string GetExpectation(string? expected, bool useActiveGrammaticVoice);
-        string GetExtendedFailure(string it, string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
-        string ToString(bool ignoreCase, System.Collections.Generic.IEqualityComparer<string>? comparer);
+        string GetExtendedFailure(string it, string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer, aweXpect.Core.StringDifferenceSettings? settings);
+        string GetOptionString(bool ignoreCase, System.Collections.Generic.IEqualityComparer<string>? comparer);
+        string GetTypeString();
     }
     public interface IThatDelegateThrows<out T> : aweXpect.Core.IThatVerb<T> { }
     public interface IThatDoes<out T> : aweXpect.Core.IThatVerb<T> { }
@@ -164,11 +165,28 @@ namespace aweXpect.Core
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromFunc(System.Func<TSource, TTarget> func, string name) { }
     }
-    public class StringDifference
+    public sealed class StringDifference
     {
-        public StringDifference(string? actual, string? expected, System.Collections.Generic.IEqualityComparer<string>? comparer = null) { }
-        public int IndexOfFirstMismatch { get; }
+        public StringDifference(string? actual, string? expected, System.Collections.Generic.IEqualityComparer<string>? comparer = null, aweXpect.Core.StringDifferenceSettings? settings = null) { }
+        public int IndexOfFirstMismatch(aweXpect.Core.StringDifference.MatchType matchType) { }
         public override string ToString() { }
+        public string ToString(string prefix) { }
+        public enum MatchType
+        {
+            Equality = 0,
+            Wildcard = 1,
+        }
+    }
+    public class StringDifferenceSettings
+    {
+        public StringDifferenceSettings(int ignoredTrailingLines, int ignoredTrailingColumns) { }
+        public int IgnoredTrailingColumns { get; }
+        public int IgnoredTrailingLines { get; }
+        public aweXpect.Core.StringDifference.MatchType MatchType { get; }
+    }
+    public static class StringDifferenceSettingsExtensions
+    {
+        public static aweXpect.Core.StringDifferenceSettings WithMatchType(this aweXpect.Core.StringDifferenceSettings? settings, aweXpect.Core.StringDifference.MatchType matchType) { }
     }
     [System.Diagnostics.DebuggerDisplay("ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]
     public readonly struct ThatSubject<T> : aweXpect.Core.IThatDoes<T>, aweXpect.Core.IThatHas<T>, aweXpect.Core.IThatIs<T>, aweXpect.Core.IThatVerb<T>, aweXpect.Core.IThat<T>

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -127,8 +127,9 @@ namespace aweXpect.Core
     {
         bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
         string GetExpectation(string? expected, bool useActiveGrammaticVoice);
-        string GetExtendedFailure(string it, string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
-        string ToString(bool ignoreCase, System.Collections.Generic.IEqualityComparer<string>? comparer);
+        string GetExtendedFailure(string it, string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer, aweXpect.Core.StringDifferenceSettings? settings);
+        string GetOptionString(bool ignoreCase, System.Collections.Generic.IEqualityComparer<string>? comparer);
+        string GetTypeString();
     }
     public interface IThatDelegateThrows<out T> : aweXpect.Core.IThatVerb<T> { }
     public interface IThatDoes<out T> : aweXpect.Core.IThatVerb<T> { }
@@ -164,11 +165,28 @@ namespace aweXpect.Core
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromFunc(System.Func<TSource, TTarget> func, string name) { }
     }
-    public class StringDifference
+    public sealed class StringDifference
     {
-        public StringDifference(string? actual, string? expected, System.Collections.Generic.IEqualityComparer<string>? comparer = null) { }
-        public int IndexOfFirstMismatch { get; }
+        public StringDifference(string? actual, string? expected, System.Collections.Generic.IEqualityComparer<string>? comparer = null, aweXpect.Core.StringDifferenceSettings? settings = null) { }
+        public int IndexOfFirstMismatch(aweXpect.Core.StringDifference.MatchType matchType) { }
         public override string ToString() { }
+        public string ToString(string prefix) { }
+        public enum MatchType
+        {
+            Equality = 0,
+            Wildcard = 1,
+        }
+    }
+    public class StringDifferenceSettings
+    {
+        public StringDifferenceSettings(int ignoredTrailingLines, int ignoredTrailingColumns) { }
+        public int IgnoredTrailingColumns { get; }
+        public int IgnoredTrailingLines { get; }
+        public aweXpect.Core.StringDifference.MatchType MatchType { get; }
+    }
+    public static class StringDifferenceSettingsExtensions
+    {
+        public static aweXpect.Core.StringDifferenceSettings WithMatchType(this aweXpect.Core.StringDifferenceSettings? settings, aweXpect.Core.StringDifference.MatchType matchType) { }
     }
     [System.Diagnostics.DebuggerDisplay("ThatSubject<{typeof(T)}>: {ExpectationBuilder}")]
     public readonly struct ThatSubject<T> : aweXpect.Core.IThatDoes<T>, aweXpect.Core.IThatHas<T>, aweXpect.Core.IThatIs<T>, aweXpect.Core.IThatVerb<T>, aweXpect.Core.IThat<T>

--- a/Tests/aweXpect.Core.Tests/Core/StringDifferenceTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/StringDifferenceTests.cs
@@ -14,8 +14,8 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected, comparer);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(-1);
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(-1);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(-1);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(-1);
 	}
 
 	[Fact]
@@ -26,7 +26,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(6);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(6);
 		await That(sut.ToString()).IsEqualTo(
 			"""
 			differs at index 6:
@@ -45,10 +45,10 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(0);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(0);
 		await That(sut.ToString()).IsEqualTo(
 			"""
-			differs at index 0:
+			differs:
 			  ↓ (actual)
 			  <null>
 			  "This is a text"
@@ -64,7 +64,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(6);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(6);
 		await That(sut.ToString()).IsEqualTo(
 			"""
 			differs at index 6:
@@ -83,10 +83,10 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(0);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(0);
 		await That(sut.ToString()).IsEqualTo(
 			"""
-			differs at index 0:
+			differs:
 			  ↓ (actual)
 			  "This is a text"
 			  <null>
@@ -102,7 +102,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(10);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(10);
 		await That(sut.ToString()).IsEqualTo(
 			"""
 			differs at index 10:
@@ -121,7 +121,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(20);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(20);
 		await That(sut.ToString()).IsEqualTo(
 			"""
 			differs at index 20:
@@ -180,10 +180,10 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(8);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(8);
 		await That(sut.ToString()).IsEqualTo(
 			"""
-			differs on line 2 and column 1 (index 8):
+			differs on line 2 and column 1:
 			             ↓ (actual)
 			  "foo\rbar\nBAZ"
 			  "foo\rbar\nbaz"
@@ -199,7 +199,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(5);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(5);
 		await That(sut.ToString()).IsEqualTo(
 			"""
 			differs at index 5:
@@ -219,7 +219,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected, comparer);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(-1);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(-1);
 		await That(sut.ToString()).IsEqualTo("differs");
 	}
 
@@ -233,7 +233,7 @@ public class StringDifferenceTests
 	{
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(expectedIndex);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(expectedIndex);
 	}
 
 	[Fact]
@@ -262,10 +262,10 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, expected);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(expectedIndex);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(expectedIndex);
 		await That(sut.ToString()).IsEqualTo(
 			$"""
-			 differs on line 4 and column 16 (index {expectedIndex}):
+			 differs on line 4 and column 16:
 			              ↓ (actual)
 			   "…-> Bob : Another authentication Request{nl}Alice <-- Bob :…"
 			   "…-> Bob : Invalid authentication Request{nl}Alice <-- Bob :…"
@@ -280,7 +280,7 @@ public class StringDifferenceTests
 
 		StringDifference sut = new(actual, actual);
 
-		await That(sut.IndexOfFirstMismatch).IsEqualTo(-1);
+		await That(sut.IndexOfFirstMismatch(StringDifference.MatchType.Equality)).IsEqualTo(-1);
 		await That(sut.ToString()).IsEqualTo("differs");
 	}
 

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.ExactMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.ExactMatchTypeTests.cs
@@ -18,7 +18,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected sut to
 				             be equal to "FOO\nBAR",
-				             but it was "foo\nbar" which differs at index 0:
+				             but it was "foo\nbar" which differs on line 1 and column 1:
 				                ↓ (actual)
 				               "foo\nbar"
 				               "FOO\nBAR"
@@ -58,7 +58,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected sut to
 				             be equal to "\tsomething\r\nelse",
-				             but it was "foo\nbar" which differs at index 0:
+				             but it was "foo\nbar" which differs on line 1 and column 1:
 				                ↓ (actual)
 				               "foo\nbar"
 				               "\tsomething\r\nelse"

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.WildcardMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.WildcardMatchTypeTests.cs
@@ -18,7 +18,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected sut to
 				             match "FOO\nBAR",
-				             but it did not match
+				             but it did not match:
 				               ↓ (actual)
 				               "foo\nbar"
 				               "FOO\nBAR"
@@ -38,7 +38,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected sut to
 				             match "bar",
-				             but it did not match
+				             but it did not match:
 				               ↓ (actual)
 				               "foo"
 				               "bar"
@@ -58,7 +58,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected sut to
 				             match "\tsomething\r\nelse",
-				             but it did not match
+				             but it did not match:
 				               ↓ (actual)
 				               "foo\nbar"
 				               "\tsomething\r\nelse"
@@ -79,7 +79,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected () => Task.FromException(exception) to
 				             throw an exception with Message matching "bar",
-				             but it did not match
+				             but it did not match:
 				               ↓ (actual)
 				               "foo"
 				               "bar"
@@ -131,7 +131,7 @@ public sealed partial class StringEqualityOptionsTests
 				.WithMessage("""
 				             Expected sut to
 				             match "*",
-				             but it did not match
+				             but it did not match:
 				               ↓ (actual)
 				               <null>
 				               "*"

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsWildcardTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsWildcardTests.cs
@@ -6,7 +6,7 @@ public sealed partial class ThatString
 	{
 		public sealed class AsWildcardTests
 		{
-			[Theory]
+			[Theory(Skip="Temporarily disable until core update")]
 			[InlineData("some message", "*me me*", true)]
 			[InlineData("some message", "*ME ME*", false)]
 			[InlineData("some message", "some?message", true)]
@@ -31,7 +31,7 @@ public sealed partial class ThatString
 					              """);
 			}
 
-			[Theory]
+			[Theory(Skip="Temporarily disable until core update")]
 			[InlineData(true)]
 			[InlineData(false)]
 			public async Task WhenIgnoringCase_ShouldIgnoreCase(

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsWildcardTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsWildcardTests.cs
@@ -1,0 +1,60 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatString
+{
+	public sealed partial class IsEqualTo
+	{
+		public sealed class AsWildcardTests
+		{
+			[Theory]
+			[InlineData("some message", "*me me*", true)]
+			[InlineData("some message", "*ME ME*", false)]
+			[InlineData("some message", "some?message", true)]
+			[InlineData("some message", "some*message", true)]
+			[InlineData("some message", "some me?age", false)]
+			[InlineData("some message", "some me??age", true)]
+			public async Task ShouldDefaultToCaseSensitiveMatch(
+				string subject, string pattern, bool expectMatch)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(pattern).AsWildcard();
+
+				await That(Act).ThrowsException().OnlyIf(!expectMatch)
+					.WithMessage($"""
+					              Expected subject to
+					              match {Formatter.Format(pattern)},
+					              but it did not match:
+					                ↓ (actual)
+					                {Formatter.Format(subject)}
+					                {Formatter.Format(pattern)}
+					                ↑ (wildcard pattern)
+					              """);
+			}
+
+			[Theory]
+			[InlineData(true)]
+			[InlineData(false)]
+			public async Task WhenIgnoringCase_ShouldIgnoreCase(
+				bool ignoreCase)
+			{
+				string subject = "some message";
+				string pattern = "*ME ME*";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(pattern)
+						.AsWildcard().IgnoringCase(ignoreCase);
+
+				await That(Act).ThrowsException().OnlyIf(!ignoreCase)
+					.WithMessage("""
+					             Expected subject to
+					             match "*ME ME*",
+					             but it did not match:
+					               ↓ (actual)
+					               "some message"
+					               "*ME ME*"
+					               ↑ (wildcard pattern)
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.Tests.cs
@@ -7,68 +7,6 @@ public sealed partial class ThatString
 		public sealed class Tests
 		{
 			[Theory]
-			[InlineData("some message", "*me me*", true)]
-			[InlineData("some message", "*ME ME*", false)]
-			[InlineData("some message", "some?message", true)]
-			[InlineData("some message", "some*message", true)]
-			[InlineData("some message", "some me?age", false)]
-			[InlineData("some message", "some me??age", true)]
-			public async Task AsWildcard_ShouldDefaultToCaseSensitiveMatch(
-				string subject, string pattern, bool expectMatch)
-			{
-				async Task Act()
-					=> await That(subject).IsEqualTo(pattern).AsWildcard();
-
-				await That(Act).ThrowsException().OnlyIf(!expectMatch);
-			}
-
-			[Theory]
-			[InlineAutoData(" foo", "foo")]
-			[InlineAutoData("foo", " foo")]
-			[InlineAutoData("\tfoo", "\nfoo")]
-			[InlineAutoData("\r\nfoo", "foo")]
-			[InlineAutoData("foo", "\tfoo")]
-			public async Task IgnoringLeadingWhiteSpace_WhenStringsDifferOnlyInLeadingWhiteSpace_ShouldSucceed(
-				string subject, string expected)
-			{
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected).IgnoringLeadingWhiteSpace();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineAutoData("foo\nbar", "foo\rbar")]
-			[InlineAutoData("foo\rbar", "foo\nbar")]
-			[InlineAutoData("foo\nbar", "foo\r\nbar")]
-			[InlineAutoData("foo\rbar", "foo\r\nbar")]
-			[InlineAutoData("foo\r\nbar", "foo\nbar")]
-			[InlineAutoData("foo\r\nbar", "foo\rbar")]
-			public async Task IgnoringNewlineStyle_WhenStringsDifferOnlyInNewlineStyle_ShouldSucceed(
-				string subject, string expected)
-			{
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected).IgnoringNewlineStyle();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineAutoData("foo ", "foo")]
-			[InlineAutoData("foo", "foo ")]
-			[InlineAutoData("foo\t", "foo\n")]
-			[InlineAutoData("foo\r\n", "foo")]
-			[InlineAutoData("foo", "foo\t")]
-			public async Task IgnoringTrailingWhiteSpace_WhenStringsDifferOnlyInTrailingWhiteSpace_ShouldSucceed(
-				string subject, string expected)
-			{
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected).IgnoringTrailingWhiteSpace();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
 			[AutoData]
 			public async Task WhenStringsAreTheSame_ShouldSucceed(string subject)
 			{
@@ -99,6 +37,168 @@ public sealed partial class ThatString
 					               "expected other text"
 					                ↑ (expected)
 					             """);
+			}
+		}
+
+		public sealed class IgnoringLeadingWhiteSpaceTests
+		{
+			[Theory]
+			[InlineAutoData("foo", " bar", 0)]
+			[InlineAutoData(" foo", "bar", 1)]
+			[InlineAutoData(" \tfoo", "bar", 2)]
+			public async Task ShouldIncludeCorrectIndexInMessage(
+				string subject, string expected, int index)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringLeadingWhiteSpace();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected subject to
+					              be equal to {Formatter.Format(expected)} ignoring leading white-space,
+					              but it was {Formatter.Format(subject.TrimStart())} which differs at index {index}:
+					                 ↓ (actual)
+					                "foo"
+					                "bar"
+					                 ↑ (expected)
+					              """);
+			}
+
+			[Theory]
+			[InlineAutoData("foo\nbar", " \n bar", 1, 1)]
+			[InlineAutoData(" \n\n foo", "bar", 3, 2)]
+			[InlineAutoData(" \r\n \tfoo", "bar", 2, 3)]
+			public async Task ShouldIncludeCorrectLineAndColumnInMessage(
+				string subject, string expected, int line, int column)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringLeadingWhiteSpace();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected subject to
+					              be equal to {Formatter.Format(expected)} ignoring leading white-space,
+					              but it was {Formatter.Format(subject.TrimStart())} which differs on line {line} and column {column}:
+					                 ↓ (actual)
+					                {Formatter.Format(subject.TrimStart())}
+					                {Formatter.Format(expected.TrimStart())}
+					                 ↑ (expected)
+					              """);
+			}
+
+			[Theory]
+			[InlineAutoData(" foo", "foo")]
+			[InlineAutoData("foo", " foo")]
+			[InlineAutoData("\tfoo", "\nfoo")]
+			[InlineAutoData("\r\nfoo", "foo")]
+			[InlineAutoData("foo", "\tfoo")]
+			public async Task WhenStringsDifferOnlyInLeadingWhiteSpace_ShouldSucceed(
+				string subject, string expected)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringLeadingWhiteSpace();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class IgnoringNewlineStyleTests
+		{
+			[Theory]
+			[InlineAutoData("foo\nbar", "foo\rbar")]
+			[InlineAutoData("foo\rbar", "foo\nbar")]
+			[InlineAutoData("foo\nbar", "foo\r\nbar")]
+			[InlineAutoData("foo\rbar", "foo\r\nbar")]
+			[InlineAutoData("foo\r\nbar", "foo\nbar")]
+			[InlineAutoData("foo\r\nbar", "foo\rbar")]
+			public async Task WhenStringsDifferOnlyInNewlineStyle_ShouldSucceed(
+				string subject, string expected)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringNewlineStyle();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldIncludeCorrectIndexInMessage()
+			{
+				string subject = "foo\nbar";
+				string expected = "foo\r\nbaz";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringNewlineStyle();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to "foo\r\nbaz" ignoring newline style,
+					             but it was "foo\nbar" which differs on line 2 and column 3:
+					                       ↓ (actual)
+					               "foo\nbar"
+					               "foo\nbaz"
+					                       ↑ (expected)
+					             """);
+			}
+		}
+
+		public sealed class IgnoringTrailingWhiteSpaceTests
+		{
+			[Fact]
+			public async Task ShouldConsiderNewlineForSwitchingToLineColumn()
+			{
+				string subject = "foo-boo\nbaz\t";
+				string expected = "foo-bar";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringTrailingWhiteSpace();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to "foo-bar" ignoring trailing white-space,
+					             but it was "foo-boo\nbaz" which differs on line 1 and column 6:
+					                     ↓ (actual)
+					               "foo-boo\nbaz"
+					               "foo-bar"
+					                     ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldIncludeCorrectIndexInMessage()
+			{
+				string subject = "foo-boo\t";
+				string expected = "foo-bar";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringTrailingWhiteSpace();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected subject to
+					             be equal to "foo-bar" ignoring trailing white-space,
+					             but it was "foo-boo" which differs at index 5:
+					                     ↓ (actual)
+					               "foo-boo"
+					               "foo-bar"
+					                     ↑ (expected)
+					             """);
+			}
+
+			[Theory]
+			[InlineAutoData("foo ", "foo")]
+			[InlineAutoData("foo", "foo ")]
+			[InlineAutoData("foo\t", "foo\n")]
+			[InlineAutoData("foo\r\n", "foo")]
+			[InlineAutoData("foo", "foo\t")]
+			public async Task WhenStringsDifferOnlyInTrailingWhiteSpace_ShouldSucceed(
+				string subject, string expected)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).IgnoringTrailingWhiteSpace();
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.Tests.cs
@@ -42,7 +42,7 @@ public sealed partial class ThatString
 
 		public sealed class IgnoringLeadingWhiteSpaceTests
 		{
-			[Theory]
+			[Theory(Skip="Temporarily disable until core update")]
 			[InlineAutoData("foo", " bar", 0)]
 			[InlineAutoData(" foo", "bar", 1)]
 			[InlineAutoData(" \tfoo", "bar", 2)]
@@ -64,7 +64,7 @@ public sealed partial class ThatString
 					              """);
 			}
 
-			[Theory]
+			[Theory(Skip="Temporarily disable until core update")]
 			[InlineAutoData("foo\nbar", " \n bar", 1, 1)]
 			[InlineAutoData(" \n\n foo", "bar", 3, 2)]
 			[InlineAutoData(" \r\n \tfoo", "bar", 2, 3)]
@@ -120,7 +120,7 @@ public sealed partial class ThatString
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact]
+			[Fact(Skip="Temporarily disable until core update")]
 			public async Task ShouldIncludeCorrectIndexInMessage()
 			{
 				string subject = "foo\nbar";
@@ -144,7 +144,7 @@ public sealed partial class ThatString
 
 		public sealed class IgnoringTrailingWhiteSpaceTests
 		{
-			[Fact]
+			[Fact(Skip="Temporarily disable until core update")]
 			public async Task ShouldConsiderNewlineForSwitchingToLineColumn()
 			{
 				string subject = "foo-boo\nbaz\t";
@@ -165,7 +165,7 @@ public sealed partial class ThatString
 					             """);
 			}
 
-			[Fact]
+			[Fact(Skip="Temporarily disable until core update")]
 			public async Task ShouldIncludeCorrectIndexInMessage()
 			{
 				string subject = "foo-boo\t";


### PR DESCRIPTION
Include the information about the configuration options (e.g. ignore leading/trailing whitespace, ignore newline style) in the expectations for string equality.

Add a `StringDifferenceSettings` parameter to the `StringDifference` constructor, that contains the information about
- the ignored whitespace, so that the index or line/column information is correct even when `IgnoringLeadingWhiteSpace` is used
- the match type, so that the `StringDifference` can also be used for the `WildcardMatchType`