### PR TITLE
feat: include the key information in dictionary `WhoseValue`

### DIFF
--- a/Source/aweXpect/Results/ContainsValueResult.cs
+++ b/Source/aweXpect/Results/ContainsValueResult.cs
@@ -9,17 +9,22 @@ namespace aweXpect.Results;
 /// <remarks>
 ///     <seealso cref="AndOrResult{TCollection, TThat}" />
 /// </remarks>
-public class ContainsValueResult<TCollection, TThat, TValue>
+public class ContainsValueResult<TCollection, TThat, TKey, TValue>
 	: AndOrResult<TCollection, TThat>
 {
 	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly TKey _key;
 	private readonly Func<TCollection, TValue> _memberAccessor;
 
-	internal ContainsValueResult(ExpectationBuilder expectationBuilder, TThat returnValue,
+	internal ContainsValueResult(
+		ExpectationBuilder expectationBuilder,
+		TThat returnValue,
+		TKey key,
 		Func<TCollection, TValue> memberAccessor)
 		: base(expectationBuilder, returnValue)
 	{
 		_expectationBuilder = expectationBuilder;
+		_key = key;
 		_memberAccessor = memberAccessor;
 	}
 
@@ -27,5 +32,5 @@ public class ContainsValueResult<TCollection, TThat, TValue>
 	///     Further expectations on the selected value of the dictionary.
 	/// </summary>
 	public IThat<TValue> WhoseValue
-		=> new ThatSubject<TValue>(_expectationBuilder.ForWhich(_memberAccessor, " whose value should ", "the value"));
+		=> new ThatSubject<TValue>(_expectationBuilder.ForWhich(_memberAccessor, " whose value should ", $"value [{Formatter.Format(_key)}]"));
 }

--- a/Source/aweXpect/Results/ContainsValuesResult.cs
+++ b/Source/aweXpect/Results/ContainsValuesResult.cs
@@ -10,17 +10,22 @@ namespace aweXpect.Results;
 /// <remarks>
 ///     <seealso cref="AndOrResult{TCollection, TThat}" />
 /// </remarks>
-public class ContainsValuesResult<TCollection, TThat, TValue>
+public class ContainsValuesResult<TCollection, TThat, TKey, TValue>
 	: AndOrResult<TCollection, TThat>
 {
 	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly TKey[] _keys;
 	private readonly Func<TCollection, IEnumerable<TValue>> _memberAccessor;
 
-	internal ContainsValuesResult(ExpectationBuilder expectationBuilder, TThat returnValue,
+	internal ContainsValuesResult(
+		ExpectationBuilder expectationBuilder,
+		TThat returnValue,
+		TKey[] keys,
 		Func<TCollection, IEnumerable<TValue>> memberAccessor)
 		: base(expectationBuilder, returnValue)
 	{
 		_expectationBuilder = expectationBuilder;
+		_keys = keys;
 		_memberAccessor = memberAccessor;
 	}
 
@@ -30,6 +35,6 @@ public class ContainsValuesResult<TCollection, TThat, TValue>
 	public ThatEnumerable.Elements<TValue> WhoseValues
 		=> new(
 			new ThatSubject<IEnumerable<TValue>>(_expectationBuilder
-				.ForWhich(_memberAccessor, " whose values should ", "the values")),
+				.ForWhich(_memberAccessor, " whose values should ", $"values {Formatter.Format(_keys)}")),
 			EnumerableQuantifier.All);
 }

--- a/Source/aweXpect/That/Collections/ThatDictionary.ContainsKey.cs
+++ b/Source/aweXpect/That/Collections/ThatDictionary.ContainsKey.cs
@@ -11,13 +11,14 @@ public static partial class ThatDictionary
 	/// <summary>
 	///     Verifies that the dictionary contains the <paramref name="expected" /> key.
 	/// </summary>
-	public static ContainsValueResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TValue?>
+	public static ContainsValueResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TKey, TValue?>
 		ContainsKey<TKey, TValue>(
 			this IThat<IDictionary<TKey, TValue>?> source,
 			TKey expected)
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint(it =>
 				new ContainKeyConstraint<TKey, TValue>(it, expected)),
 			source,
+			expected,
 			f => f.TryGetValue(expected, out TValue? value) ? value : default
 		);
 

