### PR TITLE
refactor: improve coverage for aweXpect (3)

### DIFF
--- a/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
@@ -28,7 +28,7 @@ public static class EquivalencyOptionsExtensions
 	/// </remarks>
 	public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(
 		this TEquivalencyOptions @this,
-		IncludeMembers fieldsToInclude)
+		IncludeMembers fieldsToInclude = IncludeMembers.Public)
 		where TEquivalencyOptions : EquivalencyTypeOptions
 		=> @this with
 		{
@@ -45,7 +45,7 @@ public static class EquivalencyOptionsExtensions
 	/// </remarks>
 	public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(
 		this TEquivalencyOptions @this,
-		IncludeMembers propertiesToInclude)
+		IncludeMembers propertiesToInclude = IncludeMembers.Public)
 		where TEquivalencyOptions : EquivalencyTypeOptions
 		=> @this with
 		{

--- a/Source/aweXpect/Json/JsonValidation.cs
+++ b/Source/aweXpect/Json/JsonValidation.cs
@@ -449,7 +449,7 @@ internal class JsonValidation : IJsonObjectResult,
 		return string.Join(failureSeparator, _failures);
 	}
 
-	private static string Format(JsonValueKind valueKind)
+	internal static string Format(JsonValueKind valueKind)
 		=> valueKind switch
 		{
 			JsonValueKind.Array => "an array",

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEquivalentTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEquivalentTo.cs
@@ -37,8 +37,8 @@ public static partial class ThatAsyncEnumerable
 						it,
 						_quantifier,
 						() => grammar == ExpectationGrammars.None
-							? $"is equivalent to {Formatter.Format(expected)}{options}"
-							: $"are equivalent to {Formatter.Format(expected)}{options}",
+							? $"is equivalent to {Formatter.Format(expected)}"
+							: $"are equivalent to {Formatter.Format(expected)}",
 						a => equalityOptions.AreConsideredEqual(a, expected),
 						"were")),
 				_subject,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEquivalentTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEquivalentTo.cs
@@ -36,8 +36,8 @@ public static partial class ThatEnumerable
 						it,
 						_quantifier,
 						() => grammar == ExpectationGrammars.None
-							? $"is equivalent to {Formatter.Format(expected)}{options}"
-							: $"are equivalent to {Formatter.Format(expected)}{options}",
+							? $"is equivalent to {Formatter.Format(expected)}"
+							: $"are equivalent to {Formatter.Format(expected)}",
 						a => equalityOptions.AreConsideredEqual(a, expected),
 						"were")),
 				_subject,

--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithRecursiveInnerExceptions.cs
@@ -25,7 +25,7 @@ public static partial class ThatDelegateThrows
 				.ForMember(
 					MemberAccessor<Exception?, IEnumerable<Exception>>.FromFunc(
 						e => e.GetInnerExpectations(), "recursive inner exceptions "),
-					(property, stringBuilder) => stringBuilder.Append("with ").Append(property).Append("where "))
+					(property, stringBuilder) => stringBuilder.Append("with ").Append(property).Append("which "))
 				.AddExpectations(e => expectations(new ThatSubject<IEnumerable<Exception>>(e)),
 					ExpectationGrammars.Nested),
 			source);

--- a/Source/aweXpect/That/Json/ThatJsonElement.cs
+++ b/Source/aweXpect/That/Json/ThatJsonElement.cs
@@ -53,14 +53,14 @@ public static partial class ThatJsonElement
 			if (actual.ValueKind != expected)
 			{
 				return new ConstraintResult.Failure<JsonElement>(actual, ToString(),
-					$"{it} was {actual.ValueKind}");
+					$"{it} was {JsonValidation.Format(actual.ValueKind)} instead of {JsonValidation.Format(expected)}");
 			}
 
 			return new ConstraintResult.Success<JsonElement>(actual, ToString());
 		}
 
 		public override string ToString()
-			=> $"is {expected}";
+			=> $"is {JsonValidation.Format(expected)}";
 	}
 }
 #endif

--- a/Source/aweXpect/That/Json/ThatNullableJsonElement.cs
+++ b/Source/aweXpect/That/Json/ThatNullableJsonElement.cs
@@ -65,14 +65,14 @@ public static partial class ThatNullableJsonElement
 			if (actual.Value.ValueKind != expected)
 			{
 				return new ConstraintResult.Failure<JsonElement?>(actual, ToString(),
-					$"{it} was {actual.Value.ValueKind}");
+					$"{it} was {JsonValidation.Format(actual.Value.ValueKind)} instead of {JsonValidation.Format(expected)}");
 			}
 
 			return new ConstraintResult.Success<JsonElement?>(actual, ToString());
 		}
 
 		public override string ToString()
