### PR TITLE
docs: limit benchmark data per default

### DIFF
--- a/Docs/pages/src/css/custom.css
+++ b/Docs/pages/src/css/custom.css
@@ -66,7 +66,7 @@
 	margin-top: -30px;
 }
 
-#view-full-benchmarks {
+#benchmarks-view-link {
 	font-style: italic;
 	text-align: center;
 	margin: 30px;

--- a/Docs/pages/src/css/custom.css
+++ b/Docs/pages/src/css/custom.css
@@ -65,3 +65,9 @@
 #index-logo {
 	margin-top: -30px;
 }
+
+#view-full-benchmarks {
+	font-style: italic;
+	text-align: center;
+	margin: 30px;
+}

--- a/Docs/pages/src/pages/benchmarks-full.js
+++ b/Docs/pages/src/pages/benchmarks-full.js
@@ -7,7 +7,7 @@ export default function Benchmarks() {
 		chartScript.setAttribute('src', 'js/chart.umd.js');
 		document.getElementById("__docusaurus").appendChild(chartScript);
 		const dataScript = document.createElement('script');
-		dataScript.setAttribute('src', 'js/limited-data.js');
+		dataScript.setAttribute('src', 'js/data.js');
 		document.getElementById("__docusaurus").appendChild(dataScript);
 		const benchmarkScript = document.createElement('script');
 		benchmarkScript.setAttribute('src', 'js/benchmarks.js');
@@ -17,7 +17,7 @@ export default function Benchmarks() {
 		<Layout title="Benchmarks" description="Benchmarks Page">
 			<div id="benchmarks-container">
 			</div>
-			<a id="view-full-benchmarks" href="/benchmarks-full">View full benchmarks</a>
+			<a id="view-full-benchmarks" href="/benchmarks">View limited benchmarks</a>
 		</Layout>
 	);
 }

--- a/Docs/pages/src/pages/benchmarks-full.js
+++ b/Docs/pages/src/pages/benchmarks-full.js
@@ -17,7 +17,7 @@ export default function Benchmarks() {
 		<Layout title="Benchmarks" description="Benchmarks Page">
 			<div id="benchmarks-container">
 			</div>
-			<a id="view-full-benchmarks" href="/benchmarks">View limited benchmarks</a>
+			<a id="benchmarks-view-link" href="/benchmarks">View limited benchmarks</a>
 		</Layout>
 	);
 }

--- a/Docs/pages/src/pages/benchmarks.js
+++ b/Docs/pages/src/pages/benchmarks.js
@@ -17,7 +17,7 @@ export default function Benchmarks() {
 		<Layout title="Benchmarks" description="Benchmarks Page">
 			<div id="benchmarks-container">
 			</div>
-			<a id="view-full-benchmarks" href="/benchmarks-full">View full benchmarks</a>
+			<a id="benchmarks-view-link" href="/benchmarks-full">View full benchmarks</a>
 		</Layout>
 	);
 }