--- a/Source/aweXpect/That/Collections/ThatDictionary.ContainsKeys.cs
+++ b/Source/aweXpect/That/Collections/ThatDictionary.ContainsKeys.cs
@@ -12,13 +12,14 @@ public static partial class ThatDictionary
 	/// <summary>
 	///     Verifies that the dictionary contains all <paramref name="expected" /> keys.
 	/// </summary>
-	public static ContainsValuesResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TValue?>
+	public static ContainsValuesResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TKey, TValue?>
 		ContainsKeys<TKey, TValue>(
 			this IThat<IDictionary<TKey, TValue>?> source,
 			params TKey[] expected)
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint(it =>
 				new ContainKeysConstraint<TKey, TValue>(it, expected)),
 			source,
+			expected,
 			f => expected.Select(e => f.TryGetValue(e, out TValue? value) ? value : default)
 		);
 

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -192,8 +192,8 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TValue> AreAllUnique<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> AreAllUnique<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, System.Func<TValue, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TMember> AreAllUnique<TKey, TValue, TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, System.Func<TValue, TMember> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.ContainsValueResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TValue?> ContainsKey<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TKey expected) { }
-        public static aweXpect.Results.ContainsValuesResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TValue?> ContainsKeys<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, params TKey[] expected) { }
+        public static aweXpect.Results.ContainsValueResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TKey, TValue?> ContainsKey<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TKey expected) { }
+        public static aweXpect.Results.ContainsValuesResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TKey, TValue?> ContainsKeys<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, params TKey[] expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> ContainsValue<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TValue expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> ContainsValues<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, params TValue[] expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> DoesNotContainKey<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TKey unexpected) { }
@@ -1038,11 +1038,11 @@ namespace aweXpect.Json
 }
 namespace aweXpect.Results
 {
-    public class ContainsValueResult<TCollection, TThat, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
+    public class ContainsValueResult<TCollection, TThat, TKey, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
     {
         public aweXpect.Core.IThat<TValue> WhoseValue { get; }
     }
-    public class ContainsValuesResult<TCollection, TThat, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
+    public class ContainsValuesResult<TCollection, TThat, TKey, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
     {
         public aweXpect.ThatEnumerable.Elements<TValue> WhoseValues { get; }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -94,8 +94,8 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TValue> AreAllUnique<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> AreAllUnique<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, System.Func<TValue, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TMember> AreAllUnique<TKey, TValue, TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, System.Func<TValue, TMember> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.ContainsValueResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TValue?> ContainsKey<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TKey expected) { }
-        public static aweXpect.Results.ContainsValuesResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TValue?> ContainsKeys<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, params TKey[] expected) { }
+        public static aweXpect.Results.ContainsValueResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TKey, TValue?> ContainsKey<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TKey expected) { }
+        public static aweXpect.Results.ContainsValuesResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>, TKey, TValue?> ContainsKeys<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, params TKey[] expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> ContainsValue<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TValue expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> ContainsValues<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, params TValue[] expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IDictionary<TKey, TValue>, aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?>> DoesNotContainKey<TKey, TValue>(this aweXpect.Core.IThat<System.Collections.Generic.IDictionary<TKey, TValue>?> source, TKey unexpected) { }
@@ -789,11 +789,11 @@ namespace aweXpect.Equivalency
 }
 namespace aweXpect.Results
 {
-    public class ContainsValueResult<TCollection, TThat, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
+    public class ContainsValueResult<TCollection, TThat, TKey, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
     {
         public aweXpect.Core.IThat<TValue> WhoseValue { get; }
     }
-    public class ContainsValuesResult<TCollection, TThat, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
+    public class ContainsValuesResult<TCollection, TThat, TKey, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
     {
         public aweXpect.ThatEnumerable.Elements<TValue> WhoseValues { get; }
     }

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKey.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKey.Tests.cs
@@ -81,7 +81,7 @@ public sealed partial class ThatDictionary
 					.WithMessage("""
 					             Expected subject to
 					             have key 2 whose value should be equal to "foo",
-					             but the value was "bar" which differs at index 0:
+					             but value [2] was "bar" which differs at index 0:
 					                ↓ (actual)
 					               "bar"
 					               "foo"


### PR DESCRIPTION
Include the key in the error message when the value did not match the expectation.