### PR TITLE
refactor!: use `StringBuilder` in `ConstraintResult`

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -22,7 +22,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core.Helpers;
+
+namespace aweXpect.Core.Constraints;
+
+/// <summary>
+///     Extensions methods on <see cref="ConstraintResult" />
+/// </summary>
+public static class ConstraintResultExtensions
+{
+	/// <summary>
+	///     Creates a new <see cref="ConstraintResult" /> from the <paramref name="inner" /> using the given
+	///     <paramref name="value" />.
+	/// </summary>
+	public static ConstraintResult UseValue<T>(this ConstraintResult inner, T value)
+		=> new ConstraintResultWrapper<T>(inner, value);
+
+	/// <summary>
+	///     Creates a new <see cref="ConstraintResult" /> with <see cref="Outcome.Failure" /> from
+	///     the <paramref name="inner" /> using the given <paramref name="value" />.
+	/// </summary>
+	public static ConstraintResult Fail<T>(this ConstraintResult inner, string failure, T value)
+		=> new ConstraintResultFailure<T>(inner, failure, true, value);
+
+	private class ConstraintResultWrapper<T>(ConstraintResult inner, T value)
+		: ConstraintResult(inner.Outcome, inner.FurtherProcessingStrategy)
+	{
+		private readonly T _value = value;
+
+		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> inner.AppendExpectation(stringBuilder, indentation);
+
+		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+			=> inner.AppendResult(stringBuilder, indentation);
+
+		internal override void UpdateExpectationText(
+			Action<StringBuilder>? prependExpectationText = null,
+			Action<StringBuilder>? appendExpectationText = null)
+			=> inner.UpdateExpectationText(prependExpectationText, appendExpectationText);
+
+		internal override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+		{
+			if (_value is TValue typedValue)
+			{
+				value = typedValue;
+				return true;
+			}
+
+			value = default;
+			return false;
+		}
+	}
+
+	private class ConstraintResultFailure<T>(ConstraintResult inner, string failure, bool useValue, T value)
+		: ConstraintResult(Outcome.Failure, inner.FurtherProcessingStrategy)
+	{
+		private readonly T _value = value;
+
+		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> inner.AppendExpectation(stringBuilder, indentation);
+
+		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(failure.Indent(indentation));
+
+		internal override void UpdateExpectationText(
+			Action<StringBuilder>? prependExpectationText = null,
+			Action<StringBuilder>? appendExpectationText = null)
+			=> inner.UpdateExpectationText(prependExpectationText, appendExpectationText);
+
+		internal override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+		{
+			if (!useValue)
+			{
+				return inner.TryGetValue(out value);
+			}
+
+			if (_value is TValue typedValue)
+			{
+				value = typedValue;
+				return true;
+			}
+
+			value = default;
+			return false;
+		}
+	}
+}

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -24,7 +24,7 @@ public static class ConstraintResultExtensions
 	public static ConstraintResult Fail<T>(this ConstraintResult inner, string failure, T value)
 		=> new ConstraintResultFailure<T>(inner, failure, true, value);
 
-	private class ConstraintResultWrapper<T>(ConstraintResult inner, T value)
+	private sealed class ConstraintResultWrapper<T>(ConstraintResult inner, T value)
 		: ConstraintResult(inner.Outcome, inner.FurtherProcessingStrategy)
 	{
 		private readonly T _value = value;
@@ -53,7 +53,7 @@ public static class ConstraintResultExtensions
 		}
 	}
 
