### PR TITLE
feat: improve equivalency

### DIFF
--- a/Source/aweXpect/Equivalency/EquivalencyComparison.Compare.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyComparison.Compare.cs
@@ -24,7 +24,8 @@ internal static partial class EquivalencyComparison
 			return CompareNulls(actual, expected, failureBuilder, memberPath, memberType);
 		}
 
-		EquivalencyComparisonType comparisonType = options.TypeComparison.Invoke(actual.GetType());
+		EquivalencyComparisonType comparisonType = typeOptions.ComparisonType
+		                                           ?? options.DefaultComparisonTypeSelector.Invoke(actual.GetType());
 		if (comparisonType == EquivalencyComparisonType.ByValue)
 		{
 			return CompareByValue(actual, expected, failureBuilder, memberPath, memberType);

--- a/Source/aweXpect/Equivalency/EquivalencyDefaults.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyDefaults.cs
@@ -11,7 +11,7 @@ public static class EquivalencyDefaults
 	///     The default selection of the <see cref="EquivalencyComparisonType" /> for
 	///     the given <paramref name="type" />.
 	/// </summary>
-	public static EquivalencyComparisonType DefaultTypeComparison(Type type)
+	public static EquivalencyComparisonType DefaultComparisonType(Type type)
 	{
 		if (type.IsPrimitive
 		    || type.IsEnum

--- a/Source/aweXpect/Equivalency/EquivalencyOptions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptions.cs
@@ -9,13 +9,13 @@ namespace aweXpect.Equivalency;
 public record EquivalencyOptions : EquivalencyTypeOptions
 {
 	/// <summary>
-	///     Specifies the selector how types should be compared.
+	///     Specifies the selector how types should be compared, if not overwritten in the <see cref="CustomOptions" />.
 	/// </summary>
 	/// <remarks>
-	///     Defaults to use the <see cref="EquivalencyDefaults.DefaultTypeComparison" />.
+	///     Defaults to use the <see cref="EquivalencyDefaults.DefaultComparisonType" />.
 	/// </remarks>
-	public Func<Type, EquivalencyComparisonType> TypeComparison { get; init; } =
-		EquivalencyDefaults.DefaultTypeComparison;
+	public Func<Type, EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; } =
+		EquivalencyDefaults.DefaultComparisonType;
 
 	/// <summary>
 	///     Custom type-specific equivalency options.
@@ -35,6 +35,6 @@ public record EquivalencyOptions<TExpected> : EquivalencyOptions
 	{
 		MembersToIgnore = inner.MembersToIgnore;
 		IgnoreCollectionOrder = inner.IgnoreCollectionOrder;
-		TypeComparison = inner.TypeComparison;
+		DefaultComparisonTypeSelector = inner.DefaultComparisonTypeSelector;
 	}
 }

--- a/Source/aweXpect/Equivalency/EquivalencyOptions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptions.cs
@@ -21,6 +21,17 @@ public record EquivalencyOptions : EquivalencyTypeOptions
 	///     Custom type-specific equivalency options.
 	/// </summary>
 	public Dictionary<Type, EquivalencyTypeOptions> CustomOptions { get; init; } = new();
+
+	/// <summary>
+	///     Specifies the <paramref name="options" /> for members of type <typeparamref name="TMember" />.
+	/// </summary>
+	public EquivalencyOptions For<TMember>(
+		Func<EquivalencyTypeOptions, EquivalencyTypeOptions> options)
+	{
+		EquivalencyTypeOptions typeOptions = options(this);
+		CustomOptions.Add(typeof(TMember), typeOptions);
+		return this;
+	}
 }
 
 /// <summary>
@@ -36,5 +47,15 @@ public record EquivalencyOptions<TExpected> : EquivalencyOptions
 		MembersToIgnore = inner.MembersToIgnore;
 		IgnoreCollectionOrder = inner.IgnoreCollectionOrder;
 		DefaultComparisonTypeSelector = inner.DefaultComparisonTypeSelector;
+	}
+
+	/// <summary>
+	///     Specifies the <paramref name="options" /> for members of type <typeparamref name="TMember" />.
+	/// </summary>
+	public new EquivalencyOptions<TExpected> For<TMember>(
+		Func<EquivalencyTypeOptions, EquivalencyTypeOptions> options)
+	{
+		base.For<TMember>(options);
+		return this;
 	}
 }

--- a/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
@@ -20,6 +20,39 @@ public static class EquivalencyOptionsExtensions
 		};
 
 	/// <summary>
