### PR TITLE
feat: add `ComplyWith` for collections

### DIFF
--- a/Docs/pages/docs/expectations/collections.md
+++ b/Docs/pages/docs/expectations/collections.md
@@ -72,15 +72,40 @@ IDictionary<int, int> subject = new Dictionary<int, int>
 await Expect.That(subject).AreAllUnique();
 ```
 
-## All satisfy
+## Elements
 
-You can verify, that all items in a collection satisfy a condition:
+You can add expectations that a certain number of elements must meet.
+
+### Comply with
+
+You can verify, that items in a collection comply with an expectation on the individual elements:
 
 ```csharp
-await Expect.That([1, 2, 3]).All().Satisfy(x => x < 4);
+await Expect.That([1, 2, 3]).All().ComplyWith(item => item.IsLessThan(4));
+await Expect.That([1, 2, 3]).AtLeast(2).ComplyWith(item => item.IsGreaterThanOrEqualTo(2));
+await Expect.That([1, 2, 3]).AtMost(1).ComplyWith(item => item.IsNegative());
+await Expect.That([1, 2, 3]).Between(2).And(3).ComplyWith(item => item.IsPositive());
+await Expect.That([1, 2, 3]).Exactly(1).ComplyWith(item => item.IsEqualTo(2));
+await Expect.That([1, 2, 3]).None().ComplyWith(item => item.IsNegative());
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+### Satisfy
+
+You can verify, that items in a collection satisfy a condition:
+
+```csharp
+await Expect.That([1, 2, 3]).All().Satisfy(item => item < 4);
+await Expect.That([1, 2, 3]).AtLeast(2).Satisfy(item => item >= 2);
+await Expect.That([1, 2, 3]).AtMost(1).Satisfy(item => item < 0);
+await Expect.That([1, 2, 3]).Between(2).And(3).Satisfy(item => item > 0);
+await Expect.That([1, 2, 3]).Exactly(1).Satisfy(item => item == 2);
+await Expect.That([1, 2, 3]).None().Satisfy(item => item < 0);
+```
+
+*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
 
 ## Sort order
 

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
@@ -13,20 +13,6 @@ public static partial class ThatAsyncEnumerable
 	public partial class Elements<TItem>
 	{
 		/// <summary>
-		///     Verifies that the items in the collection satisfy the <paramref name="expectations" />.
-		/// </summary>
-		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>
-			Are(Action<IThat<TItem>> expectations)
-		{
-			ObjectEqualityOptions options = new();
-			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
-					=> new AsyncCollectionConstraint<TItem>(it, _quantifier, expectations)),
-				_subject,
-				options);
-		}
-
-		/// <summary>
 		///     Verifies that all items in the collection are of type <typeparamref name="TType" />.
 		/// </summary>
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
@@ -1,0 +1,30 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatAsyncEnumerable
+{
+	public partial class Elements<TItem>
+	{
+		/// <summary>
+		///     Verifies that the items in the collection comply with the <paramref name="expectations" />.
+		/// </summary>
+		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>
+			ComplyWith(Action<IThat<TItem>> expectations)
+		{
+			ObjectEqualityOptions options = new();
+			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
+				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
+					=> new AsyncCollectionConstraint<TItem>(it, _quantifier, expectations)),
+				_subject,
+				options);
+		}
+	}
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -12,20 +12,6 @@ public static partial class ThatEnumerable
 	public partial class Elements<TItem>
 	{
 		/// <summary>
-		///     Verifies that the items in the collection satisfy the <paramref name="expectations" />.
-		/// </summary>
-		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>
-			Are(Action<IThat<TItem>> expectations)
-		{
-			ObjectEqualityOptions options = new();
-			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
-					=> new SyncCollectionConstraint<TItem>(it, _quantifier, expectations)),
-				_subject,
-				options);
-		}
-
-		/// <summary>
 		///     Verifies that all items in the collection are of type <typeparamref name="TType" />.
 		/// </summary>
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatEnumerable
+{
+	public partial class Elements<TItem>
+	{
+		/// <summary>
+		///     Verifies that the items in the collection comply with the <paramref name="expectations" />.
+		/// </summary>
+		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>
+			ComplyWith(Action<IThat<TItem>> expectations)
+		{
+			ObjectEqualityOptions options = new();
+			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
+				_subject.ThatIs().ExpectationBuilder.AddConstraint(it
+					=> new SyncCollectionConstraint<TItem>(it, _quantifier, expectations)),
+				_subject,
+				options);
+		}
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -92,10 +92,10 @@ namespace aweXpect
         }
         public class Elements<TItem>
         {
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Are<TType>() { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> AreEqualTo(TItem expected) { }
+            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> ComplyWith(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }
@@ -284,10 +284,10 @@ namespace aweXpect
         }
         public class Elements<TItem>
         {
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are<TType>() { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> AreEqualTo(TItem expected) { }
+            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> ComplyWith(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -187,10 +187,10 @@ namespace aweXpect
         }
         public class Elements<TItem>
         {
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Are<TType>() { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> AreEqualTo(TItem expected) { }
+            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> ComplyWith(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }

--- a/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
@@ -33,7 +33,7 @@ public sealed partial class QuantifiableCollectionItems
 			};
 
 			async Task Act()
-				=> await That(subject).All().Are(item => item.IsEquivalentTo(expected));
+				=> await That(subject).All().ComplyWith(item => item.IsEquivalentTo(expected));
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -68,7 +68,7 @@ public sealed partial class QuantifiableCollectionItems
 			};
 
 			async Task Act()
-				=> await That(subject).All().Are(item => item.IsEquivalentTo(expected));
+				=> await That(subject).All().ComplyWith(item => item.IsEquivalentTo(expected));
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.ComplyWith.Tests.cs
@@ -1,0 +1,120 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using System.Threading;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatAsyncEnumerable
+{
+	public sealed partial class All
+	{
+		public sealed class ComplyWith
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task ConsidersCancellationToken()
+				{
+					using CancellationTokenSource cts = new();
+					CancellationToken token = cts.Token;
+					IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(5, cts, token);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsLessThan(6)).WithCancellation(token);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be less than 6,
+						             but could not verify, because it was cancelled early
+						             """);
+				}
+
+				[Fact]
+				public async Task DoesNotEnumerateTwice()
+				{
+					ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsGreaterThan(-1))
+							.And.All().ComplyWith(x => x.IsGreaterThan(-1));
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(1));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be equal to 1,
+						             but not all were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentValues_ShouldFail()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(1));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be equal to 1,
+						             but not all were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable((int[]) []);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(0));
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableOnlyContainsEqualValues_ShouldSucceed()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 1, 1, 1]);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(1));
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					IAsyncEnumerable<int>? subject = null;
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(0));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be equal to 0,
+						             but it was <null>
+						             """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts, CancellationToken.None);
 
 				async Task Act()
-					=> await That(subject).All().Are(item => item.IsLessThan(6)).WithCancellation(token);
+					=> await That(subject).All().ComplyWith(item => item.IsLessThan(6)).WithCancellation(token);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -48,7 +48,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).All().Are(item => item.IsEqualTo(1));
+					=> await That(subject).All().ComplyWith(item => item.IsEqualTo(1));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -64,7 +64,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 				async Task Act()
-					=> await That(subject).All().Are(item => item.IsEqualTo(1));
+					=> await That(subject).All().ComplyWith(item => item.IsEqualTo(1));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -80,7 +80,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 				async Task Act()
-					=> await That(subject).All().Are(item => item.IsEqualTo(0));
+					=> await That(subject).All().ComplyWith(item => item.IsEqualTo(0));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -91,7 +91,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 1, 1, 1]);
 
 				async Task Act()
-					=> await That(subject).All().Are(item => item.IsEqualTo(1));
+					=> await That(subject).All().ComplyWith(item => item.IsEqualTo(1));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -102,7 +102,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).All().Are(item => item.IsEqualTo(0));
+					=> await That(subject).All().ComplyWith(item => item.IsEqualTo(0));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class All
+	{
+		public sealed class ComplyWith
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task ConsidersCancellationToken()
+				{
+					using CancellationTokenSource cts = new();
+					CancellationToken token = cts.Token;
+					IEnumerable<int> subject = GetCancellingEnumerable(5, cts);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsLessThan(6)).WithCancellation(token);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be less than 6,
+						             but could not verify, because it was cancelled early
+						             """);
+				}
+
+				[Fact]
+				public async Task DoesNotEnumerateTwice()
+				{
+					ThrowWhenIteratingTwiceEnumerable subject = new();
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsGreaterThan(-1))
+							.And.All().ComplyWith(x => x.IsGreaterThan(-1));
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(1));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be equal to 1,
+						             but not all were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentValues_ShouldFail()
+				{
+					int[] subject = [1, 1, 1, 1, 2, 2, 3];
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(1));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be equal to 1,
+						             but only 4 of 7 were
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+				{
+					IEnumerable<int> subject = ToEnumerable((int[]) []);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(0));
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableOnlyContainsEqualValues_ShouldSucceed()
+				{
+					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 1, 1, 1]);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(1));
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					IEnumerable<int>? subject = null;
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.IsEqualTo(0));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected subject to
+						             have all items be equal to 0,
+						             but it was <null>
+						             """);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
You can add expectations that a certain number of elements must meet.

### Comply with

You can verify, that items in a collection comply with an expectation on the individual elements:

```csharp
await Expect.That([1, 2, 3]).All().ComplyWith(item => item.IsLessThan(4));
await Expect.That([1, 2, 3]).AtLeast(2).ComplyWith(item => item.IsGreaterThanOrEqualTo(2));
await Expect.That([1, 2, 3]).AtMost(1).ComplyWith(item => item.IsNegative());
await Expect.That([1, 2, 3]).Between(2).And(3).ComplyWith(item => item.IsPositive());
await Expect.That([1, 2, 3]).Exactly(1).ComplyWith(item => item.IsEqualTo(2));
await Expect.That([1, 2, 3]).None().ComplyWith(item => item.IsNegative());
```

*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
