### PR TITLE
feat: include options in collection `Contains`

### DIFF
--- a/Source/aweXpect/Results/EventTriggerResult.cs
+++ b/Source/aweXpect/Results/EventTriggerResult.cs
@@ -15,10 +15,25 @@ public class EventTriggerResult<TSubject>(
 	IThat<IEventRecording<TSubject>> returnValue,
 	TriggerEventFilter filter,
 	Quantifier quantifier)
-	: CountResult<IEventRecording<TSubject>, IThat<IEventRecording<TSubject>>>(expectationBuilder, returnValue,
-		quantifier)
+	: CountResult<IEventRecording<TSubject>, IThat<IEventRecording<TSubject>>>(
+			expectationBuilder, returnValue, quantifier),
+		EventTriggerResult<TSubject>.IExtensions
 	where TSubject : notnull
 {
+	/// <inheritdoc cref="IExtensions.WithParameter{TParameter}(string, int?, Func{TParameter, bool})" />
+	EventTriggerResult<TSubject> IExtensions.WithParameter<TParameter>(
+		string expression,
+		int? position,
+		Func<TParameter, bool> predicate)
+	{
+		filter.AddPredicate(
+			o => position == null
+				? o.Any(x => x is TParameter p && predicate(p))
+				: o.Length > position && o[position.Value] is TParameter m && predicate(m),
+			expression);
+		return this;
+	}
+
 	/// <summary>
 	///     Adds a predicate for the sender of the event.
 	/// </summary>
@@ -88,23 +103,21 @@ public class EventTriggerResult<TSubject>(
 	}
 
 	/// <summary>
-	///     Adds a parameter predicate on the parameter at the given zero-based <paramref name="position" /> of type
-	///     <typeparamref name="TParameter" /> and the <paramref name="expression" /> for extension methods.
+	///     Gives access to additional methods for extensions.
 	/// </summary>
-	/// <remarks>
-	///     This method is mainly intended for extension methods, as it allows overriding the default
-	///     <paramref name="expression" />.
-	/// </remarks>
-	public EventTriggerResult<TSubject> WithParameter<TParameter>(
-		string expression,
-		int? position,
-		Func<TParameter, bool> predicate)
+	public interface IExtensions
 	{
-		filter.AddPredicate(
-			o => position == null
-				? o.Any(x => x is TParameter p && predicate(p))
-				: o.Length > position && o[position.Value] is TParameter m && predicate(m),
-			expression);
-		return this;
+		/// <summary>
+		///     Adds a parameter predicate on the parameter at the given zero-based <paramref name="position" /> of type
+		///     <typeparamref name="TParameter" /> and the <paramref name="expression" /> for extension methods.
+		/// </summary>
+		/// <remarks>
+		///     This method is mainly intended for extension methods, as it allows overriding the default
+		///     <paramref name="expression" />.
+		/// </remarks>
+		EventTriggerResult<TSubject> WithParameter<TParameter>(
+			string expression,
+			int? position,
+			Func<TParameter, bool> predicate);
 	}
 }

