### PR TITLE
feat: support `AddContext` in `MemberExpectationBuilder`

### DIFF
--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -29,18 +29,21 @@ internal class AndNode : Node
 		=> Current.AddConstraint(constraint);
 
 	/// <inheritdoc />
-	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
-		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
+		=> Current.AddMapping(memberAccessor, expectationTextGenerator, context);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
-		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator);
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, context);
 
 	public override void AddNode(Node node, string? separator = null)
 	{

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -36,14 +36,14 @@ internal class ExpectationNode : Node
 	}
 
 	/// <inheritdoc />
-	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
 	{
 		MappingNode<TValue, TTarget> mappingNode =
-			new(memberAccessor,
-				expectationTextGenerator);
+			new(memberAccessor, expectationTextGenerator, context);
 		_inner = mappingNode;
 		_combineResults = mappingNode.CombineResults;
 		return mappingNode;
@@ -52,12 +52,13 @@ internal class ExpectationNode : Node
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
 	{
 		AsyncMappingNode<TValue, TTarget> mappingNode =
-			new(memberAccessor,
-				expectationTextGenerator);
+			new(memberAccessor, expectationTextGenerator, context);
 		_inner = mappingNode;
 		_combineResults = mappingNode.CombineResults;
 		return mappingNode;

--- a/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/MappingNode.cs
@@ -16,12 +16,14 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 		_expectationTextGenerator;
 
 	private readonly MemberAccessor<TSource, TTarget> _memberAccessor;
+	private readonly Func<TSource?, Task<ConstraintResult.Context>>? _context;
 
-	public MappingNode(
-		MemberAccessor<TSource, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+	public MappingNode(MemberAccessor<TSource, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TSource?, Task<ConstraintResult.Context>>? context = null)
 	{
 		_memberAccessor = memberAccessor;
+		_context = context;
 		if (expectationTextGenerator == null)
 		{
 			_expectationTextGenerator = DefaultExpectationTextGenerator;
@@ -41,7 +43,7 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 		if (value is null || value is DelegateValue { IsNull: true })
 		{
 			ConstraintResult result = await base.IsMetBy<TTarget>(default, context, cancellationToken);
-			return result.Fail("it was <null>", value);
+			return await AddContext(result.Fail("it was <null>", value), default, _context);
 		}
 
 		if (value is not TSource typedValue)
@@ -52,7 +54,7 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 
 		TTarget matchingValue = _memberAccessor.AccessMember(typedValue);
 		ConstraintResult memberResult = await base.IsMetBy(matchingValue, context, cancellationToken);
-		return memberResult.UseValue(value);
+		return await AddContext(memberResult.UseValue(value), typedValue, _context);
 	}
 
 	internal ConstraintResult CombineResults(
@@ -65,6 +67,18 @@ internal class MappingNode<TSource, TTarget> : ExpectationNode
 		}
 
 		return new MappingConstraintResult(combinedResult, result, _expectationTextGenerator, _memberAccessor);
+	}
+
+	private static async Task<ConstraintResult> AddContext(ConstraintResult result, TSource? value,
+		Func<TSource?, Task<ConstraintResult.Context>>? context)
+	{
+		if (context is null)
+		{
+			return result;
+		}
+
+		ConstraintResult.Context? usedContext = await context(value);
+		return result.WithContext(usedContext.Title, usedContext.Content);
 	}
 
 	private static void DefaultExpectationTextGenerator(

--- a/Source/aweXpect.Core/Core/Nodes/Node.cs
+++ b/Source/aweXpect.Core/Core/Nodes/Node.cs
@@ -19,9 +19,9 @@ internal abstract class Node
 	///     Add a mapping constraint which maps the value according to the <paramref name="memberAccessor" /> to a member
 	///     and applies this value to the inner expectations.
 	/// </summary>
-	public abstract Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
+	public abstract Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null);
 
 	/// <summary>
 	///     Add a mapping constraint which maps the value according to the <paramref name="memberAccessor" /> asynchronously
@@ -29,7 +29,8 @@ internal abstract class Node
 	/// </summary>
 	public abstract Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null);
 
 	/// <summary>
 	///     Add a node as inner node.

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -29,18 +29,21 @@ internal class OrNode : Node
 		=> Current.AddConstraint(constraint);
 
 	/// <inheritdoc />
-	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
-		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
+		=> Current.AddMapping(memberAccessor, expectationTextGenerator, context);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
-		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator);
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, context);
 
 	public override void AddNode(Node node, string? separator = null)
 	{

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -44,18 +44,21 @@ internal class WhichNode<TSource, TMember> : Node
 		=> _inner?.AddConstraint(constraint);
 
 	/// <inheritdoc />
-	public override Node? AddMapping<TValue, TTarget>(
-		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
-		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator);
+		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator, context);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
-		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator);
+		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator, context);
 
 	/// <inheritdoc />
 	public override void AddNode(Node node, string? separator = null)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -128,6 +128,7 @@ namespace aweXpect.Core
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
         {
+            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContext(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context>> context) { }
             public aweXpect.Core.ExpectationBuilder AddExpectations(System.Action<aweXpect.Core.ExpectationBuilder> expectation, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> Validate(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TSource>> constraintBuilder) { }
         }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -128,6 +128,7 @@ namespace aweXpect.Core
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
         {
+            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContext(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context>> context) { }
             public aweXpect.Core.ExpectationBuilder AddExpectations(System.Action<aweXpect.Core.ExpectationBuilder> expectation, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> Validate(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TSource>> constraintBuilder) { }
         }

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
@@ -82,7 +82,7 @@ public class AsyncMappingNodeTests
 		AsyncMappingNode<string, int> node = new(
 			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "),
 			null,
-			s => Task.FromResult(new ConstraintResult.Context("context", s)));
+			s => Task.FromResult(new ConstraintResult.Context("context", s!)));
 		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
 		StringBuilder sb = new();
 

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
@@ -75,4 +75,21 @@ public class AsyncMappingNodeTests
 		await That(sb.ToString()).IsEqualTo("yeah!");
 		await That(result.GetResultText()).IsEqualTo("it was <null>");
 	}
