### PR TITLE
feat: improve equivalency by allowing to specify the supported visibility of fields and properties

### DIFF
--- a/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Equivalency.cs
+++ b/Benchmarks/aweXpect.Benchmarks/HappyCaseBenchmarks.Equivalency.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
 using FluentAssertions;
 using FluentAssertions.Primitives;
+
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
 namespace aweXpect.Benchmarks;
@@ -14,15 +15,15 @@ public partial class HappyCaseBenchmarks
 	private readonly Nested _nestedSubject = Nested.Create(10);
 
 	[Benchmark]
-	public async Task<Nested> Nested_aweXpect()
+	public async Task<Nested> Equivalency_aweXpect()
 		=> await Expect.That(_nestedSubject).IsEquivalentTo(_nestedExpectation);
 
 	[Benchmark]
-	public AndConstraint<ObjectAssertions> Nested_FluentAssertions()
+	public AndConstraint<ObjectAssertions> Equivalency_FluentAssertions()
 		=> _nestedSubject.Should().BeEquivalentTo(_nestedExpectation);
 
 	[Benchmark]
-	public async Task<Nested?> Nested_TUnit()
+	public async Task<Nested?> Equivalency_TUnit()
 		=> await Assert.That(_nestedSubject).IsEquivalentTo(_nestedExpectation);
 
 	public sealed class Nested

--- a/Source/aweXpect/Equivalency/EquivalencyTypeOptions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyTypeOptions.cs
@@ -11,6 +11,16 @@ public record EquivalencyTypeOptions
 	public string[] MembersToIgnore { get; init; } = [];
 
 	/// <summary>
+	///     Specifies which fields to include in the object comparison.
+	/// </summary>
+	public IncludeMembers Fields { get; init; } = IncludeMembers.Public;
+
+	/// <summary>
+	///     Specifies which properties to include in the object comparison.
+	/// </summary>
+	public IncludeMembers Properties { get; init; } = IncludeMembers.Public;
+
+	/// <summary>
 	///     Ignores the order of collections when checking for equivalency.
 	/// </summary>
 	public bool IgnoreCollectionOrder { get; init; }

--- a/Source/aweXpect/Equivalency/IncludeMembers.cs
+++ b/Source/aweXpect/Equivalency/IncludeMembers.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace aweXpect.Equivalency;
+
+/// <summary>
+///     Specifies which members to include in the object comparison.
+/// </summary>
+[Flags]
+public enum IncludeMembers
+{
+	/// <summary>
+	///     No members should be included in the object comparison.
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	///     Public members should be included in the object comparison.
+	/// </summary>
+	Public = 1 << 1,
+
+	/// <summary>
+	///     Internal members should be included in the object comparison.
+	/// </summary>
+	Internal = 1 << 2,
+
+	/// <summary>
+	///     Private members should be included in the object comparison.
+	/// </summary>
+	Private = 1 << 3,
+}

--- a/Source/aweXpect/Equivalency/IncludeMembersExtensions.cs
+++ b/Source/aweXpect/Equivalency/IncludeMembersExtensions.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace aweXpect.Equivalency;
+
+internal static class IncludeMembersExtensions
+{
+	public static BindingFlags GetBindingFlags(this IncludeMembers includeMembers)
+	{
+		if (includeMembers == IncludeMembers.Public)
+		{
+			return BindingFlags.Public | BindingFlags.Instance;
+		}
+
+		return BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+	}
+
+	public static IEnumerable<FieldInfo> GetFields(this Type type, IncludeMembers includeMembers)
+	{
+		if (includeMembers == IncludeMembers.None)
+		{
+			yield break;
+		}
+
+		BindingFlags bindingFlags = GetBindingFlags(includeMembers);
+		foreach (FieldInfo field in type.GetFields(bindingFlags))
+		{
+			if ((includeMembers.HasFlag(IncludeMembers.Internal) && !field.IsAssembly) ||
+			    (includeMembers.HasFlag(IncludeMembers.Public) && !field.IsPublic) ||
+			    (includeMembers.HasFlag(IncludeMembers.Private) && !field.IsPrivate))
+			{
+				continue;
+			}
+
+			yield return field;
+		}
+	}
+
+	public static IEnumerable<PropertyInfo> GetProperties(this Type type, IncludeMembers includeMembers)
+	{
+		if (includeMembers == IncludeMembers.None)
+		{
+			yield break;
+		}
+
+		BindingFlags bindingFlags = includeMembers switch
+		{
+			IncludeMembers.Public => BindingFlags.Public | BindingFlags.Instance,
+			_ => BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic
+		};
+		foreach (PropertyInfo property in type.GetProperties(bindingFlags).Where(x => x.CanRead))
+		{
+			MethodInfo getter = property.GetAccessors(true)[0];
+			if (!getter.Name.StartsWith("get_", StringComparison.Ordinal) ||
+			    (includeMembers.HasFlag(IncludeMembers.Internal) && !getter.IsAssembly) ||
+			    (includeMembers.HasFlag(IncludeMembers.Public) && !getter.IsPublic) ||
+			    (includeMembers.HasFlag(IncludeMembers.Private) && !getter.IsPrivate))
+			{
+				continue;
+			}
+
+			yield return property;
+		}
+	}
+}

