### PR TITLE
feat: support async mapping nodes

### DIFF
--- a/Source/aweXpect.Core/Core/MemberAccessor.cs
+++ b/Source/aweXpect.Core/Core/MemberAccessor.cs
@@ -52,9 +52,9 @@ public class MemberAccessor<TSource, TTarget> : MemberAccessor
 	/// <summary>
 	///     Creates a member accessor from the given <paramref name="func" />.
 	/// </summary>
-	public static MemberAccessor<TSource, TTarget?> FromFunc(
+	public static MemberAccessor<TSource, TTarget> FromFunc(
 		Func<TSource, TTarget> func, string name)
 		=> new(func, name);
 
-	internal TTarget? AccessMember(TSource value) => _accessor.Invoke(value);
+	internal TTarget AccessMember(TSource value) => _accessor.Invoke(value);
 }

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -30,10 +30,17 @@ internal class AndNode : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget?> memberAccessor,
+		MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
+
+	/// <inheritdoc />
+	public override Node? AddAsyncMapping<TValue, TTarget>(
+		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		where TTarget : default
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator);
 
 	public override void AddNode(Node node, string? separator = null)
 	{

--- a/Source/aweXpect.Core/Core/Nodes/AsyncMappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AsyncMappingNode.cs
@@ -50,7 +50,7 @@ internal class AsyncMappingNode<TSource, TTarget> : ExpectationNode
 				$"The member type for the actual value in the which node did not match.{Environment.NewLine}Expected: {Formatter.Format(typeof(TSource))},{Environment.NewLine}   Found: {Formatter.Format(value.GetType())}");
 		}
 
-		TTarget? matchingValue = await _memberAccessor.AccessMember(typedValue);
+		TTarget matchingValue = await _memberAccessor.AccessMember(typedValue);
 		ConstraintResult memberResult = await base.IsMetBy(matchingValue, context, cancellationToken);
 		return memberResult.UseValue(value);
 	}

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -37,11 +37,25 @@ internal class ExpectationNode : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget?> memberAccessor,
+		MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 	{
 		MappingNode<TValue, TTarget> mappingNode =
+			new(memberAccessor,
+				expectationTextGenerator);
+		_inner = mappingNode;
+		_combineResults = mappingNode.CombineResults;
+		return mappingNode;
+	}
+
+	/// <inheritdoc />
+	public override Node? AddAsyncMapping<TValue, TTarget>(
+		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		where TTarget : default
+	{
+		AsyncMappingNode<TValue, TTarget> mappingNode =
 			new(memberAccessor,
 				expectationTextGenerator);
 		_inner = mappingNode;

--- a/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
@@ -50,7 +50,7 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 				$"The member type for the actual value in the which node did not match.{Environment.NewLine}Expected: {Formatter.Format(typeof(TSource))},{Environment.NewLine}   Found: {Formatter.Format(value.GetType())}");
 		}
 
-		TTarget? matchingValue = _memberAccessor.AccessMember(typedValue);
+		TTarget matchingValue = _memberAccessor.AccessMember(typedValue);
 		ConstraintResult memberResult = await base.IsMetBy(matchingValue, context, cancellationToken);
 		return memberResult.UseValue(value);
 	}

--- a/Source/aweXpect.Core/Core/Nodes/Node.cs
+++ b/Source/aweXpect.Core/Core/Nodes/Node.cs
@@ -20,7 +20,15 @@ internal abstract class Node
 	///     and applies this value to the inner expectations.
 	/// </summary>
 	public abstract Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget?> memberAccessor,
