### PR TITLE
refactor: revert changes that caused bad benchmarks

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -15,14 +15,13 @@ partial class Build : NukeBuild
 {
 	[Parameter("Github Token")] readonly string GithubToken;
 
-
 	/// <summary>
 	///     Set this flag temporarily when you introduce breaking changes in the core library.
 	///     This will change the build pipeline to only build and publish the aweXpect.Core or aweXpect package.
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -21,7 +21,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
@@ -4,10 +4,16 @@ namespace aweXpect.Customization;
 
 public partial class AwexpectCustomization
 {
+	private FormattingCustomization? _formatting;
+
 	/// <summary>
 	///     Customize the formatting settings.
 	/// </summary>
-	public FormattingCustomization Formatting() => new(this);
+	public FormattingCustomization Formatting()
+	{
+		_formatting ??= new FormattingCustomization(this);
+		return _formatting;
+	}
 
 	/// <summary>
 	///     Customize the formatting settings.

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Threading;
 
 namespace aweXpect.Customization;
 
 public partial class AwexpectCustomization
 {
-	private readonly AsyncLocal<FormattingCustomizationValue> _formattingCustomizationValue = new();
-
 	/// <summary>
 	///     Customize the formatting settings.
 	/// </summary>
@@ -17,9 +14,10 @@ public partial class AwexpectCustomization
 	/// </summary>
 	public class FormattingCustomization : ICustomizationValueUpdater<FormattingCustomizationValue>
 	{
-		private readonly AwexpectCustomization _awexpectCustomization;
+		private static readonly FormattingCustomizationValue EmptyValue = new();
+		private readonly IAwexpectCustomization _awexpectCustomization;
 
-		internal FormattingCustomization(AwexpectCustomization awexpectCustomization)
+		internal FormattingCustomization(IAwexpectCustomization awexpectCustomization)
 		{
 			_awexpectCustomization = awexpectCustomization;
 			MaximumNumberOfCollectionItems = new CustomizationValue<int>(
@@ -36,19 +34,12 @@ public partial class AwexpectCustomization
 
 		/// <inheritdoc cref="ICustomizationValueUpdater{FormattingCustomizationValue}.Get()" />
 		public FormattingCustomizationValue Get()
-			=> _awexpectCustomization._formattingCustomizationValue.Value ?? new FormattingCustomizationValue();
+			=> _awexpectCustomization.Get(nameof(Formatting), EmptyValue);
 
 		/// <inheritdoc
 		///     cref="ICustomizationValueUpdater{FormattingCustomizationValue}.Update(Func{FormattingCustomizationValue,FormattingCustomizationValue})" />
 		public CustomizationLifetime Update(Func<FormattingCustomizationValue, FormattingCustomizationValue> update)
-		{
-			FormattingCustomizationValue previousValue = Get();
-			CustomizationLifetime lifetime = new(() =>
-				_awexpectCustomization._formattingCustomizationValue.Value = previousValue);
-
-			_awexpectCustomization._formattingCustomizationValue.Value = update(previousValue);
-			return lifetime;
-		}
+			=> _awexpectCustomization.Set(nameof(Formatting), update(Get()));
 	}
 
 	/// <summary>

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
@@ -50,6 +50,6 @@ public partial class AwexpectCustomization
 		/// <summary>
 		///     The maximum number of displayed items in a collection.
 		/// </summary>
-		public int MaximumNumberOfCollectionItems { get; set; } = 10;
+		public int MaximumNumberOfCollectionItems { get; init; } = 10;
 	}
 }

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Threading;
 
 namespace aweXpect.Customization;
 
 public partial class AwexpectCustomization
 {
-	private readonly AsyncLocal<ReflectionCustomizationValue> _reflectionCustomizationValue = new();
-
 	/// <summary>
 	///     Customize the reflection settings.
 	/// </summary>
@@ -17,9 +14,10 @@ public partial class AwexpectCustomization
 	/// </summary>
 	public class ReflectionCustomization : ICustomizationValueUpdater<ReflectionCustomizationValue>
 	{
-		private readonly AwexpectCustomization _awexpectCustomization;
+		private static readonly ReflectionCustomizationValue EmptyValue = new();
+		private readonly IAwexpectCustomization _awexpectCustomization;
 
-		internal ReflectionCustomization(AwexpectCustomization awexpectCustomization)
+		internal ReflectionCustomization(IAwexpectCustomization awexpectCustomization)
 		{
 			_awexpectCustomization = awexpectCustomization;
 			ExcludedAssemblyPrefixes = new CustomizationValue<string[]>(
@@ -36,19 +34,12 @@ public partial class AwexpectCustomization
 
 		/// <inheritdoc cref="ICustomizationValueUpdater{ReflectionCustomizationValue}.Get()" />
 		public ReflectionCustomizationValue Get()
-			=> _awexpectCustomization._reflectionCustomizationValue.Value ?? new ReflectionCustomizationValue();
+			=> _awexpectCustomization.Get(nameof(Reflection), EmptyValue);
 
 		/// <inheritdoc
 		///     cref="ICustomizationValueUpdater{ReflectionCustomizationValue}.Update(Func{ReflectionCustomizationValue,ReflectionCustomizationValue})" />
 		public CustomizationLifetime Update(Func<ReflectionCustomizationValue, ReflectionCustomizationValue> update)
-		{
-			ReflectionCustomizationValue previousValue = Get();
-			CustomizationLifetime lifetime = new(() =>
-				_awexpectCustomization._reflectionCustomizationValue.Value = previousValue);
-
-			_awexpectCustomization._reflectionCustomizationValue.Value = update(previousValue);
-			return lifetime;
-		}
+			=> _awexpectCustomization.Set(nameof(Reflection), update(Get()));
 	}
 
 	/// <summary>

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
@@ -4,10 +4,16 @@ namespace aweXpect.Customization;
 
 public partial class AwexpectCustomization
 {
+	private ReflectionCustomization? _reflection;
+
 	/// <summary>
 	///     Customize the reflection settings.
 	/// </summary>
-	public ReflectionCustomization Reflection() => new(this);
+	public ReflectionCustomization Reflection()
+	{
+		_reflection ??= new ReflectionCustomization(this);
+		return _reflection;
+	}
 
 	/// <summary>
 	///     Customize the reflection settings.

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
@@ -60,7 +60,7 @@ public partial class AwexpectCustomization
 		///     - Castle<br />
 		///     - DynamicProxyGenAssembly2
 		/// </remarks>
-		public string[] ExcludedAssemblyPrefixes { get; set; } =
+		public string[] ExcludedAssemblyPrefixes { get; init; } =
 		[
 			"mscorlib",
 			"System",

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Settings.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Settings.cs
@@ -5,11 +5,16 @@ namespace aweXpect.Customization;
 
 public partial class AwexpectCustomization
 {
+	private SettingsCustomization? _settings;
+
 	/// <summary>
 	///     Customize the settings.
 	/// </summary>
 	public SettingsCustomization Settings()
-		=> new(this);
+	{
+		_settings ??= new SettingsCustomization(this);
+		return _settings;
+	}
 
 	/// <summary>
 	///     Customize the settings.

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Settings.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Settings.cs
@@ -69,12 +69,12 @@ public partial class AwexpectCustomization
 		/// <summary>
 		///     If set, applies the cancellation logic for all test.
 		/// </summary>
-		public TestCancellation? TestCancellation { get; set; }
+		public TestCancellation? TestCancellation { get; init; }
 
 		/// <summary>
 		///     The default timeout for the <see cref="Signaler" />.
 		/// </summary>
-		public TimeSpan DefaultSignalerTimeout { get; set; } = TimeSpan.FromSeconds(30);
+		public TimeSpan DefaultSignalerTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
 #if NET8_0_OR_GREATER
 		/// <summary>
@@ -101,6 +101,6 @@ public partial class AwexpectCustomization
 		///     (unless an explicit tolerance is given).
 		/// </remarks>
 #endif
-		public TimeSpan DefaultTimeComparisonTolerance { get; set; } = TimeSpan.Zero;
+		public TimeSpan DefaultTimeComparisonTolerance { get; init; } = TimeSpan.Zero;
 	}
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -264,7 +264,7 @@ namespace aweXpect.Customization
         public class FormattingCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue>
         {
             public FormattingCustomizationValue() { }
-            public int MaximumNumberOfCollectionItems { get; set; }
+            public int MaximumNumberOfCollectionItems { get; init; }
         }
         public class ReflectionCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.ReflectionCustomizationValue>
         {
@@ -275,7 +275,7 @@ namespace aweXpect.Customization
         public class ReflectionCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.ReflectionCustomizationValue>
         {
             public ReflectionCustomizationValue() { }
-            public string[] ExcludedAssemblyPrefixes { get; set; }
+            public string[] ExcludedAssemblyPrefixes { get; init; }
         }
         public class SettingsCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
@@ -288,9 +288,9 @@ namespace aweXpect.Customization
         public class SettingsCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
             public SettingsCustomizationValue() { }
-            public System.TimeSpan DefaultSignalerTimeout { get; set; }
-            public System.TimeSpan DefaultTimeComparisonTolerance { get; set; }
-            public aweXpect.Customization.TestCancellation? TestCancellation { get; set; }
+            public System.TimeSpan DefaultSignalerTimeout { get; init; }
+            public System.TimeSpan DefaultTimeComparisonTolerance { get; init; }
+            public aweXpect.Customization.TestCancellation? TestCancellation { get; init; }
         }
     }
     public sealed class CustomizationLifetime : System.IDisposable

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -264,7 +264,7 @@ namespace aweXpect.Customization
         public class FormattingCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue>
         {
             public FormattingCustomizationValue() { }
-            public int MaximumNumberOfCollectionItems { get; set; }
+            public int MaximumNumberOfCollectionItems { get; init; }
         }
         public class ReflectionCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.ReflectionCustomizationValue>
         {
@@ -275,7 +275,7 @@ namespace aweXpect.Customization
         public class ReflectionCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.ReflectionCustomizationValue>
         {
             public ReflectionCustomizationValue() { }
-            public string[] ExcludedAssemblyPrefixes { get; set; }
+            public string[] ExcludedAssemblyPrefixes { get; init; }
         }
         public class SettingsCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
@@ -288,9 +288,9 @@ namespace aweXpect.Customization
         public class SettingsCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
             public SettingsCustomizationValue() { }
-            public System.TimeSpan DefaultSignalerTimeout { get; set; }
-            public System.TimeSpan DefaultTimeComparisonTolerance { get; set; }
-            public aweXpect.Customization.TestCancellation? TestCancellation { get; set; }
+            public System.TimeSpan DefaultSignalerTimeout { get; init; }
+            public System.TimeSpan DefaultTimeComparisonTolerance { get; init; }
+            public aweXpect.Customization.TestCancellation? TestCancellation { get; init; }
         }
     }
     public sealed class CustomizationLifetime : System.IDisposable


### PR DESCRIPTION
[Some changes](https://github.com/aweXpect/aweXpect/pull/342/commits/8715cb736f654d1ba0782458b889dcff8d3df281#diff-bf2dc064ff9716b62d4fd9e5984508d24d6d10674b9a8a17fc6a91cebb9859d7) in #342 caused a spike in the benchmarks.

Revert the change to use dedicated classes for known customizations, as the intended result caused unexpected increase in memory and runtime!