### PR TITLE
refactor: improve coverage for aweXpect:

### DIFF
--- a/Source/aweXpect/That/Guids/ThatNullableGuid.IsEmpty.cs
+++ b/Source/aweXpect/That/Guids/ThatNullableGuid.IsEmpty.cs
@@ -15,7 +15,7 @@ public static partial class ThatNullableGuid
 				new ValueConstraint(
 					it,
 					"is empty",
-					actual => actual != null && actual == Guid.Empty)),
+					actual => actual == Guid.Empty)),
 			source);
 
 	/// <summary>

--- a/Source/aweXpect/That/Http/StatusCodeResult.cs
+++ b/Source/aweXpect/That/Http/StatusCodeResult.cs
@@ -16,7 +16,7 @@ namespace aweXpect;
 /// </summary>
 public class StatusCodeResult(
 	IThat<HttpResponseMessage?> source,
-	Func<HttpResponseMessage?, HttpStatusCode?> mapper)
+	Func<HttpResponseMessage, HttpStatusCode> mapper)
 {
 	/// <summary>
 	///     …is equal to the <paramref name="expected" /> value.
@@ -28,7 +28,7 @@ public class StatusCodeResult(
 					it,
 					expected,
 					mapper,
-					(a, e) => a?.Equals(e) == true,
+					(a, e) => a.Equals(e),
 					$"has status code {Formatter.Format(expected)}")),
 			source);
 
@@ -42,7 +42,7 @@ public class StatusCodeResult(
 					it,
 					unexpected,
 					mapper,
-					(a, u) => a?.Equals(u) != true,
+					(a, u) => !a.Equals(u),
 					$"has status code different to {Formatter.Format(unexpected)}")),
 			source);
 
@@ -55,7 +55,7 @@ public class StatusCodeResult(
 					it,
 					null,
 					mapper,
-					(a, _) => a != null && (int)a.Value is >= 200 and < 300,
+					(a, _) => (int)a is >= 200 and < 300,
 					"has a success status code (2xx)")),
 			source);
 
@@ -68,7 +68,7 @@ public class StatusCodeResult(
 					it,
 					null,
 					mapper,
-					(a, _) => a != null && (int)a.Value is >= 300 and < 400,
+					(a, _) => (int)a is >= 300 and < 400,
 					"has a redirection status code (3xx)")),
 			source);
 
@@ -81,7 +81,7 @@ public class StatusCodeResult(
 					it,
 					null,
 					mapper,
-					(a, _) => a != null && (int)a.Value is >= 400 and < 500,
+					(a, _) => (int)a is >= 400 and < 500,
 					"has a client error status code (4xx)")),
 			source);
 
@@ -94,7 +94,7 @@ public class StatusCodeResult(
 					it,
 					null,
 					mapper,
-					(a, _) => a != null && (int)a.Value is >= 500 and < 600,
+					(a, _) => (int)a is >= 500 and < 600,
 					"has a server error status code (5xx)")),
 			source);
 
