### PR TITLE
docs: add nuget badge to extension documentation page

### DIFF
--- a/Docs/pages/docs/extensions/01-write-extensions.md
+++ b/Docs/pages/docs/extensions/01-write-extensions.md
@@ -1,4 +1,5 @@
 # Write your own extension
+[![Nuget](https://img.shields.io/nuget/v/aweXpect.Core?label=aweXpect.Core)](https://www.nuget.org/packages/aweXpect.Core)
 
 This library will never be able to cope with all ideas and use cases. Therefore, it is possible to use the [
 `aweXpect.Core`](https://www.nuget.org/packages/aweXpect.Core/) package and write your own extensions.


### PR DESCRIPTION
Add a nuget badge for aweXpect.Core to the [Write your own extension](https://awexpect.com/docs/extensions/write-extensions) page.