### PR TITLE
feat: add `CompliesWith` as generic expectation

### DIFF
--- a/Source/aweXpect/That/ThatGeneric.CompliesWith.cs
+++ b/Source/aweXpect/That/ThatGeneric.CompliesWith.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatGeneric
+{
+	/// <summary>
+	///     Verifies that the actual value complies with the <paramref name="expectations" />.
+	/// </summary>
+	public static AndOrResult<T, IThat<T>> CompliesWith<T>(this IThat<T> source,
+		Action<IThat<T>> expectations)
+		=> new(source.ThatIs().ExpectationBuilder
+				.AddConstraint((it, grammar) =>
+					new ComplyWithConstraint<T>(it, expectations)),
+			source);
+
+	private readonly struct ComplyWithConstraint<T> : IAsyncContextConstraint<T>
+	{
+		private readonly string _it;
+		private readonly ManualExpectationBuilder<T> _itemExpectationBuilder;
+
+		public ComplyWithConstraint(string it,
+			Action<IThat<T>> expectations)
+		{
+			_it = it;
+			_itemExpectationBuilder = new ManualExpectationBuilder<T>();
+			expectations.Invoke(new ThatSubject<T>(_itemExpectationBuilder));
+		}
+
+		public async Task<ConstraintResult> IsMetBy(
+			T actual,
+			IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			ConstraintResult isMatch = await _itemExpectationBuilder.IsMetBy(actual, context, cancellationToken);
+			if (isMatch.Outcome == Outcome.Success)
+			{
+				return new ConstraintResult.Success<T>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				$"{_it} was {Formatter.Format(actual)}");
+		}
+
+		public override string ToString()
+			=> $"{_itemExpectationBuilder}";
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -319,6 +319,7 @@ namespace aweXpect
     }
     public static class ThatGeneric
     {
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> CompliesWith<T>(this aweXpect.Core.IThat<T> source, System.Action<aweXpect.Core.IThat<T>> expectations) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> DoesNotSatisfy<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> For<T, TMember>(this aweXpect.Core.IThat<T> source, System.Linq.Expressions.Expression<System.Func<T, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> Satisfies<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -228,6 +228,7 @@ namespace aweXpect
     }
     public static class ThatGeneric
     {
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> CompliesWith<T>(this aweXpect.Core.IThat<T> source, System.Action<aweXpect.Core.IThat<T>> expectations) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> DoesNotSatisfy<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> For<T, TMember>(this aweXpect.Core.IThat<T> source, System.Linq.Expressions.Expression<System.Func<T, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> Satisfies<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Tests/ThatGeneric.CompliesWith.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.CompliesWith.Tests.cs
@@ -1,0 +1,40 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatGeneric
+{
+	public sealed class CompliesWith
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData(1, true)]
+			[InlineData(2, false)]
+			public async Task WhenValueIsDifferent_ShouldFail(int expectedValue, bool expectSuccess)
+			{
+				Other subject = new()
+				{
+					Value = 1,
+				};
+
+				async Task Act()
+					=> await That(subject).CompliesWith(x => x.IsEquivalentTo(new
+					{
+						Value = expectedValue,
+					}));
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(!expectSuccess)
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to new
+					             					{
+					             						Value = expectedValue,
+					             					},
+					             but it was Other {
+					               Value = 1
+					             }
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/ThatGeneric.DoesNotSatisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.DoesNotSatisfy.Tests.cs
@@ -2,25 +2,25 @@
 
 public sealed partial class ThatGeneric
 {
-	public sealed class Satisfies
+	public sealed class DoesNotSatisfy
 	{
 		public sealed class Tests
 		{
 			[Theory]
 			[InlineData(true)]
 			[InlineData(false)]
-			public async Task ShouldFailWhenPredicateResultIsFalse(bool predicateResult)
+			public async Task ShouldFailWhenPredicateResultIsTrue(bool predicateResult)
 			{
 				Other subject = new();
 
 				async Task Act()
-					=> await That(subject).Satisfies(_ => predicateResult);
+					=> await That(subject).DoesNotSatisfy(_ => predicateResult);
 
 				await That(Act).Throws<XunitException>()
-					.OnlyIf(!predicateResult)
+					.OnlyIf(predicateResult)
 					.WithMessage("""
 					             Expected that subject
-					             satisfy _ => predicateResult,
+					             not satisfy _ => predicateResult,
 					             but it was Other {
 					               Value = 0
 					             }


### PR DESCRIPTION
Add a generic expectation `CompliesWith` that allows nesting expectations within one another.

Use case is, that you could store your expecation that you want to apply to in multiple tests in a central location and ensure that all instances "comply with" the stored expectation.