### PR TITLE
chore: update aweXpect.Core to v0.23.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="0.26.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="0.22.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="0.23.0"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="0.5.0"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
@@ -3,7 +3,6 @@ using aweXpect.Core;
 using aweXpect.Equivalency;
 using aweXpect.Options;
 using aweXpect.Results;
-using EquivalencyOptions = aweXpect.Equivalency.EquivalencyOptions;
 
 // ReSharper disable once CheckNamespace
 namespace aweXpect;

--- a/Source/aweXpect/Results/ObjectCountResult.cs
+++ b/Source/aweXpect/Results/ObjectCountResult.cs
@@ -38,7 +38,6 @@ public class ObjectCountResult<TType, TThat, TElement, TSelf>(
 	: CountResult<TType, TThat, TSelf>(expectationBuilder, returnValue, quantifier)
 	where TSelf : ObjectCountResult<TType, TThat, TElement, TSelf>
 {
-#if DEBUG //TODO: Enable again after Core update
 	/// <summary>
 	///     Use equivalency to compare objects.
 	/// </summary>
@@ -50,7 +49,6 @@ public class ObjectCountResult<TType, TThat, TElement, TSelf>(
 		options.Equivalent(equivalencyOptions);
 		return (TSelf)this;
 	}
-#endif
 
 	/// <summary>
 	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="object" />s.

--- a/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;
+using aweXpect.Equivalency;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
-using EquivalencyOptions = aweXpect.Equivalency.EquivalencyOptions;
 
 namespace aweXpect;
 
@@ -27,27 +27,6 @@ public static partial class ThatObject
 			source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new IsEqualToConstraint<TSubject, TExpected>(it, expected, doNotPopulateThisValue, options)),
 			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is not equivalent to the <paramref name="unexpected" /> value.
-	/// </summary>
-	public static ObjectEqualityResult<object?, IThat<object?>, object?> NotEquivalentTo(
-		this IThatIs<object?> source,
-		object? unexpected,
-		Func<EquivalencyOptions, EquivalencyOptions>? optionsCallback = null,
-		[CallerArgumentExpression("unexpected")]
-		string doNotPopulateThisValue = "")
-	{
-		EquivalencyOptions equivalencyOptions =
-			optionsCallback?.Invoke(new EquivalencyOptions()) ?? new EquivalencyOptions();
-		ObjectEqualityOptions<object?> options = new();
-		options.Equivalent(equivalencyOptions);
-		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
-			source.ExpectationBuilder.AddConstraint(it
-				=> new IsNotEqualToConstraint(it, unexpected, doNotPopulateThisValue, options)),
-			source.ExpectSubject(),
 			options);
 	}
 }

--- a/Source/aweXpect/That/Objects/ThatObject.IsJsonSerializable.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsJsonSerializable.cs
@@ -7,7 +7,6 @@ using aweXpect.Equivalency;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
-using EquivalencyOptions = aweXpect.Equivalency.EquivalencyOptions;
 
 namespace aweXpect;
 

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -816,7 +816,6 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
-        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> NotEquivalentTo(this aweXpect.Core.IThatIs<object?> source, object? unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? optionsCallback = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatSignaler
     {
@@ -1029,6 +1028,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ObjectCountResult<TType, TThat, TElement, TSelf>
     {
         public ObjectCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.ObjectEqualityOptions<TElement> options) { }
+        public TSelf Equivalent(System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? optionsCallback = null) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class SignalCountResult : aweXpect.Results.AndOrResult<aweXpect.Signaling.SignalerResult, aweXpect.Core.IThat<aweXpect.Signaling.Signaler>>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -649,7 +649,6 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
-        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> NotEquivalentTo(this aweXpect.Core.IThatIs<object?> source, object? unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? optionsCallback = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatSignaler
     {
@@ -779,6 +778,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ObjectCountResult<TType, TThat, TElement, TSelf>
     {
         public ObjectCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.ObjectEqualityOptions<TElement> options) { }
+        public TSelf Equivalent(System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? optionsCallback = null) { }
         public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class SignalCountResult : aweXpect.Results.AndOrResult<aweXpect.Signaling.SignalerResult, aweXpect.Core.IThat<aweXpect.Signaling.Signaler>>

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
@@ -128,7 +128,6 @@ public sealed partial class ThatAsyncEnumerable
 					              """);
 			}
 
-#if DEBUG //TODO: Enable again after Core update
 			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
@@ -146,7 +145,6 @@ public sealed partial class ThatAsyncEnumerable
 
 				await That(Act).DoesNotThrow();
 			}
-#endif
 
 			[Theory]
 			[InlineData(1, false)]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
@@ -127,7 +127,6 @@ public sealed partial class ThatEnumerable
 					              """);
 			}
 
-#if DEBUG //TODO: Enable again after Core update
 			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
@@ -145,7 +144,6 @@ public sealed partial class ThatEnumerable
 
 				await That(Act).DoesNotThrow();
 			}
-#endif
 
 			[Theory]
 			[InlineData(1, false)]


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files, focusing on version updates, code cleanup, and re-enabling certain features. Below are the most important changes:

### Version Updates:
* Updated the `aweXpect.Core` package version from `0.22.0` to `0.23.0` in `Directory.Packages.props`.

### Code Cleanup:
* Removed unnecessary `#if DEBUG` directives and associated code in `ObjectCountResult.cs` and test files to re-enable features after a core update.
* Removed redundant `using` directive for `EquivalencyOptions` in multiple files (`EquivalencyExtensions.cs`, `ThatObject.IsEquivalentTo.cs`, `ThatObject.IsJsonSerializable.cs`).

### Feature Re-enablement:
* Re-enabled the `Equivalent` method in `ObjectCountResult` class and updated the expected API output files accordingly.