### PR TITLE
docs: add redirects for extensions

### DIFF
--- a/Docs/pages/docusaurus.config.ts
+++ b/Docs/pages/docusaurus.config.ts
@@ -154,6 +154,27 @@ const config: Config = {
       additionalLanguages: ['csharp']
     },
   } satisfies Preset.ThemeConfig,
+  plugins:[
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            to: '/docs/extensions/project/Json/index',
+            from: '/aweXpect.Json',
+          },
+          {
+            to: '/docs/extensions/project/Web/index',
+            from: '/aweXpect.Web',
+          },
+          {
+            to: '/docs/extensions/project/Testably/index',
+            from: '/aweXpect.Testably',
+          },
+        ],
+      },
+    ],
+  ],
 };
 
 export default config;

--- a/Docs/pages/package-lock.json
+++ b/Docs/pages/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.7.0",
+        "@docusaurus/plugin-client-redirects": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -3319,6 +3320,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.7.0.tgz",
+      "integrity": "sha512-6B4XAtE5ZVKOyhPgpgMkb7LwCkN+Hgd4vOnlbwR8nCdTQhLjz8MHbGlwwvZ/cay2SPNRX5KssqKAlcHVZP2m8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/Docs/pages/package.json
+++ b/Docs/pages/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",
+    "@docusaurus/plugin-client-redirects": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",


### PR DESCRIPTION
Use [plugin-client-redirects](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects) to add redirects for extension projects:
- `/aweXpect.Json` to [/docs/extensions/project/Json/index](https://awexpect.com/docs/extensions/project/Json/index)
- `/aweXpect.Web` to [/docs/extensions/project/Web/index](https://awexpect.com/docs/extensions/project/Web/index)
- `/aweXpect.Testably` to [/docs/extensions/project/Testably/index](https://awexpect.com/docs/extensions/project/Testably/index)