### PR TITLE
refactor: improve resilience of tests

### DIFF
--- a/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
@@ -26,7 +26,9 @@ internal class XUnit3Adapter() : TestFrameworkAdapter(
 		/// </summary>
 		private interface IAssertionException;
 
+#pragma warning disable S3871 // Exception types should be "public"
 		private sealed class XunitException(string message)
 			: Exception(message), IAssertionException;
+#pragma warning restore S3871 // Exception types should be "public"
 	}
 }

--- a/Source/aweXpect.Core/Core/IThat.cs
+++ b/Source/aweXpect.Core/Core/IThat.cs
@@ -10,6 +10,7 @@ namespace aweXpect.Core;
 ///     All implementations are also expected to implement at least <see cref="IThatVerb{T}" />!
 /// </remarks>
 // ReSharper disable once UnusedTypeParameter
+#pragma warning disable S2326 // 'T' is not used in the interface
 public interface IThat<out T>
 {
 	/// <summary>
@@ -52,3 +53,4 @@ public interface IThat<out T>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	string? ToString();
 }
+#pragma warning restore S2326 // 'T' is not used in the interface

--- a/Source/aweXpect.Core/Core/IThatVerb.cs
+++ b/Source/aweXpect.Core/Core/IThatVerb.cs
@@ -7,6 +7,7 @@ namespace aweXpect.Core;
 ///     Base class for expectations, containing an <see cref="ExpectationBuilder" />.
 /// </summary>
 // ReSharper disable once UnusedTypeParameter
+#pragma warning disable S2326 // 'T' is not used in the interface
 public interface IThatVerb<out T>
 {
 	/// <summary>
@@ -60,3 +61,4 @@ public interface IThatVerb<out T>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	string? ToString();
 }
+#pragma warning restore S2326 // 'T' is not used in the interface

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -59,7 +59,7 @@ public sealed class CustomizeSettingsTests
 			stopwatch.Stop();
 		}
 
-		await That(stopwatch.Elapsed).IsLessThan(500.Milliseconds());
+		await That(stopwatch.Elapsed).IsLessThan(2.Seconds());
 	}
 
 	[Fact]
@@ -75,7 +75,7 @@ public sealed class CustomizeSettingsTests
 			stopwatch.Stop();
 		}
 
-		await That(stopwatch.Elapsed).IsLessThanOrEqualTo(1.Seconds());
+		await That(stopwatch.Elapsed).IsLessThanOrEqualTo(2.Seconds());
 		await That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(LowTimeout).Within(50.Milliseconds());
 	}
 
@@ -114,9 +114,9 @@ public sealed class CustomizeSettingsTests
 	[Fact]
 	public async Task WithCancellation_OverwritesTheCancellationToken()
 	{
-		TimeSpan delay = 5.Seconds();
+		TimeSpan delay = 6.Seconds();
 		Stopwatch stopwatch = new();
-		using CancellationTokenSource cts = new(3.Seconds());
+		using CancellationTokenSource cts = new(4.Seconds());
 		CancellationToken cancelledToken = new(true);
 		using (IDisposable _ = Customize.aweXpect.Settings().TestCancellation
 			       .Set(TestCancellation.FromCancellationToken(() => cts.Token)))
@@ -128,7 +128,7 @@ public sealed class CustomizeSettingsTests
 			stopwatch.Stop();
 		}
 
-		await That(stopwatch.Elapsed).IsLessThanOrEqualTo(1.Seconds());
+		await That(stopwatch.Elapsed).IsLessThanOrEqualTo(2.Seconds());
 	}
 
 	/// <summary>


### PR DESCRIPTION
Make tests more resilient

* Disable S2326:
  'T' is not used in the interface for `IThat` and `IThatVerb`
* Disable S3871:
  Exception types should be "public"