-			=> $"is {expected}";
+			=> $"is {JsonValidation.Format(expected)}";
 	}
 }
 #endif

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -946,9 +946,9 @@ namespace aweXpect.Equivalency
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
-        public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers fieldsToInclude)
+        public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers fieldsToInclude = 2)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
-        public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers propertiesToInclude)
+        public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers propertiesToInclude = 2)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -757,9 +757,9 @@ namespace aweXpect.Equivalency
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
-        public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers fieldsToInclude)
+        public static TEquivalencyOptions IncludingFields<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers fieldsToInclude = 2)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
-        public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers propertiesToInclude)
+        public static TEquivalencyOptions IncludingProperties<TEquivalencyOptions>(this TEquivalencyOptions @this, aweXpect.Equivalency.IncludeMembers propertiesToInclude = 2)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
+using aweXpect.Equivalency;
 
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -69,7 +70,7 @@ public sealed partial class ThatAsyncEnumerable
 					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers(20);
 
 					async Task Act()
-						=> await That(subject).All().AreEquivalentTo(5);
+						=> await That(subject).All().AreEquivalentTo(5, o => o.IncludingFields());
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AreAllUnique.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AreAllUnique.Tests.cs
@@ -171,6 +171,22 @@ public sealed partial class ThatAsyncEnumerable
 					               "b"
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AreAllUnique();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             only has unique items,
+					             but it was <null>
+					             """);
+			}
 		}
 
 		public sealed class MemberTests
@@ -230,6 +246,22 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained 2 duplicates:
 					               1,
 					               2
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<MyClass>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AreAllUnique(x => x.Value);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             only has unique items for x => x.Value,
+					             but it was <null>
 					             """);
 			}
 		}
@@ -326,15 +358,15 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				IAsyncEnumerable<string>? subject = null;
+				IAsyncEnumerable<MyStringClass>? subject = null;
 
 				async Task Act()
