### PR TITLE
refactor: ensure correct `null` handling for `TimeSpan` expectations

### DIFF
--- a/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsEqualTo.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsEqualTo.cs
@@ -54,7 +54,7 @@ public static partial class ThatNullableTimeSpan
 		}
 
 		public override string ToString()
-			=> $"is {Formatter.Format(expected)}{tolerance}";
+			=> $"is equal to {Formatter.Format(expected)}{tolerance}";
 	}
 
 	private readonly struct IsNotEqualToConstraint(
@@ -75,6 +75,6 @@ public static partial class ThatNullableTimeSpan
 		}
 
 		public override string ToString()
-			=> $"is not {Formatter.Format(unexpected)}{tolerance}";
+			=> $"is not equal to {Formatter.Format(unexpected)}{tolerance}";
 	}
 }

--- a/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsEqualTo.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsEqualTo.cs
@@ -55,7 +55,7 @@ public static partial class ThatTimeSpan
 		}
 
 		public override string ToString()
-			=> $"is {Formatter.Format(expected)}{tolerance}";
+			=> $"is equal to {Formatter.Format(expected)}{tolerance}";
 	}
 
 	private readonly struct IsNotConstraint(
@@ -77,6 +77,6 @@ public static partial class ThatTimeSpan
 		}
 
 		public override string ToString()
-			=> $"is not {Formatter.Format(unexpected)}{tolerance}";
+			=> $"is not equal to {Formatter.Format(unexpected)}{tolerance}";
 	}
 }

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsEqualTo.Tests.cs
@@ -42,9 +42,25 @@ public sealed partial class ThatNullableTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 0:00,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
@@ -86,7 +102,7 @@ public sealed partial class ThatNullableTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsEqualTo.Tests.cs
@@ -90,6 +90,30 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task Within_WhenValuesAreEarlierWithinTheTolerance_ShouldSucceed()
+			{
+				TimeSpan? subject = CurrentTime();
+				TimeSpan? expected = EarlierTime(3);
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Within_WhenValuesAreLaterWithinTheTolerance_ShouldSucceed()
+			{
+				TimeSpan? subject = CurrentTime();
+				TimeSpan? expected = LaterTime(3);
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();
@@ -105,18 +129,6 @@ public sealed partial class ThatNullableTimeSpan
 					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
-			}
-
-			[Fact]
-			public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
-			{
-				TimeSpan? subject = CurrentTime();
-				TimeSpan? expected = LaterTime(3);
-
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsGreaterThan.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsGreaterThan.Tests.cs
@@ -75,6 +75,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is greater than 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsGreaterThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsGreaterThanOrEqualTo.Tests.cs
@@ -7,6 +7,21 @@ public sealed partial class ThatNullableTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is greater than or equal to 0:00,
+					             but it was <null>
+					             """);
+			}
+			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsLessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsLessThan.Tests.cs
@@ -75,6 +75,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is less than 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsLessThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsLessThanOrEqualTo.Tests.cs
@@ -65,6 +65,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is less than or equal to 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNegative.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNegative.Tests.cs
@@ -45,6 +45,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNegative();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is negative,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsPositive_ShouldFail()
 			{
 				TimeSpan? subject = 1.Seconds();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatNullableTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not the maximum time span, because we want to test the failure,
+					             is not equal to the maximum time span, because we want to test the failure,
 					             but it was the maximum time span
 					             """);
 			}