--- a/Source/aweXpect/Equivalency/IncludeMembersExtensions.cs
+++ b/Source/aweXpect/Equivalency/IncludeMembersExtensions.cs
@@ -45,11 +45,7 @@ internal static class IncludeMembersExtensions
 			yield break;
 		}
 
-		BindingFlags bindingFlags = includeMembers switch
-		{
-			IncludeMembers.Public => BindingFlags.Public | BindingFlags.Instance,
-			_ => BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic
-		};
+		BindingFlags bindingFlags = GetBindingFlags(includeMembers);
 		foreach (PropertyInfo property in type.GetProperties(bindingFlags).Where(x => x.CanRead))
 		{
 			MethodInfo getter = property.GetAccessors(true)[0];

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -948,8 +948,18 @@ namespace aweXpect.Equivalency
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {
         public EquivalencyTypeOptions() { }
+        public aweXpect.Equivalency.IncludeMembers Fields { get; init; }
         public bool IgnoreCollectionOrder { get; init; }
         public string[] MembersToIgnore { get; init; }
+        public aweXpect.Equivalency.IncludeMembers Properties { get; init; }
+    }
+    [System.Flags]
+    public enum IncludeMembers
+    {
+        None = 0,
+        Public = 2,
+        Internal = 4,
+        Private = 8,
     }
 }
 namespace aweXpect.Json

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -763,8 +763,18 @@ namespace aweXpect.Equivalency
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {
         public EquivalencyTypeOptions() { }
+        public aweXpect.Equivalency.IncludeMembers Fields { get; init; }
         public bool IgnoreCollectionOrder { get; init; }
         public string[] MembersToIgnore { get; init; }
+        public aweXpect.Equivalency.IncludeMembers Properties { get; init; }
+    }
+    [System.Flags]
+    public enum IncludeMembers
+    {
+        None = 0,
+        Public = 2,
+        Internal = 4,
+        Private = 8,
     }
 }
 namespace aweXpect.Results

--- a/Tests/aweXpect.Internal.Tests/Equivalency/CustomizeEquivalencyTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Equivalency/CustomizeEquivalencyTests.cs
@@ -1,0 +1,60 @@
+﻿#if NET8_0_OR_GREATER
+using aweXpect.Customization;
+using aweXpect.Equivalency;
+
+namespace aweXpect.Internal.Tests.Equivalency;
+
+public sealed class CustomizeEquivalencyTests
+{
+	[Fact]
+	public async Task SetDefaultEquivalencyDocumentOptions_ShouldApplyOptionsWithinScope()
+	{
+		int[] actual = [1, 2];
+		int[] expected = [2, 1];
+
+		async Task Act()
+			=> await That(actual).IsEquivalentTo(expected);
+
+		using (IDisposable __ = Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Set(new EquivalencyOptions
+		       {
+			       IgnoreCollectionOrder = true
+		       }))
+		{
+			await That(Act).DoesNotThrow();
+		}
+
+		await That(Act).ThrowsException()
+			.WithMessage("""
+			             Expected actual to
+			             be equivalent to expected,
+			             but it was not:
+			               Element [0] differed:
+			                    Found: 1
+			                 Expected: 2
+			             and
+			               Element [1] differed:
+			                    Found: 2
+			                 Expected: 1
+			             """);
+	}
+
+	[Fact]
+	public async Task ShouldChangeIndividualProperties()
+	{
+		await That(Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get().IgnoreCollectionOrder)
+			.IsFalse();
+
+		using (Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Set(new EquivalencyOptions
+		       {
+			       IgnoreCollectionOrder = true
+		       }))
+		{
+			await That(Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get().IgnoreCollectionOrder)
+				.IsTrue();
+		}
+
+		await That(Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get().IgnoreCollectionOrder)
+			.IsFalse();
+	}
+}
+#endif

--- a/Tests/aweXpect.Internal.Tests/Json/CustomizeJsonTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Json/CustomizeJsonTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using aweXpect.Customization;
 using aweXpect.Json;
 
-namespace aweXpect.Internal.Tests;
+namespace aweXpect.Internal.Tests.Json;
 
 public sealed class CustomizeJsonTests
 {


### PR DESCRIPTION
Part of #174 

Support specifying the visiblity of the considered fields or properties in the configuration options:

```csharp
// Include both public and internal fields
await That(actual).IsEquivalentTo(expected, o => o with {
    Fields = IncludeMembers.Public | IncludeMembers.Internal
});

// Do not use fields for equivalency check
await That(actual).IsEquivalentTo(expected, o => o with {
    Fields = IncludeMembers.None
});
```

Also add tests for equivalency customization