-	private class ConstraintResultFailure<T>(ConstraintResult inner, string failure, bool useValue, T value)
+	private sealed class ConstraintResultFailure<T>(ConstraintResult inner, string failure, bool useValue, T value)
 		: ConstraintResult(Outcome.Failure, inner.FurtherProcessingStrategy)
 	{
 		private readonly T _value = value;

--- a/Source/aweXpect.Core/Core/Constraints/FurtherProcessingStrategy.cs
+++ b/Source/aweXpect.Core/Core/Constraints/FurtherProcessingStrategy.cs
@@ -1,0 +1,25 @@
+﻿namespace aweXpect.Core.Constraints;
+
+/// <summary>
+///     The strategy how to continue processing after the current result.
+/// </summary>
+public enum FurtherProcessingStrategy
+{
+	/// <summary>
+	///     Continue processing.
+	/// </summary>
+	/// <remarks>
+	///     This is the default behaviour.
+	/// </remarks>
+	Continue,
+
+	/// <summary>
+	///     Completely ignore all future constraints.
+	/// </summary>
+	IgnoreCompletely,
+
+	/// <summary>
+	///     Ignore the result of future constraints, but include their expectations.
+	/// </summary>
+	IgnoreResult,
+}

--- a/Source/aweXpect.Core/Core/Constraints/Outcome.cs
+++ b/Source/aweXpect.Core/Core/Constraints/Outcome.cs
@@ -1,0 +1,22 @@
+﻿namespace aweXpect.Core.Constraints;
+
+/// <summary>
+///     The outcome of a <see cref="ConstraintResult" />
+/// </summary>
+public enum Outcome
+{
+	/// <summary>
+	///     The constraint was successful.
+	/// </summary>
+	Success,
+
+	/// <summary>
+	///     The constraint failed.
+	/// </summary>
+	Failure,
+
+	/// <summary>
+	///     The result could not be determined (e.g. due to timeout).
+	/// </summary>
+	Undecided,
+}

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -112,7 +112,7 @@ public abstract class ExpectationBuilder
 	/// </summary>
 	public MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(
 		MemberAccessor<TSource, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
 		bool replaceIt = true) =>
 		new((expectationBuilderCallback, expectationGrammar, sourceConstraintCallback) =>
 		{

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -237,12 +237,14 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Creates the exception message from the <paramref name="failure" />.
 	/// </summary>
-	internal static string FromFailure(string subject, ConstraintResult.Failure failure)
+	internal static string FromFailure(string subject, ConstraintResult failure)
 	{
 		StringBuilder sb = new();
 		sb.Append("Expected that ").Append(subject).AppendLine();
-		sb.Append(failure.ExpectationText).AppendLine(",");
-		sb.Append("but ").Append(failure.ResultText);
+		failure.AppendExpectation(sb);
+		sb.AppendLine(",");
+		sb.Append("but ");
+		failure.AppendResult(sb);
 		return sb.ToString();
 	}
 

--- a/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
@@ -23,6 +23,7 @@ internal readonly struct BecauseReason(string reason)
 	public ConstraintResult ApplyTo(ConstraintResult result)
 	{
 		string message = _message.Value;
-		return result.UpdateExpectationText(null, e => e.Append(message));
+		result.UpdateExpectationText(null, e => e.Append(message));
+		return result;
 	}
 }

--- a/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
@@ -23,6 +23,6 @@ internal readonly struct BecauseReason(string reason)
 	public ConstraintResult ApplyTo(ConstraintResult result)
 	{
 		string message = _message.Value;
-		return result.UpdateExpectationText(e => e.ExpectationText + message);
+		return result.UpdateExpectationText(null, e => e.Append(message));
 	}
 }

--- a/Source/aweXpect.Core/Core/Helpers/StringExtensions.cs
+++ b/Source/aweXpect.Core/Core/Helpers/StringExtensions.cs
@@ -11,7 +11,7 @@ internal static class StringExtensions
 		value?.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
 
 	[return: NotNullIfNotNull(nameof(value))]
-	public static string? Indent(this string? value, string indentation = "  ",
+	public static string? Indent(this string? value, string? indentation = "  ",
 		bool indentFirstLine = true)
 	{
 		if (value == null || string.IsNullOrEmpty(indentation))

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
@@ -94,48 +96,71 @@ internal class AndNode : Node
 			return result;
 		}
 
-		string combinedExpectation =
-			$"{combinedResult.ExpectationText}{separator}{result.ExpectationText}";
-
-		if (combinedResult is ConstraintResult.Failure leftFailure &&
-		    result is ConstraintResult.Failure rightFailure)
-		{
-			return leftFailure.CombineWith(
-				combinedExpectation,
-				CombineResultTexts(
-					leftFailure.ResultText,
-					rightFailure.ResultText,
-					furtherProcessingStrategy ?? ConstraintResult.FurtherProcessing.Continue));
-		}
-
-		if (combinedResult is ConstraintResult.Failure onlyLeftFailure)
-		{
-			return onlyLeftFailure.CombineWith(
-				combinedExpectation,
-				onlyLeftFailure.ResultText);
-		}
-
-		if (result is ConstraintResult.Failure onlyRightFailure)
-		{
-			return onlyRightFailure.CombineWith(
-				combinedExpectation,
-				onlyRightFailure.ResultText);
-		}
-
-		return combinedResult.CombineWith(combinedExpectation, "");
+		return new AndConstraintResult(combinedResult, result, separator,
+			furtherProcessingStrategy ?? ConstraintResult.FurtherProcessing.Continue);
 	}
 
-	private static string CombineResultTexts(
-		string leftResultText,
-		string rightResultText,
+	private class AndConstraintResult(
+		ConstraintResult left,
+		ConstraintResult right,
+		string separator,
 		ConstraintResult.FurtherProcessing furtherProcessingStrategy)
+		: ConstraintResult(And(left.Outcome, right.Outcome), furtherProcessingStrategy)
 	{
-		if (furtherProcessingStrategy == ConstraintResult.FurtherProcessing.IgnoreResult ||
-		    leftResultText == rightResultText)
+		private readonly FurtherProcessing _furtherProcessingStrategy = furtherProcessingStrategy;
+
+		private static Outcome And(Outcome left, Outcome right)
+			=> (left, right) switch
+			{
+				(Outcome.Success, Outcome.Success) => Outcome.Success,
+				(_, Outcome.Failure) => Outcome.Failure,
+				(Outcome.Failure, _) => Outcome.Failure,
+				(_, _) => Outcome.Undecided,
+			};
+
+		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
-			return leftResultText;
+			left.AppendExpectation(stringBuilder);
+			stringBuilder.Append(separator);
+			right.AppendExpectation(stringBuilder);
 		}
 
-		return $"{leftResultText} and {rightResultText}";
+		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (left.Outcome == Outcome.Failure)
+			{
+				left.AppendResult(stringBuilder, indentation);
+				if (right.Outcome == Outcome.Failure &&
+				    _furtherProcessingStrategy != FurtherProcessing.IgnoreResult &&
+				    left.GetResultText() != right.GetResultText())
+				{
+					stringBuilder.Append(" and ");
+					right.AppendResult(stringBuilder, indentation);
+				}
+			}
+			else if (right.Outcome == Outcome.Failure)
+			{
+				right.AppendResult(stringBuilder, indentation);
+			}
+		}
+
+		internal override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value)
+			where TValue : default
+		{
+			if (left.TryGetValue<TValue>(out var leftValue))
+			{
+				value = leftValue;
+				return true;
+			}
+
+			if (right.TryGetValue<TValue>(out var rightValue))
+			{
+				value = rightValue;
+				return true;
+			}
+
+			value = default;
+			return false;
+		}
 	}
 }

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -11,13 +11,18 @@ using aweXpect.Core.Helpers;
 
 namespace aweXpect.Core.Nodes;
 
-internal class AndNode(Node node) : Node
+internal class AndNode : Node
 {
 	private const string DefaultSeparator = " and ";
 	private readonly List<(string, Node)> _nodes = new();
 	private string? _currentSeparator;
 
-	private Node Current { get; set; } = node;
+	public AndNode(Node node)
+	{
+		Current = node;
+	}
+
+	private Node Current { get; set; }
 
 	/// <inheritdoc />
 	public override void AddConstraint(IConstraint constraint)
@@ -95,7 +100,7 @@ internal class AndNode(Node node) : Node
 			furtherProcessingStrategy ?? FurtherProcessingStrategy.Continue);
 	}
 