+	///     Includes fields according to the <paramref name="fieldsToInclude" /> parameter.
+	/// </summary>
+	/// <remarks>
+	///     If <paramref name="fieldsToInclude" /> is set to <see cref="IncludeMembers.None" />, fields are excluded from the
+	///     comparison.
+	/// </remarks>
+	public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		IncludeMembers fieldsToInclude)
+		where TEquivalencyOptions : EquivalencyTypeOptions
+		=> @this with
+		{
+			Fields = fieldsToInclude
+		};
+
+	/// <summary>
+	///     Includes properties according to the <paramref name="propertiesToInclude" /> parameter.
+	/// </summary>
+	/// <remarks>
+	///     If <paramref name="propertiesToInclude" /> is set to <see cref="IncludeMembers.None" />, properties are excluded
+	///     from the
+	///     comparison.
+	/// </remarks>
+	public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		IncludeMembers propertiesToInclude)
+		where TEquivalencyOptions : EquivalencyTypeOptions
+		=> @this with
+		{
+			Properties = propertiesToInclude
+		};
+
+	/// <summary>
 	///     Ignores the order of collections when checking for equivalency
 	///     when <paramref name="ignoreCollectionOrder" /> is <see langword="true" />.
 	/// </summary>

--- a/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
@@ -10,7 +10,10 @@ public static class EquivalencyOptionsExtensions
 	/// <summary>
 	///     Ignores the <paramref name="memberToIgnore" /> when checking for equivalency.
 	/// </summary>