+
+	[Fact]
+	public async Task WithContext_ShouldAddContext()
+	{
+		AsyncMappingNode<string, int> node = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "),
+			null,
+			s => Task.FromResult(new ConstraintResult.Context("context", s)));
+		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
+		StringBuilder sb = new();
+
+		ConstraintResult result = await node.IsMetBy("foobar", null!, CancellationToken.None);
+
+		result.AppendExpectation(sb);
+		await That(sb.ToString()).IsEqualTo("yeah: 6");
+		await That(result.GetContexts()).Contains(x => x is { Title: "context", Content: "foobar", });
+	}
 }

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
@@ -77,7 +77,7 @@ public class MappingNodeTests
 	{
 		MappingNode<string, int> node = new(MemberAccessor<string, int>.FromFunc(s => s.Length, " length "),
 			null,
-			s => Task.FromResult(new ConstraintResult.Context("context", s)));
+			s => Task.FromResult(new ConstraintResult.Context("context", s!)));
 		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
 		StringBuilder sb = new();
 

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -124,7 +124,8 @@ public sealed class WhichNodeTests
 		DummyNode node1 = new("", () => new ConstraintResult.Success<string?>("1", ""));
 		WhichNode<string, int> whichNode = new(node1, s => s.Length);
 		whichNode.AddNode(new ExpectationNode());
-		whichNode.AddMapping(MemberAccessor<int, int>.FromFunc(i => 2 * i, "doubled:"));
+		whichNode.AddMapping(MemberAccessor<int, int>.FromFunc(i => 2 * i, "doubled:"),
+			context: i => Task.FromResult(new ConstraintResult.Context("context", i.ToString())));
 		whichNode.AddConstraint(new DummyConstraint("c2", () => new ConstraintResult.Success<int>(4, "e2")));
 		StringBuilder sb = new();
 
@@ -133,6 +134,7 @@ public sealed class WhichNodeTests
 		result.AppendExpectation(sb);
 		await That(result.Outcome).IsEqualTo(Outcome.Success);
 		await That(sb.ToString()).IsEqualTo("doubled:e2");
+		await That(result.GetContexts()).Contains(x => x is { Title: "context", Content: "3", });
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -17,13 +17,17 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
 		=> throw new NotSupportedException();
 
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
+		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		where TValue : default
 		where TTarget : default
 		=> throw new NotSupportedException();
 


### PR DESCRIPTION
Allow specifying a context in the `MemberExpectationBuilder` that is applied to the generated result.