-	private class AndConstraintResult(
+	private sealed class AndConstraintResult(
 		ConstraintResult left,
 		ConstraintResult right,
 		string separator,

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -11,18 +11,13 @@ using aweXpect.Core.Helpers;
 
 namespace aweXpect.Core.Nodes;
 
-internal class AndNode : Node
+internal class AndNode(Node node) : Node
 {
 	private const string DefaultSeparator = " and ";
 	private readonly List<(string, Node)> _nodes = new();
 	private string? _currentSeparator;
 
-	public AndNode(Node node)
-	{
-		Current = node;
-	}
-
-	private Node Current { get; set; }
+	private Node Current { get; set; } = node;
 
 	/// <inheritdoc />
 	public override void AddConstraint(IConstraint constraint)
@@ -31,7 +26,7 @@ internal class AndNode : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
 

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -55,7 +55,7 @@ internal class AndNode(Node node) : Node
 			combinedResult = CombineResults(combinedResult, result, separator,
 				combinedResult?.FurtherProcessingStrategy);
 			if (result.FurtherProcessingStrategy ==
-			    ConstraintResult.FurtherProcessing.IgnoreCompletely)
+			    FurtherProcessingStrategy.IgnoreCompletely)
 			{
 				return combinedResult;
 			}
@@ -84,7 +84,7 @@ internal class AndNode(Node node) : Node
 		ConstraintResult? combinedResult,
 		ConstraintResult result,
 		string separator,
-		ConstraintResult.FurtherProcessing? furtherProcessingStrategy)
+		FurtherProcessingStrategy? furtherProcessingStrategy)
 	{
 		if (combinedResult == null)
 		{
@@ -92,17 +92,17 @@ internal class AndNode(Node node) : Node
 		}
 
 		return new AndConstraintResult(combinedResult, result, separator,
-			furtherProcessingStrategy ?? ConstraintResult.FurtherProcessing.Continue);
+			furtherProcessingStrategy ?? FurtherProcessingStrategy.Continue);
 	}
 
 	private class AndConstraintResult(
 		ConstraintResult left,
 		ConstraintResult right,
 		string separator,
-		ConstraintResult.FurtherProcessing furtherProcessingStrategy)
+		FurtherProcessingStrategy furtherProcessingStrategy)
 		: ConstraintResult(And(left.Outcome, right.Outcome), furtherProcessingStrategy)
 	{
-		private readonly FurtherProcessing _furtherProcessingStrategy = furtherProcessingStrategy;
+		private readonly FurtherProcessingStrategy _furtherProcessingStrategy = furtherProcessingStrategy;
 
 		private static Outcome And(Outcome left, Outcome right)
 			=> (left, right) switch
@@ -126,7 +126,7 @@ internal class AndNode(Node node) : Node
 			{
 				left.AppendResult(stringBuilder, indentation);
 				if (right.Outcome == Outcome.Failure &&
-				    _furtherProcessingStrategy != FurtherProcessing.IgnoreResult &&
+				    _furtherProcessingStrategy != FurtherProcessingStrategy.IgnoreResult &&
 				    left.GetResultText() != right.GetResultText())
 				{
 					stringBuilder.Append(" and ");

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
@@ -37,7 +38,7 @@ internal class ExpectationNode : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 	{
 		MappingNode<TValue, TTarget> mappingNode =

--- a/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
@@ -77,7 +77,7 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 		StringBuilder expectation)
 		=> expectation.Append(memberAccessor);
 
-	private class MappingConstraintResult(
+	private sealed class MappingConstraintResult(
 		ConstraintResult left,
 		ConstraintResult right,
 		Action<MemberAccessor<TSource, TTarget?>, StringBuilder>? expectationTextGenerator,

--- a/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,14 +11,14 @@ namespace aweXpect.Core.Nodes;
 
 internal class MappingNode<TSource, TTarget> : ExpectationNode
 {
-	private readonly Func<MemberAccessor<TSource, TTarget?>, string, string>
+	private readonly Action<MemberAccessor<TSource, TTarget?>, StringBuilder>
 		_expectationTextGenerator;
 
 	private readonly MemberAccessor<TSource, TTarget?> _memberAccessor;
 
 	public MappingNode(
 		MemberAccessor<TSource, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 	{
 		_memberAccessor = memberAccessor;
 		if (expectationTextGenerator == null)
@@ -65,49 +66,80 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 		if (combinedResult == null)
 		{
 			return result.UpdateExpectationText(
-				e => _expectationTextGenerator(_memberAccessor, e.ExpectationText));
+				e => _expectationTextGenerator(_memberAccessor, e));
 		}
 
-		string combinedExpectation =
-			$"{combinedResult.ExpectationText}{_expectationTextGenerator(_memberAccessor, result.ExpectationText)}";
-
-		if (combinedResult is ConstraintResult.Failure leftFailure &&
-		    result is ConstraintResult.Failure rightFailure)
-		{
-			return leftFailure.CombineWith(
-				combinedExpectation,
-				CombineResultTexts(leftFailure.ResultText, rightFailure.ResultText));
-		}
-
-		if (combinedResult is ConstraintResult.Failure onlyLeftFailure)
-		{
-			return onlyLeftFailure.CombineWith(
-				combinedExpectation,
-				onlyLeftFailure.ResultText);
-		}
-
-		if (result is ConstraintResult.Failure onlyRightFailure)
-		{
-			return onlyRightFailure.CombineWith(
-				combinedExpectation,
-				onlyRightFailure.ResultText);
-		}
-
-		return combinedResult.CombineWith(combinedExpectation, "");
+		return new MappingConstraintResult(combinedResult, result, _expectationTextGenerator, _memberAccessor);
 	}
 
-	private static string CombineResultTexts(string leftResultText, string rightResultText)
+	private class MappingConstraintResult(
+		ConstraintResult left,
+		ConstraintResult right,
+		Action<MemberAccessor<TSource, TTarget?>, StringBuilder>? expectationTextGenerator,
+		MemberAccessor<TSource, TTarget?> memberAccessor)
+		: ConstraintResult(And(left.Outcome, right.Outcome), FurtherProcessing.Continue)
 	{
-		if (leftResultText == rightResultText)
+		private static Outcome And(Outcome left, Outcome right)
+			=> (left, right) switch
+			{
+				(Outcome.Success, Outcome.Success) => Outcome.Success,
+				(_, Outcome.Failure) => Outcome.Failure,
+				(Outcome.Failure, _) => Outcome.Failure,
+				(_, _) => Outcome.Undecided,
+			};
+
+		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
-			return leftResultText;
+			left.AppendExpectation(stringBuilder);
+			if (expectationTextGenerator is not null)
+			{
+				expectationTextGenerator(memberAccessor, stringBuilder);
+			}
+			right.AppendExpectation(stringBuilder);
 		}
 
-		return $"{leftResultText} and {rightResultText}";
+		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (left.Outcome == Outcome.Failure)
+			{
+				left.AppendResult(stringBuilder, indentation);
+				if (right.Outcome == Outcome.Failure &&
+				    left.GetResultText() != right.GetResultText())
+				{
+					stringBuilder.Append(" and ");
+					right.AppendResult(stringBuilder, indentation);
+				}
+			}
+			else if (right.Outcome == Outcome.Failure)
+			{
+				right.AppendResult(stringBuilder, indentation);
+			}
+		}
+
+		internal override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value)
+			where TValue : default
+		{
+			if (left.TryGetValue<TValue>(out var leftValue))
+			{
+				value = leftValue;
+				return true;
+			}
+
+			if (right.TryGetValue<TValue>(out var rightValue))
+			{
+				value = rightValue;
+				return true;
+			}
+
+			value = default;
+			return false;
+		}
 	}
 
-	private static string DefaultExpectationTextGenerator(
+	private static void DefaultExpectationTextGenerator(
 		MemberAccessor<TSource, TTarget?> memberAccessor,
-		string expectationText)
-		=> memberAccessor + expectationText;
+		StringBuilder expectation)
+	{
+		expectation.Append(memberAccessor);
+	}
 }

--- a/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
@@ -56,6 +57,7 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 	public override string ToString()
 		=> _memberAccessor + base.ToString();
 
+	// TODO VAB: Rework
 	internal ConstraintResult CombineResults(
 		ConstraintResult? combinedResult,
 		ConstraintResult result)

--- a/Source/aweXpect.Core/Core/Nodes/Node.cs
+++ b/Source/aweXpect.Core/Core/Nodes/Node.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
@@ -20,7 +21,7 @@ internal abstract class Node
 	/// </summary>
 	public abstract Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null);
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
 
 	/// <summary>
 	///     Add a node as inner node.

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -11,13 +11,18 @@ using aweXpect.Core.Helpers;
 
 namespace aweXpect.Core.Nodes;
 
-internal class OrNode(Node node) : Node
+internal class OrNode : Node
 {
 	private const string DefaultSeparator = " or ";
 	private readonly List<(string, Node)> _nodes = new();
 	private string? _currentSeparator;
 
-	internal Node Current { get; set; } = node;
+	public OrNode(Node node)
+	{
+		Current = node;
+	}
+
+	internal Node Current { get; set; }
 
 	/// <inheritdoc />
 	public override void AddConstraint(IConstraint constraint)
@@ -90,7 +95,7 @@ internal class OrNode(Node node) : Node
 			furtherProcessingStrategy ?? FurtherProcessingStrategy.Continue);
 	}
 
