### PR TITLE
fix: publish symbol packages

### DIFF
--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -44,7 +44,7 @@ partial class Build
 				foreach (string symbolPackage in
 				         Directory.EnumerateFiles(project.Directory / "bin", "*.snupkg", SearchOption.AllDirectories))
 				{
-					File.Move(symbolPackage, packagesDirectory / Path.GetFileName(symbolPackage));
+					File.Move(symbolPackage, packagesDirectory / project.Name / Path.GetFileName(symbolPackage));
 					Debug("Found symbol package: {PackagePath}", symbolPackage);
 				}
 			}


### PR DESCRIPTION
The path for publishing the symbol packages was incorrect.