### PR TITLE
refactor: update "needs" in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
     pack:
         name: "Pack"
         runs-on: ubuntu-latest
-        needs: [ publish-test-results, benchmarks, static-code-analysis ]
+        needs: [ publish-test-results, static-code-analysis ]
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -167,7 +167,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack, mutation-tests ]
+        needs: [ pack, build-pages, mutation-tests ]
         permissions:
             contents: write
         steps:
@@ -209,7 +209,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack ]
+        needs: [ pack, build-pages ]
         steps:
             -   name: Download packages
                 uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,56 @@ on:
         branches: [ main ]
 
 jobs:
+    benchmarks:
+        name: "Benchmarks"
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        env:
+            DOTNET_NOLOGO: true
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Run benchmarks
+                run: ./build.sh Benchmarks
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+
+    build-pages:
+        name: Build Pages
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        runs-on: ubuntu-latest
+        needs: [ benchmarks ]
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Merge benchmarks branch
+                run: |
+                    git config --global user.email "benchmarks@testably.org"
+                    git config --global user.name "Benchmark User"
+                    git fetch origin
+                    git merge origin/benchmarks --no-edit
+            -   uses: actions/setup-node@v4
+                with:
+                    node-version: 18
+                    cache: npm
+                    cache-dependency-path: ./Docs/pages/package-lock.json
+            -   name: Install dependencies
+                working-directory: ./Docs/pages
+                run: npm ci
+            -   name: Build website
+                working-directory: ./Docs/pages
+                run: npm run build
+
     unit-tests:
         name: "Unit tests"
         strategy:
@@ -36,7 +86,7 @@ jobs:
                     path: |
                         ./Artifacts/*
                         ./TestResults/*.trx
-    
+
     api-tests:
         name: "API tests"
         runs-on: ubuntu-latest
@@ -61,7 +111,26 @@ jobs:
                     path: |
                         ./Artifacts/*
                         ./TestResults/*.trx
-    
+
+    publish-test-results:
+        name: "Publish Tests Results"
+        needs: [ api-tests, unit-tests ]
+        runs-on: ubuntu-latest
+        permissions:
+            checks: write
+            pull-requests: write
+        if: always()
+        steps:
+            -   name: Download Artifacts
+                uses: actions/download-artifact@v4
+                with:
+                    path: artifacts
+            -   name: Publish Test Results
+                uses: EnricoMi/publish-unit-test-result-action@v2
+                with:
+                    comment_mode: always
+                    files: "artifacts/**/**/*.trx"
+
     mutation-tests:
         name: "Mutation tests"
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -84,30 +153,7 @@ jobs:
                 run: ./build.sh MutationTests
                 env:
                     GithubToken: ${{ secrets.GITHUB_TOKEN }}
-    
-    benchmarks:
-        name: "Benchmarks"
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
-        env:
-            DOTNET_NOLOGO: true
-        steps:
-            -   uses: actions/checkout@v4
-                with:
-                    fetch-depth: 0
-            -   name: Setup .NET SDKs
-                uses: actions/setup-dotnet@v4
-                with:
-                    dotnet-version: |
-                        8.0.x
-            -   name: Run benchmarks
-                run: ./build.sh Benchmarks
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
-    
+
     static-code-analysis:
         name: "Static code analysis"
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -127,49 +173,3 @@ jobs:
                         8.0.x
             -   name: Run sonarcloud analysis
                 run: ./build.sh CodeAnalysis
-    
-    publish-test-results:
-        name: "Publish Tests Results"
-        needs: [ api-tests, unit-tests ]
-        runs-on: ubuntu-latest
-        permissions:
-            checks: write
-            pull-requests: write
-        if: always()
-        steps:
-            -   name: Download Artifacts
-                uses: actions/download-artifact@v4
-                with:
-                    path: artifacts
-            -   name: Publish Test Results
-                uses: EnricoMi/publish-unit-test-result-action@v2
-                with:
-                    comment_mode: always
-                    files: "artifacts/**/**/*.trx"
-    
-    build-pages:
-        name: Build Pages
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        runs-on: ubuntu-latest
-        needs: [ benchmarks ]
-        steps:
-            -   uses: actions/checkout@v4
-                with:
-                    fetch-depth: 0
-            -   name: Merge benchmarks branch
-                run: |
-                    git config --global user.email "benchmarks@testably.org"
-                    git config --global user.name "Benchmark User"
-                    git fetch origin
-                    git merge origin/benchmarks --no-edit
-            -   uses: actions/setup-node@v4
-                with:
-                    node-version: 18
-                    cache: npm
-                    cache-dependency-path: ./Docs/pages/package-lock.json
-            -   name: Install dependencies
-                working-directory: ./Docs/pages
-                run: npm ci
-            -   name: Build website
-                working-directory: ./Docs/pages
-                run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
         branches: [ main ]
 
 jobs:
-    benchmarks:
+    x_benchmarks:
         name: "Benchmarks"
         if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
         name: Build Pages
         if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        needs: [ benchmarks ]
+        needs: [ x_benchmarks ]
         steps:
             -   uses: actions/checkout@v4
                 with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,56 +6,6 @@ on:
         branches: [ main ]
 
 jobs:
-    x_benchmarks:
-        name: "Benchmarks"
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
-        env:
-            DOTNET_NOLOGO: true
-        steps:
-            -   uses: actions/checkout@v4
-                with:
-                    fetch-depth: 0
-            -   name: Setup .NET SDKs
-                uses: actions/setup-dotnet@v4
-                with:
-                    dotnet-version: |
-                        8.0.x
-            -   name: Run benchmarks
-                run: ./build.sh Benchmarks
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
-
-    build-pages:
-        name: Build Pages
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        runs-on: ubuntu-latest
-        needs: [ x_benchmarks ]
-        steps:
-            -   uses: actions/checkout@v4
-                with:
-                    fetch-depth: 0
-            -   name: Merge benchmarks branch
-                run: |
-                    git config --global user.email "benchmarks@testably.org"
-                    git config --global user.name "Benchmark User"
-                    git fetch origin
-                    git merge origin/benchmarks --no-edit
-            -   uses: actions/setup-node@v4
-                with:
-                    node-version: 18
-                    cache: npm
-                    cache-dependency-path: ./Docs/pages/package-lock.json
-            -   name: Install dependencies
-                working-directory: ./Docs/pages
-                run: npm ci
-            -   name: Build website
-                working-directory: ./Docs/pages
-                run: npm run build
-
     unit-tests:
         name: "Unit tests"
         strategy:
@@ -86,7 +36,7 @@ jobs:
                     path: |
                         ./Artifacts/*
                         ./TestResults/*.trx
-
+    
     api-tests:
         name: "API tests"
         runs-on: ubuntu-latest
@@ -111,26 +61,7 @@ jobs:
                     path: |
                         ./Artifacts/*
                         ./TestResults/*.trx
-
-    publish-test-results:
-        name: "Publish Tests Results"
-        needs: [ api-tests, unit-tests ]
-        runs-on: ubuntu-latest
-        permissions:
-            checks: write
-            pull-requests: write
-        if: always()
-        steps:
-            -   name: Download Artifacts
-                uses: actions/download-artifact@v4
-                with:
-                    path: artifacts
-            -   name: Publish Test Results
-                uses: EnricoMi/publish-unit-test-result-action@v2
-                with:
-                    comment_mode: always
-                    files: "artifacts/**/**/*.trx"
-
+    
     mutation-tests:
         name: "Mutation tests"
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -153,7 +84,30 @@ jobs:
                 run: ./build.sh MutationTests
                 env:
                     GithubToken: ${{ secrets.GITHUB_TOKEN }}
-
+    
+    benchmarks:
+        name: "Benchmarks"
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        env:
+            DOTNET_NOLOGO: true
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Run benchmarks
+                run: ./build.sh Benchmarks
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+    
     static-code-analysis:
         name: "Static code analysis"
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -173,3 +127,49 @@ jobs:
                         8.0.x
             -   name: Run sonarcloud analysis
                 run: ./build.sh CodeAnalysis
+    
+    publish-test-results:
+        name: "Publish Tests Results"
+        needs: [ api-tests, unit-tests ]
+        runs-on: ubuntu-latest
+        permissions:
+            checks: write
+            pull-requests: write
+        if: always()
+        steps:
+            -   name: Download Artifacts
+                uses: actions/download-artifact@v4
+                with:
+                    path: artifacts
+            -   name: Publish Test Results
+                uses: EnricoMi/publish-unit-test-result-action@v2
+                with:
+                    comment_mode: always
+                    files: "artifacts/**/**/*.trx"
+    
+    build-pages:
+        name: Build Pages
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        runs-on: ubuntu-latest
+        needs: [ benchmarks ]
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Merge benchmarks branch
+                run: |
+                    git config --global user.email "benchmarks@testably.org"
+                    git config --global user.name "Benchmark User"
+                    git fetch origin
+                    git merge origin/benchmarks --no-edit
+            -   uses: actions/setup-node@v4
+                with:
+                    node-version: 18
+                    cache: npm
+                    cache-dependency-path: ./Docs/pages/package-lock.json
+            -   name: Install dependencies
+                working-directory: ./Docs/pages
+                run: npm ci
+            -   name: Build website
+                working-directory: ./Docs/pages
+                run: npm run build


### PR DESCRIPTION
"Pack" can now run independent of benchmarks, but the push actions require that build-pages (and thus also benchmarks) succeeded successfully.