-	private class OrConstraintResult(
+	private sealed class OrConstraintResult(
 		ConstraintResult left,
 		ConstraintResult right,
 		string separator,

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -11,18 +11,13 @@ using aweXpect.Core.Helpers;
 
 namespace aweXpect.Core.Nodes;
 
-internal class OrNode : Node
+internal class OrNode(Node node) : Node
 {
 	private const string DefaultSeparator = " or ";
 	private readonly List<(string, Node)> _nodes = new();
 	private string? _currentSeparator;
 
-	public OrNode(Node node)
-	{
-		Current = node;
-	}
-
-	internal Node Current { get; set; }
+	internal Node Current { get; set; } = node;
 
 	/// <inheritdoc />
 	public override void AddConstraint(IConstraint constraint)
@@ -31,7 +26,7 @@ internal class OrNode : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
 

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -50,7 +50,7 @@ internal class OrNode(Node node) : Node
 			combinedResult = CombineResults(combinedResult, result, separator,
 				combinedResult?.FurtherProcessingStrategy);
 			if (result.FurtherProcessingStrategy ==
-			    ConstraintResult.FurtherProcessing.IgnoreCompletely)
+			    FurtherProcessingStrategy.IgnoreCompletely)
 			{
 				return combinedResult;
 			}
@@ -79,7 +79,7 @@ internal class OrNode(Node node) : Node
 		ConstraintResult? combinedResult,
 		ConstraintResult result,
 		string separator,
-		ConstraintResult.FurtherProcessing? furtherProcessingStrategy)
+		FurtherProcessingStrategy? furtherProcessingStrategy)
 	{
 		if (combinedResult == null)
 		{
@@ -87,17 +87,17 @@ internal class OrNode(Node node) : Node
 		}
 
 		return new OrConstraintResult(combinedResult, result, separator,
-			furtherProcessingStrategy ?? ConstraintResult.FurtherProcessing.Continue);
+			furtherProcessingStrategy ?? FurtherProcessingStrategy.Continue);
 	}
 
 	private class OrConstraintResult(
 		ConstraintResult left,
 		ConstraintResult right,
 		string separator,
-		ConstraintResult.FurtherProcessing furtherProcessingStrategy)
+		FurtherProcessingStrategy furtherProcessingStrategy)
 		: ConstraintResult(Or(left.Outcome, right.Outcome), furtherProcessingStrategy)
 	{
-		private readonly FurtherProcessing _furtherProcessingStrategy = furtherProcessingStrategy;
+		private readonly FurtherProcessingStrategy _furtherProcessingStrategy = furtherProcessingStrategy;
 
 		private static Outcome Or(Outcome left, Outcome right)
 			=> (left, right) switch
@@ -121,7 +121,7 @@ internal class OrNode(Node node) : Node
 			{
 				left.AppendResult(stringBuilder, indentation);
 				if (right.Outcome == Outcome.Failure &&
-				    _furtherProcessingStrategy != FurtherProcessing.IgnoreResult &&
+				    _furtherProcessingStrategy != FurtherProcessingStrategy.IgnoreResult &&
 				    left.GetResultText() != right.GetResultText())
 				{
 					stringBuilder.Append(" and ");

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -97,7 +97,7 @@ internal class WhichNode<TSource, TMember> : Node
 		return CombineResults(parentResult, result, _separator ?? "", FurtherProcessingStrategy.IgnoreResult, matchingValue);
 	}
 
-	private class WhichConstraintResult(
+	private sealed class WhichConstraintResult(
 		ConstraintResult left,
 		ConstraintResult right,
 		string separator,

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -45,7 +45,7 @@ internal class WhichNode<TSource, TMember> : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator);
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
@@ -93,7 +93,7 @@ public abstract partial class ThatDelegate
 			{
 				return new ConstraintResult.Failure<TException?>(null, ToString(),
 					"it did not throw any exception",
-					ConstraintResult.FurtherProcessing.IgnoreResult);
+					FurtherProcessingStrategy.IgnoreResult);
 			}
 
 			return new ConstraintResult.Failure<TException?>(null, ToString(),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.cs
@@ -26,11 +26,11 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 		{
 			return new ConstraintResult.Failure<Exception?>(exception, DoesNotThrowExpectation,
 				$"it did throw {FormatForMessage(exception)}",
-				ConstraintResult.FurtherProcessing.IgnoreCompletely);
+				FurtherProcessingStrategy.IgnoreCompletely);
 		}
 
 		return new ConstraintResult.Success<TException?>(default, DoesNotThrowExpectation,
-			ConstraintResult.FurtherProcessing.IgnoreCompletely);
+			FurtherProcessingStrategy.IgnoreCompletely);
 	}
 
 	internal static string FormatForMessage(Exception? exception)

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Which.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Which.cs
@@ -15,7 +15,7 @@ public partial class ThatDelegateThrows<TException>
 		Action<IThat<TMember?>> expectations)
 		=> new(ExpectationBuilder.ForMember(
 					MemberAccessor<TException, TMember?>.FromExpression(memberSelector),
-					(member, expectation) => $"whose {member}{expectation}")
+					(member, expectation) => expectation.Append("whose ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			this);
 }

--- a/Source/aweXpect.Core/Results/AndOrWhichResult.cs
+++ b/Source/aweXpect.Core/Results/AndOrWhichResult.cs
@@ -43,7 +43,7 @@ public class AndOrWhichResult<TType, TThat, TSelf>(
 		=> new(
 			_expectationBuilder
 				.ForMember(MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
-					(member, expectation) => $" which {member}{expectation}")
+					(member, stringBuilder) => stringBuilder.Append(" which ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			_returnValue);
 
@@ -75,7 +75,7 @@ public class AndOrWhichResult<TType, TThat, TSelf>(
 				_expectationBuilder
 					.ForMember(
 						MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
-						(member, expectation) => $" which {member}{expectation}")
+						(member, stringBuilder) => stringBuilder.Append(" which ").Append(member))
 					.AddExpectations(e
 						=> expectations(new ThatSubject<TMember?>(e))),
 				_returnValue);

--- a/Source/aweXpect.Core/Results/AndOrWhoseResult.cs
+++ b/Source/aweXpect.Core/Results/AndOrWhoseResult.cs
@@ -43,7 +43,7 @@ public class AndOrWhoseResult<TType, TThat, TSelf>(
 		=> new(
 			_expectationBuilder
 				.ForMember(MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
-					(member, expectation) => $" whose {member}{expectation}")
+					(member, stringBuilder) => stringBuilder.Append(" whose ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			_returnValue);
 
@@ -75,7 +75,7 @@ public class AndOrWhoseResult<TType, TThat, TSelf>(
 				_expectationBuilder
 					.ForMember(
 						MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
-						(member, expectation) => $" whose {member}{expectation}")
+						(member, stringBuilder) => stringBuilder.Append(" whose ").Append(member))
 					.AddExpectations(e
 						=> expectations(new ThatSubject<TMember?>(e))),
 				_returnValue);

--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -53,10 +53,10 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 	{
 		ConstraintResult result = await expectationBuilder.IsMet();
 
-		if (result is ConstraintResult.Failure failure)
+		if (result.Outcome == Outcome.Failure)
 		{
 			Fail.Test(ExpectationBuilder.FromFailure(
-				expectationBuilder.Subject, failure));
+				expectationBuilder.Subject, result));
 		}
 	}
 }
@@ -125,20 +125,15 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	{
 		ConstraintResult result = await expectationBuilder.IsMet();
 
-		if (result is ConstraintResult.Success<TType> matchingSuccess)
-		{
-			return matchingSuccess.Value;
-		}
-
-		if (result is ConstraintResult.Success success &&
-		    success.TryGetValue(out TType? value))
+		if (result.Outcome == Outcome.Success &&
+		    result.TryGetValue(out TType? value))
 		{
 			return value;
 		}
 
-		if (result is ConstraintResult.Failure failure)
+		if (result.Outcome == Outcome.Failure)
 		{
-			Fail.Test(ExpectationBuilder.FromFailure(expectationBuilder.Subject, failure));
+			Fail.Test(ExpectationBuilder.FromFailure(expectationBuilder.Subject, result));
 		}
 
 		throw new FailException(

--- a/Source/aweXpect/Results/JsonWhichResult.cs
+++ b/Source/aweXpect/Results/JsonWhichResult.cs
@@ -32,7 +32,7 @@ public class JsonWhichResult(
 					using JsonDocument jsonDocument = JsonDocument.Parse(s, options);
 					return jsonDocument.RootElement.Clone();
 				}, "it"),
-				(_, expectation) => $" which {expectation}")
+				(_, stringBuilder) => stringBuilder.Append(" which "))
 			.AddExpectations(e => expectations(new ThatSubject<JsonElement?>(e)));
 		return this;
 	}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