--- a/Docs/pages/static/js/benchmarks.js
+++ b/Docs/pages/static/js/benchmarks.js
@@ -1,14 +1,12 @@
 (function () {
-	const benchmarkData = window.BENCHMARK_DATA;
 	function init() {
-		
+
 		const main = document.getElementById('benchmarks-container');
-		for (const name in benchmarkData) {
-			renderChart(main, name, benchmarkData[name]);
+		for (const name in window.BENCHMARK_DATA) {
+			renderChart(main, name, window.BENCHMARK_DATA[name]);
 		}
 	}
 
-	
 	function renderChart(main, name, data) {
 		const div = document.createElement("div");
 		const h = document.createElement("h3");
@@ -72,7 +70,9 @@
 	}
 
 	function waitForScripts() {
-		if (typeof Chart !== 'undefined' && window.BENCHMARK_DATA !== 'undefined') {
+		if (typeof Chart !== 'undefined' &&
+			typeof window.BENCHMARK_DATA !== 'undefined' &&
+			window.BENCHMARK_DATA != null) {
 			init();
 		} else {
 			setTimeout(waitForScripts, 100);

--- a/Docs/pages/static/js/limited-data.js
+++ b/Docs/pages/static/js/limited-data.js
@@ -1,0 +1,1038 @@
+﻿window.BENCHMARK_DATA = {
+	"Bool": {
+		"commits": [
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					175.14546832671533,
+					177.29154222806295,
+					171.39480076517378,
+					174.4086271127065,
+					273.48835127694264
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					528,
+					528,
+					528,
+					528,
+					528
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					187.26639924049377,
+					192.08625297546388,
+					187.4921813805898,
+					195.93506077357702,
+					353.86444727579754
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					688,
+					688,
+					688,
+					688,
+					688
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					753.2436855951945,
+					797.6635966618855,
+					850.6571072798508,
+					856.7023104349772,
+					1642.9863611857097
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					2216,
+					2216,
+					2384,
+					2384,
+					2384
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	},
+	"Equivalency": {
+		"commits": [
+			{
+				"sha": "12c765936621a94deca594b414cc58bb9098a568",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:06:28 2025 \u002B0100",
+				"message": "docs: include documentation from extensions (#379)"
+			},
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"12c76593",
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					273441.09012276784,
+					281912.22239583335,
+					286711.9208635603,
+					283452.5561899039,
+					283193.7769042969
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					284916,
+					284916,
+					284916,
+					284916,
+					284916
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					2035662.0341796875,
+					2088522.0908854166,
+					2035642.0755208333,
+					2039569.595703125,
+					1921541.68046875
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					3977738,
+					3977738,
+					3977738,
+					3977738,
+					3977736
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					654776.5223214285,
+					655973.9303152902,
+					706164.5739583333,
+					694925.7700846355,
+					627531.4439871652
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					836713,
+					836713,
+					836713,
+					866721,
+					866721
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	},
+	"ItemsCount_AtLeast": {
+		"commits": [
+			{
+				"sha": "12c765936621a94deca594b414cc58bb9098a568",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:06:28 2025 \u002B0100",
+				"message": "docs: include documentation from extensions (#379)"
+			},
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"12c76593",
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					592.9470985276358,
+					591.1330007712046,
+					595.5652925491333,
+					592.4628366742816,
+					585.9565873827253
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					1192,
+					1192,
+					1192,
+					1192,
+					1192
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					423.12928873697916,
+					420.13100739887784,
+					422.00289414723716,
+					417.7492156982422,
+					408.1910690307617
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					1744,
+					1744,
+					1744,
+					1744,
+					1744
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					15792.64008585612,
+					14296.464766366142,
+					17459.05538736979,
+					14530.966874186199,
+					14198.330862426757
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					27288,
+					27288,
+					27288,
+					27456,
+					27456
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	},
+	"Int_GreaterThan": {
+		"commits": [
+			{
+				"sha": "12c765936621a94deca594b414cc58bb9098a568",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:06:28 2025 \u002B0100",
+				"message": "docs: include documentation from extensions (#379)"
+			},
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"12c76593",
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					224.60964151791163,
+					223.97930095990498,
+					243.5355607509613,
+					218.29143880094801,
+					217.2662386383329
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					880,
+					880,
+					880,
+					880,
+					880
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					198.48603370984395,
+					189.4258601298699,
+					206.3274233977,
+					197.94542695681255,
+					189.117862256368
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					960,
+					960,
+					960,
+					960,
+					960
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					1056.343430519104,
+					1032.077123778207,
+					1086.7516090393067,
+					1169.0910301208496,
+					1161.04303250994
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					2848,
+					2848,
+					2848,
+					2952,
+					2952
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	},
+	"String": {
+		"commits": [
+			{
+				"sha": "12c765936621a94deca594b414cc58bb9098a568",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:06:28 2025 \u002B0100",
+				"message": "docs: include documentation from extensions (#379)"
+			},
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"12c76593",
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					336.8282773835318,
+					332.7059574860793,
+					346.1113056818644,
+					343.7549833615621,
+					345.63378025690713
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					952,
+					952,
+					952,
+					952,
+					952
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					419.61893234934126,
+					417.6162357966105,
+					429.3557568868001,
+					421.3166163444519,
+					417.2386638777597
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					1904,
+					1904,
+					1904,
+					1904,
+					1904
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					1082.4938897450766,
+					1084.3970548189604,
+					1123.0915534973144,
+					1194.9090049743652,
+					1226.2943860371909
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					2896,
+					2896,
+					2896,
+					3064,
+					3064
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	},
+	"StringArray": {
+		"commits": [
+			{
+				"sha": "12c765936621a94deca594b414cc58bb9098a568",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:06:28 2025 \u002B0100",
+				"message": "docs: include documentation from extensions (#379)"
+			},
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"12c76593",
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					1195.2053229992207,
+					1180.2425022125244,
+					1229.7892965952556,
+					1160.7693789555476,
+					1185.6329675038655
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					2336,
+					2336,
+					2336,
+					2336,
+					2336
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					1174.6949152946472,
+					1250.3417900630407,
+					1204.3439136505126,
+					1179.2887406349182,
+					1181.5666632334392
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					3888,
+					3888,
+					3888,
+					3888,
+					3888
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					2451.161515045166,
+					2384.0196060180665,
+					2512.7467631022137,
+					2758.1383440835134,
+					2705.6514710017614
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					4112,
+					4112,
+					4112,
+					4520,
+					4520
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	},
+	"StringArrayInAnyOrder": {
+		"commits": [
+			{
+				"sha": "12c765936621a94deca594b414cc58bb9098a568",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:06:28 2025 \u002B0100",
+				"message": "docs: include documentation from extensions (#379)"
+			},
+			{
+				"sha": "b2959468330f7657c88caec2d68758ad54689183",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 21:19:16 2025 \u002B0100",
+				"message": "chore: add \u0022repository_dispatch\u0022 to build.yml (#380)"
+			},
+			{
+				"sha": "07843f7f35cffea48197c86ff295104aa393761c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sat Feb 15 22:43:16 2025 \u002B0100",
+				"message": "refactor: use the \u0022InternalsVisibleTo\u0022 attribute in csproj (#381)"
+			},
+			{
+				"sha": "84eb74e03f254e780e7537e3198faac120ac8a4e",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:33:35 2025 \u002B0100",
+				"message": "chore: update TUnit to v0.13.0 (#382)"
+			},
+			{
+				"sha": "da1f968c659fc1139f484d4e3ab5a4387fe8fb4c",
+				"author": "Valentin Breu\u00DF",
+				"date": "Sun Feb 16 04:48:16 2025 \u002B0100",
+				"message": "docs: add \u0022Getting started\u0022 button to home page (#383)"
+			}
+		],
+		"labels": [
+			"12c76593",
+			"b2959468",
+			"07843f7f",
+			"84eb74e0",
+			"da1f968c"
+		],
+		"datasets": [
+			{
+				"label": "aweXpect time",
+				"unit": "ns",
+				"data": [
+					1332.8758734189546,
+					1256.7335456848145,
+					1336.4578235332783,
+					1292.3768703460694,
+					1271.804393181434
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "aweXpect memory",
+				"unit": "b",
+				"data": [
+					2368,
+					2368,
+					2368,
+					2368,
+					2368
+				],
+				"borderColor": "#63A2AC",
+				"backgroundColor": "#63A2AC",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "FluentAssertions time",
+				"unit": "ns",
+				"data": [
+					87393.13723958333,
+					85774.96432059152,
+					87558.49938557943,
+					87915.97680664062,
+					84799.45596313477
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "FluentAssertions memory",
+				"unit": "b",
+				"data": [
+					54273,
+					54271,
+					54271,
+					54271,
+					54273
+				],
+				"borderColor": "#FF671B",
+				"backgroundColor": "#FF671B",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			},
+			{
+				"label": "TUnit time",
+				"unit": "ns",
+				"data": [
+					7174.545727539063,
+					6509.206927998861,
+					6950.305025736491,
+					7325.4052281697595,
+					6838.678946903774
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y",
+				"borderDash": [],
+				"pointStyle": "circle"
+			},
+			{
+				"label": "TUnit memory",
+				"unit": "b",
+				"data": [
+					7912,
+					7912,
+					7912,
+					8800,
+					8800
+				],
+				"borderColor": "#1A6029",
+				"backgroundColor": "#1A6029",
+				"yAxisID": "y1",
+				"borderDash": [
+					5,
+					5
+				],
+				"pointStyle": "triangle"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Limit the benchmark data to the last 50 commits per default. Add link to view the full benchmark data (https://awexpect.com/benchmarks-full)