@@ -107,18 +107,18 @@ public class StatusCodeResult(
 					it,
 					null,
 					mapper,
-					(a, _) => a != null && (int)a.Value is >= 400 and < 600,
+					(a, _) => (int)a is >= 400 and < 600,
 					"has an error status code (4xx or 5xx)")),
 			source);
 
 	private readonly struct PropertyConstraint(
 		string it,
 		HttpStatusCode? expected,
-		Func<HttpResponseMessage, HttpStatusCode?> mapper,
-		Func<HttpStatusCode?, HttpStatusCode?, bool> condition,
-		string expectation) : IAsyncConstraint<HttpResponseMessage>
+		Func<HttpResponseMessage, HttpStatusCode> mapper,
+		Func<HttpStatusCode, HttpStatusCode?, bool> condition,
+		string expectation) : IAsyncConstraint<HttpResponseMessage?>
 	{
-		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage actual, CancellationToken cancellationToken)
+		public async Task<ConstraintResult> IsMetBy(HttpResponseMessage? actual, CancellationToken cancellationToken)
 		{
 			if (actual == null)
 			{
@@ -126,7 +126,7 @@ public class StatusCodeResult(
 					$"{it} was <null>");
 			}
 
-			HttpStatusCode? value = mapper(actual);
+			HttpStatusCode value = mapper(actual);
 			if (condition(value, expected))
 			{
 				return new ConstraintResult.Success<HttpResponseMessage>(actual, ToString());

--- a/Source/aweXpect/That/Http/ThatHttpResponseMessage.HasStatusCode.cs
+++ b/Source/aweXpect/That/Http/ThatHttpResponseMessage.HasStatusCode.cs
@@ -10,6 +10,6 @@ public static partial class ThatHttpResponseMessage
 	///     Verifies that the status code of the <see cref="HttpResponseMessage" /> subject…
 	/// </summary>
 	public static StatusCodeResult HasStatusCode(this IThat<HttpResponseMessage?> source)
-		=> new(source, a => a?.StatusCode);
+		=> new(source, a => a.StatusCode);
 }
 #endif

--- a/Source/aweXpect/That/Strings/ThatString.EndsWith.cs
+++ b/Source/aweXpect/That/Strings/ThatString.EndsWith.cs
@@ -40,13 +40,19 @@ public static partial class ThatString
 
 	private readonly struct EndsWithConstraint(
 		string it,
-		string expected,
+		string? expected,
 		StringEqualityOptions options)
 		: IValueConstraint<string?>
 	{
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(string? actual)
 		{
+			if (expected is null)
+			{
+				return new ConstraintResult.Failure<string?>(null, ToString(),
+					$"{Formatter.Format(actual)} cannot be validated against <null>");
+			}
+
 			if (actual is null)
 			{
 				return new ConstraintResult.Failure<string?>(null, ToString(),
@@ -56,7 +62,7 @@ public static partial class ThatString
 			if (expected.Length > actual.Length)
 			{
 				return new ConstraintResult.Failure<string?>(actual, ToString(),
-					$"{it} had only length {actual.Length} which is shorter than the expected length of {expected.Length}");
+					$"{it} was {Formatter.Format(actual)} and with length {actual.Length} is shorter than the expected length of {expected.Length}");
 			}
 
 			if (options.AreConsideredEqual(
@@ -76,13 +82,19 @@ public static partial class ThatString
 
 	private readonly struct DoesNotEndWithConstraint(
 		string it,
-		string unexpected,
+		string? unexpected,
 		StringEqualityOptions options)
 		: IValueConstraint<string?>
 	{
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(string? actual)
 		{
+			if (unexpected is null)
+			{
+				return new ConstraintResult.Failure<string?>(null, ToString(),
+					$"{Formatter.Format(actual)} cannot be validated against <null>");
+			}
+
 			if (actual is null)
 			{
 				return new ConstraintResult.Failure<string?>(null, ToString(),

--- a/Source/aweXpect/That/Strings/ThatString.StartsWith.cs
+++ b/Source/aweXpect/That/Strings/ThatString.StartsWith.cs
@@ -38,15 +38,62 @@ public static partial class ThatString
 			options);
 	}
 
-	private readonly struct DoesNotStartWithConstraint(
+	private readonly struct StartsWithConstraint(
 		string it,
-		string unexpected,
+		string? expected,
 		StringEqualityOptions options)
 		: IValueConstraint<string?>
 	{
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(string? actual)
 		{
+			if (expected is null)
+			{
+				return new ConstraintResult.Failure<string?>(null, ToString(),
+					$"{Formatter.Format(actual)} cannot be validated against <null>");
+			}
+
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<string?>(null, ToString(),
+					$"{it} was <null>");
+			}
+
+			if (expected.Length > actual.Length)
+			{
+				return new ConstraintResult.Failure<string?>(actual, ToString(),
+					$"{it} was {Formatter.Format(actual)} and with length {actual.Length} is shorter than the expected length of {expected.Length}");
+			}
+
+			if (options.AreConsideredEqual(actual[..expected.Length], expected))
+			{
+				return new ConstraintResult.Success<string?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure<string?>(actual, ToString(),
+				$"{it} was {Formatter.Format(actual)}");
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"starts with {Formatter.Format(expected)}{options}";
+	}
+
+	private readonly struct DoesNotStartWithConstraint(
+		string it,
+		string? unexpected,
+		StringEqualityOptions options)
+		: IValueConstraint<string?>
+	{
+		/// <inheritdoc />
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			if (unexpected is null)
+			{
+				return new ConstraintResult.Failure<string?>(null, ToString(),
+					$"{Formatter.Format(actual)} cannot be validated against <null>");
+			}
+
 			if (actual is null)
 			{
 				return new ConstraintResult.Failure<string?>(null, ToString(),
@@ -66,40 +113,5 @@ public static partial class ThatString
 		/// <inheritdoc />
 		public override string ToString()
 			=> $"does not start with {Formatter.Format(unexpected)}{options}";
-	}
-
-	private readonly struct StartsWithConstraint(
-		string it,
-		string expected,
-		StringEqualityOptions options)
-		: IValueConstraint<string?>
-	{
-		/// <inheritdoc />
-		public ConstraintResult IsMetBy(string? actual)
-		{
-			if (actual is null)
-			{
-				return new ConstraintResult.Failure<string?>(null, ToString(),
-					$"{it} was <null>");
-			}
-
-			if (expected.Length > actual.Length)
-			{
-				return new ConstraintResult.Failure<string?>(actual, ToString(),
-					$"{it} had only length {actual.Length} which is shorter than the expected length of {expected.Length}");
-			}
-
-			if (options.AreConsideredEqual(actual[..expected.Length], expected))
-			{
-				return new ConstraintResult.Success<string?>(actual, ToString());
-			}
-
-			return new ConstraintResult.Failure<string?>(actual, ToString(),
-				$"{it} was {Formatter.Format(actual)}");
-		}
-
-		/// <inheritdoc />
-		public override string ToString()
-			=> $"starts with {Formatter.Format(expected)}{options}";
 	}
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -29,7 +29,7 @@ namespace aweXpect
     }
     public class StatusCodeResult
     {
-        public StatusCodeResult(aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Func<System.Net.Http.HttpResponseMessage?, System.Net.HttpStatusCode?> mapper) { }
+        public StatusCodeResult(aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Func<System.Net.Http.HttpResponseMessage, System.Net.HttpStatusCode> mapper) { }
         public aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> ClientError() { }
         public aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> DifferentTo(System.Net.HttpStatusCode? unexpected) { }
         public aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> EqualTo(System.Net.HttpStatusCode? expected) { }

--- a/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
@@ -31,6 +31,55 @@ public sealed class EventTriggerResultTests
 			             """);
 	}
 
+	[Fact]
+	public async Task WithMultipleMatchingParameters_PredicateChecksForAnyOne()
+	{
+		CustomEventWithParametersClass<string, int, string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string, int, string>> recording = sut.Record().Events();
+
+		sut.NotifyCustomEvent("foo", 1, "bar");
+		sut.NotifyCustomEvent("bar", 2, "foo");
+
+		async Task Act() =>
+			await ((EventTriggerResult<CustomEventWithParametersClass<string, int, string>>.IExtensions)That(recording)
+					.Triggered(nameof(CustomEventWithParametersClass<string, int, string>.CustomEvent)))
+				.WithParameter<string>(" with my parameter", null, s => s == "foo")
+				.AtLeast(2.Times());
+
+		await That(Act).DoesNotThrow();
+	}
+
+	[Theory]
+	[InlineData(0, false)]
+	[InlineData(1, true)]
+	[InlineData(2, false)]
+	[InlineData(3, true)]
+	[InlineData(4, true)]
+	public async Task WithPosition_ShouldConsiderPosition(int position, bool expectFailure)
+	{
+		CustomEventWithParametersClass<string, string, string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string, string, string>> recording = sut.Record().Events();
+
+		sut.NotifyCustomEvent("foo", "bar", "baz");
+		sut.NotifyCustomEvent("bar", "baz", "foo");
+
+		async Task Act() =>
+			await ((EventTriggerResult<CustomEventWithParametersClass<string, string, string>>.IExtensions)
+					That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, string, string>.CustomEvent)))
+				.WithParameter<string>(" with my parameter", position, s => s == "foo");
+
+		await That(Act).Throws<XunitException>().OnlyIf(expectFailure)
+			.WithMessage("""
+			             Expected that recording
+			             has recorded the CustomEvent event on sut with my parameter at least once,
+			             but it was never recorded in [
+			               CustomEvent("foo", "bar", "baz"),
+			               CustomEvent("bar", "baz", "foo")
+			             ]
+			             """);
+	}
+
 	private sealed class CustomEventWithParametersClass<T1>
 	{
 		public delegate void CustomEventDelegate(T1 arg1);
@@ -39,5 +88,15 @@ public sealed class EventTriggerResultTests
 
 		public void NotifyCustomEvent(T1 arg1)
 			=> CustomEvent?.Invoke(arg1);
+	}
+
+	private sealed class CustomEventWithParametersClass<T1, T2, T3>
+	{
+		public delegate void CustomEventDelegate(T1 arg1, T2 arg2, T3 arg3);
+
+		public event CustomEventDelegate? CustomEvent;
+
+		public void NotifyCustomEvent(T1 arg1, T2 arg2, T3 arg3)
+			=> CustomEvent?.Invoke(arg1, arg2, arg3);
 	}
 }

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithSenderTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithSenderTests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatEventRecording
 		public sealed class WithSenderTests
 		{
 			[Fact]
-			public async Task WithSender_WhenEventIsTriggeredBySomethingElse_ShouldFail()
+			public async Task WhenEventIsTriggeredBySomethingElse_ShouldFail()
 			{
 				PropertyChangedClass sender = new()
 				{
@@ -43,7 +43,7 @@ public sealed partial class ThatEventRecording
 			}
 
 			[Fact]
-			public async Task WithSender_WhenEventIsTriggeredByTheExpectedSender_ShouldSucceed()
+			public async Task WhenEventIsTriggeredByTheExpectedSender_ShouldSucceed()
 			{
 				PropertyChangedClass sender = new()
 				{
@@ -60,6 +60,21 @@ public sealed partial class ThatEventRecording
 				async Task Act() =>
 					await That(recording).Triggered(nameof(INotifyPropertyChanged.PropertyChanged))
 						.WithSender(s => s == sender);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithCustomEvent_WhenSenderIsTheOnlyParameter_ShouldSucceed()
+			{
+				CustomEventWithParametersClass<EventArgs> sut = new();
+				IEventRecording<CustomEventWithParametersClass<EventArgs>> recording = sut.Record().Events();
+
+				sut.NotifyCustomEvent(new PropertyChangedEventArgs("foo"));
+
+				async Task Act() =>
+					await That(recording).Triggered(nameof(CustomEventWithParametersClass<EventArgs>.CustomEvent))
+						.WithSender(_ => true);
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.TimesTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.TimesTests.cs
@@ -18,15 +18,16 @@ public sealed partial class ThatSignaler
 				CancellationToken token = cts.Token;
 
 				signaler.Signal();
+				signaler.Signal();
 
 				async Task Act() =>
-					await That(signaler).Signaled(2.Times()).WithCancellation(token);
+					await That(signaler).Signaled(3.Times()).WithCancellation(token);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that signaler
-					             has recorded the callback at least 2 times,
-					             but it was only recorded once
+					             has recorded the callback at least 3 times,
+					             but it was only recorded 2 times
 					             """);
 			}
 
@@ -90,6 +91,27 @@ public sealed partial class ThatSignaler
 					await That(signaler).Signaled(2.Times());
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTriggeredOnlyOnce_ShouldFail()
+			{
+				Signaler signaler = new();
+				using CancellationTokenSource cts = new();
+				cts.CancelAfter(50.Milliseconds());
+				CancellationToken token = cts.Token;
+
+				signaler.Signal();
+
+				async Task Act() =>
+					await That(signaler).Signaled(2.Times()).WithCancellation(token);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that signaler
+					             has recorded the callback at least 2 times,
+					             but it was only recorded once
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotEndWith.Tests.cs
@@ -71,11 +71,11 @@ public sealed partial class ThatString
 			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
-				string? subject = "text";
-				string expected = null;
+				string subject = "text";
+				string? expected = null;
 
 				async Task Act()
-					=> await That(subject).DoesNotEndWith(expected);
+					=> await That(subject).DoesNotEndWith(expected!);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotEndWith.Tests.cs
@@ -69,6 +69,23 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string? subject = "text";
+				string expected = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotEndWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not end with <null>,
+					             but "text" cannot be validated against <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectDoesEndWithExpected_ShouldFail()
 			{
 				string subject = "some text";
@@ -95,6 +112,40 @@ public sealed partial class ThatString
 					=> await That(subject).DoesNotEndWith(expected);
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEqualToExpected_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = subject;
+
+				async Task Act()
+					=> await That(subject).DoesNotEndWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not end with "some text",
+					             but it was "some text"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+				string expected = "text";
+
+				async Task Act()
+					=> await That(subject).DoesNotEndWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not end with "text",
+					             but it was <null>
+					             """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotStartWith.Tests.cs
@@ -71,11 +71,11 @@ public sealed partial class ThatString
 			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
-				string? subject = "text";
-				string expected = null;
+				string subject = "text";
+				string? expected = null;
 
 				async Task Act()
-					=> await That(subject).DoesNotStartWith(expected);
+					=> await That(subject).DoesNotStartWith(expected!);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotStartWith.Tests.cs
@@ -69,6 +69,23 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string? subject = "text";
+				string expected = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotStartWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not start with <null>,
+					             but "text" cannot be validated against <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectDoesNotStartWithExpected_ShouldSucceed()
 			{
 				string subject = "some text";
@@ -94,6 +111,40 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not start with "SOME" ignoring case,
 					             but it was "some text"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEqualToExpected_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = subject;
+
+				async Task Act()
+					=> await That(subject).DoesNotStartWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not start with "some text",
+					             but it was "some text"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+				string expected = "text";
+
+				async Task Act()
+					=> await That(subject).DoesNotStartWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not start with "text",
+					             but it was <null>
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
@@ -82,11 +82,11 @@ public sealed partial class ThatString
 			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
-				string? subject = "text";
-				string expected = null;
+				string subject = "text";
+				string? expected = null;
 
 				async Task Act()
-					=> await That(subject).EndsWith(expected);
+					=> await That(subject).EndsWith(expected!);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
@@ -80,6 +80,23 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string? subject = "text";
+				string expected = null;
+
+				async Task Act()
+					=> await That(subject).EndsWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with <null>,
+					             but "text" cannot be validated against <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectDoesNotEndWithExpected_ShouldFail()
 			{
 				string subject = "some arbitrary text";
@@ -106,6 +123,52 @@ public sealed partial class ThatString
 					=> await That(subject).EndsWith(expected);
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEqualToExpected_ShouldSucceed()
+			{
+				string subject = "some text";
+				string expected = subject;
+
+				async Task Act()
+					=> await That(subject).EndsWith(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+				string expected = "text";
+
+				async Task Act()
+					=> await That(subject).EndsWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "text",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsShorterThanExpected_ShouldFail()
+			{
+				string subject = "text";
+				string expected = "text and more";
+
+				async Task Act()
+					=> await That(subject).EndsWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "text and more",
+					             but it was "text" and with length 4 is shorter than the expected length of 13
+					             """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsOneOf.Tests.cs
@@ -6,6 +6,22 @@ public sealed partial class ThatString
 	{
 		public sealed class Tests
 		{
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOneOf("foo", "bar");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is one of ["foo", "bar"],
+					             but it was <null>
+					             """);
+			}
+
 			[Theory]
 			[InlineData("foo", "bar", "baz")]
 			public async Task WhenValueIsDifferentToAllExpected_ShouldFail(

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsValidJson.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsValidJson.Tests.cs
@@ -60,22 +60,6 @@ public sealed partial class ThatString
 					              """).AsWildcard();
 			}
 
-			[Fact]
-			public async Task WhenActualIsNull_ShouldFail()
-			{
-				string? subject = null;
-
-				async Task Act()
-					=> await That(subject).IsValidJson();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is valid JSON,
-					             but it was <null>
-					             """);
-			}
-
 			[Theory]
 			[InlineData("42")]
 			[InlineData("\"foo\"")]
@@ -94,6 +78,22 @@ public sealed partial class ThatString
 					=> await That(subject).IsValidJson();
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsValidJson();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is valid JSON,
+					             but it was <null>
+					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
@@ -81,6 +81,23 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string? subject = "text";
+				string expected = null;
+
+				async Task Act()
+					=> await That(subject).StartsWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with <null>,
+					             but "text" cannot be validated against <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectDoesNotStartWithExpected_ShouldFail()
 			{
 				string subject = "some arbitrary text";
@@ -94,6 +111,52 @@ public sealed partial class ThatString
 					             Expected that subject
 					             starts with "text",
 					             but it was "some arbitrary text"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEqualToExpected_ShouldSucceed()
+			{
+				string subject = "some text";
+				string expected = subject;
+
+				async Task Act()
+					=> await That(subject).StartsWith(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+				string expected = "text";
+
+				async Task Act()
+					=> await That(subject).StartsWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "text",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsShorterThanExpected_ShouldFail()
+			{
+				string subject = "text";
+				string expected = "text and more";
+
+				async Task Act()
+					=> await That(subject).StartsWith(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "text and more",
+					             but it was "text" and with length 4 is shorter than the expected length of 13
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
@@ -83,11 +83,11 @@ public sealed partial class ThatString
 			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
-				string? subject = "text";
-				string expected = null;
+				string subject = "text";
+				string? expected = null;
 
 				async Task Act()
-					=> await That(subject).StartsWith(expected);
+					=> await That(subject).StartsWith(expected!);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""


### PR DESCRIPTION
- Add missing tests for `EventTriggerResult`
- Add missing tests for edge cases in string `StartWith`/`EndWith`/`IsOneOf`
- Add missing test for `Signaler` without parameters
- Refactor nullability in Http `StatusCodeResult`