@@ -69,7 +69,7 @@ public static partial class ThatAsyncEnumerable
 			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
 			{
 				ConstraintResult isMatch = await _itemExpectationBuilder.IsMetBy(item, context, cancellationToken);
-				if (isMatch is ConstraintResult.Success)
+				if (isMatch.Outcome == Outcome.Success)
 				{
 					matchingCount++;
 				}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -67,7 +67,7 @@ public static partial class ThatEnumerable
 				foreach (TItem item in materialized)
 				{
 					ConstraintResult isMatch = await _itemExpectationBuilder.IsMetBy(item, context, cancellationToken);
-					if (isMatch is ConstraintResult.Success)
+					if (isMatch.Outcome == Outcome.Success)
 					{
 						matchingCount++;
 					}

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -25,7 +25,7 @@ public static partial class ThatDelegateThrows
 				.ForMember(
 					MemberAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
 						e => e.GetInnerExpectations(), "recursive inner exceptions "),
-					(property, expectation) => $"with {property}where {expectation}")
+					(property, stringBuilder) => stringBuilder.Append("with ").Append(property).Append("where "))
 				.AddExpectations(e => expectations(new ThatSubject<IEnumerable<Exception>>(e)),
 					ExpectationGrammars.Nested),
 			source);

--- a/Source/aweXpect/That/Exceptions/ThatException.HasRecursiveInnerExceptions.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.HasRecursiveInnerExceptions.cs
@@ -23,7 +23,10 @@ public static partial class ThatException
 				.ForMember(MemberAccessor<Exception?, IEnumerable<Exception?>>.FromFunc(
 						e => e.GetInnerExpectations(),
 						"recursive inner exceptions "),
-					(property, expectation) => $"has {property}which {expectation}",
+					(property, stringBuilder) =>
+					{
+						stringBuilder.Append("has ").Append(property).Append("which ");
+					},
 					false)
 				.AddExpectations(e => expectations(
 					new ThatSubject<IEnumerable<Exception>>(e)), ExpectationGrammars.Nested),

