### PR TITLE
feat: change options to `record` types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>
+		<PackageVersion Include="IsExternalInit" Version="1.0.3"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nuke.Common" Version="9.0.4"/>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -42,6 +42,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="IsExternalInit">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/aweXpect.Core/Formatting/FormattingOptions.cs
+++ b/Source/aweXpect.Core/Formatting/FormattingOptions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Formatting options used in the <see cref="ValueFormatter" />.
 /// </summary>
-public class FormattingOptions
+public record FormattingOptions
 {
 	private FormattingOptions(bool useLineBreaks, string indentation = "")
 	{

--- a/Source/aweXpect.Core/Options/CollectionOrderOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionOrderOptions.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Options;
 /// <summary>
 ///     The options for specifying a <see cref="IComparer{TItem}" /> to use to compare the order of items.
 /// </summary>
-public class CollectionOrderOptions<TItem>
+public record CollectionOrderOptions<TItem>
 {
 	private IComparer<TItem>? _comparer;
 

--- a/Source/aweXpect.Core/Options/SignalerOptions.cs
+++ b/Source/aweXpect.Core/Options/SignalerOptions.cs
@@ -9,7 +9,7 @@ namespace aweXpect.Options;
 /// <summary>
 ///     Options for <see cref="Signaler" />
 /// </summary>
-public class SignalerOptions
+public record SignalerOptions
 {
 	/// <summary>
 	///     The timeout to use for the recording.
@@ -31,7 +31,7 @@ public class SignalerOptions
 /// <summary>
 ///     Options for <see cref="Signaler{TParameter}" />
 /// </summary>
-public class SignalerOptions<TParameter> : SignalerOptions
+public record SignalerOptions<TParameter> : SignalerOptions
 {
 	private StringBuilder? _builder;
 	private List<Func<TParameter, bool>>? _predicates;

--- a/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
@@ -20,7 +20,7 @@ public static class EquivalencyExtensions
 		where TSelf : ObjectEqualityResult<TType, TThat, TElement, TSelf>
 	{
 		((IOptionsProvider<ObjectEqualityOptions<TElement>>)result).Options.SetMatchType(
-			new EquivalencyComparer(EquivalencyOptions.FromCallback(equivalencyOptions)));
+			new EquivalencyComparer(EquivalencyOptionsExtensions.FromCallback(equivalencyOptions)));
 		return (TSelf)result;
 	}
 

--- a/Source/aweXpect/Equivalency/EquivalencyOptions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptions.cs
@@ -1,52 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace aweXpect.Equivalency;
+﻿namespace aweXpect.Equivalency;
 
 /// <summary>
 ///     Options for equivalency.
 /// </summary>
-public class EquivalencyOptions
+public record EquivalencyOptions
 {
-	private readonly List<string> _membersToIgnore = new();
-
 	/// <summary>
 	///     The members that should be ignored when checking for equivalency.
 	/// </summary>
-	public IReadOnlyList<string> MembersToIgnore => _membersToIgnore;
+	public string[] MembersToIgnore { get; init; } = [];
 
 	/// <summary>
 	///     Ignores the order of collections when checking for equivalency.
 	/// </summary>
-	public bool IgnoreCollectionOrder { get; private set; }
-
-	/// <summary>
-	///     Ignores the <paramref name="memberToIgnore" /> when checking for equivalency.
-	/// </summary>
-	public EquivalencyOptions IgnoringMember(string memberToIgnore)
-	{
-		_membersToIgnore.Add(memberToIgnore);
-		return this;
-	}
-
-	/// <summary>
-	///     Ignores the order of collections when checking for equivalency
-	///     when <paramref name="ignoreCollectionOrder" /> is <see langword="true" />.
-	/// </summary>
-	public EquivalencyOptions IgnoringCollectionOrder(bool ignoreCollectionOrder = true)
-	{
-		IgnoreCollectionOrder = ignoreCollectionOrder;
-		return this;
-	}
-
-	/// <summary>
-	///     Creates a new <see cref="EquivalencyOptions" /> instance from the provided <paramref name="callback" />.
-	/// </summary>
-	/// <remarks>
-	///     Uses the default instance, when no <paramref name="callback" /> is given.
-	/// </remarks>
-	public static EquivalencyOptions FromCallback(Func<EquivalencyOptions, EquivalencyOptions>? callback)
-		=> callback is null
-			? new EquivalencyOptions()
-			: callback(new EquivalencyOptions());
+	public bool IgnoreCollectionOrder { get; init; }
 }

--- a/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace aweXpect.Equivalency;
+
+/// <summary>
+///     Extension methods for <see cref="EquivalencyOptions" />.
+/// </summary>
+public static class EquivalencyOptionsExtensions
+{
+	/// <summary>
+	///     Ignores the <paramref name="memberToIgnore" /> when checking for equivalency.
+	/// </summary>
+	public static EquivalencyOptions IgnoringMember(this EquivalencyOptions @this, string memberToIgnore)
+		=> @this with
+		{
+			MembersToIgnore = [..@this.MembersToIgnore, memberToIgnore]
+		};
+
+	/// <summary>
+	///     Ignores the order of collections when checking for equivalency
+	///     when <paramref name="ignoreCollectionOrder" /> is <see langword="true" />.
+	/// </summary>
+	public static EquivalencyOptions IgnoringCollectionOrder(this EquivalencyOptions @this,
+		bool ignoreCollectionOrder = true)
+		=> @this with
+		{
+			IgnoreCollectionOrder = ignoreCollectionOrder
+		};
+
+	/// <summary>
+	///     Creates a new <see cref="EquivalencyOptions" /> instance from the provided <paramref name="callback" />.
+	/// </summary>
+	/// <remarks>
+	///     Uses the default instance, when no <paramref name="callback" /> is given.
+	/// </remarks>
+	internal static EquivalencyOptions FromCallback(Func<EquivalencyOptions, EquivalencyOptions>? callback)
+		=> callback is null
+			? new EquivalencyOptions()
+			: callback(new EquivalencyOptions());
+}

--- a/Source/aweXpect/Json/JsonOptions.cs
+++ b/Source/aweXpect/Json/JsonOptions.cs
@@ -1,5 +1,4 @@
 ﻿#if NET8_0_OR_GREATER
-using System;
 using System.Text.Json;
 using aweXpect.Customization;
 
@@ -8,40 +7,22 @@ namespace aweXpect.Json;
 /// <summary>
 ///     Options for strings as JSON.
 /// </summary>
-public class JsonOptions
+public record JsonOptions
 {
-	private JsonDocumentOptions? _options;
+	private readonly JsonDocumentOptions? _options;
 
 	/// <summary>
 	///     The current <see cref="JsonDocumentOptions" /> to use when interpreting a <see langword="string" /> as JSON.
 	/// </summary>
 	public JsonDocumentOptions DocumentOptions
-		=> _options ?? Customize.aweXpect.Json().DefaultJsonDocumentOptions.Get();
+	{
+		get => _options ?? Customize.aweXpect.Json().DefaultJsonDocumentOptions.Get();
+		init => _options = value;
+	}
 
 	/// <summary>
 	///     Flag indicating, if the additional properties in the subject should be ignored.
 	/// </summary>
-	public bool IgnoreAdditionalProperties { get; private set; }
-
-	/// <summary>
-	///     Specify the <see cref="JsonDocumentOptions" /> to use when interpreting a <see langword="string" /> as JSON.
-	/// </summary>
-	public JsonOptions WithJsonOptions(
-		Func<JsonDocumentOptions, JsonDocumentOptions> jsonDocumentOptions)
-	{
-		_options ??= Customize.aweXpect.Json().DefaultJsonDocumentOptions.Get();
-		_options = jsonDocumentOptions(_options.Value);
-		return this;
-	}
-
-	/// <summary>
-	///     Ignores additional properties in the subject
-	///     when <paramref name="ignoreAdditionalProperties" /> is <see langword="true" />
-	/// </summary>
-	public JsonOptions IgnoringAdditionalProperties(bool ignoreAdditionalProperties = true)
-	{
-		IgnoreAdditionalProperties = ignoreAdditionalProperties;
-		return this;
-	}
+	public bool IgnoreAdditionalProperties { get; init; }
 }
 #endif

--- a/Source/aweXpect/Json/JsonOptionsExtensions.cs
+++ b/Source/aweXpect/Json/JsonOptionsExtensions.cs
@@ -1,0 +1,38 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Text.Json;
+
+namespace aweXpect.Json;
+
+/// <summary>
+///     Extension methods for <see cref="JsonOptions" />.
+/// </summary>
+public static class JsonOptionsExtensions
+{
+	/// <summary>
+	///     Specify the <see cref="JsonDocumentOptions" /> to use when interpreting a <see langword="string" /> as JSON.
+	/// </summary>
+	public static JsonOptions WithJsonOptions(
+		this JsonOptions @this,
+		Func<JsonDocumentOptions, JsonDocumentOptions> jsonDocumentOptions)
+	{
+		JsonDocumentOptions options = jsonDocumentOptions(@this.DocumentOptions);
+		return @this with
+		{
+			DocumentOptions = options
+		};
+	}
+
+	/// <summary>
+	///     Ignores additional properties in the subject
+	///     when <paramref name="ignoreAdditionalProperties" /> is <see langword="true" />
+	/// </summary>
+	public static JsonOptions IgnoringAdditionalProperties(
+		this JsonOptions @this,
+		bool ignoreAdditionalProperties = true)
+		=> @this with
+		{
+			IgnoreAdditionalProperties = ignoreAdditionalProperties
+		};
+}
+#endif

--- a/Source/aweXpect/That/Json/ThatJsonElement.IsArray.cs
+++ b/Source/aweXpect/That/Json/ThatJsonElement.IsArray.cs
@@ -28,8 +28,10 @@ public static partial class ThatJsonElement
 		Func<IJsonArrayResult, IJsonArrayResult> expectation,
 		Func<JsonOptions, JsonOptions>? options = null)
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);

--- a/Source/aweXpect/That/Json/ThatJsonElement.IsObject.cs
+++ b/Source/aweXpect/That/Json/ThatJsonElement.IsObject.cs
@@ -30,8 +30,10 @@ public static partial class ThatJsonElement
 		Func<IJsonObjectResult, IJsonObjectResult> expectation,
 		Func<JsonOptions, JsonOptions>? options = null)
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);

