### PR TITLE
feat: add overwriting the global timeout locally

### DIFF
--- a/Docs/pages/docs/concepts/cancellation.md
+++ b/Docs/pages/docs/concepts/cancellation.md
@@ -4,33 +4,39 @@ sidebar_position: 1
 
 # Cancellation
 
-You can add cancellation support on the expectations, so that they can't run indefinitely:
+You can add cancellation support on the expectations, so that they don't run indefinitely:
 
-## Global settings
 
-### Timeout
+## Timeout
 You can set a global timeout that is applied for all expectations:
 ```csharp
 // Sets a global timeout of 10 seconds
 Customize.aweXpect.Settings().TestCancellation
     .Set(TestCancellation.FromTimeout(TimeSpan.FromSeconds(10)));
-// Uses the CancellationToken from the test context
-Customize.aweXpect.Settings().TestCancellation.Set(() => TestContext.Current.CancellationToken);
 ```
 
-### `CancellationToken`
+*Note: Like all customization options, the setter returns an `IDisposable` that will remove the cancellation on `Dispose()`.*
+
+You can overwrite or apply the timeout also on individual expectations, using the `WithTimeout(TimeSpan)` method, e.g.
+```csharp
+IAsyncEnumerable<int> myEnumerable = // ...
+await Expect.That(myEnumerable).All().AreEqualTo(1)
+    .WithTimeout(TimeSpan.FromSeconds(10));
+```
+
+*Note: A local timeout will replace the global one and not be applied additionally.
+
+
+## `CancellationToken`
 
 You can set a global provider for getting a `CancellationToken` that is applied for all expectations:
 ```csharp
 // Uses the CancellationToken from the test context
 Customize.aweXpect.Settings().TestCancellation
-    .Set(() => TestContext.Current.CancellationToken);
+    .Set(TestCancellation.FromCancellationToken(() => TestContext.Current.CancellationToken));
 ```
 
-Note: Like all customization options, the setter returns an `IDisposable` that will remove the cancellation on `Dispose()`.
-
-
-## Local settings
+*Note: Like all customization options, the setter returns an `IDisposable` that will remove the cancellation on `Dispose()`.*
 
 You can overwrite or apply the `CancellationToken` also on individual expectations, using the `WithCancellation(CancellationToken)` method, e.g. 
 ```csharp
@@ -40,5 +46,5 @@ await Expect.That(myEnumerable).All().AreEqualTo(1)
     .WithCancellation(cts.Token);
 ```
 
-Note: A local `CancellationToken` will replace the global one and not be applied additionally.
-If necessary, provide a [linked cancellation token](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.createlinkedtokensource) yourself!
+*Note: A local `CancellationToken` will replace the global one and not be applied additionally.
+If necessary, provide a [linked cancellation token](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.createlinkedtokensource) yourself!*

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -20,6 +20,7 @@ public abstract class ExpectationBuilder
 	private const string DefaultCurrentSubject = "it";
 
 	private CancellationToken? _cancellationToken;
+	private TimeSpan? _timeout;
 
 	/// <summary>
 	///     The current name for the subject (defaults to <see cref="DefaultCurrentSubject" />).
@@ -155,6 +156,12 @@ public abstract class ExpectationBuilder
 		=> _cancellationToken = cancellationToken;
 
 	/// <summary>
+	///     Adds a <paramref name="timeout" /> to be used by the constraints.
+	/// </summary>
+	public void WithTimeout(TimeSpan timeout)
+		=> _timeout = timeout;
+
+	/// <summary>
 	///     Adds a <paramref name="reason" /> to the current expectation constraint.
 	/// </summary>
 	internal void AddReason(string reason)
@@ -276,7 +283,7 @@ public abstract class ExpectationBuilder
 		ITimeSystem timeSystem = _timeSystem ?? RealTimeSystem.Instance;
 		TestCancellation? testCancellation = Customize.aweXpect.Settings().TestCancellation.Get();
 		_cancellationToken ??= testCancellation?.CancellationTokenFactory?.Invoke() ?? CancellationToken.None;
