### PR TITLE
refactor!: move `PropertyResult` to aweXpect.Core

### DIFF
--- a/Source/aweXpect.Core/Core/Helpers/ExpectHelpers.cs
+++ b/Source/aweXpect.Core/Core/Helpers/ExpectHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using aweXpect.Core;
+
+namespace aweXpect.Core.Helpers;
+
+internal static class ExpectHelpers
+{
+	public static IThatIs<T> ThatIs<T>(this IThat<T> subject)
+	{
+		if (subject is IThatIs<T> thatIs)
+		{
+			return thatIs;
+		}
+
+		if (subject is IThatVerb<T> thatVerb)
+		{
+			return new ThatSubject<T>(thatVerb.ExpectationBuilder);
+		}
+
+		throw new NotSupportedException("IThat<T> must also implement IThatIs<T>");
+	}
+}

--- a/Source/aweXpect.Core/Results/PropertyResult.cs
+++ b/Source/aweXpect.Core/Results/PropertyResult.cs
@@ -1,8 +1,7 @@
-﻿#if !DEBUG
-using System;
+﻿using System;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
-using aweXpect.Helpers;
+using aweXpect.Core.Helpers;
 
 namespace aweXpect.Results;
 
@@ -530,4 +529,3 @@ public static class PropertyResult
 			=> expectation;
 	}
 }
-#endif

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -783,6 +783,55 @@ namespace aweXpect.Results
         public ObjectEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
+    public static class PropertyResult
+    {
+        public class DateTimeKind<TItem>
+        {
+            public DateTimeKind(aweXpect.Core.IThat<TItem> source, System.Func<TItem, System.DateTimeKind?> mapper, string propertyExpression) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(System.DateTimeKind expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(System.DateTimeKind unexpected) { }
+        }
+        public class Int<TItem>
+        {
+            public Int(aweXpect.Core.IThat<TItem> source, System.Func<TItem, int?> mapper, string propertyExpression, System.Action<int?, string>? validation = null) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(int? unexpected) { }
+        }
+        public class NullableInt<TItem>
+        {
+            public NullableInt(aweXpect.Core.IThat<TItem> source, System.Func<TItem, int?> mapper, string propertyExpression, System.Action<int?, string>? validation = null) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(int? unexpected) { }
+        }
+        public class NullableLong<TItem>
+        {
+            public NullableLong(aweXpect.Core.IThat<TItem> source, System.Func<TItem, long?> mapper, string propertyExpression, System.Action<long?, string>? validation = null) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(long? unexpected) { }
+        }
+        public class TimeSpan<TItem>
+        {
+            public TimeSpan(aweXpect.Core.IThat<TItem> source, System.Func<TItem, System.TimeSpan?> mapper, string propertyExpression) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(System.TimeSpan? unexpected) { }
+        }
+    }
     public class StringCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat, aweXpect.Results.StringCountResult<TType, TThat>>
     {
         public StringCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -770,6 +770,55 @@ namespace aweXpect.Results
         public ObjectEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions options) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
+    public static class PropertyResult
+    {
+        public class DateTimeKind<TItem>
+        {
+            public DateTimeKind(aweXpect.Core.IThat<TItem> source, System.Func<TItem, System.DateTimeKind?> mapper, string propertyExpression) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(System.DateTimeKind expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(System.DateTimeKind unexpected) { }
+        }
+        public class Int<TItem>
+        {
+            public Int(aweXpect.Core.IThat<TItem> source, System.Func<TItem, int?> mapper, string propertyExpression, System.Action<int?, string>? validation = null) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(int? unexpected) { }
+        }
+        public class NullableInt<TItem>
+        {
+            public NullableInt(aweXpect.Core.IThat<TItem> source, System.Func<TItem, int?> mapper, string propertyExpression, System.Action<int?, string>? validation = null) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(int? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(int? unexpected) { }
+        }
+        public class NullableLong<TItem>
+        {
+            public NullableLong(aweXpect.Core.IThat<TItem> source, System.Func<TItem, long?> mapper, string propertyExpression, System.Action<long?, string>? validation = null) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(long? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(long? unexpected) { }
+        }
+        public class TimeSpan<TItem>
+        {
+            public TimeSpan(aweXpect.Core.IThat<TItem> source, System.Func<TItem, System.TimeSpan?> mapper, string propertyExpression) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> EqualTo(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThan(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> GreaterThanOrEqualTo(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThan(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> LessThanOrEqualTo(System.TimeSpan? expected) { }
+            public aweXpect.Results.AndOrResult<TItem, aweXpect.Core.IThat<TItem>> NotEqualTo(System.TimeSpan? unexpected) { }
+        }
+    }
     public class StringCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat, aweXpect.Results.StringCountResult<TType, TThat>>
     {
         public StringCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }


### PR DESCRIPTION
Part one for moving the `PropertyResult` class to aweXpect.Core, so that it can be used by extension projects.