--- a/Source/aweXpect/That/Json/ThatJsonElement.Matches.cs
+++ b/Source/aweXpect/That/Json/ThatJsonElement.Matches.cs
@@ -20,8 +20,10 @@ public static partial class ThatJsonElement
 		Func<JsonOptions, JsonOptions>? options = null,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);
@@ -42,8 +44,10 @@ public static partial class ThatJsonElement
 		Func<JsonOptions, JsonOptions>? options = null,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);

--- a/Source/aweXpect/That/Json/ThatNullableJsonElement.IsArray.cs
+++ b/Source/aweXpect/That/Json/ThatNullableJsonElement.IsArray.cs
@@ -30,8 +30,10 @@ public static partial class ThatNullableJsonElement
 		Func<IJsonArrayResult, IJsonArrayResult> expectation,
 		Func<JsonOptions, JsonOptions>? options = null)
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);

--- a/Source/aweXpect/That/Json/ThatNullableJsonElement.IsObject.cs
+++ b/Source/aweXpect/That/Json/ThatNullableJsonElement.IsObject.cs
@@ -30,8 +30,10 @@ public static partial class ThatNullableJsonElement
 		Func<IJsonObjectResult, IJsonObjectResult> expectation,
 		Func<JsonOptions, JsonOptions>? options = null)
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);

