### PR TITLE
refactor: consolidate error messages for delegates

### DIFF
--- a/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
@@ -54,7 +54,9 @@ public abstract partial class ThatDelegate
 
 			if (value is null)
 			{
-				return new ConstraintResult.Failure<Exception?>(null, ToString(), "it did not throw any exception");
+				return new ConstraintResult.Failure<Exception?>(null, ToString(),
+					"it did not throw any exception",
+					FurtherProcessingStrategy.IgnoreResult);
 			}
 
 			return new ConstraintResult.Failure<Exception?>(null, ToString(),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
@@ -54,7 +54,9 @@ public abstract partial class ThatDelegate
 
 			if (value is null)
 			{
-				return new ConstraintResult.Failure<TException?>(null, ToString(), "it did not throw any exception");
+				return new ConstraintResult.Failure<TException?>(null, ToString(),
+					"it did not throw any exception",
+					FurtherProcessingStrategy.IgnoreResult);
 			}
 
 			return new ConstraintResult.Failure<TException?>(null, ToString(),
@@ -86,7 +88,9 @@ public abstract partial class ThatDelegate
 
 			if (value is null)
 			{
-				return new ConstraintResult.Failure<Exception?>(null, ToString(), "it did not throw any exception");
+				return new ConstraintResult.Failure<Exception?>(null, ToString(),
+					"it did not throw any exception",
+					FurtherProcessingStrategy.IgnoreResult);
 			}
 
 			return new ConstraintResult.Failure<Exception?>(null, ToString(),

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.WithInner.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.WithInner.cs
@@ -48,8 +48,7 @@ public partial class ThatDelegateThrows<TException>
 					$"with an inner {(innerExceptionType == typeof(Exception) ? ExceptionString : Formatter.Format(innerExceptionType))} whose",
 					false)
 				.Validate(it
-					=> new InnerExceptionIsTypeConstraint(it,
-						innerExceptionType))
+					=> new InnerExceptionIsTypeConstraint(it, innerExceptionType))
 				.AddExpectations(e => expectations(new ThatSubject<Exception?>(e)), ExpectationGrammars.Nested),
 			this);
 
