### PR TITLE
refactor: improve code coverage of aweXpect.Core

### DIFF
--- a/Source/aweXpect.Core/Core/Adapters/MsTestAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/MsTestAdapter.cs
@@ -1,4 +1,5 @@
-﻿namespace aweXpect.Adapters;
+﻿// ReSharper disable UnusedType.Global
+namespace aweXpect.Core.Adapters;
 
 /// <summary>
 ///     Implements the MS test framework adapter.

--- a/Source/aweXpect.Core/Core/Adapters/NUnitAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/NUnitAdapter.cs
@@ -1,4 +1,5 @@
-﻿namespace aweXpect.Adapters;
+﻿// ReSharper disable UnusedType.Global
+namespace aweXpect.Core.Adapters;
 
 /// <summary>
 ///     Implements the NUnit test framework adapter.
@@ -6,7 +7,6 @@
 /// <remarks>
 ///     <see href="https://github.com/nunit/nunit" />
 /// </remarks>
-// ReSharper disable once UnusedMember.Global
 internal class NUnitAdapter() : TestFrameworkAdapter(
 	"nunit.framework,",
 	(a, m) => FromType("NUnit.Framework.AssertionException", a, m),

--- a/Source/aweXpect.Core/Core/Adapters/TUnitAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/TUnitAdapter.cs
@@ -3,9 +3,9 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using aweXpect.Core.Adapters;
+// ReSharper disable UnusedType.Global
 
-namespace aweXpect.Adapters;
+namespace aweXpect.Core.Adapters;
 
 /// <summary>
 ///     Implements the TUnit test framework adapter.
@@ -13,7 +13,6 @@ namespace aweXpect.Adapters;
 /// <remarks>
 ///     <see href="https://github.com/thomhurst/TUnit" />
 /// </remarks>
-// ReSharper disable once UnusedMember.Global
 [ExcludeFromCodeCoverage]
 internal class TUnitAdapter : ITestFrameworkAdapter
 {

--- a/Source/aweXpect.Core/Core/Adapters/TestFrameworkAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/TestFrameworkAdapter.cs
@@ -3,9 +3,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using aweXpect.Core.Adapters;
 
-namespace aweXpect.Adapters;
+namespace aweXpect.Core.Adapters;
 
 internal abstract class TestFrameworkAdapter(
 	string assemblyName,
@@ -37,14 +36,14 @@ internal abstract class TestFrameworkAdapter(
 			{
 				// For netfx the assembly is not in AppDomain by default, so we can't just scan AppDomain.CurrentDomain
 				_assembly = AppDomain.CurrentDomain.GetAssemblies()
-					.FirstOrDefault(a
-						=> a.FullName?.StartsWith(assemblyName, StringComparison.OrdinalIgnoreCase) == true);
-				return _assembly is not null;
+					.First(a => a.FullName?.StartsWith(assemblyName, StringComparison.OrdinalIgnoreCase) == true);
 			}
 			catch
 			{
-				return false;
+				// Ignore any exception while trying to load the assembly
 			}
+
+			return _assembly is not null;
 		}
 	}
 

--- a/Source/aweXpect.Core/Core/Adapters/XUnit2Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit2Adapter.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Adapters;
+﻿// ReSharper disable UnusedType.Global
+
+namespace aweXpect.Core.Adapters;
 
 /// <summary>
 ///     Implements the XUnit v2 test framework adapter.
@@ -6,7 +8,6 @@
 /// <remarks>
 ///     <see href="https://github.com/xunit/xunit" />
 /// </remarks>
-// ReSharper disable once UnusedMember.Global
 internal class XUnit2Adapter() : TestFrameworkAdapter(
 	"xunit.assert",
 	(a, m) => FromType("Xunit.Sdk.XunitException", a, m),

--- a/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+// ReSharper disable UnusedType.Global
 
-namespace aweXpect.Adapters;
+namespace aweXpect.Core.Adapters;
 
 /// <summary>
 ///     Implements the XUnit v3 test framework adapter.
@@ -9,7 +10,6 @@ namespace aweXpect.Adapters;
 /// <remarks>
 ///     <see href="https://github.com/xunit/xunit" />
 /// </remarks>
-// ReSharper disable once UnusedMember.Global
 [ExcludeFromCodeCoverage]
 internal class XUnit3Adapter() : TestFrameworkAdapter(
 	"xunit.v3.assert",

--- a/Source/aweXpect.Core/Core/Ambient/Initialization.cs
+++ b/Source/aweXpect.Core/Core/Ambient/Initialization.cs
@@ -43,7 +43,7 @@ internal static class Initialization
 		ITestFrameworkAdapter testFramework = DetectFramework(AppDomain.CurrentDomain.GetAssemblies()
 			.Where(assembly => Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
 				.All(excludedAssemblyPrefix => !assembly.FullName!.StartsWith(excludedAssemblyPrefix)))
-			.SelectMany(assembly => assembly.GetTypes().Where(x => x.IsVisible || x.IsPublic || !x.IsNested || !x.IsNestedPrivate)));
+			.SelectMany(assembly => assembly.GetTypes().Where(x => !x.IsNestedPrivate)));
 		return new InitializationState(testFramework);
 	}
 

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResult.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResult.cs
@@ -78,7 +78,7 @@ public abstract class ConstraintResult
 
 	internal virtual string GetResultText()
 	{
-		StringBuilder? sb = new();
+		StringBuilder sb = new();
 		AppendResult(sb);
 		return sb.ToString();
 	}

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -54,8 +54,7 @@ internal class OrNode : Node
 			ConstraintResult result = await node.IsMetBy(value, context, cancellationToken);
 			combinedResult = CombineResults(combinedResult, result, separator,
 				combinedResult?.FurtherProcessingStrategy);
-			if (result.FurtherProcessingStrategy ==
-			    FurtherProcessingStrategy.IgnoreCompletely)
+			if (result.FurtherProcessingStrategy == FurtherProcessingStrategy.IgnoreCompletely)
 			{
 				return combinedResult;
 			}
@@ -133,7 +132,8 @@ internal class OrNode : Node
 					right.AppendResult(stringBuilder, indentation);
 				}
 			}
