### PR TITLE
refactor: improve coverage for aweXpect (4)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="0.33.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="0.31.0"/>
-		<PackageVersion Include="aweXpect.Chronology" Version="0.5.0"/>
+		<PackageVersion Include="aweXpect.Chronology" Version="0.6.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.cs
@@ -213,11 +213,6 @@ public partial class StringEqualityOptions : IOptionsEquality<string?>
 		}
 		else
 		{
-			if (sb.Length > 0)
-			{
-				sb.Append(' ');
-			}
-
 			sb.Append(" ignoring");
 		}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Satisfy.Tests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatAsyncEnumerable
 	{
 		public sealed class Satisfy
 		{
-			public sealed class Tests
+			public sealed class ItemsTests
 			{
 				[Fact]
 				public async Task DoesNotEnumerateTwice()
@@ -85,7 +85,63 @@ public sealed partial class ThatAsyncEnumerable
 						             """);
 				}
 			}
-			// ReSharper disable once MemberHidesStaticFromOuterClass
+
+			public sealed class StringTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentValues_ShouldFail()
+				{
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x?.StartsWith("ba") == true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             satisfies x => x?.StartsWith("ba") == true for all items,
+						             but not all did
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+				{
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable((string[]) []);
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x == "");
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableOnlyContainsMatchingValues_ShouldSucceed()
+				{
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz"]);
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x?.Length == 3);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					IAsyncEnumerable<string>? subject = null;
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x == "");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             satisfies x => x == "" for all items,
+						             but it was <null>
+						             """);
+				}
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtLeastTests.cs
@@ -69,6 +69,22 @@ public sealed partial class ThatAsyncEnumerable
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().AtLeast(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has at least 2 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtMostTests.cs
@@ -69,6 +69,22 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 3
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().AtMost(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has at most 2 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.BetweenTests.cs
@@ -73,6 +73,22 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 7
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().Between(2).And(4);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has between 2 and 4 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.EqualToTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.EqualToTests.cs
@@ -74,6 +74,22 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 3
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().EqualTo(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has exactly 2 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Satisfy.Tests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatEnumerable
 	{
 		public sealed class Satisfy
 		{
-			public sealed class Tests
+			public sealed class ItemTests
 			{
 				[Fact]
 				public async Task ConsidersCancellationToken()
@@ -109,6 +109,63 @@ public sealed partial class ThatEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             satisfies x => x == 0 for all items,
+						             but it was <null>
+						             """);
+				}
+			}
+
+			public sealed class StringTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentValues_ShouldFail()
+				{
+					string[] subject = ["foo", "bar", "baz"];
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x?.StartsWith("ba") == true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             satisfies x => x?.StartsWith("ba") == true for all items,
+						             but only 2 of 3 did
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldSucceed()
+				{
+					IEnumerable<string> subject = ToEnumerable((string[]) []);
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x == "");
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableOnlyContainsMatchingValues_ShouldSucceed()
+				{
+					IEnumerable<string> subject = ToEnumerable(["foo", "bar", "baz"]);
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x?.Length == 3);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					IEnumerable<string>? subject = null;
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(x => x == "");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             satisfies x => x == "" for all items,
 						             but it was <null>
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtLeastTests.cs
@@ -105,6 +105,22 @@ public sealed partial class ThatEnumerable
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().AtLeast(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has at least 2 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtMostTests.cs
@@ -105,6 +105,22 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().AtMost(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has at most 2 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.BetweenTests.cs
@@ -115,6 +115,22 @@ public sealed partial class ThatEnumerable
 					             but found at least 7
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().Between(2).And(4);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has between 2 and 4 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.EqualToTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.EqualToTests.cs
@@ -115,6 +115,22 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasCount().EqualTo(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has exactly 2 items,
+					             but it was <null>
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
@@ -7,443 +7,18 @@ public sealed partial class ThatString
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task AtLeast_WhenExpectedStringOccursEnoughTimes_ShouldSucceed()
+			public async Task WhenActualIsNull_ShouldFail()
 			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
+				string? subject = null;
 
 				async Task Act()
-					=> await That(subject).Contains(expected).AtLeast(3);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task AtLeast_WhenExpectedStringOccursFewerTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtLeast(5);
+					=> await That(subject).Contains("");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             contains "in" at least 5 times,
-					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task AtLeast_WhenExpectedStringOccursNever_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "text that does not occur";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtLeast(1);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "text that does not occur" at least once,
-					             but it contained it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task AtLeast_WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtLeast(-1);
-
-				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
-					.WithMessage("*'minimum'*").AsWildcard().And
-					.WithParamName("minimum");
-			}
-
-			[Fact]
-			public async Task AtMost_WhenExpectedStringOccursMoreTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtMost(2);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" at most 2 times,
-					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task AtMost_WhenExpectedStringOccursNever_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "text that does not occur";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtMost(1);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task AtMost_WhenExpectedStringSufficientlyFewTimes_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtMost(3);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task AtMost_WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtMost(-1);
-
-				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
-					.WithMessage("*'maximum'*").AsWildcard().And
-					.WithParamName("maximum");
-			}
-
-			[Fact]
-			public async Task Between_WhenExpectedStringOccursFewerTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(4).And(9);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" between 4 and 9 times,
-					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task Between_WhenExpectedStringOccursMoreTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(1).And(2);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" between 1 and 2 times,
-					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task Between_WhenExpectedStringOccursSufficientTimes_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(1).And(4);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Between_WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(1).And(-3);
-
-				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
-					.WithMessage("*'maximum'*").AsWildcard().And
-					.WithParamName("maximum");
-			}
-
-			[Fact]
-			public async Task Between_WhenMinimumEqualsMaximum_ShouldBehaveLikeExactly()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(3).And(3);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Between_WhenMinimumIsGreaterThanMaximum_ShouldThrowArgumentException()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(4).And(3);
-
-				await That(Act).ThrowsExactly<ArgumentException>()
-					.WithMessage("*'maximum'*greater*'minimum'*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task Between_WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Between(-1).And(3);
-
-				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
-					.WithMessage("*'minimum'*").AsWildcard().And
-					.WithParamName("minimum");
-			}
-
-			[Fact]
-			public async Task
-				Exactly_WhenExpectedIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Exactly(-1);
-
-				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
-					.WithMessage("*'expected'*").AsWildcard().And
-					.WithParamName("expected");
-			}
-
-			[Fact]
-			public async Task Exactly_WhenExpectedStringOccursCorrectlyOften_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Exactly(3);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Exactly_WhenExpectedStringOccursFewerTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Exactly(4);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" exactly 4 times,
-					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task Exactly_WhenExpectedStringOccursMoreTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Exactly(2);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" exactly 2 times,
-					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task IgnoringCase_ShouldIncludeSettingInExpectationText()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtLeast(7).IgnoringCase();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" at least 7 times ignoring case,
-					             but it contained it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task
-				IgnoringCase_WhenExpectedStringOccursEnoughTimesCaseInsensitive_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).AtLeast(5).IgnoringCase();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Never_WhenExpectedStringDoesNotOccur_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "detective";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Never();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Never_WhenExpectedStringOccursMoreTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "investigator";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Never();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not contain "investigator",
-					             but it contained it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task Once_WhenExpectedStringOccursExactly1Times_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "investigator";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Once();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Once_WhenExpectedStringOccursFewerTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "detective";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Once();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "detective" exactly once,
-					             but it contained it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task Once_WhenExpectedStringOccursMoreTimes_ShouldFail()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "word";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Once();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "word" exactly once,
-					             but it contained it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
-					             """);
-			}
-
-			[Fact]
-			public async Task
-				Using_WhenExpectedStringOccursEnoughTimesForTheComparer_ShouldSucceed()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Exactly(4)
-						.Using(new IgnoreCaseForVocalsComparer());
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task
-				Using_WhenExpectedStringOccursIncorrectTimesForTheComparer_ShouldIncludeComparerInMessage()
-			{
-				string subject =
-					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "in";
-
-				async Task Act()
-					=> await That(subject).Contains(expected).Exactly(5)
-						.Using(new IgnoreCaseForVocalsComparer());
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             contains "in" exactly 5 times using IgnoreCaseForVocalsComparer,
-					             but it contained it 4 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             contains "" at least once,
+					             but it was <null>
 					             """);
 			}
 
@@ -473,6 +48,471 @@ public sealed partial class ThatString
 					             Expected that subject
 					             contains "not" at least once,
 					             but it contained it 0 times in "some text"
+					             """);
+			}
+		}
+
+		public sealed class AtLeastTests
+		{
+			[Fact]
+			public async Task WhenExpectedStringOccursEnoughTimes_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtLeast(3);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursFewerTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtLeast(5);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" at least 5 times,
+					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "text that does not occur";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtLeast(1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "text that does not occur" at least once,
+					             but it contained it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtLeast(-1);
+
+				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
+					.WithMessage("*'minimum'*").AsWildcard().And
+					.WithParamName("minimum");
+			}
+		}
+
+		public sealed class AtMostTests
+		{
+			[Fact]
+			public async Task WhenExpectedStringOccursMoreTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtMost(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" at most 2 times,
+					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "text that does not occur";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtMost(1);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringSufficientlyFewTimes_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtMost(3);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtMost(-1);
+
+				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
+					.WithMessage("*'maximum'*").AsWildcard().And
+					.WithParamName("maximum");
+			}
+		}
+
+		public sealed class BetweenTests
+		{
+			[Fact]
+			public async Task WhenExpectedStringOccursFewerTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(4).And(9);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" between 4 and 9 times,
+					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursMoreTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(1).And(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" between 1 and 2 times,
+					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursSufficientTimes_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(1).And(4);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMaximumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(1).And(-3);
+
+				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
+					.WithMessage("*'maximum'*").AsWildcard().And
+					.WithParamName("maximum");
+			}
+
+			[Fact]
+			public async Task WhenMinimumEqualsMaximum_ShouldBehaveLikeExactly()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(3).And(3);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsGreaterThanMaximum_ShouldThrowArgumentException()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(4).And(3);
+
+				await That(Act).ThrowsExactly<ArgumentException>()
+					.WithMessage("*'maximum'*greater*'minimum'*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Between(-1).And(3);
+
+				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
+					.WithMessage("*'minimum'*").AsWildcard().And
+					.WithParamName("minimum");
+			}
+		}
+
+		public sealed class ExactlyTests
+		{
+			[Fact]
+			public async Task
+				WhenExpectedIsLessThanZero_ShouldThrowArgumentOutOfRangeException()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Exactly(-1);
+
+				await That(Act).ThrowsExactly<ArgumentOutOfRangeException>()
+					.WithMessage("*'expected'*").AsWildcard().And
+					.WithParamName("expected");
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursCorrectlyOften_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Exactly(3);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursFewerTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Exactly(4);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" exactly 4 times,
+					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursMoreTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Exactly(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" exactly 2 times,
+					             but it contained it 3 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+		}
+
+		public sealed class IgnoringCaseTests
+		{
+			[Fact]
+			public async Task ShouldIncludeSettingInExpectationText()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtLeast(7).IgnoringCase();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" at least 7 times ignoring case,
+					             but it contained it 5 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				WhenExpectedStringOccursEnoughTimesCaseInsensitive_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).AtLeast(5).IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NeverTests
+		{
+			[Fact]
+			public async Task WhenExpectedStringDoesNotOccur_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "detective";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Never();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursMoreTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "investigator";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Never();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain "investigator",
+					             but it contained it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+		}
+
+		public sealed class OnceTests
+		{
+			[Fact]
+			public async Task WhenExpectedStringOccursExactly1Times_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "investigator";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Once();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursFewerTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "detective";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Once();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "detective" exactly once,
+					             but it contained it 0 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedStringOccursMoreTimes_ShouldFail()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "word";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Once();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "word" exactly once,
+					             but it contained it 2 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
+					             """);
+			}
+		}
+
+		public sealed class UsingTests
+		{
+			[Fact]
+			public async Task
+				WhenExpectedStringOccursEnoughTimesForTheComparer_ShouldSucceed()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Exactly(4)
+						.Using(new IgnoreCaseForVocalsComparer());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task
+				WhenExpectedStringOccursIncorrectTimesForTheComparer_ShouldIncludeComparerInMessage()
+			{
+				string subject =
+					"In this text in between the word an investigator should find the word 'IN' multiple times.";
+				string expected = "in";
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Exactly(5)
+						.Using(new IgnoreCaseForVocalsComparer());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains "in" exactly 5 times using IgnoreCaseForVocalsComparer,
+					             but it contained it 4 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 					             """);
 			}
 		}


### PR DESCRIPTION
- Add missing null test for string `Contains`
- Add missing null tests for collections `HasCount()`
- Add missing tests for collections `Satisfy`
- Update aweXpect.Chronology to v0.6.0