### PR TITLE
refactor: ensure correct `null` handling for `DateOnly` and `TimeOnly`

### DIFF
--- a/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatDateOnly
 					new ConditionConstraintWithTolerance(
 						it,
 						expected,
-						(e, t) => $"is {Formatter.Format(e)}{t.ToDayString()}",
+						(e, t) => $"is equal to {Formatter.Format(e)}{t.ToDayString()}",
 						(a, e, t) => e != null &&
 						             Math.Abs(a.DayNumber - e.Value.DayNumber) <= (int)t.TotalDays,
 						(a, _, i) => $"{i} was {Formatter.Format(a)}",
@@ -43,7 +43,7 @@ public static partial class ThatDateOnly
 				new ConditionConstraintWithTolerance(
 					it,
 					unexpected,
-					(e, t) => $"is not {Formatter.Format(e)}{t.ToDayString()}",
+					(e, t) => $"is not equal to {Formatter.Format(e)}{t.ToDayString()}",
 					(a, u, t) => u == null ||
 					             Math.Abs(a.DayNumber - u.Value.DayNumber) > (int)t.TotalDays,
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatNullableDateOnly
 				new ConditionConstraintWithTolerance(
 					it,
 					expected,
-					(e, t) => $"is {Formatter.Format(e)}{t.ToDayString()}",
+					(e, t) => $"is equal to {Formatter.Format(e)}{t.ToDayString()}",
 					(a, e, t) => (a == null && e == null) ||
 					             (a != null && e != null &&
 					              Math.Abs(a.Value.DayNumber - e.Value.DayNumber) <= (int)t.TotalDays),
@@ -44,7 +44,7 @@ public static partial class ThatNullableDateOnly
 					new ConditionConstraintWithTolerance(
 						it,
 						unexpected,
-						(e, t) => $"is not {Formatter.Format(e)}{t.ToDayString()}",
+						(e, t) => $"is not equal to {Formatter.Format(e)}{t.ToDayString()}",
 						(a, u, t) => a == null != (u == null) ||
 						             (a != null && u != null &&
 						              Math.Abs(a.Value.DayNumber - u.Value.DayNumber) > (int)t.TotalDays),

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsEqualTo.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatNullableTimeOnly
 				new ConditionConstraintWithTolerance(
 					it,
 					expected,
-					(e, t) => $"is {Formatter.Format(e)}{t}",
+					(e, t) => $"is equal to {Formatter.Format(e)}{t}",
 					(a, e, t) => (a == null && e == null) ||
 					             (a != null && e != null &&
 					              Math.Abs(a.Value.Ticks - e.Value.Ticks) <= t.Ticks),
@@ -44,7 +44,7 @@ public static partial class ThatNullableTimeOnly
 				new ConditionConstraintWithTolerance(
 					it,
 					unexpected,
-					(e, t) => $"is not {Formatter.Format(e)}{t}",
+					(e, t) => $"is not equal to {Formatter.Format(e)}{t}",
 					(a, u, t) => a == null != (u == null) ||
 					             (a != null && u != null &&
 					              Math.Abs(a.Value.Ticks - u.Value.Ticks) > t.Ticks),

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsEqualTo.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatTimeOnly
 				new ConditionConstraintWithTolerance(
 					it,
 					expected,
-					(e, t) => $"is {Formatter.Format(e)}{t}",
+					(e, t) => $"is equal to {Formatter.Format(e)}{t}",
 					(a, e, t) => e != null &&
 					             Math.Abs(a.Ticks - e.Value.Ticks) <= t.Ticks,
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
@@ -43,7 +43,7 @@ public static partial class ThatTimeOnly
 				new ConditionConstraintWithTolerance(
 					it,
 					unexpected,
-					(e, t) => $"is not {Formatter.Format(e)}{t}",
+					(e, t) => $"is not equal to {Formatter.Format(e)}{t}",
 					(a, u, t) => u == null ||
 					             Math.Abs(a.Ticks - u.Value.Ticks) > t.Ticks,
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is <null>,
+					              is equal to <null>,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -36,7 +36,7 @@ public sealed partial class ThatDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -73,7 +73,7 @@ public sealed partial class ThatDateOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotEqualTo.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
+					              is not equal to {Formatter.Format(unexpected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -68,7 +68,7 @@ public sealed partial class ThatDateOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± {tolerance} days, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± {tolerance} days, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsAfter.Tests.cs
@@ -76,6 +76,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsBefore.Tests.cs
@@ -76,6 +76,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatNullableDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is <null>,
+					              is equal to <null>,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -36,7 +36,7 @@ public sealed partial class ThatNullableDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was <null>
 					              """);
 			}
@@ -65,8 +65,25 @@ public sealed partial class ThatNullableDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to {Formatter.Format(expected)},
+					              but it was <null>
 					              """);
 			}
 
@@ -102,7 +119,7 @@ public sealed partial class ThatNullableDateOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotAfter.Tests.cs
@@ -49,6 +49,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotBefore.Tests.cs
@@ -49,6 +49,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotEqualTo.Tests.cs
@@ -43,7 +43,7 @@ public sealed partial class ThatNullableDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not <null>,
+					             is not equal to <null>,
 					             but it was <null>
 					             """);
 			}
@@ -53,6 +53,18 @@ public sealed partial class ThatNullableDateOnly
 			{
 				DateOnly? subject = CurrentTime();
 				DateOnly? unexpected = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldSucceed()
+			{
+				DateOnly? unexpected = CurrentTime();
+				DateOnly? subject = null;
 
 				async Task Act()
 					=> await That(subject).IsNotEqualTo(unexpected);
@@ -72,7 +84,7 @@ public sealed partial class ThatNullableDateOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
+					              is not equal to {Formatter.Format(unexpected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -97,7 +109,7 @@ public sealed partial class ThatNullableDateOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± {tolerance} days, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± {tolerance} days, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotOnOrAfter.Tests.cs
@@ -59,6 +59,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsNotOnOrBefore.Tests.cs
@@ -59,6 +59,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsOnOrAfter.Tests.cs
@@ -66,6 +66,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatNullableDateOnly.IsOnOrBefore.Tests.cs
@@ -66,6 +66,23 @@ public sealed partial class ThatNullableDateOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateOnly? expected = CurrentTime();
+				DateOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsAfter.Tests.cs
@@ -76,6 +76,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsBefore.Tests.cs
@@ -76,6 +76,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsEqualTo.Tests.cs
@@ -7,6 +7,23 @@ public sealed partial class ThatNullableTimeOnly
 	{
 		public sealed class Tests
 		{
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
 			[Fact]
 			public async Task WhenOnlyExpectedIsNull_ShouldFail()
 			{
@@ -19,7 +36,7 @@ public sealed partial class ThatNullableTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is <null>,
+					              is equal to <null>,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -36,7 +53,7 @@ public sealed partial class ThatNullableTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was <null>
 					              """);
 			}
@@ -65,7 +82,7 @@ public sealed partial class ThatNullableTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -103,7 +120,7 @@ public sealed partial class ThatNullableTimeOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotAfter.Tests.cs
@@ -49,6 +49,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotBefore.Tests.cs
@@ -49,6 +49,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotEqualTo.Tests.cs
@@ -43,7 +43,7 @@ public sealed partial class ThatNullableTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not <null>,
+					             is not equal to <null>,
 					             but it was <null>
 					             """);
 			}
@@ -53,6 +53,18 @@ public sealed partial class ThatNullableTimeOnly
 			{
 				TimeOnly? subject = CurrentTime();
 				TimeOnly? unexpected = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldSucceed()
+			{
+				TimeOnly? unexpected = CurrentTime();
+				TimeOnly? subject = null;
 
 				async Task Act()
 					=> await That(subject).IsNotEqualTo(unexpected);
@@ -72,7 +84,7 @@ public sealed partial class ThatNullableTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
+					              is not equal to {Formatter.Format(unexpected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -98,7 +110,7 @@ public sealed partial class ThatNullableTimeOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotOnOrAfter.Tests.cs
@@ -59,6 +59,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsNotOnOrBefore.Tests.cs
@@ -59,6 +59,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsOnOrAfter.Tests.cs
@@ -66,6 +66,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsOnOrBefore.Tests.cs
@@ -66,6 +66,23 @@ public sealed partial class ThatNullableTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				TimeOnly? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is <null>,
+					              is equal to <null>,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -36,7 +36,7 @@ public sealed partial class ThatTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -74,7 +74,7 @@ public sealed partial class ThatTimeOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotEqualTo.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTimeOnly
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
+					              is not equal to {Formatter.Format(unexpected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -69,7 +69,7 @@ public sealed partial class ThatTimeOnly
 					.OnlyIf(expectToThrow)
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± {Formatter.Format(tolerance)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}


### PR DESCRIPTION
Similar to #365 change `IsEqualTo` expectation text from "is XXX" to "is equal to XXX" and add tests for the `null` case for `DateOnly` and `TimeOnly`.