### PR TITLE
refactor: improve coverage for aweXpect (2)

### DIFF
--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
@@ -14,7 +14,13 @@ public abstract partial class EnumerableQuantifier
 
 	private sealed class NoneQuantifier(ExpectationGrammars expectationGrammars) : EnumerableQuantifier
 	{
-		public override string ToString() => "none";
+		public override string ToString()
+			=> (expectationGrammars.HasFlag(ExpectationGrammars.Nested), expectationGrammars.HasFlag(ExpectationGrammars.Plural)) switch
+			{
+				(true, _) => "none",
+				(_, true) => "no",
+				_ => "none",
+			};
 
 		/// <inheritdoc />
 		public override bool IsDeterminable(int matchingCount, int notMatchingCount)

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
@@ -52,7 +52,7 @@ public abstract partial class EnumerableQuantifier
 			return quantifierExpectation;
 		}
 
-		if (expectationGrammars == ExpectationGrammars.Nested)
+		if (expectationGrammars.HasFlag(ExpectationGrammars.Nested))
 		{
 			return $"{quantifierExpectation} {expectationExpression}";
 		}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.None.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.None.cs
@@ -12,13 +12,13 @@ public static partial class ThatAsyncEnumerable
 	/// </summary>
 	public static Elements<TItem> None<TItem>(
 		this IThat<IAsyncEnumerable<TItem>?> subject)
-		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars));
+		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars | ExpectationGrammars.Plural));
 
 	/// <summary>
 	///     Verifies that in the collection no items…
 	/// </summary>
 	public static Elements None(
 		this IThat<IAsyncEnumerable<string?>?> subject)
-		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars));
+		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars | ExpectationGrammars.Plural));
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
@@ -23,9 +23,9 @@ public static partial class ThatEnumerable
 					=> new CollectionConstraint<string?>(
 						it,
 						_quantifier,
-						() => grammar switch
+						() => grammar.HasFlag(ExpectationGrammars.Nested) switch
 						{
-							ExpectationGrammars.Nested => $"satisfy {doNotPopulateThisValue}",
+							true => $"satisfy {doNotPopulateThisValue}",
 							_ => $"satisfies {doNotPopulateThisValue}",
 						},
 						predicate,
@@ -47,9 +47,9 @@ public static partial class ThatEnumerable
 					=> new CollectionConstraint<TItem>(
 						it,
 						_quantifier,
-						() => grammar switch
+						() => grammar.HasFlag(ExpectationGrammars.Nested) switch
 						{
-							ExpectationGrammars.Nested => $"satisfy {doNotPopulateThisValue}",
+							true => $"satisfy {doNotPopulateThisValue}",
 							_ => $"satisfies {doNotPopulateThisValue}",
 						},
 						predicate,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.None.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.None.cs
@@ -11,12 +11,12 @@ public static partial class ThatEnumerable
 	/// </summary>
 	public static Elements<TItem> None<TItem>(
 		this IThat<IEnumerable<TItem>?> subject)
-		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars));
+		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars | ExpectationGrammars.Plural));
 
 	/// <summary>
 	///     Verifies that in the collection no items…
 	/// </summary>
 	public static Elements None(
 		this IThat<IEnumerable<string?>?> subject)
-		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars));
+		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars | ExpectationGrammars.Plural));
 }

--- a/Source/aweXpect/That/DateTimeOffsets/ThatDateTimeOffset.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatDateTimeOffset.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatDateTimeOffset
 				new ConditionConstraint(
 					it,
 					expected,
-					$"is {Formatter.Format(expected)}{tolerance}",
+					$"is equal to {Formatter.Format(expected)}{tolerance}",
 					(a, e, t) => IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),
