### PR TITLE
fix: consider `FurtherProcessingStrategy` in `MappingNode`

### DIFF
--- a/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
@@ -105,6 +105,7 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 			{
 				left.AppendResult(stringBuilder, indentation);
 				if (right.Outcome == Outcome.Failure &&
+				    left.FurtherProcessingStrategy == FurtherProcessingStrategy.Continue &&
 				    !left.HasSameResultTextAs(right))
 				{
 					stringBuilder.Append(" and ");

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyConstraintResult.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyConstraintResult.cs
@@ -5,17 +5,32 @@ namespace aweXpect.Core.Tests.TestHelpers;
 
 public class DummyConstraintResult : ConstraintResult
 {
+	private readonly string? _expectationText;
+	private readonly string? _failureText;
+
 	public DummyConstraintResult(Outcome outcome,
-		FurtherProcessingStrategy furtherProcessingStrategy = FurtherProcessingStrategy.Continue)
+		FurtherProcessingStrategy furtherProcessingStrategy = FurtherProcessingStrategy.Continue,
+		string? expectationText = null,
+		string? failureText = null)
 		: base(outcome, furtherProcessingStrategy)
 	{
+		_expectationText = expectationText;
+		_failureText = failureText;
 	}
 
 	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
 	{
+		if (_expectationText != null)
+		{
+			stringBuilder.Append(_expectationText);
+		}
 	}
 
 	public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
 	{
+		if (_failureText != null)
+		{
+			stringBuilder.Append(_failureText);
+		}
 	}
 }


### PR DESCRIPTION
The processing strategy was not taken into account when combining two nodes in the `MappingNode`.