--- a/Source/aweXpect/That/Json/ThatNullableJsonElement.Matches.cs
+++ b/Source/aweXpect/That/Json/ThatNullableJsonElement.Matches.cs
@@ -21,8 +21,10 @@ public static partial class ThatNullableJsonElement
 		Func<JsonOptions, JsonOptions>? options = null,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);
@@ -43,8 +45,10 @@ public static partial class ThatNullableJsonElement
 		Func<JsonOptions, JsonOptions>? options = null,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		JsonOptions jsonOptions = new();
-		jsonOptions.IgnoringAdditionalProperties();
+		JsonOptions jsonOptions = new()
+		{
+			IgnoreAdditionalProperties = true
+		};
 		if (options != null)
 		{
 			jsonOptions = options(jsonOptions);

--- a/Source/aweXpect/That/Objects/ThatObject.IsJsonSerializable.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsJsonSerializable.cs
@@ -21,7 +21,7 @@ public static partial class ThatObject
 		=> new(
 			source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new BeJsonSerializableConstraint<object>(it, new JsonSerializerOptions(),
-					EquivalencyOptions.FromCallback(equivalencyOptions))),
+					EquivalencyOptionsExtensions.FromCallback(equivalencyOptions))),
 			source);
 
 	/// <summary>
@@ -34,7 +34,7 @@ public static partial class ThatObject
 		=> new(
 			source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new BeJsonSerializableConstraint<object>(it, serializerOptions,
-					EquivalencyOptions.FromCallback(equivalencyOptions))),
+					EquivalencyOptionsExtensions.FromCallback(equivalencyOptions))),
 			source);
 
 	/// <summary>