-			else if (right.Outcome == Outcome.Failure)
+			else if (right.Outcome == Outcome.Failure &&
+			         _furtherProcessingStrategy != FurtherProcessingStrategy.IgnoreResult)
 			{
 				right.AppendResult(stringBuilder, indentation);
 			}

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -131,7 +131,6 @@ internal class WhichNode<TSource, TMember> : Node
 		TMember? value)
 		: ConstraintResult(And(left.Outcome, right.Outcome), furtherProcessingStrategy)
 	{
-		private readonly FurtherProcessingStrategy _furtherProcessingStrategy = furtherProcessingStrategy;
 		// ReSharper disable once ReplaceWithPrimaryConstructorParameter
 		private readonly TMember? _value = value;
 

--- a/Source/aweXpect.Core/Core/StringDifference.cs
+++ b/Source/aweXpect.Core/Core/StringDifference.cs
@@ -231,7 +231,7 @@ public sealed class StringDifference(
 		int maxCommonLength = Math.Min(actualValue.Length, expectedValue.Length);
 		int min = 0;
 		int max = maxCommonLength + 1;
-		while (min <= max)
+		while (min < max)
 		{
 			int mid = (min + max) / 2;
 			if (mid == min)
@@ -242,10 +242,6 @@ public sealed class StringDifference(
 			if (comparer.Equals(actualValue[..mid], expectedValue[..mid]))
 			{
 				min = mid;
-			}
-			else if (mid <= min + 1)
-			{
-				break;
 			}
 			else
 			{
@@ -272,7 +268,7 @@ public sealed class StringDifference(
 		int indexOfWordBoundary = value
 			.LastIndexOf(' ', Math.Min(maxLength + lengthOfWhitespace, value.Length) - 1);
 
-		if (indexOfWordBoundary >= minLength)
+		if (indexOfWordBoundary > minLength)
 		{
 			return indexOfWordBoundary;
 		}

--- a/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using aweXpect.Adapters;
+using aweXpect.Core.Adapters;
 using aweXpect.Core.Tests.TestHelpers;
 
 namespace aweXpect.Core.Tests.Core.Adapters;

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
@@ -141,6 +141,56 @@ public class ConstraintResultTests
 	}
 
 	[Fact]
+	public async Task UpdateExpectationText_ShouldKeepPrefixWhenNull()
+	{
+		ConstraintResult.Success sut = new("foo");
+		StringBuilder sb = new();
+		sut.UpdateExpectationText(s => s.Append("prefix-foo\n"), s => s.Append("\nsuffix-foo"));
+
+		sut.UpdateExpectationText(null, s => s.Append("\nsuffix-foo2"));
+
+		sut.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("prefix-foo\nfoo\nsuffix-foo2");
+	}
+
+	[Fact]
+	public async Task UpdateExpectationText_ShouldKeepSuffixWhenNull()
+	{
+		ConstraintResult.Success sut = new("foo");
+		StringBuilder sb = new();
+		sut.UpdateExpectationText(s => s.Append("prefix-foo\n"), s => s.Append("\nsuffix-foo"));
+
+		sut.UpdateExpectationText(s => s.Append("prefix-foo2\n"));
+
+		sut.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("prefix-foo2\nfoo\nsuffix-foo");
+	}
+
+	[Fact]
+	public async Task UpdateExpectationText_ShouldSupportPrefixOnly()
+	{
+		ConstraintResult.Success sut = new("foo");
+		StringBuilder sb = new();
+
+		sut.UpdateExpectationText(s => s.Append("prefix-foo\n"));
+
+		sut.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("prefix-foo\nfoo");
+	}
+
+	[Fact]
+	public async Task UpdateExpectationText_ShouldSupportSuffixOnly()
+	{
+		ConstraintResult.Success sut = new("foo");
+		StringBuilder sb = new();
+
+		sut.UpdateExpectationText(null, s => s.Append("\nsuffix-foo"));
+
+		sut.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo\nsuffix-foo");
+	}
+
+	[Fact]
 	public async Task UpdateExpectationText_ShouldUsePrefixAndSuffixForAppendExpectation()
 	{
 		ConstraintResult.Success sut = new("foo");

--- a/Tests/aweXpect.Core.Tests/Core/Helpers/StringExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Helpers/StringExtensionsTests.cs
@@ -68,6 +68,19 @@ public class StringExtensionsTests
 		await That(result).IsNull();
 	}
 
+	[Theory]
+	[InlineData("", "a ")]
+	[InlineData("apple", "an apple")]
+	[InlineData("bee", "a bee")]
+	[InlineData("Exception", "an Exception")]
+	[InlineData("NotSupportedException", "a NotSupportedException")]
+	public async Task PrependAOrAn(string input, string expected)
+	{
+		string result = input.PrependAOrAn();
+
+		await That(result).IsEqualTo(expected);
+	}
+
 	[Fact]
 	public async Task RemoveNewlineStyle_ShouldReplaceNewlinesWithSlashN()
 	{
@@ -79,13 +92,12 @@ public class StringExtensionsTests
 		await That(result).IsEqualTo(expected);
 	}
 
-
 	[Fact]
 	public async Task RemoveNewlineStyle_WhenNull_ShouldReturnNull()
 	{
 		string? input = null;
 
-		string? result = input.Indent();
+		string? result = input.RemoveNewlineStyle();
 
 		await That(result).IsNull();
 	}

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AndNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AndNodeTests.cs
@@ -30,6 +30,23 @@ public sealed class AndNodeTests
 	}
 
 	[Fact]
+	public async Task ShouldConsiderFurtherProcessingStrategy()
+	{
+		AndNode node = new(new DummyNode("",
+			() => new ConstraintResult.Failure("foo", "-")));
+		node.AddNode(new DummyNode("",
+			() => new ConstraintResult.Failure("bar", "-", FurtherProcessingStrategy.IgnoreCompletely)), " my ");
+		node.AddNode(new DummyNode("",
+			() => new ConstraintResult.Failure("baz", "-")), " is ");
+		StringBuilder sb = new();
+
+		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
+
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo my bar");
+	}
+
+	[Fact]
 	public async Task ToString_ShouldCombineAllNodes()
 	{
 #pragma warning disable CS4014
@@ -112,6 +129,20 @@ public sealed class AndNodeTests
 
 		result.AppendExpectation(sb);
 		await That(sb.ToString()).IsEqualTo("foo my bar");
+	}
+
+	[Fact]
+	public async Task WithCustomSeparators_ShouldUseItInsteadOfOr()
+	{
+		AndNode node = new(new DummyNode("", () => new ConstraintResult.Failure("foo", "-")));
+		node.AddNode(new DummyNode("", () => new ConstraintResult.Failure("bar", "-")), " my ");
+		node.AddNode(new DummyNode("", () => new ConstraintResult.Failure("baz", "-")), " is ");
+		StringBuilder sb = new();
+
+		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
+
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("foo my bar is baz");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
@@ -328,5 +328,22 @@ public class ExpectationNodeTests
 		await That(value).IsEqualTo(1);
 	}
 
+	[Fact]
+	public async Task TryGetValue_WhenNeitherLeftNorRightHasValue_ShouldReturnFalse()
+	{
+		DummyConstraint constraint1 = new("", () => new ConstraintResult.Success(""));
+		DummyConstraint constraint2 = new("", () => new ConstraintResult.Success(""));
+		ExpectationNode node = new();
+		node.AddConstraint(constraint1);
+		node.AddMapping(MemberAccessor<int, int>.FromFunc(_ => 0, "length"));
+		node.AddConstraint(constraint2);
+		ConstraintResult constraintResult = await node.IsMetBy(3, null!, CancellationToken.None);
+
+		bool result = constraintResult.TryGetValue(out string? value);
+
+		await That(result).IsFalse();
+		await That(value).IsNull();
+	}
+
 	private class UnsupportedConstraint : IConstraint;
 }

--- a/Tests/aweXpect.Core.Tests/Core/StringDifferenceTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/StringDifferenceTests.cs
@@ -5,6 +5,20 @@ namespace aweXpect.Core.Tests.Core;
 
 public class StringDifferenceTests
 {
+	[Theory]
+	[InlineData(StringDifference.MatchType.Wildcard)]
+	[InlineData(StringDifference.MatchType.Regex)]
+	public async Task IndexOfFirstMismatch_ForWildcardOrRegex_ShouldBeZero(StringDifference.MatchType matchType)
+	{
+		const string actual = "Foo";
+		const string expected = "Foo";
+		StringDifference sut = new(actual, expected);
+
+		int result = sut.IndexOfFirstMismatch(matchType);
+
+		await That(result).IsEqualTo(0);
+	}
+
 	[Fact]
 	public async Task ShouldCacheIndexOfFirstMismatch()
 	{
@@ -155,9 +169,9 @@ public class StringDifferenceTests
 	[Fact]
 	public async Task WhenNoTrailingWordBoundaryExistsBetween45And60Characters_ShouldFallbackTo50Characters()
 	{
-		const string actual = "This text contains a lot of words and is used for testing the WordBoundaryAlgorithm";
+		const string actual = "This text contains lot of words and is used for testing the WordBoundaryAlgorithm";
 		const string expected =
-			"This text is used to verify when between 45 'and60characters' no word boundary exists";
+			"This text is used to verify when  between  45 and60characters_no word boundary exists";
 		StringDifference sut = new(actual, expected);
 
 		string result = sut.ToString();
@@ -166,8 +180,8 @@ public class StringDifferenceTests
 			"""
 			differs at index 10:
 			             ↓ (actual)
-			  "This text contains a lot of words and is used for testing…"
-			  "This text is used to verify when between 45 'and60…"
+			  "This text contains lot of words and is used for testing the…"
+			  "This text is used to verify when  between  45 and6…"
 			             ↑ (expected)
 			""");
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/FormattingOptionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/FormattingOptionsTests.cs
@@ -3,18 +3,29 @@
 public class FormattingOptionsTests
 {
 	[Fact]
+	public async Task Indented_ShouldUseLineBreaks()
+	{
+		FormattingOptions options = FormattingOptions.Indented;
+
+		await That(options.UseLineBreaks).IsTrue();
+		await That(options.Indentation).IsEqualTo("  ");
+	}
+
+	[Fact]
 	public async Task MultipleLines_ShouldUseLineBreaks()
 	{
-		FormattingOptions multipleLines = FormattingOptions.MultipleLines;
+		FormattingOptions options = FormattingOptions.MultipleLines;
 
-		await That(multipleLines.UseLineBreaks).IsTrue();
+		await That(options.UseLineBreaks).IsTrue();
+		await That(options.Indentation).IsEmpty();
 	}
 
 	[Fact]
 	public async Task SingleLine_ShouldNotUseLineBreaks()
 	{
-		FormattingOptions multipleLines = FormattingOptions.SingleLine;
+		FormattingOptions options = FormattingOptions.SingleLine;
 
-		await That(multipleLines.UseLineBreaks).IsFalse();
+		await That(options.UseLineBreaks).IsFalse();
+		await That(options.Indentation).IsEmpty();
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
@@ -42,7 +42,7 @@ public partial class ValueFormatters
 		public async Task NullableShouldUseRoundtripFormat()
 		{
 			Guid? value = Guid.NewGuid();
-			string expectedResult = value.ToString();
+			string? expectedResult = value.ToString();
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
@@ -42,7 +42,7 @@ public partial class ValueFormatters
 		public async Task NullableShouldUseRoundtripFormat()
 		{
 			Guid? value = Guid.NewGuid();
-			string? expectedResult = value.ToString();
+			string expectedResult = value.ToString();
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);

--- a/Tests/aweXpect.Internal.Tests/Helpers/StringExtensionsTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Helpers/StringExtensionsTests.cs
@@ -47,6 +47,7 @@ public class StringExtensionsTests
 	}
 
 	[Theory]
+	[InlineData("", "a ")]
 	[InlineData("apple", "an apple")]
 	[InlineData("bee", "a bee")]
 	[InlineData("Exception", "an Exception")]

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
@@ -56,13 +56,13 @@ public sealed partial class ThatDelegate
 			{
 				Action action = () => { };
 
-				async Task<CustomException> Act()
-					=> await That(action).Throws<CustomException>();
+				async Task<Exception> Act()
+					=> await That(action).Throws<Exception>();
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that action
-					             throws a CustomException,
+					             throws an exception,
 					             but it did not throw any exception
 					             """);
 			}
@@ -186,12 +186,12 @@ public sealed partial class ThatDelegate
 				Action action = () => { };
 
 				async Task<Exception> Act()
-					=> await That(action).Throws(typeof(CustomException));
+					=> await That(action).Throws(typeof(Exception));
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that action
-					             throws a CustomException,
+					             throws an exception,
 					             but it did not throw any exception
 					             """);
 			}


### PR DESCRIPTION
Add missing tests
Fix namespace of adapters
Update nodes and corresponding tests
Refactor `StringDifference` so that tests are exhaustive
Add tests for indented Formatting options