@@ -42,7 +42,7 @@ public static partial class ThatDateTimeOffset
 				new ConditionConstraint(
 					it,
 					unexpected,
-					$"is not {Formatter.Format(unexpected)}{tolerance}",
+					$"is not equal to {Formatter.Format(unexpected)}{tolerance}",
 					(a, e, t) => !IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatNullableDateTimeOffset
 				new ConditionConstraint(
 					it,
 					expected,
-					$"is {Formatter.Format(expected)}{tolerance}",
+					$"is equal to {Formatter.Format(expected)}{tolerance}",
 					(a, e, t) => IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),
@@ -42,7 +42,7 @@ public static partial class ThatNullableDateTimeOffset
 				new ConditionConstraint(
 					it,
 					unexpected,
-					$"is not {Formatter.Format(unexpected)}{tolerance}",
+					$"is not equal to {Formatter.Format(unexpected)}{tolerance}",
 					(a, e, t) => !IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.cs
@@ -12,15 +12,10 @@ public static partial class ThatNullableDateTimeOffset
 {
 	private static bool IsWithinTolerance(TimeSpan? tolerance, TimeSpan? difference)
 	{
-		if (difference == null)
-		{
-			return false;
-		}
-
 		tolerance ??= Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
 
-		return difference.Value <= tolerance.Value &&
-		       difference.Value >= tolerance.Value.Negate();
+		return difference <= tolerance.Value &&
+		       difference >= tolerance.Value.Negate();
 	}
 
 	private readonly struct ConditionConstraint(

--- a/Source/aweXpect/That/DateTimes/ThatDateTime.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateTimes/ThatDateTime.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatDateTime
 				new ConditionConstraint(
 					it,
 					expected,
-					$"is {Formatter.Format(expected)}{tolerance}",
+					$"is equal to {Formatter.Format(expected)}{tolerance}",
 					(a, e, t) => AreKindCompatible(a.Kind, e.Kind) && IsWithinTolerance(t, a - e),
 					(a, e, i) => AreKindCompatible(a.Kind, e?.Kind)
 						? $"{i} was {Formatter.Format(a)}"
@@ -44,7 +44,7 @@ public static partial class ThatDateTime
 				new ConditionConstraint(
 					it,
 					unexpected,
-					$"is not {Formatter.Format(unexpected)}{tolerance}",
+					$"is not equal to {Formatter.Format(unexpected)}{tolerance}",
 					(a, e, t) => !AreKindCompatible(a.Kind, e.Kind) || !IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/aweXpect/That/DateTimes/ThatDateTime.cs
+++ b/Source/aweXpect/That/DateTimes/ThatDateTime.cs
@@ -46,6 +46,6 @@ public static partial class ThatDateTime
 		}
 
 		public override string ToString()
-			=> expectation + tolerance;
+			=> $"{expectation}{tolerance}";
 	}
 }

--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsEqualTo.cs
@@ -21,7 +21,7 @@ public static partial class ThatNullableDateTime
 				new ConditionConstraint(
 					it,
 					expected,
-					$"is {Formatter.Format(expected)}{tolerance}",
+					$"is equal to {Formatter.Format(expected)}{tolerance}",
 					(a, e, t) => AreKindCompatible(a?.Kind, e?.Kind) && IsWithinTolerance(t, a - e),
 					(a, e, i) => AreKindCompatible(a?.Kind, e?.Kind)
 						? $"{i} was {Formatter.Format(a)}"
@@ -44,7 +44,7 @@ public static partial class ThatNullableDateTime
 				new ConditionConstraint(
 					it,
 					unexpected,
-					$"is not {Formatter.Format(unexpected)}{tolerance}",
+					$"is not equal to {Formatter.Format(unexpected)}{tolerance}",
 					(a, e, t) => !AreKindCompatible(a?.Kind, e?.Kind) || !IsWithinTolerance(t, a - e),
 					(a, _, i) => $"{i} was {Formatter.Format(a)}",
 					tolerance)),

--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTime.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTime.cs
@@ -12,15 +12,10 @@ public static partial class ThatNullableDateTime
 {
 	private static bool IsWithinTolerance(TimeSpan? tolerance, TimeSpan? difference)
 	{
-		if (difference == null)
-		{
-			return false;
-		}
-
 		tolerance ??= Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
 
-		return difference.Value <= tolerance.Value &&
-		       difference.Value >= tolerance.Value.Negate();
+		return difference <= tolerance.Value &&
+		       difference >= tolerance.Value.Negate();
 	}
 
 	private readonly struct ConditionConstraint(
@@ -44,6 +39,6 @@ public static partial class ThatNullableDateTime
 		}
 
 		public override string ToString()
-			=> expectation + tolerance;
+			=> $"{expectation}{tolerance}";
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.EndsWith.Tests.cs
@@ -24,17 +24,6 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task ShouldSupportCaseInsensitiveComparison()
-			{
-				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["FOO", "BAR"]);
-
-				async Task Act()
-					=> await That(subject).EndsWith("bar").IgnoringCase();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
 				IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers(x => new MyClass(x), 6);
@@ -120,18 +109,6 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task WhenSubjectEndsWithExpectedValues_ShouldSucceed()
-			{
-				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
-				IEnumerable<string> expected = ["bar", "baz"];
-
-				async Task Act()
-					=> await That(subject).EndsWith(expected);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IAsyncEnumerable<int>? subject = null;
@@ -145,6 +122,48 @@ public sealed partial class ThatAsyncEnumerable
 					             ends with [],
 					             but it was <null>
 					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldIncludeOptionsInFailureMessage()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).EndsWith("FOO", "BAZ").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with ["FOO", "BAZ"] ignoring case,
+					             but it contained "bar" at index 1 instead of "FOO"
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).EndsWith("BAR", "BAZ").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectEndsWithExpectedValues_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+				IEnumerable<string> expected = ["bar", "baz"];
+
+				async Task Act()
+					=> await That(subject).EndsWith(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.AreEqualTo.Tests.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
 using System.Threading;
 
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatEnumerable
+public sealed partial class ThatAsyncEnumerable
 {
 	public sealed partial class None
 	{
@@ -18,7 +19,7 @@ public sealed partial class ThatEnumerable
 				{
 					using CancellationTokenSource cts = new();
 					CancellationToken token = cts.Token;
-					IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
+					IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(8)
@@ -35,7 +36,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task DoesNotEnumerateTwice()
 				{
-					ThrowWhenIteratingTwiceEnumerable subject = new();
+					ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(15)
@@ -47,7 +48,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task DoesNotMaterializeEnumerable()
 				{
-					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(5);
@@ -63,7 +64,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableContainsEqualValues_ShouldFail()
 				{
-					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(1);
@@ -79,7 +80,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 				{
-					IEnumerable<int> subject = ToEnumerable((int[]) []);
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable((int[]) []);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(0);
@@ -90,7 +91,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableOnlyContainsDifferentValues_ShouldSucceed()
 				{
-					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(42);
@@ -101,7 +102,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
-					IEnumerable<int>? subject = null;
+					IAsyncEnumerable<int>? subject = null;
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo(0);
@@ -120,7 +121,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task ShouldSupportIgnoringCase()
 				{
-					IEnumerable<string> subject = ToEnumerable(["FOO", "BAR", "BAZ"]);
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["FOO", "BAR", "BAZ"]);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo("bar").IgnoringCase();
@@ -136,7 +137,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableContainsEqualValues_ShouldFail()
 				{
-					IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo("bar");
@@ -152,7 +153,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 				{
-					IEnumerable<string> subject = [];
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(Array.Empty<string>());
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo("foo");
@@ -163,7 +164,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableOnlyContainsDifferentValues_ShouldSucceed()
 				{
-					IEnumerable<string> subject = ToEnumerable(["FOO", "BAR", "BAZ"]);
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["FOO", "BAR", "BAZ"]);
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo("bar");
@@ -174,7 +175,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
-					IEnumerable<string>? subject = null;
+					IAsyncEnumerable<string>? subject = null;
 
 					async Task Act()
 						=> await That(subject).None().AreEqualTo("");
@@ -190,3 +191,4 @@ public sealed partial class ThatEnumerable
 		}
 	}
 }
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Satisfy.Tests.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
 using System.Threading;
 
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatEnumerable
+public sealed partial class ThatAsyncEnumerable
 {
 	public sealed partial class None
 	{
@@ -18,7 +19,7 @@ public sealed partial class ThatEnumerable
 				{
 					using CancellationTokenSource cts = new();
 					CancellationToken token = cts.Token;
-					IEnumerable<int> subject = GetCancellingEnumerable(6, cts);
+					IAsyncEnumerable<int> subject = GetCancellingAsyncEnumerable(6, cts);
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item < 0)
@@ -35,7 +36,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task DoesNotEnumerateTwice()
 				{
-					ThrowWhenIteratingTwiceEnumerable subject = new();
+					ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item == 15)
@@ -47,7 +48,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task DoesNotMaterializeEnumerable()
 				{
-					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item == 5);
@@ -63,7 +64,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableContainsEqualValues_ShouldFail()
 				{
-					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item == 1);
@@ -79,7 +80,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
 				{
-					IEnumerable<int> subject = ToEnumerable((int[]) []);
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable((int[]) []);
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item == 0);
@@ -90,7 +91,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenEnumerableOnlyContainsDifferentValues_ShouldSucceed()
 				{
-					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 2, 2, 3]);
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 2, 2, 3]);
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item == 42);
@@ -101,7 +102,7 @@ public sealed partial class ThatEnumerable
 				[Fact]
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
-					IEnumerable<int>? subject = null;
+					IAsyncEnumerable<int>? subject = null;
 
 					async Task Act()
 						=> await That(subject).None().Satisfy(item => item == 0);
@@ -117,3 +118,4 @@ public sealed partial class ThatEnumerable
 		}
 	}
 }
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Tests.cs
@@ -8,7 +8,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatAsyncEnumerable
 {
-	public sealed class None
+	public sealed partial class None
 	{
 		public sealed class Tests
 		{
@@ -27,7 +27,7 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             satisfies y => y < 0 for none items,
+					             satisfies y => y < 0 for no items,
 					             but could not verify, because it was cancelled early
 					             """);
 			}
@@ -55,7 +55,7 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equal to 5 for none items,
+					             is equal to 5 for no items,
 					             but at least one was
 					             """);
 			}
@@ -71,7 +71,7 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equal to 1 for none items,
+					             is equal to 1 for no items,
 					             but at least one was
 					             """);
 			}
@@ -98,7 +98,7 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equal to 0 for none items,
+					             is equal to 0 for no items,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.StartsWith.Tests.cs
@@ -35,17 +35,6 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task ShouldSupportCaseInsensitiveComparison()
-			{
-				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["FOO", "BAR"]);
-
-				async Task Act()
-					=> await That(subject).StartsWith("foo").IgnoringCase();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
 				IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers(x => new MyClass(x), 20);
@@ -143,6 +132,36 @@ public sealed partial class ThatAsyncEnumerable
 					             starts with [],
 					             but it was <null>
 					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldIncludeOptionsInFailureMessage()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).StartsWith("FOO", "BAZ").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with ["FOO", "BAZ"] ignoring case,
+					             but it contained "bar" at index 1 instead of "BAZ"
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).StartsWith("FOO", "BAR").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.Tests.cs
@@ -24,17 +24,6 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task ShouldSupportCaseInsensitiveComparison()
-			{
-				IEnumerable<string> subject = ToEnumerable(["FOO", "BAR"]);
-
-				async Task Act()
-					=> await That(subject).EndsWith("bar").IgnoringCase();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
 				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(x => new MyClass(x), 6);
@@ -120,18 +109,6 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenSubjectEndsWithExpectedValues_ShouldSucceed()
-			{
-				IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
-				IEnumerable<string> expected = ["bar", "baz"];
-
-				async Task Act()
-					=> await That(subject).EndsWith(expected);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IEnumerable<int>? subject = null;
@@ -145,6 +122,48 @@ public sealed partial class ThatEnumerable
 					             ends with [],
 					             but it was <null>
 					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldIncludeOptionsInFailureMessage()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).EndsWith("FOO", "BAZ").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with ["FOO", "BAZ"] ignoring case,
+					             but it contained "bar" at index 1 instead of "FOO"
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).EndsWith("BAR", "BAZ").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectEndsWithExpectedValues_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+				IEnumerable<string> expected = ["bar", "baz"];
+
+				async Task Act()
+					=> await That(subject).EndsWith(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.Tests.cs
@@ -129,6 +129,36 @@ public sealed partial class ThatEnumerable
 					             but it was <null>
 					             """);
 			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldIncludeOptionsInFailureMessage()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).StartsWith("FOO", "BAZ").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with ["FOO", "BAZ"] ignoring case,
+					             but it contained "bar" at index 1 instead of "BAZ"
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+
+				async Task Act()
+					=> await That(subject).StartsWith("FOO", "BAR").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
 
 			[Fact]
 			public async Task WhenSubjectStartsWithExpectedValues_ShouldSucceed()

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsEqualTo.Tests.cs
@@ -42,7 +42,7 @@ public sealed partial class ThatDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -86,7 +86,7 @@ public sealed partial class ThatDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsNotEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not 9999-12-31T23:59:59.9999999+00:00, because we want to test the failure,
+					             is not equal to 9999-12-31T23:59:59.9999999+00:00, because we want to test the failure,
 					             but it was 9999-12-31T23:59:59.9999999+00:00
 					             """);
 			}
@@ -37,7 +37,7 @@ public sealed partial class ThatDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not 0001-01-01T00:00:00.0000000+00:00, because we want to test the failure,
+					             is not equal to 0001-01-01T00:00:00.0000000+00:00, because we want to test the failure,
 					             but it was 0001-01-01T00:00:00.0000000+00:00
 					             """);
 			}
@@ -67,7 +67,7 @@ public sealed partial class ThatDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -112,7 +112,7 @@ public sealed partial class ThatDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsAfter.Tests.cs
@@ -75,6 +75,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsBefore.Tests.cs
@@ -75,6 +75,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsEqualTo.Tests.cs
@@ -18,7 +18,7 @@ public sealed partial class ThatNullableDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)},
+					              is equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotAfter.Tests.cs
@@ -48,6 +48,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotBefore.Tests.cs
@@ -48,6 +48,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotEqualTo.Tests.cs
@@ -30,7 +30,7 @@ public sealed partial class ThatNullableDateTimeOffset
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
+					              is not equal to {Formatter.Format(unexpected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotOnOrAfter.Tests.cs
@@ -58,6 +58,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsNotOnOrBefore.Tests.cs
@@ -58,6 +58,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsOnOrAfter.Tests.cs
@@ -65,6 +65,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatNullableDateTimeOffset.IsOnOrBefore.Tests.cs
@@ -65,6 +65,23 @@ public sealed partial class ThatNullableDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTimeOffset? subject = null;
+				DateTimeOffset? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsEqualTo.Tests.cs
@@ -58,7 +58,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -104,7 +104,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we also test the kind property,
+					              is equal to {Formatter.Format(expected)}, because we also test the kind property,
 					              but it differed in the Kind property
 					              """);
 			}
@@ -136,7 +136,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsNotEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not 9999-12-31T23:59:59.9999999, because we want to test the failure,
+					             is not equal to 9999-12-31T23:59:59.9999999, because we want to test the failure,
 					             but it was 9999-12-31T23:59:59.9999999
 					             """);
 			}
@@ -37,7 +37,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not 0001-01-01T00:00:00.0000000, because we want to test the failure,
+					             is not equal to 0001-01-01T00:00:00.0000000, because we want to test the failure,
 					             but it was 0001-01-01T00:00:00.0000000
 					             """);
 			}
@@ -67,7 +67,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -125,7 +125,7 @@ public sealed partial class ThatDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsAfter.Tests.cs
@@ -75,6 +75,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsBefore.Tests.cs
@@ -75,6 +75,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsEqualTo.Tests.cs
@@ -86,7 +86,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -104,7 +104,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)}, because we also test the kind property,
+					              is equal to {Formatter.Format(expected)}, because we also test the kind property,
 					              but it differed in the Kind property
 					              """);
 			}
