### PR TITLE
refactor: simplify build pipeline to push nuget packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
     pack:
         name: "Pack"
         runs-on: ubuntu-latest
-        needs: [ publish-test-results, benchmarks ]
+        needs: [ publish-test-results, benchmarks, static-code-analysis ]
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -167,7 +167,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack, mutation-tests, static-code-analysis ]
+        needs: [ pack, mutation-tests ]
         permissions:
             contents: write
         steps:
@@ -209,7 +209,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack, mutation-tests, static-code-analysis ]
+        needs: [ pack ]
         steps:
             -   name: Download packages
                 uses: actions/download-artifact@v4


### PR DESCRIPTION
Remove the need for "MutationTests" for publishing a Core package (as it will always be followed by a main package shortly).