### PR TITLE
refactor: consolidate use of EquivalencyOptions

### DIFF
--- a/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
@@ -17,18 +17,18 @@ public static class EquivalencyExtensions
 	/// </summary>
 	public static TSelf Equivalent<TType, TThat, TElement, TSelf>(
 		this ObjectEqualityResult<TType, TThat, TElement, TSelf> result,
-		Func<EquivalencyOptions, EquivalencyOptions>? equivalencyOptions = null)
+		Func<EquivalencyOptions, EquivalencyOptions>? options = null)
 		where TSelf : ObjectEqualityResult<TType, TThat, TElement, TSelf>
 	{
 		((IOptionsProvider<ObjectEqualityOptions<TElement>>)result).Options.SetMatchType(
-			new EquivalencyComparer(EquivalencyOptionsExtensions.FromCallback(equivalencyOptions)));
+			new EquivalencyComparer(EquivalencyOptionsExtensions.FromCallback(options)));
 		return (TSelf)result;
 	}
 
 	/// <summary>
 	///     Use equivalency to compare objects.
 	/// </summary>
-	public static ObjectEqualityOptions<TSubject> Equivalent<TSubject>(this ObjectEqualityOptions<TSubject> options,
+	internal static ObjectEqualityOptions<TSubject> Equivalent<TSubject>(this ObjectEqualityOptions<TSubject> options,
 		EquivalencyOptions equivalencyOptions)
 	{
 		options.SetMatchType(new EquivalencyComparer(equivalencyOptions));

--- a/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using aweXpect.Customization;
 
 namespace aweXpect.Equivalency;
 
@@ -73,8 +74,8 @@ public static class EquivalencyOptionsExtensions
 	/// </remarks>
 	internal static EquivalencyOptions FromCallback(Func<EquivalencyOptions, EquivalencyOptions>? callback)
 		=> callback is null
-			? new EquivalencyOptions()
-			: callback(new EquivalencyOptions());
+			? Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get()
+			: callback(Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get());
 
 	/// <summary>
 	///     Returns type-specific <see cref="EquivalencyTypeOptions" />.

--- a/Source/aweXpect/Results/ObjectCountResult.cs
+++ b/Source/aweXpect/Results/ObjectCountResult.cs
@@ -44,9 +44,7 @@ public class ObjectCountResult<TType, TThat, TElement, TSelf>(
 	public TSelf Equivalent(
 		Func<EquivalencyOptions, EquivalencyOptions>? optionsCallback = null)
 	{
-		EquivalencyOptions equivalencyOptions =
-			optionsCallback?.Invoke(new EquivalencyOptions()) ?? new EquivalencyOptions();
-		options.Equivalent(equivalencyOptions);
+		options.Equivalent(EquivalencyOptionsExtensions.FromCallback(optionsCallback));
 		return (TSelf)this;
 	}
 

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -18,8 +18,7 @@ namespace aweXpect
     }
     public static class EquivalencyExtensions
     {
-        public static aweXpect.Options.ObjectEqualityOptions<TSubject> Equivalent<TSubject>(this aweXpect.Options.ObjectEqualityOptions<TSubject> options, aweXpect.Equivalency.EquivalencyOptions equivalencyOptions) { }
-        public static TSelf Equivalent<TType, TThat, TElement, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TElement, TSelf> result, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null)
+        public static TSelf Equivalent<TType, TThat, TElement, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TElement, TSelf> result, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? options = null)
             where TSelf : aweXpect.Results.ObjectEqualityResult<TType, TThat, TElement, TSelf> { }
     }
     public static class ThatAsyncEnumerable

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -18,8 +18,7 @@ namespace aweXpect
     }
     public static class EquivalencyExtensions
     {
-        public static aweXpect.Options.ObjectEqualityOptions<TSubject> Equivalent<TSubject>(this aweXpect.Options.ObjectEqualityOptions<TSubject> options, aweXpect.Equivalency.EquivalencyOptions equivalencyOptions) { }
-        public static TSelf Equivalent<TType, TThat, TElement, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TElement, TSelf> result, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? equivalencyOptions = null)
+        public static TSelf Equivalent<TType, TThat, TElement, TSelf>(this aweXpect.Results.ObjectEqualityResult<TType, TThat, TElement, TSelf> result, System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? options = null)
             where TSelf : aweXpect.Results.ObjectEqualityResult<TType, TThat, TElement, TSelf> { }
     }
     public static class ThatBool

--- a/Tests/aweXpect.Internal.Tests/Helpers/ObjectEqualityOptionsTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Helpers/ObjectEqualityOptionsTests.cs
@@ -1,7 +1,7 @@
 ﻿using aweXpect.Equivalency;
 using aweXpect.Options;
 
-namespace aweXpect.Core.Tests.Options;
+namespace aweXpect.Internal.Tests.Helpers;
 
 public class ObjectEqualityOptionsTests
 {


### PR DESCRIPTION
- Always use a Func<EquivalencyOptions, EquivalencyOptions> to adapt the equivalency options
- If not set always use the default value from `Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get()`