+		MemberAccessor<TValue, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
+
+	/// <summary>
+	///     Add a mapping constraint which maps the value according to the <paramref name="memberAccessor" /> asynchronously
+	///     to a member and applies this value to the inner expectations.
+	/// </summary>
+	public abstract Node? AddAsyncMapping<TValue, TTarget>(
+		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
 
 	/// <summary>

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -30,10 +30,17 @@ internal class OrNode : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget?> memberAccessor,
+		MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
+
+	/// <inheritdoc />
+	public override Node? AddAsyncMapping<TValue, TTarget>(
+		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		where TTarget : default
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator);
 
 	public override void AddNode(Node node, string? separator = null)
 	{

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -45,10 +45,17 @@ internal class WhichNode<TSource, TMember> : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget?> memberAccessor,
+		MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator);
+
+	/// <inheritdoc />
+	public override Node? AddAsyncMapping<TValue, TTarget>(
+		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		where TTarget : default
+		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator);
 
 	/// <inheritdoc />
 	public override void AddNode(Node node, string? separator = null)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -119,7 +119,8 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
-        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
+        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForAsyncMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, System.Threading.Tasks.Task<TTarget?>> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
+        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
@@ -203,7 +204,7 @@ namespace aweXpect.Core
     public class MemberAccessor<TSource, TTarget> : aweXpect.Core.MemberAccessor
     {
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
-        public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromFunc(System.Func<TSource, TTarget> func, string name) { }
+        public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFunc(System.Func<TSource, TTarget> func, string name) { }
     }
     public sealed class StringDifference
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -119,7 +119,8 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
-        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget?> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
+        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForAsyncMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, System.Threading.Tasks.Task<TTarget?>> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
+        public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
@@ -203,7 +204,7 @@ namespace aweXpect.Core
     public class MemberAccessor<TSource, TTarget> : aweXpect.Core.MemberAccessor
     {
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
-        public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromFunc(System.Func<TSource, TTarget> func, string name) { }
+        public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFunc(System.Func<TSource, TTarget> func, string name) { }
     }
     public sealed class StringDifference
     {

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Text;
+using System.Threading;
+using aweXpect.Chronology;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.Nodes;
+using aweXpect.Core.Sources;
+using aweXpect.Core.Tests.TestHelpers;
+
+namespace aweXpect.Core.Tests.Core.Nodes;
+
+public class AsyncMappingNodeTests
+{
+	[Fact]
+	public async Task IsMetBy_ShouldUseInnerConstraintWithOuterValue()
+	{
+		AsyncMappingNode<string, int> node =
+			new(MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "));
+		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
+		StringBuilder sb = new();
+
+		ConstraintResult result = await node.IsMetBy("foobar", null!, CancellationToken.None);
+
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("yeah: 6");
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(result.TryGetValue(out string? value)).IsTrue();
+		await That(value).IsEqualTo("foobar");
+	}
+
+	[Fact]
+	public async Task IsMetBy_WithInvalidType_ShouldThrowInvalidOperationException()
+	{
+		AsyncMappingNode<string, int> node =
+			new(MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "));
+		node.AddConstraint(new DummyValueConstraint<int?>(v => new ConstraintResult.Success<int?>(v, "yeah!")));
+		async Task Act() => await node.IsMetBy(42, null!, CancellationToken.None);
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("""
+			             The member type for the actual value in the which node did not match.
+			             Expected: string,
+			                Found: int
+			             """);
+	}
+
+	[Fact]
+	public async Task IsMetBy_WithNullDelegate_ShouldReturnNullFailure()
+	{
+		DelegateValue<string?> value = new("foo", null, 10.Milliseconds(), true);
+		AsyncMappingNode<string?, int?> node =
+			new(MemberAccessor<string?, Task<int?>>.FromFunc(s => Task.FromResult(s?.Length), " length "));
+		node.AddConstraint(new DummyValueConstraint<int?>(v => new ConstraintResult.Success<int?>(v, "yeah!")));
+		StringBuilder sb = new();
+
+		ConstraintResult result = await node.IsMetBy(value, null!, CancellationToken.None);
+
+		result.AppendExpectation(sb);
+		await That(result.Outcome).IsEqualTo(Outcome.Failure);
+		await That(sb.ToString()).IsEqualTo("yeah!");
+		await That(result.GetResultText()).IsEqualTo("it was <null>");
+	}
+
+	[Fact]
+	public async Task IsMetBy_WithNullValue_ShouldReturnNullFailure()
+	{
+		AsyncMappingNode<string?, int?> node =
+			new(MemberAccessor<string?, Task<int?>>.FromFunc(s => Task.FromResult(s?.Length), " length "));
+		node.AddConstraint(new DummyValueConstraint<int?>(v => new ConstraintResult.Success<int?>(v, "yeah!")));
+		StringBuilder sb = new();
+
+		ConstraintResult result = await node.IsMetBy<string?>(null, null!, CancellationToken.None);
+
+		result.AppendExpectation(sb);
+		await That(result.Outcome).IsEqualTo(Outcome.Failure);
+		await That(sb.ToString()).IsEqualTo("yeah!");
+		await That(result.GetResultText()).IsEqualTo("it was <null>");
+	}
+}

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -21,6 +21,12 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 		where TTarget : default
 		=> throw new NotSupportedException();
 
+	public override Node? AddAsyncMapping<TValue, TTarget>(
+		MemberAccessor<TValue, Task<TTarget?>> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		where TTarget : default
+		=> throw new NotSupportedException();
+
 	public override void AddNode(Node node, string? separator = null)
 		=> throw new NotSupportedException();
 

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -16,13 +16,13 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 		=> throw new NotSupportedException();
 
 	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget?> memberAccessor,
+		MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> throw new NotSupportedException();
 
 	public override Node? AddAsyncMapping<TValue, TTarget>(
-		MemberAccessor<TValue, Task<TTarget?>> memberAccessor,
+		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TTarget : default
 		=> throw new NotSupportedException();


### PR DESCRIPTION
Allow extensions to specify an async mapping node (`AddAsyncMapping`) (e.g. for asynchronously reading the string stream in a `HttpContent`)
Also fix the nullability in the existing `AddMapping` method