@@ -100,7 +99,7 @@ public partial class ThatDelegateThrows<TException>
 			}
 
 			return new ConstraintResult.Failure<Exception?>(actual, "",
-				$"{it} was {ThatDelegate.FormatForMessage(actual)}");
+				$"{it} was {ThatDelegate.FormatForMessage(actual?.InnerException)}");
 		}
 
 		#endregion

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
@@ -6,6 +6,22 @@ public sealed partial class ThatDelegate
 	{
 		public sealed class GenericTests
 		{
+			[Fact]
+			public async Task ShouldSupportChainedConstraints()
+			{
+				Action action = () => { };
+
+				async Task Act()
+					=> await That(action).Throws<ArgumentException>().WithMessage("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that action
+					             throws an ArgumentException with Message equal to "foo",
+					             but it did not throw any exception
+					             """);
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenAwaited_ShouldReturnThrownException(string value)
@@ -120,6 +136,22 @@ public sealed partial class ThatDelegate
 
 		public sealed class TypeTests
 		{
+			[Fact]
+			public async Task ShouldSupportChainedConstraints()
+			{
+				Action action = () => { };
+
+				async Task Act()
+					=> await That(action).Throws(typeof(ArgumentException)).WithMessage("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that action
+					             throws an ArgumentException with Message equal to "foo",
+					             but it did not throw any exception
+					             """);
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenAwaited_ShouldReturnThrownException(string value)
@@ -148,7 +180,7 @@ public sealed partial class ThatDelegate
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact(Skip="Wait for next core update")]
+			[Fact(Skip = "Wait for next core update")]
 			public async Task WhenNoExceptionIsThrown_ShouldFail()
 			{
 				Action action = () => { };

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
@@ -6,7 +6,7 @@ public sealed partial class ThatDelegate
 	{
 		public sealed class GenericTests
 		{
-			[Fact]
+			[Fact(Skip="Wait for next core update")]
 			public async Task ShouldSupportChainedConstraints()
 			{
 				Action action = () => { };
@@ -136,7 +136,7 @@ public sealed partial class ThatDelegate
 
 		public sealed class TypeTests
 		{
-			[Fact]
+			[Fact(Skip="Wait for next core update")]
 			public async Task ShouldSupportChainedConstraints()
 			{
 				Action action = () => { };

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.OnlyIfTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.OnlyIfTests.cs
@@ -19,16 +19,6 @@ public sealed partial class ThatDelegate
 				}
 
 				[Fact]
-				public async Task ShouldSupportChainedConstraintsForTypedException()
-				{
-					Action action = () => { };
-
-					await That(action).ThrowsExactly<ArgumentException>()
-						.OnlyIf(false)
-						.WithMessage("foo");
-				}
-
-				[Fact]
 				public async Task WhenAwaited_OnlyIfFalse_ShouldReturnNull()
 				{
 					Action action = () => { };
@@ -116,16 +106,6 @@ public sealed partial class ThatDelegate
 					Action action = () => { };
 
 					await That(action).ThrowsExactly(typeof(Exception))
-						.OnlyIf(false)
-						.WithMessage("foo");
-				}
-
-				[Fact]
-				public async Task ShouldSupportChainedConstraintsForTypedException()
-				{
-					Action action = () => { };
-
-					await That(action).ThrowsExactly(typeof(ArgumentException))
 						.OnlyIf(false)
 						.WithMessage("foo");
 				}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Tests.cs
@@ -6,6 +6,22 @@ public sealed partial class ThatDelegate
 	{
 		public sealed class GenericTests
 		{
+			[Fact]
+			public async Task ShouldSupportChainedConstraints()
+			{
+				Action action = () => { };
+
+				async Task Act()
+					=> await That(action).ThrowsExactly<Exception>().WithMessage("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that action
+					             throws exactly an Exception with Message equal to "foo",
+					             but it did not throw any exception
+					             """);
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenAwaited_ShouldReturnThrownException(string value)
@@ -35,7 +51,7 @@ public sealed partial class ThatDelegate
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact(Skip="Wait for next core update")]
+			[Fact(Skip = "Wait for next core update")]
 			public async Task WhenNoExceptionIsThrown_ShouldFail()
 			{
 				Action action = () => { };
@@ -108,6 +124,22 @@ public sealed partial class ThatDelegate
 
 		public sealed class TypeTests
 		{
+			[Fact]
+			public async Task ShouldSupportChainedConstraints()
+			{
+				Action action = () => { };
+
+				async Task Act()
+					=> await That(action).ThrowsExactly(typeof(Exception)).WithMessage("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that action
+					             throws exactly an Exception with Message equal to "foo",
+					             but it did not throw any exception
+					             """);
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenAwaited_ShouldReturnThrownException(string value)
@@ -136,7 +168,7 @@ public sealed partial class ThatDelegate
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact(Skip="Wait for next core update")]
+			[Fact(Skip = "Wait for next core update")]
 			public async Task WhenNoExceptionIsThrown_ShouldFail()
 			{
 				Action action = () => { };

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Tests.cs
@@ -6,7 +6,7 @@ public sealed partial class ThatDelegate
 	{
 		public sealed class GenericTests
 		{
-			[Fact]
+			[Fact(Skip="Wait for next core update")]
 			public async Task ShouldSupportChainedConstraints()
 			{
 				Action action = () => { };
@@ -124,7 +124,7 @@ public sealed partial class ThatDelegate
 
 		public sealed class TypeTests
 		{
-			[Fact]
+			[Fact(Skip="Wait for next core update")]
 			public async Task ShouldSupportChainedConstraints()
 			{
 				Action action = () => { };

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.OnlyIfTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.OnlyIfTests.cs
@@ -17,16 +17,6 @@ public sealed partial class ThatDelegate
 			}
 
 			[Fact]
-			public async Task ShouldSupportChainedConstraintsForTypedException()
-			{
-				Action action = () => { };
-
-				await That(action).ThrowsException()
-					.OnlyIf(false)
-					.WithMessage("foo");
-			}
-
-			[Fact]
 			public async Task WhenAwaited_OnlyIfFalse_ShouldReturnNull()
 			{
 				Action action = () => { };

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
@@ -9,65 +9,6 @@ public sealed partial class ThatDelegate
 			public sealed class GenericTests
 			{
 				[Fact]
-				public async Task CustomException_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
-				{
-					string message = "bar";
-					Action action = ()
-						=> throw new OuterException(innerException: new CustomException(message));
-
-					async Task Act()
-						=> await That(action).ThrowsException().WithInner<CustomException>(x => x.HasMessage("foo"));
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that action
-						             throws an exception with an inner CustomException whose Message is equal to "foo",
-						             but it was "bar" which differs at index 0:
-						                ↓ (actual)
-						               "bar"
-						               "foo"
-						                ↑ (expected)
-						             """);
-				}
-
-				[Fact]
-				public async Task Exception_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
-				{
-					string message = "bar";
-					Action action = ()
-						=> throw new OuterException(innerException: new CustomException(message));
-
-					async Task Act()
-						=> await That(action).ThrowsException().WithInner<Exception>(x => x.HasMessage("foo"));
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that action
-						             throws an exception with an inner exception whose Message is equal to "foo",
-						             but it was "bar" which differs at index 0:
-						                ↓ (actual)
-						               "bar"
-						               "foo"
-						                ↑ (expected)
-						             """);
-				}
-
-				[Theory]
-				[AutoData]
-				public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException(
-					string message)
-				{
-					Exception exception = new OuterException(innerException: new CustomException(message));
-					void Delegate() => throw exception;
-
-					Exception result = await That(Delegate)
-						.ThrowsException().WithInner<CustomException>(
-							e => e.HasMessage(message));
-
-					await That(result).IsSameAs(exception);
-				}
-
-				[Fact]
 				public async Task WhenAwaited_WithoutExpectations_ShouldReturnThrownException()
 				{
 					Exception exception = new OuterException(innerException: new CustomException());
@@ -171,65 +112,9 @@ public sealed partial class ThatDelegate
 						             but it was <null>
 						             """);
 				}
-
-				[Fact]
-				public async Task WithInnerExpectations_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
-				{
-					string message = "bar";
-					Action action = ()
-						=> throw new OuterException(innerException: new CustomException(message));
-
-					async Task Act()
-						=> await That(action).ThrowsException().WithInner<Exception>(x => x.HasMessage("foo"));
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that action
-						             throws an exception with an inner exception whose Message is equal to "foo",
-						             but it was "bar" which differs at index 0:
-						                ↓ (actual)
-						               "bar"
-						               "foo"
-						                ↑ (expected)
-						             """);
-				}
-
-				[Fact]
-				public async Task WithInnerExpectations_WhenInnerExceptionIsNotPresent_ShouldFail()
-				{
-					Action action = () => throw new OuterException();
-
-					async Task Act()
-						=> await That(action).ThrowsException()
-							.WithInner<Exception>(x => x.HasMessage("foo"));
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that action
-						             throws an exception with an inner exception whose Message is equal to "foo",
-						             but it was <null>
-						             """);
-				}
-
-				[Fact]
-				public async Task WithInnerExpectations_WhenNoExceptionIsThrown_ShouldFail()
-				{
-					Action action = () => { };
-
-					async Task Act()
-						=> await That(action).ThrowsException()
-							.WithInner<CustomException>(x => x.HasMessage("foo"));
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that action
-						             throws an exception with an inner CustomException whose Message is equal to "foo",
-						             but it did not throw any exception
-						             """);
-				}
 			}
 
-			public sealed class TypeTests
+			public sealed class GenericWithExpectationTests
 			{
 				[Fact]
 				public async Task CustomException_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
@@ -239,8 +124,7 @@ public sealed partial class ThatDelegate
 						=> throw new OuterException(innerException: new CustomException(message));
 
 					async Task Act()
-						=> await That(action).ThrowsException()
-							.WithInner(typeof(CustomException), x => x.HasMessage("foo"));
+						=> await That(action).ThrowsException().WithInner<CustomException>(x => x.HasMessage("foo"));
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -262,8 +146,7 @@ public sealed partial class ThatDelegate
 						=> throw new OuterException(innerException: new CustomException(message));
 
 					async Task Act()
-						=> await That(action).ThrowsException()
-							.WithInner(typeof(Exception), x => x.HasMessage("foo"));
+						=> await That(action).ThrowsException().WithInner<Exception>(x => x.HasMessage("foo"));
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -277,6 +160,99 @@ public sealed partial class ThatDelegate
 						             """);
 				}
 
+				[Theory]
+				[AutoData]
+				public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException(
+					string message)
+				{
+					Exception exception = new OuterException(innerException: new CustomException(message));
+					void Delegate() => throw exception;
+
+					Exception result = await That(Delegate)
+						.ThrowsException().WithInner<CustomException>(
+							e => e.HasMessage(message));
+
+					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
+				{
+					string message = "bar";
+					Action action = ()
+						=> throw new OuterException(innerException: new CustomException(message));
+
+					async Task Act()
+						=> await That(action).ThrowsException().WithInner<Exception>(x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner exception whose Message is equal to "foo",
+						             but it was "bar" which differs at index 0:
+						                ↓ (actual)
+						               "bar"
+						               "foo"
+						                ↑ (expected)
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenInnerExceptionDoesNotMatchType_ShouldFail()
+				{
+					Action action = ()
+						=> throw new OuterException(innerException: new CustomException("foo"));
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner<MyException>(x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner MyException whose Message is equal to "foo",
+						             but it was a CustomException:
+						               foo
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenInnerExceptionIsNotPresent_ShouldFail()
+				{
+					Action action = () => throw new OuterException();
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner<Exception>(x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner exception whose Message is equal to "foo",
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrown_ShouldFail()
+				{
+					Action action = () => { };
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner<CustomException>(x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner CustomException whose Message is equal to "foo",
+						             but it did not throw any exception
+						             """);
+				}
+			}
+
+			public sealed class TypeTests
+			{
 				[Theory]
 				[AutoData]
 				public async Task WhenAwaited_WithExpectations_ShouldReturnThrownException(
@@ -397,9 +373,35 @@ public sealed partial class ThatDelegate
 						             but it was <null>
 						             """);
 				}
+			}
+
+			public sealed class TypeWithExpectationTests
+			{
+				[Fact]
+				public async Task CustomException_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
+				{
+					string message = "bar";
+					Action action = ()
+						=> throw new OuterException(innerException: new CustomException(message));
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner(typeof(CustomException), x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner CustomException whose Message is equal to "foo",
+						             but it was "bar" which differs at index 0:
+						                ↓ (actual)
+						               "bar"
+						               "foo"
+						                ↑ (expected)
+						             """);
+				}
 
 				[Fact]
-				public async Task WithInnerExpectations_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
+				public async Task Exception_WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
 				{
 					string message = "bar";
 					Action action = ()
@@ -422,7 +424,66 @@ public sealed partial class ThatDelegate
 				}
 
 				[Fact]
-				public async Task WithInnerExpectations_WhenNoExceptionIsThrown_ShouldFail()
+				public async Task WhenInnerExceptionDoesNotMatchCriteria_ShouldFail()
+				{
+					string message = "bar";
+					Action action = ()
+						=> throw new OuterException(innerException: new CustomException(message));
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner(typeof(Exception), x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner exception whose Message is equal to "foo",
+						             but it was "bar" which differs at index 0:
+						                ↓ (actual)
+						               "bar"
+						               "foo"
+						                ↑ (expected)
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenInnerExceptionDoesNotMatchType_ShouldFail()
+				{
+					Action action = ()
+						=> throw new OuterException(innerException: new CustomException("foo"));
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner(typeof(MyException), x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner MyException whose Message is equal to "foo",
+						             but it was a CustomException:
+						               foo
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenInnerExceptionIsNotPresent_ShouldFail()
+				{
+					Action action = () => throw new OuterException();
+
+					async Task Act()
+						=> await That(action).ThrowsException()
+							.WithInner(typeof(Exception), x => x.HasMessage("foo"));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception with an inner exception whose Message is equal to "foo",
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrown_ShouldFail()
 				{
 					Action action = () => { };
 

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
@@ -446,7 +446,7 @@ public sealed partial class ThatDelegate
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Wait for next core update")]
 				public async Task WhenInnerExceptionDoesNotMatchType_ShouldFail()
 				{
 					Action action = ()
@@ -465,7 +465,7 @@ public sealed partial class ThatDelegate
 						             """);
 				}
 
-				[Fact]
+				[Fact(Skip="Wait for next core update")]
 				public async Task WhenInnerExceptionIsNotPresent_ShouldFail()
 				{
 					Action action = () => throw new OuterException();


### PR DESCRIPTION
The error messages were different, when using a generic or type expectation.