@@ -46,7 +46,7 @@ public static partial class ThatObject
 		=> new(
 			source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new BeJsonSerializableConstraint<T>(it, new JsonSerializerOptions(),
-					EquivalencyOptions.FromCallback(equivalencyOptions))),
+					EquivalencyOptionsExtensions.FromCallback(equivalencyOptions))),
 			source);
 
 	/// <summary>
@@ -59,7 +59,7 @@ public static partial class ThatObject
 		=> new(
 			source.ThatIs().ExpectationBuilder.AddConstraint(it
 				=> new BeJsonSerializableConstraint<T>(it, serializerOptions,
-					EquivalencyOptions.FromCallback(equivalencyOptions))),
+					EquivalencyOptionsExtensions.FromCallback(equivalencyOptions))),
 			source);
 
 	private readonly struct BeJsonSerializableConstraint<T>(

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -906,14 +906,16 @@ namespace aweXpect
 }
 namespace aweXpect.Equivalency
 {
-    public class EquivalencyOptions
+    public class EquivalencyOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyOptions>
     {
         public EquivalencyOptions() { }
-        public bool IgnoreCollectionOrder { get; }
-        public System.Collections.Generic.IReadOnlyList<string> MembersToIgnore { get; }
-        public aweXpect.Equivalency.EquivalencyOptions IgnoringCollectionOrder(bool ignoreCollectionOrder = true) { }
-        public aweXpect.Equivalency.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
-        public static aweXpect.Equivalency.EquivalencyOptions FromCallback(System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? callback) { }
+        public bool IgnoreCollectionOrder { get; init; }
+        public string[] MembersToIgnore { get; init; }
+    }
+    public static class EquivalencyOptionsExtensions
+    {
+        public static aweXpect.Equivalency.EquivalencyOptions IgnoringCollectionOrder(this aweXpect.Equivalency.EquivalencyOptions @this, bool ignoreCollectionOrder = true) { }
+        public static aweXpect.Equivalency.EquivalencyOptions IgnoringMember(this aweXpect.Equivalency.EquivalencyOptions @this, string memberToIgnore) { }
     }
 }
 namespace aweXpect.Json
@@ -967,13 +969,16 @@ namespace aweXpect.Json
             public System.Text.Json.JsonSerializerOptions DefaultJsonSerializerOptions { get; init; }
         }
     }
