### PR TITLE
fix: incorrectly named exception expectation

### DIFF
--- a/Source/aweXpect/That/Exceptions/ThatException.HasInner.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.HasInner.cs
@@ -45,7 +45,8 @@ public static partial class ThatException
 		Action<IThat<Exception?>> expectations)
 		=> new(source.ThatIs().ExpectationBuilder
 				.ForMember<Exception?, Exception?>(e => e?.InnerException,
-					$"has an inner {innerExceptionType.Name} whose")
+					$"has an inner {innerExceptionType.Name} whose",
+					false)
 				.Validate(it
 					=> new InnerExceptionIsTypeConstraint(it,
 						innerExceptionType))
@@ -55,7 +56,7 @@ public static partial class ThatException
 	/// <summary>
 	///     Verifies that the actual exception has an inner exception of type <paramref name="innerExceptionType" />.
 	/// </summary>
-	public static AndOrResult<Exception?, IThat<Exception?>> HaveInner(
+	public static AndOrResult<Exception?, IThat<Exception?>> HasInner(
 		this IThat<Exception?> source,
 		Type innerExceptionType)
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)

--- a/Source/aweXpect/That/Exceptions/ThatException.HasParamName.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.HasParamName.cs
@@ -28,12 +28,6 @@ public static partial class ThatException
 	{
 		public ConstraintResult IsMetBy(Exception? actual)
 		{
-			if (actual == null)
-			{
-				return new ConstraintResult.Failure(ToString(),
-					$"{it} was <null>");
-			}
-
 			if (actual is TArgumentException argumentException)
 			{
 				if (argumentException.ParamName == expected)
@@ -47,7 +41,7 @@ public static partial class ThatException
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				$"{it} was {actual.GetType().Name.PrependAOrAn()}");
+				$"{it} was {Formatter.Format(actual)}");
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Exceptions/ThatException.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.cs
@@ -135,7 +135,7 @@ public static partial class ThatException
 			return new ConstraintResult.Failure<Exception?>(actual, "",
 				actual == null
 					? $"{it} was <null>"
-					: $"{it} was {actual.FormatForMessage()}");
+					: $"{it} was {actual.InnerException?.FormatForMessage()}");
 		}
 
 		#endregion

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -321,6 +321,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasHResult<TException>(this aweXpect.Core.IThat<TException> source, int expected)
             where TException : System.Exception? { }
+        public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInner(this aweXpect.Core.IThat<System.Exception?> source, System.Type innerExceptionType) { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInner(this aweXpect.Core.IThat<System.Exception?> source, System.Type innerExceptionType, System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInner<TInnerException>(this aweXpect.Core.IThat<System.Exception?> source)
             where TInnerException : System.Exception? { }
@@ -332,7 +333,6 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasParamName<TException>(this aweXpect.Core.IThat<TException> source, string expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasRecursiveInnerExceptions(this aweXpect.Core.IThat<System.Exception?> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HaveInner(this aweXpect.Core.IThat<System.Exception?> source, System.Type innerExceptionType) { }
     }
     public static class ThatGeneric
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -214,6 +214,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasHResult<TException>(this aweXpect.Core.IThat<TException> source, int expected)
             where TException : System.Exception? { }
+        public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInner(this aweXpect.Core.IThat<System.Exception?> source, System.Type innerExceptionType) { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInner(this aweXpect.Core.IThat<System.Exception?> source, System.Type innerExceptionType, System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInner<TInnerException>(this aweXpect.Core.IThat<System.Exception?> source)
             where TInnerException : System.Exception? { }
@@ -225,7 +226,6 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasParamName<TException>(this aweXpect.Core.IThat<TException> source, string expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasRecursiveInnerExceptions(this aweXpect.Core.IThat<System.Exception?> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
-        public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HaveInner(this aweXpect.Core.IThat<System.Exception?> source, System.Type innerExceptionType) { }
     }
     public static class ThatGeneric
     {

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.GenericTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.GenericTests.cs
@@ -2,9 +2,9 @@
 
 public sealed partial class ThatException
 {
-	public sealed class HasInner
+	public sealed partial class HasInner
 	{
-		public sealed class Tests
+		public sealed class GenericTests
 		{
 			[Fact]
 			public async Task WhenInnerExceptionHasCorrectMessageButUnexpectedType_ShouldFail()

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.TypeTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.TypeTests.cs
@@ -1,0 +1,107 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatException
+{
+	public sealed partial class HasInner
+	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenInnerExceptionHasCorrectMessageButUnexpectedType_ShouldFail()
+			{
+				Exception subject = new("outer", new Exception("inner"));
+
+				async Task Act()
+					=> await That(subject).HasInner(typeof(CustomException), e => e.HasMessage("inner"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has an inner CustomException whose Message is equal to "inner",
+					             but it was an Exception:
+					               inner
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInnerExceptionHasCorrectTypeAndMessage_ShouldSucceed()
+			{
+				Exception subject = new("outer",
+					new CustomException("inner"));
+
+				async Task Act()
+					=> await That(subject).HasInner(typeof(CustomException), e => e.HasMessage("inner"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInnerExceptionHasCorrectTypeButUnexpectedMessage_ShouldFail()
+			{
+				Exception subject = new("outer",
+					new CustomException("inner"));
+
+				async Task Act()
+					=> await That(subject).HasInner(typeof(CustomException), e => e.HasMessage("some other message"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has an inner CustomException whose Message is equal to "some other message",
+					             but it was "inner" which differs at index 0:
+					                ↓ (actual)
+					               "inner"
+					               "some other message"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInnerExceptionIsNotOfTheExpectedType_ShouldFail()
+			{
+				Exception subject = new("outer",
+					new Exception("inner"));
+
+				async Task Act()
+					=> await That(subject).HasInner(typeof(CustomException));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has an inner CustomException,
+					             but it was an Exception:
+					               inner
+					             """);
+			}
+
+
+			[Fact]
+			public async Task WhenInnerExceptionMeetsType_ShouldSucceed()
+			{
+				Exception subject = new("outer",
+					new CustomException("inner"));
+
+				async Task Act()
+					=> await That(subject).HasInner(typeof(CustomException));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Exception? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasInner(typeof(CustomException));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has an inner CustomException,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Rename "HaveInner" to "HasInner" and consolidate the behavior between generic and type-based expectations.