-		return IsMet(GetRootNode(), context, timeSystem, testCancellation?.Timeout, _cancellationToken.Value);
+		return IsMet(GetRootNode(), context, timeSystem, _timeout ?? testCancellation?.Timeout, _cancellationToken.Value);
 	}
 
 	internal abstract Task<ConstraintResult> IsMet(Node rootNode,

--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +22,40 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 	public ExpectationResult Because(string reason)
 	{
 		expectationBuilder.AddReason(reason);
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <see cref="CancellationToken" /> to be passed to expectations.
+	/// </summary>
+	/// <remarks>
+	///     Use
+	///     <c>
+	///         Customize.aweXpect.Settings().TestCancellation
+	///         .Set(TestCancellation.FromCancellationToken(() => cancellationToken))
+	///     </c>
+	///     to apply the <paramref name="cancellationToken" /> globally.
+	/// </remarks>
+	public ExpectationResult WithCancellation(CancellationToken cancellationToken)
+	{
+		expectationBuilder.WithCancellation(cancellationToken);
+		return this;
+	}
+
+	/// <summary>
+	///     Sets the <paramref name="timeout" /> to be passed to expectations.
+	/// </summary>
+	/// <remarks>
+	///     Use
+	///     <c>
+	///         Customize.aweXpect.Settings().TestCancellation
+	///         .Set(TestCancellation.FromTimeout(timeout))
+	///     </c>
+	///     to apply the <paramref name="timeout" /> globally.
+	/// </remarks>
+	public ExpectationResult WithTimeout(TimeSpan timeout)
+	{
+		expectationBuilder.WithTimeout(timeout);
 		return this;
 	}
 
@@ -98,11 +133,36 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	}
 
 	/// <summary>
-	///     Sets the <see cref="CancellationToken" /> to be passed to expectations.
+	///     Sets the <paramref name="cancellationToken" /> to be passed to expectations.
 	/// </summary>
+	/// <remarks>
+	///     Use
+	///     <c>
+	///         Customize.aweXpect.Settings().TestCancellation
+	///         .Set(TestCancellation.FromCancellationToken(() => cancellationToken))
+	///     </c>
+	///     to apply the <paramref name="cancellationToken" /> globally.
+	/// </remarks>
 	public TSelf WithCancellation(CancellationToken cancellationToken)
 	{
 		expectationBuilder.WithCancellation(cancellationToken);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Sets the <paramref name="timeout" /> to be passed to expectations.
+	/// </summary>
+	/// <remarks>
+	///     Use
+	///     <c>
+	///         Customize.aweXpect.Settings().TestCancellation
+	///         .Set(TestCancellation.FromTimeout(timeout))
+	///     </c>
+	///     to apply the <paramref name="timeout" /> globally.
+	/// </remarks>
+	public TSelf WithTimeout(TimeSpan timeout)
+	{
+		expectationBuilder.WithTimeout(timeout);
 		return (TSelf)this;
 	}
 

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -131,6 +131,24 @@ public sealed class CustomizeSettingsTests
 		await That(stopwatch.Elapsed).IsLessThanOrEqualTo(2.Seconds());
 	}
 
+	[Fact]
+	public async Task WithTimeout_OverwritesTheCancellationToken()
+	{
+		TimeSpan delay = 6.Seconds();
+		Stopwatch stopwatch = new();
+		using (IDisposable _ = Customize.aweXpect.Settings().TestCancellation
+			       .Set(TestCancellation.FromTimeout(4.Seconds())))
+		{
+			stopwatch.Start();
+			await That(cancellationToken => Task.Delay(delay, cancellationToken))
+				.Throws<TaskCanceledException>()
+				.WithTimeout(20.Milliseconds());
+			stopwatch.Stop();
+		}
+
+		await That(stopwatch.Elapsed).IsLessThanOrEqualTo(2.Seconds());
+	}
+
 	/// <summary>
 	///     The minimal timeout for tests, that have to await this long.
 	/// </summary>

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesWithin.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesWithin.Tests.cs
@@ -1,4 +1,6 @@
-﻿#if NET8_0_OR_GREATER
+﻿using System.Diagnostics;
+using System.Threading;
+#if NET8_0_OR_GREATER
 using System.Threading;
 #endif
 
@@ -393,6 +395,86 @@ public sealed partial class ThatDelegate
 					             executes within 0:00.500,
 					             but it was <null>
 					             """);
+			}
+		}
+
+		public sealed class WithTimeoutTests
+		{
+			[Fact]
+			public async Task WithoutReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task> @delegate = token => Task.Delay(6.Seconds(), token);
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(50.Milliseconds()).WithTimeout(50.Milliseconds());
+
+				sw.Start();
+				await That(Act).Throws<XunitException>();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(1.Seconds());
+			}
+
+			[Fact]
+			public async Task WithReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task<int>> @delegate = async token =>
+				{
+					await Task.Delay(6.Seconds(), token);
+					return 1;
+				};
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(50.Milliseconds()).WithTimeout(50.Milliseconds());
+
+				sw.Start();
+				await That(Act).Throws<XunitException>();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(1.Seconds());
+			}
+		}
+
+		public sealed class WithCancellationTests
+		{
+			[Fact]
+			public async Task WithoutReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task> @delegate = token => Task.Delay(6.Seconds(), token);
+				CancellationToken cancelledToken = new(true);
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(50.Milliseconds()).WithCancellation(cancelledToken);
+
+				sw.Start();
+				await That(Act).Throws<XunitException>();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(1.Seconds());
+			}
+
+			[Fact]
+			public async Task WithReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task<int>> @delegate = async token =>
+				{
+					await Task.Delay(6.Seconds(), token);
+					return 1;
+				};
+				CancellationToken cancelledToken = new(true);
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(50.Milliseconds()).WithCancellation(cancelledToken);
+
+				sw.Start();
+				await That(Act).Throws<XunitException>();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(1.Seconds());
 			}
 		}
 	}


### PR DESCRIPTION
Add `.WithTimeout(TimeSpan)` methods to the `ExpectationResult` that allow overwriting the globally defined timespan on an individual basis.

This is especially useful in combination with the `ExecutesWithin` method, as it will allow cancelling the (potentially long-running) task when the expected timeout is exceeded.