### PR TITLE
refactor: execute code cleanup

### DIFF
--- a/Pipeline/Build.ApiChecks.cs
+++ b/Pipeline/Build.ApiChecks.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Nuke.Common;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
@@ -24,7 +23,9 @@ partial class Build
 			};
 
 			DotNetTest(s => s
-				.SetConfiguration(Configuration == Configuration.Debug || BuildScope == BuildScope.CoreOnly ? "Debug" : "Release")
+				.SetConfiguration(Configuration == Configuration.Debug || BuildScope == BuildScope.CoreOnly
+					? "Debug"
+					: "Release")
 				.SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
 				.EnableNoBuild()
 				.SetResultsDirectory(TestResultsDirectory)

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -157,7 +157,10 @@ partial class Build
 		.DependsOn(BenchmarkComment)
 		.DependsOn(BenchmarkReport);
 
-	async Task UploadBenchmarkFile(string filename, PageBenchmarkReportGenerator.CommitInfo commitInfo, BenchmarkFile currentFile,
+	async Task UploadBenchmarkFile(
+		string filename,
+		PageBenchmarkReportGenerator.CommitInfo commitInfo,
+		BenchmarkFile currentFile,
 		string updatedFileContent)
 	{
 		using HttpClient client = new();

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -17,7 +17,7 @@ partial class Build
 		.Executes(() =>
 		{
 			Configuration = Configuration.Debug;
-			
+
 			SonarScannerTasks.SonarScannerBegin(s => s
 				.SetOrganization("awexpect")
 				.SetProjectKey("aweXpect_aweXpect")

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;

--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Serilog;
+
 // ReSharper disable AllUnderscoreLocalParameterName
 
 namespace Build;

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -13,8 +13,6 @@ namespace Build;
 )]
 partial class Build : NukeBuild
 {
-	[Parameter("Github Token")] readonly string GithubToken;
-
 	/// <summary>
 	///     Set this flag temporarily when you introduce breaking changes in the core library.
 	///     This will change the build pipeline to only build and publish the aweXpect.Core or aweXpect package.
@@ -22,6 +20,8 @@ partial class Build : NukeBuild
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
 	readonly BuildScope BuildScope = BuildScope.Default;
+
+	[Parameter("Github Token")] readonly string GithubToken;
 
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 
@@ -33,5 +33,4 @@ partial class Build : NukeBuild
 	GitHubActions GitHubActions => GitHubActions.Instance;
 
 	public static int Main() => Execute<Build>(x => x.Pack, x => x.ApiChecks, x => x.Benchmarks, x => x.CodeAnalysis);
-
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ By using async assertions per default, we have a consistent API and other perks:
 ### Extensible
 
 We added lots of extensibility points to allow you to build custom extensions.  
-The [aweXpect.Core](https://www.nuget.org/packages/aweXpect.Core/) package is intended to be a stable source for extensions, so that the risk of version conflicts between different extensions can be reduced.
+The [aweXpect.Core](https://www.nuget.org/packages/aweXpect.Core/) package is intended to be a stable source for
+extensions, so that the risk of version conflicts between different extensions can be reduced.
 
 You can extend the functionality for any types, by adding extension methods on `IThat<TType>`.
 More information can be found in the [extensibility guide](https://awexpect.com/docs/category/extensibility).

--- a/Source/aweXpect.Analyzers/aweXpect.Analyzers.csproj
+++ b/Source/aweXpect.Analyzers/aweXpect.Analyzers.csproj
@@ -13,8 +13,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="aweXpect.Analyzers.Tests" PublicKey="$(PublicKey)" />
-		<InternalsVisibleTo Include="aweXpect.Analyzers.CodeFixers" PublicKey="$(PublicKey)" />
+		<InternalsVisibleTo Include="aweXpect.Analyzers.Tests" PublicKey="$(PublicKey)"/>
+		<InternalsVisibleTo Include="aweXpect.Analyzers.CodeFixers" PublicKey="$(PublicKey)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/aweXpect.Core/Core/Adapters/MsTestAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/MsTestAdapter.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable UnusedType.Global
+
 namespace aweXpect.Core.Adapters;
 
 /// <summary>

--- a/Source/aweXpect.Core/Core/Adapters/NUnitAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/NUnitAdapter.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable UnusedType.Global
+
 namespace aweXpect.Core.Adapters;
 
 /// <summary>

--- a/Source/aweXpect.Core/Core/Adapters/TUnitAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/TUnitAdapter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+
 // ReSharper disable UnusedType.Global
 
 namespace aweXpect.Core.Adapters;

--- a/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+
 // ReSharper disable UnusedType.Global
 
 namespace aweXpect.Core.Adapters;

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -20,7 +20,6 @@ public abstract class ExpectationBuilder
 	private const string DefaultCurrentSubject = "it";
 
 	private CancellationToken? _cancellationToken;
-	private TimeSpan? _timeout;
 
 	/// <summary>
 	///     The current name for the subject (defaults to <see cref="DefaultCurrentSubject" />).
@@ -28,6 +27,7 @@ public abstract class ExpectationBuilder
 	private string _it = DefaultCurrentSubject;
 
 	private Node _node = new ExpectationNode();
+	private TimeSpan? _timeout;
 
 	private ITimeSystem? _timeSystem;
 
@@ -283,7 +283,8 @@ public abstract class ExpectationBuilder
 		ITimeSystem timeSystem = _timeSystem ?? RealTimeSystem.Instance;
 		TestCancellation? testCancellation = Customize.aweXpect.Settings().TestCancellation.Get();
 		_cancellationToken ??= testCancellation?.CancellationTokenFactory?.Invoke() ?? CancellationToken.None;
-		return IsMet(GetRootNode(), context, timeSystem, _timeout ?? testCancellation?.Timeout, _cancellationToken.Value);
+		return IsMet(GetRootNode(), context, timeSystem, _timeout ?? testCancellation?.Timeout,
+			_cancellationToken.Value);
 	}
 
 	internal abstract Task<ConstraintResult> IsMet(Node rootNode,

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -160,13 +160,13 @@ internal class AndNode : Node
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value)
 			where TValue : default
 		{
-			if (left.TryGetValue<TValue>(out TValue? leftValue))
+			if (left.TryGetValue(out TValue? leftValue))
 			{
 				value = leftValue;
 				return true;
 			}
 
-			if (right.TryGetValue<TValue>(out TValue? rightValue))
+			if (right.TryGetValue(out TValue? rightValue))
 			{
 				value = rightValue;
 				return true;

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -155,13 +155,13 @@ internal class OrNode : Node
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value)
 			where TValue : default
 		{
-			if (left.TryGetValue<TValue>(out TValue? leftValue))
+			if (left.TryGetValue(out TValue? leftValue))
 			{
 				value = leftValue;
 				return true;
 			}
 
-			if (right.TryGetValue<TValue>(out TValue? rightValue))
+			if (right.TryGetValue(out TValue? rightValue))
 			{
 				value = rightValue;
 				return true;

--- a/Source/aweXpect.Core/aweXpect.Core.csproj
+++ b/Source/aweXpect.Core/aweXpect.Core.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="aweXpect.Core.Tests" PublicKey="$(PublicKey)" />
+		<InternalsVisibleTo Include="aweXpect.Core.Tests" PublicKey="$(PublicKey)"/>
 	</ItemGroup>
 
 </Project>

--- a/Source/aweXpect/That/Collections/CollectionCountResult.cs
+++ b/Source/aweXpect/That/Collections/CollectionCountResult.cs
@@ -12,19 +12,19 @@ public class CollectionCountResult<TReturn>(Func<EnumerableQuantifier, TReturn> 
 	/// </summary>
 	public TReturn EqualTo(int expected)
 		=> factory(EnumerableQuantifier.Exactly(expected));
-	
+
 	/// <summary>
 	///     Verifies that the collection has at least <paramref name="minimum" /> items.
 	/// </summary>
 	public TReturn AtLeast(int minimum)
 		=> factory(EnumerableQuantifier.AtLeast(minimum));
-	
+
 	/// <summary>
 	///     Verifies that the collection has at most <paramref name="maximum" /> items.
 	/// </summary>
 	public TReturn AtMost(int maximum)
 		=> factory(EnumerableQuantifier.AtMost(maximum));
-	
+
 	/// <summary>
 	///     Verifies that the collection has between <paramref name="minimum" />…
 	/// </summary>

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
@@ -15,12 +15,13 @@ public abstract partial class EnumerableQuantifier
 	private sealed class NoneQuantifier(ExpectationGrammars expectationGrammars) : EnumerableQuantifier
 	{
 		public override string ToString()
-			=> (expectationGrammars.HasFlag(ExpectationGrammars.Nested), expectationGrammars.HasFlag(ExpectationGrammars.Plural)) switch
-			{
-				(true, _) => "none",
-				(_, true) => "no",
-				_ => "none",
-			};
+			=> (expectationGrammars.HasFlag(ExpectationGrammars.Nested),
+					expectationGrammars.HasFlag(ExpectationGrammars.Plural)) switch
+				{
+					(true, _) => "none",
+					(_, true) => "no",
+					_ => "none",
+				};
 
 		/// <inheritdoc />
 		public override bool IsDeterminable(int matchingCount, int notMatchingCount)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core;
@@ -9,7 +10,6 @@ using aweXpect.Results;
 
 // ReSharper disable PossibleMultipleEnumeration
 
-#if NET8_0_OR_GREATER
 namespace aweXpect;
 
 public static partial class ThatAsyncEnumerable

--- a/Source/aweXpect/That/Collections/ThatEnumerable.AtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.AtLeast.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Helpers;
-using aweXpect.Results;
 
 namespace aweXpect;
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.AtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.AtMost.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using aweXpect.Core;
-using aweXpect.Helpers;
-using aweXpect.Results;
 
 namespace aweXpect;
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Between.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Between.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using aweXpect.Core;
-using aweXpect.Helpers;
 using aweXpect.Results;
 
 namespace aweXpect;

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Exactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Exactly.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using aweXpect.Core;
-using aweXpect.Helpers;
-using aweXpect.Results;
 
 namespace aweXpect;
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasCount.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasCount.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Results;

--- a/Source/aweXpect/That/Collections/ThatEnumerable.None.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.None.cs
@@ -11,12 +11,16 @@ public static partial class ThatEnumerable
 	/// </summary>
 	public static Elements<TItem> None<TItem>(
 		this IThat<IEnumerable<TItem>?> subject)
-		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars | ExpectationGrammars.Plural));
+		=> new(subject,
+			EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars |
+			                          ExpectationGrammars.Plural));
 
 	/// <summary>
 	///     Verifies that in the collection no items…
 	/// </summary>
 	public static Elements None(
 		this IThat<IEnumerable<string?>?> subject)
-		=> new(subject, EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars | ExpectationGrammars.Plural));
+		=> new(subject,
+			EnumerableQuantifier.None(subject.ThatIs().ExpectationBuilder.ExpectationGrammars |
+			                          ExpectationGrammars.Plural));
 }

--- a/Source/aweXpect/aweXpect.csproj
+++ b/Source/aweXpect/aweXpect.csproj
@@ -12,7 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="aweXpect.Internal.Tests" PublicKey="$(PublicKey)" />
+		<InternalsVisibleTo Include="aweXpect.Internal.Tests" PublicKey="$(PublicKey)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
@@ -60,7 +60,7 @@ public sealed class TestFrameworkAdapterTests
 	[Fact]
 	public async Task Throw_MissingAssemblyName_ShouldThrowNotSupportedException()
 	{
-		MyTestFrameworkAdapter adapter = new(MissingAssembly, failException: new MyException());
+		MyTestFrameworkAdapter adapter = new(MissingAssembly, new MyException());
 		_ = adapter.IsAvailable;
 
 		await That(() => adapter.Throw("foo")).Throws<NotSupportedException>()

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Text;
 using aweXpect.Core.Constraints;
-using aweXpect.Core.Tests.TestHelpers;
 
 namespace aweXpect.Core.Tests.Core.Constraints;
 

--- a/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
@@ -13,7 +13,8 @@ public class ManualExpectationBuilderTests
 		ManualExpectationBuilder<int> sut = new();
 		sut.AddConstraint((_, _) => new DummyConstraint<int>(_ => true));
 
-		async Task Act() => await sut.IsMet(new ExpectationNode(), null!, new TimeSystemMock(), null, CancellationToken.None);
+		async Task Act() => await sut.IsMet(
+			new ExpectationNode(), null!, new TimeSystemMock(), null, CancellationToken.None);
 
 		await That(Act).Throws<NotSupportedException>()
 			.WithMessage("Use IsMetBy for ManualExpectationBuilder!");

--- a/Tests/aweXpect.Core.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Core.Tests/ExpectTests.cs
@@ -5,29 +5,27 @@ namespace aweXpect.Core.Tests;
 
 public class ExpectTests
 {
-	private class MyExpectation(Expectation.Result result) : Expectation
-	{
-		internal override Task<Result> GetResult(int index) => Task.FromResult(result);
-	}
-
 	[Fact]
-	public async Task Context_ShouldBeIncludedInMessage()
+	public async Task Context_FromSuccess_ShouldNotBeIncludedInMessage()
 	{
-		Expectation.Result result = new(1, "foo", new ConstraintResult.Failure("expectation", "result")
-			.WithContext("context-title", "contest-content"));
+		Expectation.Result result1 = new(1, "foo1", new ConstraintResult.Failure("expectation1", "result1")
+			.WithContext("context-title1", "contest-content1"));
+		Expectation.Result result2 = new(1, "foo2", new ConstraintResult.Success("expectation2")
+			.WithContext("context-title2", "contest-content2"));
 
 		async Task Act()
-			=> await ThatAll(new MyExpectation(result));
+			=> await ThatAll(new MyExpectation(result1), new MyExpectation(result2));
 
 		await That(Act).Throws<XunitException>()
 			.WithMessage("""
 			             Expected all of the following to succeed:
-			             foo expectation
+			             foo1 expectation1
+			             foo2 expectation2
 			             but
-			              [01] result
+			              [01] result1
 
-			             context-title:
-			             contest-content
+			             context-title1:
+			             contest-content1
 			             """);
 	}
 
@@ -61,26 +59,23 @@ public class ExpectTests
 	}
 
 	[Fact]
-	public async Task Context_FromSuccess_ShouldNotBeIncludedInMessage()
+	public async Task Context_ShouldBeIncludedInMessage()
 	{
-		Expectation.Result result1 = new(1, "foo1", new ConstraintResult.Failure("expectation1", "result1")
-			.WithContext("context-title1", "contest-content1"));
-		Expectation.Result result2 = new(1, "foo2", new ConstraintResult.Success("expectation2")
-			.WithContext("context-title2", "contest-content2"));
+		Expectation.Result result = new(1, "foo", new ConstraintResult.Failure("expectation", "result")
+			.WithContext("context-title", "contest-content"));
 
 		async Task Act()
-			=> await ThatAll(new MyExpectation(result1), new MyExpectation(result2));
+			=> await ThatAll(new MyExpectation(result));
 
 		await That(Act).Throws<XunitException>()
 			.WithMessage("""
 			             Expected all of the following to succeed:
-			             foo1 expectation1
-			             foo2 expectation2
+			             foo expectation
 			             but
-			              [01] result1
+			              [01] result
 
-			             context-title1:
-			             contest-content1
+			             context-title:
+			             contest-content
 			             """);
 	}
 
@@ -116,4 +111,8 @@ public class ExpectTests
 		await That(Act).DoesNotThrow();
 	}
 #endif
+	private class MyExpectation(Expectation.Result result) : Expectation
+	{
+		internal override Task<Result> GetResult(int index) => Task.FromResult(result);
+	}
 }

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
@@ -45,23 +45,6 @@ public sealed partial class ThatDelegate
 			}
 
 			[Fact]
-			public async Task WhenInnerExceptionDoesNotMatch_ShouldFail()
-			{
-				Action action = () => throw new OuterException(innerException: new CustomException());
-
-				async Task Act()
-					=> await That(action).ThrowsException().WithRecursiveInnerExceptions(
-						e => e.All().Satisfy(_ => false));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that action
-					             throws an exception with recursive inner exceptions which all satisfy _ => false,
-					             but not all did
-					             """);
-			}
-
-			[Fact]
 			public async Task WhenExpectingInnerExceptionsToBeEmpty_ShouldFail()
 			{
 				Action action = () => throw new OuterException(innerException: new CustomException());
@@ -77,6 +60,23 @@ public sealed partial class ThatDelegate
 					             but recursive inner exceptions was [
 					               aweXpect.Tests.ThatDelegate+CustomException: WhenExpectingInnerExceptionsToBeEmpty_ShouldFail
 					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInnerExceptionDoesNotMatch_ShouldFail()
+			{
+				Action action = () => throw new OuterException(innerException: new CustomException());
+
+				async Task Act()
+					=> await That(action).ThrowsException().WithRecursiveInnerExceptions(
+						e => e.All().Satisfy(_ => false));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that action
+					             throws an exception with recursive inner exceptions which all satisfy _ => false,
+					             but not all did
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatNullableTimeOnly.IsEqualTo.Tests.cs
@@ -7,23 +7,6 @@ public sealed partial class ThatNullableTimeOnly
 	{
 		public sealed class Tests
 		{
-
-			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
-			{
-				TimeOnly? expected = CurrentTime();
-				TimeOnly? subject = null;
-
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is equal to {Formatter.Format(expected)},
-					              but it was <null>
-					              """);
-			}
 			[Fact]
 			public async Task WhenOnlyExpectedIsNull_ShouldFail()
 			{
@@ -84,6 +67,23 @@ public sealed partial class ThatNullableTimeOnly
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeOnly? expected = CurrentTime();
+				TimeOnly? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to {Formatter.Format(expected)},
+					              but it was <null>
 					              """);
 			}
 

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsGreaterThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsGreaterThanOrEqualTo.Tests.cs
@@ -7,21 +7,6 @@ public sealed partial class ThatNullableTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
-			{
-				TimeSpan? subject = null;
-
-				async Task Act()
-					=> await That(subject).IsGreaterThanOrEqualTo(TimeSpan.Zero);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is greater than or equal to 0:00,
-					             but it was <null>
-					             """);
-			}
-			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
 				TimeSpan? subject = CurrentTime();
@@ -77,6 +62,22 @@ public sealed partial class ThatNullableTimeSpan
 					              is greater than or equal to {Formatter.Format(expected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(TimeSpan.Zero);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is greater than or equal to 0:00,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotNegative.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatNullableTimeSpan.IsNotNegative.Tests.cs
@@ -7,21 +7,6 @@ public sealed partial class ThatNullableTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
-			{
-				TimeSpan? subject = null;
-
-				async Task Act()
-					=> await That(subject).IsNotNegative();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is not negative,
-					             but it was <null>
-					             """);
-			}
-			[Fact]
 			public async Task WhenSubjectIsMaxValue_ShouldSucceed()
 			{
 				TimeSpan? subject = TimeSpan.MaxValue;
@@ -62,6 +47,22 @@ public sealed partial class ThatNullableTimeSpan
 					              is not negative,
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				TimeSpan? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotNegative();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not negative,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]


### PR DESCRIPTION
Execute code cleanup to get rid of unused using statements or incorrect formatting.