-	public static EquivalencyOptions IgnoringMember(this EquivalencyOptions @this, string memberToIgnore)
+	public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		string memberToIgnore)
+		where TEquivalencyOptions : EquivalencyTypeOptions
 		=> @this with
 		{
 			MembersToIgnore = [..@this.MembersToIgnore, memberToIgnore]
@@ -20,8 +23,10 @@ public static class EquivalencyOptionsExtensions
 	///     Ignores the order of collections when checking for equivalency
 	///     when <paramref name="ignoreCollectionOrder" /> is <see langword="true" />.
 	/// </summary>
-	public static EquivalencyOptions IgnoringCollectionOrder(this EquivalencyOptions @this,
+	public static TEquivalencyOptions IgnoringCollectionOrder<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
 		bool ignoreCollectionOrder = true)
+		where TEquivalencyOptions : EquivalencyTypeOptions
 		=> @this with
 		{
 			IgnoreCollectionOrder = ignoreCollectionOrder
@@ -41,7 +46,8 @@ public static class EquivalencyOptionsExtensions
 	/// <summary>
 	///     Returns type-specific <see cref="EquivalencyTypeOptions" />.
 	/// </summary>
-	internal static EquivalencyTypeOptions GetTypeOptions(this EquivalencyOptions @this, Type? type, EquivalencyTypeOptions defaultValue)
+	internal static EquivalencyTypeOptions GetTypeOptions(this EquivalencyOptions @this, Type? type,
+		EquivalencyTypeOptions defaultValue)
 	{
 		if (type != null && @this.CustomOptions.TryGetValue(type, out EquivalencyTypeOptions? customOptions))
 		{

--- a/Source/aweXpect/Equivalency/EquivalencyTypeOptions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyTypeOptions.cs
@@ -6,6 +6,14 @@ namespace aweXpect.Equivalency;
 public record EquivalencyTypeOptions
 {
 	/// <summary>
+	///     The comparison type to use.<br />
+	///     If not set (<see langword="null" />), uses the
+	///     <see cref="EquivalencyOptions.DefaultComparisonTypeSelector" /> to
+	///     determine the <see cref="EquivalencyComparisonType" />.
+	/// </summary>
+	public EquivalencyComparisonType? ComparisonType { get; init; }
+
+	/// <summary>
 	///     The members that should be ignored when checking for equivalency.
 	/// </summary>
 	public string[] MembersToIgnore { get; init; } = [];

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -943,6 +943,10 @@ namespace aweXpect.Equivalency
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers fieldsToInclude)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers propertiesToInclude)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -928,13 +928,13 @@ namespace aweXpect.Equivalency
     }
     public static class EquivalencyDefaults
     {
-        public static aweXpect.Equivalency.EquivalencyComparisonType DefaultTypeComparison(System.Type type) { }
+        public static aweXpect.Equivalency.EquivalencyComparisonType DefaultComparisonType(System.Type type) { }
     }
     public class EquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions>
     {
         public EquivalencyOptions() { }
         public System.Collections.Generic.Dictionary<System.Type, aweXpect.Equivalency.EquivalencyTypeOptions> CustomOptions { get; init; }
-        public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> TypeComparison { get; init; }
+        public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; }
     }
     public static class EquivalencyOptionsExtensions
     {
@@ -948,6 +948,7 @@ namespace aweXpect.Equivalency
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {
         public EquivalencyTypeOptions() { }
+        public aweXpect.Equivalency.EquivalencyComparisonType? ComparisonType { get; init; }
         public aweXpect.Equivalency.IncludeMembers Fields { get; init; }
         public bool IgnoreCollectionOrder { get; init; }
         public string[] MembersToIgnore { get; init; }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -935,15 +935,19 @@ namespace aweXpect.Equivalency
         public EquivalencyOptions() { }
         public System.Collections.Generic.Dictionary<System.Type, aweXpect.Equivalency.EquivalencyTypeOptions> CustomOptions { get; init; }
         public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; }
+        public aweXpect.Equivalency.EquivalencyOptions For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
     }
     public static class EquivalencyOptionsExtensions
     {
-        public static aweXpect.Equivalency.EquivalencyOptions IgnoringCollectionOrder(this aweXpect.Equivalency.EquivalencyOptions @this, bool ignoreCollectionOrder = true) { }
-        public static aweXpect.Equivalency.EquivalencyOptions IgnoringMember(this aweXpect.Equivalency.EquivalencyOptions @this, string memberToIgnore) { }
+        public static TEquivalencyOptions IgnoringCollectionOrder<TEquivalencyOptions>(this TEquivalencyOptions @this, bool ignoreCollectionOrder = true)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>
     {
         public EquivalencyOptions(aweXpect.Equivalency.EquivalencyOptions inner) { }
+        public new aweXpect.Equivalency.EquivalencyOptions<TExpected> For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
     }
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -750,15 +750,19 @@ namespace aweXpect.Equivalency
         public EquivalencyOptions() { }
         public System.Collections.Generic.Dictionary<System.Type, aweXpect.Equivalency.EquivalencyTypeOptions> CustomOptions { get; init; }
         public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; }
+        public aweXpect.Equivalency.EquivalencyOptions For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
     }
     public static class EquivalencyOptionsExtensions
     {
-        public static aweXpect.Equivalency.EquivalencyOptions IgnoringCollectionOrder(this aweXpect.Equivalency.EquivalencyOptions @this, bool ignoreCollectionOrder = true) { }
-        public static aweXpect.Equivalency.EquivalencyOptions IgnoringMember(this aweXpect.Equivalency.EquivalencyOptions @this, string memberToIgnore) { }
+        public static TEquivalencyOptions IgnoringCollectionOrder<TEquivalencyOptions>(this TEquivalencyOptions @this, bool ignoreCollectionOrder = true)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>
     {
         public EquivalencyOptions(aweXpect.Equivalency.EquivalencyOptions inner) { }
+        public new aweXpect.Equivalency.EquivalencyOptions<TExpected> For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
     }
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -743,13 +743,13 @@ namespace aweXpect.Equivalency
     }
     public static class EquivalencyDefaults
     {
-        public static aweXpect.Equivalency.EquivalencyComparisonType DefaultTypeComparison(System.Type type) { }
+        public static aweXpect.Equivalency.EquivalencyComparisonType DefaultComparisonType(System.Type type) { }
     }
     public class EquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions>
     {
         public EquivalencyOptions() { }
         public System.Collections.Generic.Dictionary<System.Type, aweXpect.Equivalency.EquivalencyTypeOptions> CustomOptions { get; init; }
-        public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> TypeComparison { get; init; }
+        public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; }
     }
     public static class EquivalencyOptionsExtensions
     {
@@ -763,6 +763,7 @@ namespace aweXpect.Equivalency
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {
         public EquivalencyTypeOptions() { }
+        public aweXpect.Equivalency.EquivalencyComparisonType? ComparisonType { get; init; }
         public aweXpect.Equivalency.IncludeMembers Fields { get; init; }
         public bool IgnoreCollectionOrder { get; init; }
         public string[] MembersToIgnore { get; init; }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -758,6 +758,10 @@ namespace aweXpect.Equivalency
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers fieldsToInclude)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers propertiesToInclude)
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>
     {

--- a/Tests/aweXpect.Internal.Tests/Equivalency/EquivalencyComparerTests.ComparisonTypeTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Equivalency/EquivalencyComparerTests.ComparisonTypeTests.cs
@@ -31,18 +31,11 @@ public sealed partial class EquivalencyComparerTests
 					Value = 1
 				}
 			};