-    public class JsonOptions
+    public class JsonOptions : System.IEquatable<aweXpect.Json.JsonOptions>
     {
         public JsonOptions() { }
-        public System.Text.Json.JsonDocumentOptions DocumentOptions { get; }
-        public bool IgnoreAdditionalProperties { get; }
-        public aweXpect.Json.JsonOptions IgnoringAdditionalProperties(bool ignoreAdditionalProperties = true) { }
-        public aweXpect.Json.JsonOptions WithJsonOptions(System.Func<System.Text.Json.JsonDocumentOptions, System.Text.Json.JsonDocumentOptions> jsonDocumentOptions) { }
+        public System.Text.Json.JsonDocumentOptions DocumentOptions { get; init; }
+        public bool IgnoreAdditionalProperties { get; init; }
+    }
+    public static class JsonOptionsExtensions
+    {
+        public static aweXpect.Json.JsonOptions IgnoringAdditionalProperties(this aweXpect.Json.JsonOptions @this, bool ignoreAdditionalProperties = true) { }
+        public static aweXpect.Json.JsonOptions WithJsonOptions(this aweXpect.Json.JsonOptions @this, System.Func<System.Text.Json.JsonDocumentOptions, System.Text.Json.JsonDocumentOptions> jsonDocumentOptions) { }
     }
 }
 namespace aweXpect.Results

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -721,14 +721,16 @@ namespace aweXpect
 }
 namespace aweXpect.Equivalency
 {
-    public class EquivalencyOptions
+    public class EquivalencyOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyOptions>
     {
         public EquivalencyOptions() { }
-        public bool IgnoreCollectionOrder { get; }
-        public System.Collections.Generic.IReadOnlyList<string> MembersToIgnore { get; }
-        public aweXpect.Equivalency.EquivalencyOptions IgnoringCollectionOrder(bool ignoreCollectionOrder = true) { }
-        public aweXpect.Equivalency.EquivalencyOptions IgnoringMember(string memberToIgnore) { }
-        public static aweXpect.Equivalency.EquivalencyOptions FromCallback(System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? callback) { }
+        public bool IgnoreCollectionOrder { get; init; }
+        public string[] MembersToIgnore { get; init; }
+    }
+    public static class EquivalencyOptionsExtensions
+    {
+        public static aweXpect.Equivalency.EquivalencyOptions IgnoringCollectionOrder(this aweXpect.Equivalency.EquivalencyOptions @this, bool ignoreCollectionOrder = true) { }
+        public static aweXpect.Equivalency.EquivalencyOptions IgnoringMember(this aweXpect.Equivalency.EquivalencyOptions @this, string memberToIgnore) { }
     }
 }
 namespace aweXpect.Results

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -404,7 +404,7 @@ namespace aweXpect.Formatting
         public FormattingContext() { }
         public System.Collections.Generic.HashSet<object> FormattedObjects { get; }
     }
-    public class FormattingOptions
+    public class FormattingOptions : System.IEquatable<aweXpect.Formatting.FormattingOptions>
     {
         public static aweXpect.Formatting.FormattingOptions Indented { get; }
         public static aweXpect.Formatting.FormattingOptions MultipleLines { get; }
@@ -536,7 +536,7 @@ namespace aweXpect.Options
             Contains = 8,
         }
     }
-    public class CollectionOrderOptions<TItem>
+    public class CollectionOrderOptions<TItem> : System.IEquatable<aweXpect.Options.CollectionOrderOptions<TItem>>
     {
         public CollectionOrderOptions() { }
         public System.Collections.Generic.IComparer<TItem> GetComparer() { }
@@ -573,13 +573,13 @@ namespace aweXpect.Options
         public void Exactly(int expected) { }
         public override string ToString() { }
     }
-    public class SignalerOptions
+    public class SignalerOptions : System.IEquatable<aweXpect.Options.SignalerOptions>
     {
         public SignalerOptions() { }
         public System.TimeSpan? Timeout { get; set; }
         public override string ToString() { }
     }