--- a/Source/aweXpect/That/ThatGeneric.For.cs
+++ b/Source/aweXpect/That/ThatGeneric.For.cs
@@ -20,7 +20,7 @@ public static partial class ThatGeneric
 		expectationBuilder
 			.ForMember(
 				MemberAccessor<T, TMember?>.FromExpression(memberSelector),
-				(member, expectation) => $"for {member}{expectation}")
+				(member, stringBuilder) => stringBuilder.Append("for ").Append(member))
 			.AddExpectations(e => expectations(new ThatSubject<TMember?>(e)));
 		return new AndOrResult<T, IThat<T>>(expectationBuilder, source);
 	}

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -100,7 +100,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
-        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Func<aweXpect.Core.MemberAccessor, string, string>? expectationTextGenerator = null, bool replaceIt = true) { }
+        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -16,14 +16,19 @@ namespace aweXpect.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
+        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
+        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
         public string ExpectationText { get; }
         public aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
-        public abstract aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText);
+        public aweXpect.Core.Constraints.Outcome Outcome { get; }
+        public virtual void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
+        public virtual void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
+        public virtual aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
         public class Failure : aweXpect.Core.Constraints.ConstraintResult
         {
             public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public string ResultText { get; }
+            public override void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
             public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override string ToString() { }
         }
@@ -68,6 +73,12 @@ namespace aweXpect.Core.Constraints
     public interface IValueConstraint<in TValue> : aweXpect.Core.Constraints.IConstraint
     {
         aweXpect.Core.Constraints.ConstraintResult IsMetBy(TValue actual);
+    }
+    public enum Outcome
+    {
+        Success = 0,
+        Failure = 1,
+        Undecided = 2,
     }
 }
 namespace aweXpect.Core.EvaluationContext
@@ -730,20 +741,20 @@ namespace aweXpect.Results
         public abstract class Combination : aweXpect.Results.Expectation
         {
             protected Combination(aweXpect.Results.Expectation[] expectations) { }
+            protected abstract aweXpect.Core.Constraints.Outcome CheckOutcome(aweXpect.Core.Constraints.Outcome? previous, aweXpect.Core.Constraints.Outcome current);
             public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
             protected abstract string GetSubjectLine();
-            protected abstract bool IsSuccess(int failureCount, int totalCount);
             public class All : aweXpect.Results.Expectation.Combination
             {
                 public All(aweXpect.Results.Expectation[] expectations) { }
+                protected override aweXpect.Core.Constraints.Outcome CheckOutcome(aweXpect.Core.Constraints.Outcome? previous, aweXpect.Core.Constraints.Outcome current) { }
                 protected override string GetSubjectLine() { }
-                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
             public class Any : aweXpect.Results.Expectation.Combination
             {
                 public Any(aweXpect.Results.Expectation[] expectations) { }
+                protected override aweXpect.Core.Constraints.Outcome CheckOutcome(aweXpect.Core.Constraints.Outcome? previous, aweXpect.Core.Constraints.Outcome current) { }
                 protected override string GetSubjectLine() { }
-                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
         }
     }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -16,46 +16,41 @@ namespace aweXpect.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
-        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
-        public string ExpectationText { get; }
-        public aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
+        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy) { }
+        public aweXpect.Core.Constraints.FurtherProcessingStrategy FurtherProcessingStrategy { get; }
         public aweXpect.Core.Constraints.Outcome Outcome { get; }
         public virtual void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
         public virtual void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