-			EquivalencyComparer sut = new(new EquivalencyOptions
-			{
-				CustomOptions =
+			EquivalencyComparer sut = new(new EquivalencyOptions()
+				.For<MyClass2>(o => o with
 				{
-					{
-						typeof(MyClass2), new EquivalencyTypeOptions
-						{
-							ComparisonType = EquivalencyComparisonType.ByValue
-						}
-					}
-				}
-			});
+					ComparisonType = EquivalencyComparisonType.ByValue
+				}));
 
 			bool result = sut.AreConsideredEqual(actual, expected);
 			string failure = sut.GetExtendedFailure("it", actual, expected);

--- a/Tests/aweXpect.Internal.Tests/Equivalency/EquivalencyComparerTests.ComparisonTypeTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Equivalency/EquivalencyComparerTests.ComparisonTypeTests.cs
@@ -1,5 +1,7 @@
 ﻿using aweXpect.Equivalency;
 
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+
 namespace aweXpect.Internal.Tests.Equivalency;
 
 public sealed partial class EquivalencyComparerTests
@@ -79,8 +81,8 @@ public sealed partial class EquivalencyComparerTests
 
 		private class MyClassWithDifferentProperties
 		{
-			public MyClass1 Property1 { get; set; }
-			public MyClass2 Property2 { get; set; }
+			public MyClass1? Property1 { get; set; }
+			public MyClass2? Property2 { get; set; }
 		}
 
 		private class MyClass1

--- a/Tests/aweXpect.Internal.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
@@ -1,0 +1,67 @@
+﻿using aweXpect.Equivalency;
+
+namespace aweXpect.Internal.Tests.Equivalency;
+
+public sealed class EquivalencyOptionsExtensionsTests
+{
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task Generic_For_IgnoringCollectionOrder_ShouldSetOptionForType(bool ignoreCollectionOrder)
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o => o.IgnoringCollectionOrder(ignoreCollectionOrder));
+
+		await That(result.IgnoreCollectionOrder).IsFalse();
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass));
+		await That(result.CustomOptions[typeof(MyClass)].IgnoreCollectionOrder).IsEqualTo(ignoreCollectionOrder);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Generic_For_IgnoringMember_ShouldSetOptionForType(string memberToIgnore)
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o => o.IgnoringMember(memberToIgnore));
+
+		await That(result.MembersToIgnore).IsEmpty();
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass));
+		await That(result.CustomOptions[typeof(MyClass)].MembersToIgnore).HasSingle().Which.IsEqualTo(memberToIgnore);
+	}
+
+	[Theory]
+	[InlineData(IncludeMembers.None)]
+	[InlineData(IncludeMembers.Public)]
+	[InlineData(IncludeMembers.Internal)]
+	[InlineData(IncludeMembers.Private)]
+	public async Task Generic_For_IncludingFields_ShouldSetOptionForType(IncludeMembers fieldsToInclude)
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o => o.IncludingFields(fieldsToInclude));
+
+		await That(result.Fields).IsEqualTo(IncludeMembers.Public);
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass));
+		await That(result.CustomOptions[typeof(MyClass)].Fields).IsEqualTo(fieldsToInclude);
+	}
+
+	[Theory]
+	[InlineData(IncludeMembers.None)]
+	[InlineData(IncludeMembers.Public)]
+	[InlineData(IncludeMembers.Internal)]
+	[InlineData(IncludeMembers.Private)]
+	public async Task Generic_For_IncludingProperties_ShouldSetOptionForType(IncludeMembers propertiesToInclude)
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o => o.IncludingProperties(propertiesToInclude));
+
+		await That(result.Properties).IsEqualTo(IncludeMembers.Public);
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass));
+		await That(result.CustomOptions[typeof(MyClass)].Properties).IsEqualTo(propertiesToInclude);
+	}
+
+	private class MyClass;
+}


### PR DESCRIPTION
Part of #174 

* Support specifying the `ComparisonType` in the `CustomOptions`
* Add `For` method on `EquivalencyOptions`
* Add `IncludingFields`/`IncludingProperties` to `EquivalencyOptions`