### PR TITLE
docs: fix link in README

### DIFF
--- a/Docs/pages/docs/extensions/project/Testably/_category_.json
+++ b/Docs/pages/docs/extensions/project/Testably/_category_.json
@@ -1,6 +1,6 @@
 {
 	"label": "aweXpect.Testably",
-	"position": 2,
+	"position": 3,
 	"link": {
 		"type": "doc",
 		"id": "extensions/project/Testably/index"

--- a/Docs/pages/docs/extensions/project/Web/_category_.json
+++ b/Docs/pages/docs/extensions/project/Web/_category_.json
@@ -1,6 +1,6 @@
 {
 	"label": "aweXpect.Web",
-	"position": 3,
+	"position": 2,
 	"link": {
 		"type": "doc",
 		"id": "extensions/project/Web/index"

--- a/Docs/pages/src/components/HomepageFeatures/index.tsx
+++ b/Docs/pages/src/components/HomepageFeatures/index.tsx
@@ -19,20 +19,20 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: 'Extensible',
-    Svg: require('@site/static/img/extensibility.svg').default,
-    description: (
-      <>
-        We added lots of extensibility points to allow you to build custom extensions.
-      </>
-    ),
-  },
-  {
     title: 'Performant',
     Svg: require('@site/static/img/speed.svg').default,
     description: (
       <>
         A focus on performance allows you to execute your tests as fast as possible.
+      </>
+    ),
+  },
+  {
+    title: 'Extensible',
+    Svg: require('@site/static/img/extensibility.svg').default,
+    description: (
+      <>
+        We added lots of extensibility points to allow you to build custom extensions.
       </>
     ),
   },

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ By using async assertions per default, we have a consistent API and other perks:
 	- Expectations can be combined directly (via `Expect.ThatAll`) instead of relying on global state (
 	  e.g. [assertion scopes](https://fluentassertions.com/introduction#assertion-scopes))
 
+
+### Performant
+
+A focus on performance allows you to execute your tests as fast as possible.  
+Special care is taken for the happy case (succeeding tests) to be as performant as possible. See
+the [benchmarks](https://awexpect.com/benchmarks) for more details.
+
+
 ### Extensible
 
 We added lots of extensibility points to allow you to build custom extensions.  
@@ -49,10 +57,18 @@ The [aweXpect.Core](https://www.nuget.org/packages/aweXpect.Core/) package is in
 extensions, so that the risk of version conflicts between different extensions can be reduced.
 
 You can extend the functionality for any types, by adding extension methods on `IThat<TType>`.
-More information can be found in the [extensibility guide](https://awexpect.com/docs/category/extensibility).
+More information can be found in the [extensibility guide](https://awexpect.com/docs/extensions/write-extensions).
 
-### Performant
+**Extension packages**
 
-A focus on performance allows you to execute your tests as fast as possible.  
-Special care is taken for the happy case (succeeding tests) to be as performant as possible. See
-the [benchmarks](https://awexpect.com/benchmarks) for more details.
+- [aweXpect.Json](https://github.com/aweXpect/aweXpect.Json)  
+  [![Nuget](https://img.shields.io/nuget/v/aweXpect.Json)](https://www.nuget.org/packages/aweXpect.Json)  
+  Expectations for the System.Text.Json namespace.
+
+- [aweXpect.Web](https://github.com/aweXpect/aweXpect.Web)  
+  [![Nuget](https://img.shields.io/nuget/v/aweXpect.Web)](https://www.nuget.org/packages/aweXpect.Web)  
+  Expectations for HttpClient.
+
+- [aweXpect.Testably](https://github.com/aweXpect/aweXpect.Testably)  
+  [![Nuget](https://img.shields.io/nuget/v/aweXpect.Testably)](https://www.nuget.org/packages/aweXpect.Testably)
+  Expectations for the file and time system from [Testably.Abstractions](https://github.com/Testably/Testably.Abstractions).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ extensions, so that the risk of version conflicts between different extensions c
 You can extend the functionality for any types, by adding extension methods on `IThat<TType>`.
 More information can be found in the [extensibility guide](https://awexpect.com/docs/extensions/write-extensions).
 
-**Extension packages**
+**Extension projects**
 
 - [aweXpect.Json](https://github.com/aweXpect/aweXpect.Json)  
   [![Nuget](https://img.shields.io/nuget/v/aweXpect.Json)](https://www.nuget.org/packages/aweXpect.Json)  


### PR DESCRIPTION
- Fix the link to the extensibility guide
- Add list of Extension projects
- Keep order of extenion projects and main features consistent between documentation and readme