@@ -37,7 +37,7 @@ public sealed partial class ThatNullableTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not the minimum time span, because we want to test the failure,
+					             is not equal to the minimum time span, because we want to test the failure,
 					             but it was the minimum time span
 					             """);
 			}
@@ -55,6 +55,17 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldSucceed()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(TimeSpan.Zero);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsTheSame_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();
@@ -67,7 +78,7 @@ public sealed partial class ThatNullableTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -112,7 +123,7 @@ public sealed partial class ThatNullableTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotEqualTo.Tests.cs
@@ -98,20 +98,25 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
-			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+			public async Task Within_WhenValuesAreEarlierWithinTheTolerance_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();
-				TimeSpan? unexpected = LaterTime(4);
+				TimeSpan? unexpected = EarlierTime(3);
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected)
-						.Within(3.Seconds());
+					=> await That(subject).IsNotEqualTo(unexpected).Within(3.Seconds())
+						.Because("we want to test the failure");
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
-			public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+			public async Task Within_WhenValuesAreLaterWithinTheTolerance_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();
 				TimeSpan? unexpected = LaterTime(3);
@@ -126,6 +131,19 @@ public sealed partial class ThatNullableTimeSpan
 					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+
+			[Fact]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeSpan? subject = CurrentTime();
+				TimeSpan? unexpected = LaterTime(4);
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotGreaterThan.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotGreaterThan.Tests.cs
@@ -48,6 +48,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotGreaterThan(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not greater than 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotGreaterThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotGreaterThanOrEqualTo.Tests.cs
@@ -58,6 +58,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotGreaterThanOrEqualTo(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not greater than or equal to 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotLessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotLessThan.Tests.cs
@@ -48,6 +48,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotLessThan(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not less than 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotLessThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotLessThanOrEqualTo.Tests.cs
@@ -58,6 +58,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotLessThanOrEqualTo(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not less than or equal to 0:00,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotNegative.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotNegative.Tests.cs
@@ -7,6 +7,21 @@ public sealed partial class ThatNullableTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotNegative();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not negative,
+					             but it was <null>
+					             """);
+			}
+			[Fact]
 			public async Task WhenSubjectIsMaxValue_ShouldSucceed()
 			{
 				TimeSpan? subject = TimeSpan.MaxValue;

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotPositive.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotPositive.Tests.cs
@@ -45,6 +45,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotPositive();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not positive,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsPositive_ShouldFail()
 			{
 				TimeSpan? subject = 1.Seconds();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsPositive.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsPositive.Tests.cs
@@ -50,6 +50,22 @@ public sealed partial class ThatNullableTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsPositive();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is positive,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsPositive_ShouldSucceed()
 			{
 				TimeSpan? subject = 1.Seconds();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsEqualTo.Tests.cs
@@ -91,6 +91,30 @@ public sealed partial class ThatTimeSpan
 			}
 
 			[Fact]
+			public async Task Within_WhenValuesAreEarlierWithinTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? expected = EarlierTime(3);
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Within_WhenValuesAreLaterWithinTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? expected = LaterTime(3);
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail()
 			{
 				TimeSpan subject = CurrentTime();
@@ -106,18 +130,6 @@ public sealed partial class ThatTimeSpan
 					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
-			}
-
-			[Fact]
-			public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
-			{
-				TimeSpan subject = CurrentTime();
-				TimeSpan? expected = EarlierTime(3);
-
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsEqualTo.Tests.cs
@@ -7,6 +7,23 @@ public sealed partial class ThatTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).Because("we want to test the null-case");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to <null>, because we want to test the null-case,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectAndExpectedAreMaxValue_ShouldSucceed()
 			{
 				TimeSpan subject = TimeSpan.MaxValue;
@@ -42,7 +59,7 @@ public sealed partial class ThatTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -86,7 +103,7 @@ public sealed partial class ThatTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -95,7 +112,7 @@ public sealed partial class ThatTimeSpan
 			public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 			{
 				TimeSpan subject = CurrentTime();
-				TimeSpan? expected = LaterTime(3);
+				TimeSpan? expected = EarlierTime(3);
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(3.Seconds());

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not the maximum time span, because we want to test the failure,
+					             is not equal to the maximum time span, because we want to test the failure,
 					             but it was the maximum time span
 					             """);
 			}
@@ -37,7 +37,7 @@ public sealed partial class ThatTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not the minimum time span, because we want to test the failure,
+					             is not equal to the minimum time span, because we want to test the failure,
 					             but it was the minimum time span
 					             """);
 			}
@@ -67,9 +67,21 @@ public sealed partial class ThatTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenUnexpectedIsNull_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -112,7 +124,7 @@ public sealed partial class ThatTimeSpan
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotEqualTo.Tests.cs
@@ -99,20 +99,25 @@ public sealed partial class ThatTimeSpan
 			}
 
 			[Fact]
-			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+			public async Task Within_WhenValuesAreEarlierWithinTheTolerance_ShouldFail()
 			{
 				TimeSpan subject = CurrentTime();
-				TimeSpan? unexpected = LaterTime(4);
+				TimeSpan? unexpected = EarlierTime(3);
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected)
-						.Within(3.Seconds());
+					=> await That(subject).IsNotEqualTo(unexpected).Within(3.Seconds())
+						.Because("we want to test the failure");
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
-			public async Task Within_WhenValuesAreWithinTheTolerance_ShouldFail()
+			public async Task Within_WhenValuesAreLaterWithinTheTolerance_ShouldFail()
 			{
 				TimeSpan subject = CurrentTime();
 				TimeSpan? unexpected = LaterTime(3);
@@ -127,6 +132,19 @@ public sealed partial class ThatTimeSpan
 					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+
+			[Fact]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? unexpected = LaterTime(4);
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}


### PR DESCRIPTION
Change `IsEqualTo` expectation text from "is 0:00" to "is equal to 0:00" and add tests for the `null` case.