-					=> await That(subject).AreAllUnique();
+					=> await That(subject).AreAllUnique(x => x.Value);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             only has unique items,
+					             only has unique items for x => x.Value,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtLeast.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtLeast.Tests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatAsyncEnumerable
 {
 	public sealed class AtLeast
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -105,6 +105,68 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for at least one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtLeast(3).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for at least 3 items,
+					             but only 2 of 3 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtLeast(2).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtLeast(3).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at least 3 items,
+					             but only 2 of 4 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AtLeast(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at least one item,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtMost.Tests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatAsyncEnumerable
 {
 	public sealed class AtMost
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -99,6 +99,68 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for at most one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtMost(1).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for at most one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtMost(2).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtMost(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at most one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AtMost(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at most one item,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Between.Tests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatAsyncEnumerable
 {
 	public sealed class Between
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -115,6 +115,84 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for between 0 and 1 items,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(0).And(1).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for between 0 and 1 items,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(2).And(3).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(3).And(4).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for between 3 and 4 items,
+					             but only 2 of 4 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(0).And(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for between 0 and 1 items,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).Between(1).And(3).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for between 1 and 3 items,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Exactly.Tests.cs
@@ -10,7 +10,7 @@ public sealed partial class ThatAsyncEnumerable
 {
 	public sealed class Exactly
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -115,6 +115,84 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for exactly one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(1).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for exactly one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(2).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "FOO", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(3).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for exactly 3 items,
+					             but only 2 of 4 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for exactly one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).Exactly(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for exactly one item,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using aweXpect.Equivalency;
 
 // ReSharper disable PossibleMultipleEnumeration
 
@@ -31,7 +32,7 @@ public sealed partial class ThatEnumerable
 					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 					async Task Act()
-						=> await That(subject).All().AreEquivalentTo(1);
+						=> await That(subject).All().AreEquivalentTo(1, o => o.IncludingFields());
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AreAllUnique.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AreAllUnique.Tests.cs
@@ -248,6 +248,22 @@ public sealed partial class ThatEnumerable
 					               2
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<MyClass>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AreAllUnique(x => x.Value);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             only has unique items for x => x.Value,
+					             but it was <null>
+					             """);
+			}
 		}
 
 		public sealed class StringMemberTests
@@ -336,6 +352,22 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 duplicates:
 					               "a",
 					               "b"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<MyStringClass>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AreAllUnique(x => x.Value);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             only has unique items for x => x.Value,
+					             but it was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.Tests.cs
@@ -9,7 +9,7 @@ public sealed partial class ThatEnumerable
 {
 	public sealed class AtLeast
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -87,6 +87,68 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for at least one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtLeast(3).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for at least 3 items,
+					             but only 2 of 3 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtLeast(2).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtLeast(3).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at least 3 items,
+					             but only 2 of 4 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AtLeast(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at least one item,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
@@ -9,7 +9,7 @@ public sealed partial class ThatEnumerable
 {
 	public sealed class AtMost
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -124,6 +124,68 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for at most one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtMost(1).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for at most one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtMost(2).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).AtMost(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at most one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).AtMost(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for at most one item,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
@@ -9,7 +9,7 @@ public sealed partial class ThatEnumerable
 {
 	public sealed class Between
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -113,6 +113,84 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for between 0 and 1 items,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(0).And(1).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for between 0 and 1 items,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(2).And(3).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(3).And(4).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for between 3 and 4 items,
+					             but only 2 of 4 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Between(0).And(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for between 0 and 1 items,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).Between(1).And(3).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for between 1 and 3 items,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
@@ -9,7 +9,7 @@ public sealed partial class ThatEnumerable
 {
 	public sealed class Exactly
 	{
-		public sealed class Tests
+		public sealed class ItemsTests
 		{
 			[Fact]
 			public async Task ConsidersCancellationToken()
@@ -114,6 +114,84 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 0 for exactly one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(1).AreEqualTo("foo").IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" ignoring case for exactly one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedNumberOfEqualItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(2).AreEqualTo("foo");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooFewEqualItems_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "FOO", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(3).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for exactly 3 items,
+					             but only 2 of 4 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTooManyEqualItems_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["foo", "foo", "bar"]);
+
+				async Task Act()
+					=> await That(subject).Exactly(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for exactly one item,
+					             but at least 2 were
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).Exactly(1).AreEqualTo("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to "foo" for exactly one item,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
@@ -26,7 +26,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>().OnlyIf(shouldThrow)
 					.WithMessage($"""
 					              Expected that action
-					              throws an exception with recursive inner exceptions where at least {minimum} are of type CustomException,
+					              throws an exception with recursive inner exceptions which at least {minimum} are of type CustomException,
 					              but only 1 of 5 were
 					              """);
 			}
@@ -56,8 +56,27 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that action
-					             throws an exception with recursive inner exceptions where all satisfy _ => false,
+					             throws an exception with recursive inner exceptions which all satisfy _ => false,
 					             but not all did
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectingInnerExceptionsToBeEmpty_ShouldFail()
+			{
+				Action action = () => throw new OuterException(innerException: new CustomException());
+
+				async Task Act()
+					=> await That(action).ThrowsException().WithRecursiveInnerExceptions(
+						innerExceptions => innerExceptions.IsEmpty());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that action
+					             throws an exception with recursive inner exceptions which are empty,
+					             but recursive inner exceptions was [
+					               aweXpect.Tests.ThatDelegate+CustomException: WhenExpectingInnerExceptionsToBeEmpty_ShouldFail
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Json/ThatJsonElement.IsArray.Tests.cs
+++ b/Tests/aweXpect.Tests/Json/ThatJsonElement.IsArray.Tests.cs
@@ -67,10 +67,42 @@ public sealed partial class ThatJsonElement
 			}
 
 			[Theory]
+			[InlineData("[]")]
+			[InlineData("[1, 2]")]
+			public async Task WhenJsonIsAnArray_ShouldSucceed(string json)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
 			[InlineData("{}", "an object")]
 			[InlineData("2", "a number")]
 			[InlineData("\"foo\"", "a string")]
 			public async Task WhenJsonIsNoArray_ShouldFail(string json, string kindString)
+			{
+				JsonElement subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is an array,
+					              but it was {kindString} instead of an array
+					              """);
+			}
+
+			[Theory]
+			[InlineData("{}", "an object")]
+			[InlineData("2", "a number")]
+			[InlineData("\"foo\"", "a string")]
+			public async Task WhenJsonIsNoArray_WithExpectations_ShouldFail(string json, string kindString)
 			{
 				JsonElement subject = FromString(json);
 

--- a/Tests/aweXpect.Tests/Json/ThatJsonElement.MatchesExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Json/ThatJsonElement.MatchesExactly.Tests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET8_0_OR_GREATER
 using System.Text.Json;
+using aweXpect.Json;
 
 namespace aweXpect.Tests;
 
@@ -183,6 +184,17 @@ public sealed partial class ThatJsonElement
 					             """);
 			}
 
+			[Fact]
+			public async Task WhenSubjectContainsAdditionalElements_WhenIgnoringAdditionalProperties_ShouldSucceed()
+			{
+				JsonElement subject = FromString("[1, 2, 3]");
+
+				async Task Act()
+					=> await That(subject).MatchesExactly([1, 2], o => o.IgnoringAdditionalProperties());
+
+				await That(Act).DoesNotThrow();
+			}
+
 			public static TheoryData<object, string> MatchingArrayValues
 				=> new()
 				{
@@ -322,6 +334,20 @@ public sealed partial class ThatJsonElement
 					             					} exactly,
 					             but it differed as $.foo had unexpected Null
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAdditionalProperties_WhenIgnoringAdditionalProperties_ShouldSucceed()
+			{
+				JsonElement subject = FromString("{\"foo\": null, \"bar\": 2}");
+
+				async Task Act()
+					=> await That(subject).MatchesExactly(new
+					{
+						bar = 2,
+					}, o => o.IgnoringAdditionalProperties());
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Json/ThatNullableJsonElement.IsArray.Tests.cs
+++ b/Tests/aweXpect.Tests/Json/ThatNullableJsonElement.IsArray.Tests.cs
@@ -67,10 +67,42 @@ public sealed partial class ThatNullableJsonElement
 			}
 
 			[Theory]
+			[InlineData("[]")]
+			[InlineData("[1, 2]")]
+			public async Task WhenJsonIsAnArray_ShouldSucceed(string json)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
 			[InlineData("{}", "an object")]
 			[InlineData("2", "a number")]
 			[InlineData("\"foo\"", "a string")]
 			public async Task WhenJsonIsNoArray_ShouldFail(string json, string kindString)
+			{
+				JsonElement? subject = FromString(json);
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is an array,
+					              but it was {kindString} instead of an array
+					              """);
+			}
+
+			[Theory]
+			[InlineData("{}", "an object")]
+			[InlineData("2", "a number")]
+			[InlineData("\"foo\"", "a string")]
+			public async Task WhenJsonIsNoArray_WithExpectations_ShouldFail(string json, string kindString)
 			{
 				JsonElement? subject = FromString(json);
 
@@ -83,6 +115,38 @@ public sealed partial class ThatNullableJsonElement
 					              is an array and $[0] matches true,
 					              but it was {kindString} instead of an array
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				JsonElement? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsArray();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an array,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithExpectations_ShouldFail()
+			{
+				JsonElement? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsArray(o => o.At(0).Matching(true));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an array and $[0] matches true,
+					             but it was <null>
+					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Tests/Json/ThatNullableJsonElement.MatchesExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Json/ThatNullableJsonElement.MatchesExactly.Tests.cs
@@ -1,5 +1,6 @@
 ﻿#if NET8_0_OR_GREATER
 using System.Text.Json;
+using aweXpect.Json;
 
 namespace aweXpect.Tests;
 
@@ -199,6 +200,17 @@ public sealed partial class ThatNullableJsonElement
 					             """);
 			}
 
+			[Fact]
+			public async Task WhenSubjectContainsAdditionalElements_WhenIgnoringAdditionalProperties_ShouldSucceed()
+			{
+				JsonElement? subject = FromString("[1, 2, 3]");
+
+				async Task Act()
+					=> await That(subject).MatchesExactly([1, 2], o => o.IgnoringAdditionalProperties());
+
+				await That(Act).DoesNotThrow();
+			}
+
 			public static TheoryData<object, string> MatchingArrayValues
 				=> new()
 				{
@@ -338,6 +350,20 @@ public sealed partial class ThatNullableJsonElement
 					             					} exactly,
 					             but it differed as $.foo had unexpected Null
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectHasAdditionalProperties_WhenIgnoringAdditionalProperties_ShouldSucceed()
+			{
+				JsonElement? subject = FromString("{\"foo\": null, \"bar\": 2}");
+
+				async Task Act()
+					=> await That(subject).MatchesExactly(new
+					{
+						bar = 2,
+					}, o => o.IgnoringAdditionalProperties());
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsNotOneOf.Tests.cs
@@ -6,6 +6,22 @@ public sealed partial class ThatString
 	{
 		public sealed class Tests
 		{
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf("foo", "bar");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not one of ["foo", "bar"],
+					             but it was <null>
+					             """);
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenUnexpectedIsNull_ShouldSucceed(


### PR DESCRIPTION
- Add missing tests for Json expectations
- Add missing test for empty recursive inner exceptions
- Add missing null test for string `IsNotOneOf`
- Add missing null test for collections `AreAllUnique`
- Add missing tests for collections of strings