@@ -136,7 +136,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+					              is equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotAfter.Tests.cs
@@ -48,6 +48,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotBefore.Tests.cs
@@ -48,6 +48,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not 9999-12-31T23:59:59.9999999, because we want to test the failure,
+					             is not equal to 9999-12-31T23:59:59.9999999, because we want to test the failure,
 					             but it was 9999-12-31T23:59:59.9999999
 					             """);
 			}
@@ -37,7 +37,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not 0001-01-01T00:00:00.0000000, because we want to test the failure,
+					             is not equal to 0001-01-01T00:00:00.0000000, because we want to test the failure,
 					             but it was 0001-01-01T00:00:00.0000000
 					             """);
 			}
@@ -67,7 +67,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(unexpected)}, because we want to test the failure,
+					              is not equal to {Formatter.Format(unexpected)}, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
@@ -125,7 +125,7 @@ public sealed partial class ThatNullableDateTime
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
+					              is not equal to {Formatter.Format(expected)} ± 0:03, because we want to test the failure,
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotOnOrAfter.Tests.cs
@@ -58,6 +58,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsNotOnOrBefore.Tests.cs
@@ -58,6 +58,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldFail()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsOnOrAfter.Tests.cs
@@ -65,6 +65,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsOnOrAfter(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or after {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatNullableDateTime.IsOnOrBefore.Tests.cs
@@ -65,6 +65,23 @@ public sealed partial class ThatNullableDateTime
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				DateTime? subject = null;
+				DateTime? expected = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsOnOrBefore(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is on or before {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsSame_ShouldSucceed()
 			{
 				DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesWithin.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesWithin.Tests.cs
@@ -21,6 +21,22 @@ public sealed partial class ThatDelegate
 			}
 
 			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage()
 			{
 				Action @delegate = () => throw new MyException();
@@ -65,6 +81,22 @@ public sealed partial class ThatDelegate
 					=> await That(@delegate).ExecutesWithin(5000.Milliseconds());
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Func<Task> @delegate = () => Task.Delay(50.Milliseconds());
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
 			}
 
 			[Fact]
@@ -115,6 +147,22 @@ public sealed partial class ThatDelegate
 			}
 
 			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Func<Task<int>> @delegate = () => Task.Delay(50.Milliseconds()).ContinueWith(_ => 1);
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage()
 			{
 				Func<Task<int>> @delegate = () => Task.FromException<int>(new MyException());
@@ -160,6 +208,22 @@ public sealed partial class ThatDelegate
 					=> await That(Delegate).ExecutesWithin(5000.Milliseconds());
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask Delegate() => new(Task.Delay(50.Milliseconds()));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
 			}
 
 			[Fact]
@@ -213,6 +277,22 @@ public sealed partial class ThatDelegate
 			}
 
 			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask Delegate(CancellationToken token) => new(Task.Delay(50.Milliseconds(), token));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage()
 			{
 				ValueTask Delegate(CancellationToken _)
@@ -260,6 +340,22 @@ public sealed partial class ThatDelegate
 					=> await That(Delegate).ExecutesWithin(5000.Milliseconds());
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask<int> Delegate() => new(Task.Delay(50.Milliseconds()).ContinueWith(_ => 1));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
 			}
 
 			[Fact]
@@ -313,6 +409,23 @@ public sealed partial class ThatDelegate
 			}
 
 			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask<int> Delegate(CancellationToken token)
+					=> new(Task.Delay(50.Milliseconds(), token).ContinueWith(_ => 1, token));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenDelegateThrowsAnException_ShouldFailWithDescriptiveMessage()
 			{
 				ValueTask<int> Delegate(CancellationToken _)
@@ -359,6 +472,26 @@ public sealed partial class ThatDelegate
 					=> await That(@delegate).ExecutesWithin(5000.Milliseconds());
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Func<int> @delegate = () =>
+				{
+					Thread.Sleep(50);
+					return 0;
+				};
+
+				async Task Act()
+					=> await That(@delegate).ExecutesWithin(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes within 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Enums/ThatNullableEnum.DoesNotHaveValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatNullableEnum.DoesNotHaveValue.Tests.cs
@@ -38,6 +38,22 @@ public sealed partial class ThatNullableEnum
 			}
 
 			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				MyNumbers? subject = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotHaveValue(1L);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have value 1,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenUnexpectedIsNull_ShouldSucceed()
 			{
 				MyColors? subject = MyColors.Yellow;

--- a/Tests/aweXpect.Tests/Enums/ThatNullableEnum.HasValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatNullableEnum.HasValue.Tests.cs
@@ -52,6 +52,22 @@ public sealed partial class ThatNullableEnum
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				MyNumbers? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasValue(1L);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has value 1,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Add missing tests for nullable enums
- Add missing tests for `ExecutesWithin` when the timeout was exceeded
- Ensure correct `null` handling for `DateTime` and `DateTimeOffset` and change the expectation text from "is XXX" to "is equal to XXX"
- Refactor collection expectations for "None" and replace "for none items" with "for no items"