-        public virtual aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
         public class Failure : aweXpect.Core.Constraints.ConstraintResult
         {
-            public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
-            public string ResultText { get; }
+            public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
             public override void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
-            public override string ToString() { }
         }
         public class Failure<T> : aweXpect.Core.Constraints.ConstraintResult.Failure
         {
-            public Failure(T value, string expectationText, string resultText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
+            public Failure(T value, string expectationText, string resultText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
             public T Value { get; }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
-        }
-        public enum FurtherProcessing
-        {
-            Continue = 0,
-            IgnoreCompletely = 1,
-            IgnoreResult = 2,
         }
         public class Success : aweXpect.Core.Constraints.ConstraintResult
         {
-            public Success(string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
-            public override string ToString() { }
+            public Success(string expectationText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
         }
         public class Success<T> : aweXpect.Core.Constraints.ConstraintResult.Success
         {
-            public Success(T value, string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
+            public Success(T value, string expectationText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
             public T Value { get; }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
         }
+    }
+    public static class ConstraintResultExtensions
+    {
+        public static aweXpect.Core.Constraints.ConstraintResult Fail<T>(this aweXpect.Core.Constraints.ConstraintResult inner, string failure, T value) { }
+        public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
+    }
+    public enum FurtherProcessingStrategy
+    {
+        Continue = 0,
+        IgnoreCompletely = 1,
+        IgnoreResult = 2,
     }
     public interface IAsyncConstraint<in TValue> : aweXpect.Core.Constraints.IConstraint
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -100,7 +100,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
-        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Func<aweXpect.Core.MemberAccessor, string, string>? expectationTextGenerator = null, bool replaceIt = true) { }
+        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -16,46 +16,41 @@ namespace aweXpect.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
-        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
-        public string ExpectationText { get; }
-        public aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
+        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy) { }
+        public aweXpect.Core.Constraints.FurtherProcessingStrategy FurtherProcessingStrategy { get; }
         public aweXpect.Core.Constraints.Outcome Outcome { get; }
         public virtual void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
         public virtual void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
-        public virtual aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
         public class Failure : aweXpect.Core.Constraints.ConstraintResult
         {
-            public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
-            public string ResultText { get; }
+            public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
             public override void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
-            public override string ToString() { }
         }
         public class Failure<T> : aweXpect.Core.Constraints.ConstraintResult.Failure
         {
-            public Failure(T value, string expectationText, string resultText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
+            public Failure(T value, string expectationText, string resultText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
             public T Value { get; }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
-        }
-        public enum FurtherProcessing
-        {
-            Continue = 0,
-            IgnoreCompletely = 1,
-            IgnoreResult = 2,
         }
         public class Success : aweXpect.Core.Constraints.ConstraintResult
         {
-            public Success(string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
-            public override string ToString() { }
+            public Success(string expectationText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
         }
         public class Success<T> : aweXpect.Core.Constraints.ConstraintResult.Success
         {
-            public Success(T value, string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
+            public Success(T value, string expectationText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
             public T Value { get; }
-            public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
         }
+    }
+    public static class ConstraintResultExtensions
+    {
+        public static aweXpect.Core.Constraints.ConstraintResult Fail<T>(this aweXpect.Core.Constraints.ConstraintResult inner, string failure, T value) { }
+        public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
+    }
+    public enum FurtherProcessingStrategy
+    {
+        Continue = 0,
+        IgnoreCompletely = 1,
+        IgnoreResult = 2,
     }
     public interface IAsyncConstraint<in TValue> : aweXpect.Core.Constraints.IConstraint
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -16,14 +16,19 @@ namespace aweXpect.Core.Constraints
 {
     public abstract class ConstraintResult
     {
-        protected ConstraintResult(string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
+        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
+        protected ConstraintResult(aweXpect.Core.Constraints.Outcome outcome, string expectationText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy) { }
         public string ExpectationText { get; }
         public aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing FurtherProcessingStrategy { get; }
-        public abstract aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText);
+        public aweXpect.Core.Constraints.Outcome Outcome { get; }
+        public virtual void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
+        public virtual void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
+        public virtual aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
         public class Failure : aweXpect.Core.Constraints.ConstraintResult
         {
             public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.ConstraintResult.FurtherProcessing furtherProcessingStrategy = 0) { }
             public string ResultText { get; }
+            public override void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
             public override aweXpect.Core.Constraints.ConstraintResult CombineWith(string expectationText, string resultText) { }
             public override string ToString() { }
         }
@@ -68,6 +73,12 @@ namespace aweXpect.Core.Constraints
     public interface IValueConstraint<in TValue> : aweXpect.Core.Constraints.IConstraint
     {
         aweXpect.Core.Constraints.ConstraintResult IsMetBy(TValue actual);
+    }
+    public enum Outcome
+    {
+        Success = 0,
+        Failure = 1,
+        Undecided = 2,
     }
 }
 namespace aweXpect.Core.EvaluationContext
@@ -717,20 +728,20 @@ namespace aweXpect.Results
         public abstract class Combination : aweXpect.Results.Expectation
         {
             protected Combination(aweXpect.Results.Expectation[] expectations) { }
+            protected abstract aweXpect.Core.Constraints.Outcome CheckOutcome(aweXpect.Core.Constraints.Outcome? previous, aweXpect.Core.Constraints.Outcome current);
             public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
             protected abstract string GetSubjectLine();
-            protected abstract bool IsSuccess(int failureCount, int totalCount);
             public class All : aweXpect.Results.Expectation.Combination
             {
                 public All(aweXpect.Results.Expectation[] expectations) { }
+                protected override aweXpect.Core.Constraints.Outcome CheckOutcome(aweXpect.Core.Constraints.Outcome? previous, aweXpect.Core.Constraints.Outcome current) { }
                 protected override string GetSubjectLine() { }
-                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
             public class Any : aweXpect.Results.Expectation.Combination
             {
                 public Any(aweXpect.Results.Expectation[] expectations) { }
+                protected override aweXpect.Core.Constraints.Outcome CheckOutcome(aweXpect.Core.Constraints.Outcome? previous, aweXpect.Core.Constraints.Outcome current) { }
                 protected override string GetSubjectLine() { }
-                protected override bool IsSuccess(int failureCount, int totalCount) { }
             }
         }
     }

--- a/Tests/aweXpect.Core.Tests/Core/ConstraintResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ConstraintResultTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Core.Constraints;
+﻿using System.Text;
+using aweXpect.Core.Constraints;
 
 namespace aweXpect.Core.Tests.Core;
 
@@ -9,10 +10,12 @@ public sealed class ConstraintResultTests
 	public async Task Failure_WithoutValue_ShouldStoreTexts(string expectationText,
 		string resultText)
 	{
+		StringBuilder sb = new();
 		ConstraintResult.Failure subject = new(expectationText, resultText);
 
-		await That(subject.ExpectationText).IsEqualTo(expectationText);
-		await That(subject.ResultText).IsEqualTo(resultText);
+		subject.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo(expectationText);
+		await That(subject.GetResultText()).IsEqualTo(resultText);
 	}
 
 	[Theory]
@@ -24,12 +27,14 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1,
 		};
+		StringBuilder sb = new();
 
 		ConstraintResult.Failure<Dummy> subject = new(value, expectationText, resultText);
 
+		subject.AppendExpectation(sb);
 		await That(subject.Value).IsEquivalentTo(value);
-		await That(subject.ExpectationText).IsEqualTo(expectationText);
-		await That(subject.ResultText).IsEqualTo(resultText);
+		await That(sb.ToString()).IsEqualTo(expectationText);
+		await That(subject.GetResultText()).IsEqualTo(resultText);
 	}
 
 	[Theory]
@@ -40,35 +45,13 @@ public sealed class ConstraintResultTests
 		{
 			Value = 1,
 		};
+		StringBuilder sb = new();
 
 		ConstraintResult.Success<Dummy> subject = new(value, expectationText);
 
+		subject.AppendExpectation(sb);
 		await That(subject.Value).IsEquivalentTo(value);
-		await That(subject.ExpectationText).IsEqualTo(expectationText);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task ToString_Failure_ShouldBeExpectationTextWithPrependedFailed(
-		string expectationText)
-	{
-		ConstraintResult.Failure subject = new(expectationText, "result text");
-
-		string result = subject.ToString();
-
-		await That(result).IsEqualTo($"FAILED {expectationText}");
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task ToString_Success_ShouldBeExpectationTextWithPrependedSucceeded(
-		string expectationText)
-	{
-		ConstraintResult.Success subject = new(expectationText);
-
-		string result = subject.ToString();
-
-		await That(result).IsEqualTo($"SUCCEEDED {expectationText}");
+		await That(sb.ToString()).IsEqualTo(expectationText);
 	}
 
 	private sealed class Dummy

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Text;
+using System.Threading;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Helpers;
 using aweXpect.Core.Nodes;
@@ -51,10 +52,12 @@ public class ExpectationNodeTests
 		node.AddConstraint(new DummyAsyncConstraint<int>(_
 			=> Task.FromResult<ConstraintResult>(new ConstraintResult.Success("foo"))));
 		node.SetReason(new BecauseReason("my reason"));
+		StringBuilder sb = new();
 
 		ConstraintResult result = await node.IsMetBy(44, null!, CancellationToken.None);
 
-		await That(result.ExpectationText).IsEqualTo("foo, because my reason");
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo, because my reason");
 	}
 
 	[Fact]
@@ -81,10 +84,12 @@ public class ExpectationNodeTests
 		node.AddConstraint(new DummyAsyncContextConstraint<int>(_
 			=> Task.FromResult<ConstraintResult>(new ConstraintResult.Success("foo"))));
 		node.SetReason(new BecauseReason("my reason"));
+		StringBuilder sb = new();
 
 		ConstraintResult result = await node.IsMetBy(44, null!, CancellationToken.None);
 
-		await That(result.ExpectationText).IsEqualTo("foo, because my reason");
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo, because my reason");
 	}
 
 	[Fact]
@@ -110,10 +115,12 @@ public class ExpectationNodeTests
 		ExpectationNode node = new();
 		node.AddConstraint(new DummyContextConstraint<int>(_ => new ConstraintResult.Success("foo")));
 		node.SetReason(new BecauseReason("my reason"));
+		StringBuilder sb = new();
 
 		ConstraintResult result = await node.IsMetBy(44, null!, CancellationToken.None);
 
-		await That(result.ExpectationText).IsEqualTo("foo, because my reason");
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo, because my reason");
 	}
 
 	[Fact]
@@ -139,10 +146,12 @@ public class ExpectationNodeTests
 		ExpectationNode node = new();
 		node.AddConstraint(new DummyValueConstraint<int>(_ => new ConstraintResult.Success("foo")));
 		node.SetReason(new BecauseReason("my reason"));
+		StringBuilder sb = new();
 
 		ConstraintResult result = await node.IsMetBy(44, null!, CancellationToken.None);
 
-		await That(result.ExpectationText).IsEqualTo("foo, because my reason");
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo, because my reason");
 	}
 
 	[Fact]
@@ -234,13 +243,15 @@ public class ExpectationNodeTests
 		node.AddMapping(MemberAccessor<int, int>.FromFunc(s => s, " with mapping "));
 		node.AddConstraint(new DummyValueConstraint<int>(v
 			=> new ConstraintResult.Failure<int>(2 * v, "bar", "same failure")));
+		StringBuilder sb = new();
 
 		ConstraintResult result = await node.IsMetBy(42, null!, CancellationToken.None);
 
-		await That(result).Is<ConstraintResult.Failure<int>>()
-			.Whose(p => p.Value, v => v.IsEqualTo(42))
-			.AndWhose(p => p.ExpectationText, e => e.IsEqualTo("foo with mapping bar"))
-			.AndWhose(p => p.ResultText, r => r.IsEqualTo("same failure"));
+		result.AppendExpectation(sb);
+		await That(result.TryGetValue(out int value)).IsTrue();
+		await That(value).IsEqualTo(42);
+		await That(sb.ToString()).IsEqualTo("foo with mapping bar");
+		await That(result.GetResultText()).IsEqualTo("same failure");
 	}
 
 	[Fact]
@@ -252,13 +263,15 @@ public class ExpectationNodeTests
 		node.AddMapping(MemberAccessor<int, int>.FromFunc(s => s, " with mapping "));
 		node.AddConstraint(new DummyValueConstraint<int>(v
 			=> new ConstraintResult.Failure<int>(2 * v, "bar", "inner failure")));
+		StringBuilder sb = new();
 
 		ConstraintResult result = await node.IsMetBy(42, null!, CancellationToken.None);
 
-		await That(result).Is<ConstraintResult.Failure<int>>()
-			.Whose(p => p.Value, v => v.IsEqualTo(42))
-			.AndWhose(p => p.ExpectationText, e => e.IsEqualTo("foo with mapping bar"))
-			.AndWhose(p => p.ResultText, r => r.IsEqualTo("outer failure and inner failure"));
+		result.AppendExpectation(sb);
+		await That(result.TryGetValue(out int value)).IsTrue();
+		await That(value).IsEqualTo(42);
+		await That(sb.ToString()).IsEqualTo("foo with mapping bar");
+		await That(result.GetResultText()).IsEqualTo("outer failure and inner failure");
 	}
 #endif
 }

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Text;
+using System.Threading;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
 using aweXpect.Core.Helpers;
@@ -16,7 +17,7 @@ internal class DummyNode(string name) : Node
 
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget?> memberAccessor,
-		Func<MemberAccessor, string, string>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> throw new NotSupportedException();
 


### PR DESCRIPTION
Replace explicit strings with `StringBuilder` in `ConstraintResult` and add an explicit enum `Outcome` instead of relying on the type of the constraint result.