-    public class SignalerOptions<TParameter> : aweXpect.Options.SignalerOptions
+    public class SignalerOptions<TParameter> : aweXpect.Options.SignalerOptions, System.IEquatable<aweXpect.Options.SignalerOptions<TParameter>>
     {
         public SignalerOptions() { }
         public bool Matches(TParameter parameter) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -399,7 +399,7 @@ namespace aweXpect.Formatting
         public FormattingContext() { }
         public System.Collections.Generic.HashSet<object> FormattedObjects { get; }
     }
-    public class FormattingOptions
+    public class FormattingOptions : System.IEquatable<aweXpect.Formatting.FormattingOptions>
     {
         public static aweXpect.Formatting.FormattingOptions Indented { get; }
         public static aweXpect.Formatting.FormattingOptions MultipleLines { get; }
@@ -523,7 +523,7 @@ namespace aweXpect.Options
             Contains = 8,
         }
     }
-    public class CollectionOrderOptions<TItem>
+    public class CollectionOrderOptions<TItem> : System.IEquatable<aweXpect.Options.CollectionOrderOptions<TItem>>
     {
         public CollectionOrderOptions() { }
         public System.Collections.Generic.IComparer<TItem> GetComparer() { }
@@ -560,13 +560,13 @@ namespace aweXpect.Options
         public void Exactly(int expected) { }
         public override string ToString() { }
     }
-    public class SignalerOptions
+    public class SignalerOptions : System.IEquatable<aweXpect.Options.SignalerOptions>
     {
         public SignalerOptions() { }
         public System.TimeSpan? Timeout { get; set; }
         public override string ToString() { }
     }
-    public class SignalerOptions<TParameter> : aweXpect.Options.SignalerOptions
+    public class SignalerOptions<TParameter> : aweXpect.Options.SignalerOptions, System.IEquatable<aweXpect.Options.SignalerOptions<TParameter>>
     {
         public SignalerOptions() { }
         public bool Matches(TParameter parameter) { }

--- a/Tests/aweXpect.Core.Tests/Options/JsonOptionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/JsonOptionsTests.cs
@@ -20,28 +20,27 @@ public class JsonOptionsTests
 		int maxDepth = new Random().Next(1, 10);
 		JsonOptions sut = new();
 
-		sut.WithJsonOptions(o => o with
+		JsonOptions result = sut.WithJsonOptions(o => o with
 		{
 			MaxDepth = maxDepth
 		});
 
-		await That(sut.DocumentOptions.MaxDepth).IsEqualTo(maxDepth);
+		await That(result.DocumentOptions.MaxDepth).IsEqualTo(maxDepth);
 	}
 
 	[Fact]
 	public async Task WithJsonOptions_ShouldSupportProvidingFixedOptions()
 	{
 		int maxDepth = new Random().Next(1, 10);
+		JsonOptions sut = new();
 		JsonDocumentOptions documentOptions = new()
 		{
 			MaxDepth = maxDepth
 		};
 
-		JsonOptions sut = new();
+		JsonOptions result = sut.WithJsonOptions(_ => documentOptions);
 
-		sut.WithJsonOptions(_ => documentOptions);
-
-		await That(sut.DocumentOptions.MaxDepth).IsEqualTo(maxDepth);
+		await That(result.DocumentOptions.MaxDepth).IsEqualTo(maxDepth);
 	}
 }
 #endif

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Tests;
+﻿using aweXpect.Equivalency;
+
+namespace aweXpect.Tests;
 
 public sealed partial class ThatObject
 {

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsJsonSerializable.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsJsonSerializable.Tests.cs
@@ -1,6 +1,7 @@
 ﻿#if NET8_0_OR_GREATER
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using aweXpect.Equivalency;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsJson.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsJson.Tests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET8_0_OR_GREATER
 using aweXpect.Customization;
+using aweXpect.Json;
 
 namespace aweXpect.Tests;
 


### PR DESCRIPTION
Change options to `record` types, so that you can use the "with" keyword and reduce the risk of "shared options" between tests that influence each other.