--- a/Source/aweXpect/Results/JsonWhichResult.cs
+++ b/Source/aweXpect/Results/JsonWhichResult.cs
@@ -22,14 +22,9 @@ public class JsonWhichResult(
 	public AndOrResult<string?, IThat<string?>> Which(Action<IThat<JsonElement?>> expectations)
 	{
 		_expectationBuilder
-			.ForMember(MemberAccessor<string?, JsonElement?>.FromFunc(s =>
+			.ForMember(MemberAccessor<string, JsonElement?>.FromFunc(jsonString =>
 				{
-					if (s is null)
-					{
-						return null;
-					}
-
-					using JsonDocument jsonDocument = JsonDocument.Parse(s, options);
+					using JsonDocument jsonDocument = JsonDocument.Parse(jsonString, options);
 					return jsonDocument.RootElement.Clone();
 				}, "it"),
 				(_, stringBuilder) => stringBuilder.Append(" which "))

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -28,7 +28,7 @@ public static partial class ThatEnumerable
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new ContainConstraint<TItem>(
 					it,
-					q => $"contains {Formatter.Format(expected)} {q}",
+					q => $"contains {Formatter.Format(expected)}{options} {q}",
 					a => options.AreConsideredEqual(a, expected),
 					quantifier)),
 			source,
@@ -215,8 +215,7 @@ public static partial class ThatEnumerable
 				$"{it} contained it {count} times in {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)}");
 		}
 
-		public override string ToString()
-			=> expectationText(quantifier);
+		public override string ToString() => expectationText(quantifier);
 	}
 
 	private readonly struct NotContainConstraint<TItem>(

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1055,7 +1055,7 @@ namespace aweXpect.Results
     {
         public aweXpect.ThatEnumerable.Elements<TValue> WhoseValues { get; }
     }
-    public class EventTriggerResult<TSubject> : aweXpect.Results.CountResult<aweXpect.Recording.IEventRecording<TSubject>, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>>>
+    public class EventTriggerResult<TSubject> : aweXpect.Results.CountResult<aweXpect.Recording.IEventRecording<TSubject>, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>>>, aweXpect.Results.EventTriggerResult<TSubject>.IExtensions
         where TSubject :  notnull
     {
         public EventTriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>> returnValue, aweXpect.Options.TriggerEventFilter filter, aweXpect.Options.Quantifier quantifier) { }
@@ -1063,8 +1063,11 @@ namespace aweXpect.Results
             where TEventArgs : System.EventArgs { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate) { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithSender(System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public interface IExtensions
+        {
+            aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
+        }
     }
     public class JsonWhichResult : aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -803,7 +803,7 @@ namespace aweXpect.Results
     {
         public aweXpect.ThatEnumerable.Elements<TValue> WhoseValues { get; }
     }
-    public class EventTriggerResult<TSubject> : aweXpect.Results.CountResult<aweXpect.Recording.IEventRecording<TSubject>, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>>>
+    public class EventTriggerResult<TSubject> : aweXpect.Results.CountResult<aweXpect.Recording.IEventRecording<TSubject>, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>>>, aweXpect.Results.EventTriggerResult<TSubject>.IExtensions
         where TSubject :  notnull
     {
         public EventTriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>> returnValue, aweXpect.Options.TriggerEventFilter filter, aweXpect.Options.Quantifier quantifier) { }
@@ -811,8 +811,11 @@ namespace aweXpect.Results
             where TEventArgs : System.EventArgs { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate) { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithSender(System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public interface IExtensions
+        {
+            aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
+        }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>
     {

--- a/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Recording;
+using aweXpect.Results;
+
+namespace aweXpect.Internal.Tests.Results;
+
+public sealed class EventTriggerResultTests
+{
+	[Fact]
+	public async Task WhenCastingToIExtensions_CanSpecifyNameOfParameter()
+	{
+		CustomEventWithParametersClass<string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string>> recording = sut.Record().Events();
+
+		sut.NotifyCustomEvent("foo");
+		sut.NotifyCustomEvent("bar");
+
+		async Task Act() =>
+			await ((EventTriggerResult<CustomEventWithParametersClass<string>>.IExtensions)That(recording)
+					.Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent)))
+				.WithParameter<string>(" with my parameter", null, s => s == "foo")
+				.AtLeast(2.Times());
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that recording
+			             has recorded the CustomEvent event on sut with my parameter at least 2 times,
+			             but it was recorded once in [
+			               CustomEvent("foo"),
+			               CustomEvent("bar")
+			             ]
+			             """);
+	}
+
+	private sealed class CustomEventWithParametersClass<T1>
+	{
+		public delegate void CustomEventDelegate(T1 arg1);
+
+		public event CustomEventDelegate? CustomEvent;
+
+		public void NotifyCustomEvent(T1 arg1)
+			=> CustomEvent?.Invoke(arg1);
+	}
+}

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChanged.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChanged.Tests.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed class DoesNotHaveTriggeredPropertyChanged
+	public sealed class DidNotTriggerPropertyChanged
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChangedFor.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChangedFor.Tests.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed class DoesNotHaveTriggeredPropertyChangedFor
+	public sealed class DidNotTriggerPropertyChangedFor
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.CountTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.CountTests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed partial class HasTriggered
+	public sealed partial class Triggered
 	{
 		public sealed class CountTests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed partial class HasTriggered
+	public sealed partial class Triggered
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithParameterTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithParameterTests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed partial class HasTriggered
+	public sealed partial class Triggered
 	{
 		public sealed class WithParameterTests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithSenderTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithSenderTests.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed partial class HasTriggered
+	public sealed partial class Triggered
 	{
 		public sealed class WithSenderTests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithTests.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed partial class HasTriggered
+	public sealed partial class Triggered
 	{
 		public sealed class WithTests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed class HasTriggeredPropertyChanged
+	public sealed class TriggeredPropertyChanged
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed class HasTriggeredPropertyChangedFor
+	public sealed class TriggeredPropertyChangedFor
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsValidJson.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsValidJson.Tests.cs
@@ -100,6 +100,22 @@ public sealed partial class ThatString
 		public sealed class WhichTests
 		{
 			[Fact]
+			public async Task WhenActualIsNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsValidJson().Which(d => d.Matches([1, 2]));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is valid JSON which matches [1, 2],
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenExpectationInWhichFails_ShouldFail()
 			{
 				string subject = "[1, 2]";


### PR DESCRIPTION
Include information about the used options like "Using" or "Equivalent" in the expectation for collection `Contains` method.

Hide `EventTriggerResult<TSubject>.WithParameter<TParameter>(string, int? Func<TParameter, bool>)` method behind an interface, as this method is mainly intended for extension methods, as it allows overriding the default expression.

Also add some missing tests.