### PR TITLE
feat: trim common whitespace from expectation expressions

### DIFF
--- a/Source/aweXpect/Helpers/StringExtensions.cs
+++ b/Source/aweXpect/Helpers/StringExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 
 namespace aweXpect.Helpers;
 
@@ -25,12 +27,62 @@ internal static class StringExtensions
 
 	public static string PrependAOrAn(this string value)
 	{
-		char[] vocals = ['a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U'];
+		char[] vocals = ['a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U',];
 		if (value.Length > 0 && vocals.Contains(value[0]))
 		{
 			return $"an {value}";
 		}
 
 		return $"a {value}";
+	}
+
+	public static string TrimCommonWhiteSpace(this string value)
+	{
+		string[] lines = value.Split('\n');
+		if (lines.Length <= 1)
+		{
+			return value;
+		}
+
+		StringBuilder sb = new();
+		foreach (char c in lines[1])
+		{
+			if (char.IsWhiteSpace(c))
+			{
+				sb.Append(c);
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		string commonWhiteSpace = sb.ToString();
+
+		for (int l = 2; l < lines.Length; l++)
+		{
+			if (lines[l].StartsWith(commonWhiteSpace))
+			{
+				continue;
+			}
+
+			for (int i = 0; i < Math.Min(lines[l].Length, commonWhiteSpace.Length); i++)
+			{
+				if (lines[l][i] != commonWhiteSpace[i])
+				{
+					commonWhiteSpace = commonWhiteSpace[..i];
+					break;
+				}
+			}
+		}
+
+		sb.Clear();
+		sb.Append(lines[0]);
+		foreach (string? line in lines.Skip(1))
+		{
+			sb.Append('\n').Append(line[commonWhiteSpace.Length..]);
+		}
+
+		return sb.ToString();
 	}
 }

--- a/Source/aweXpect/Results/EventTriggerResult.cs
+++ b/Source/aweXpect/Results/EventTriggerResult.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;
+using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Recording;
 
@@ -47,7 +48,7 @@ public class EventTriggerResult<TSubject>(
 	{
 		filter.AddPredicate(
 			o => o.Length > 0 && predicate(o[0]),
-			$" with sender {doNotPopulateThisValue}");
+			$" with sender {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
 		return this;
 	}
 
@@ -65,7 +66,7 @@ public class EventTriggerResult<TSubject>(
 	{
 		filter.AddPredicate(
 			o => o.Length > 1 && o[1] is TEventArgs m && predicate(m),
-			$" with {Formatter.Format(typeof(TEventArgs))} {doNotPopulateThisValue}");
+			$" with {Formatter.Format(typeof(TEventArgs))} {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
 		return this;
 	}
 
@@ -81,7 +82,7 @@ public class EventTriggerResult<TSubject>(
 	{
 		filter.AddPredicate(
 			o => o.Any(x => x is TParameter m && predicate(m)),
-			$" with {Formatter.Format(typeof(TParameter))} parameter {doNotPopulateThisValue}");
+			$" with {Formatter.Format(typeof(TParameter))} parameter {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
 		return this;
 	}
 
@@ -98,7 +99,7 @@ public class EventTriggerResult<TSubject>(
 	{
 		filter.AddPredicate(
 			o => o.Length > position && o[position] is TParameter m && predicate(m),
-			$" with {Formatter.Format(typeof(TParameter))} parameter [{position}] {doNotPopulateThisValue}");
+			$" with {Formatter.Format(typeof(TParameter))} parameter [{position}] {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
 		return this;
 	}
 

--- a/Source/aweXpect/Results/SignalCountResult.cs
+++ b/Source/aweXpect/Results/SignalCountResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;
+using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Signaling;
 
@@ -61,7 +62,7 @@ public class SignalCountResult<TParameter, TSelf>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		options.WithPredicate(predicate, doNotPopulateThisValue);
+		options.WithPredicate(predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return (TSelf)this;
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.AreAllUnique.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.AreAllUnique.cs
@@ -62,7 +62,7 @@ public static partial class ThatAsyncEnumerable
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TMember>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new AreAllUniqueWithPredicateConstraint<TItem, TMember, TMember>(it, memberAccessor,
-					doNotPopulateThisValue,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
 			source, options
 		);
@@ -83,7 +83,7 @@ public static partial class ThatAsyncEnumerable
 		return new StringEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new AreAllUniqueWithPredicateConstraint<TItem, string, string>(it, memberAccessor,
-					doNotPopulateThisValue,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
 			source, options
 		);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
@@ -77,7 +77,7 @@ public static partial class ThatAsyncEnumerable
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new ContainConstraint<TItem>(
 					it,
-					q => $"contains item matching {doNotPopulateThisValue} {q}",
+					q => $"contains item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} {q}",
 					predicate,
 					quantifier)),
 			source,
@@ -97,7 +97,7 @@ public static partial class ThatAsyncEnumerable
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
 		return new ObjectCollectionContainResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -116,7 +116,7 @@ public static partial class ThatAsyncEnumerable
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
 		return new StringCollectionContainResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<string?, string?>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -170,7 +170,7 @@ public static partial class ThatAsyncEnumerable
 		=> new(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new NotContainConstraint<TItem>(it,
-					() => $"does not contain item matching {doNotPopulateThisValue}",
+					() => $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 					predicate)),
 			source);
 

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEquivalentTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEquivalentTo.cs
@@ -37,8 +37,8 @@ public static partial class ThatAsyncEnumerable
 						it,
 						_quantifier,
 						() => grammar == ExpectationGrammars.None
-							? $"is equivalent to {Formatter.Format(expected)}"
-							: $"are equivalent to {Formatter.Format(expected)}",
+							? $"is equivalent to {doNotPopulateThisValue.TrimCommonWhiteSpace()}"
+							: $"are equivalent to {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 						a => equalityOptions.AreConsideredEqual(a, expected),
 						"were")),
 				_subject,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Satisfy.cs
@@ -24,7 +24,7 @@ public static partial class ThatAsyncEnumerable
 					=> new CollectionConstraint<string?>(
 						it,
 						_quantifier,
-						() => $"satisfies {doNotPopulateThisValue}",
+						() => $"satisfies {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 						predicate,
 						"did")),
 				_subject);
@@ -44,7 +44,7 @@ public static partial class ThatAsyncEnumerable
 					=> new CollectionConstraint<TItem>(
 						it,
 						_quantifier,
-						() => $"satisfies {doNotPopulateThisValue}",
+						() => $"satisfies {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 						predicate,
 						"did")),
 				_subject);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.EndsWith.cs
@@ -30,7 +30,7 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new EndsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected.ToArray(),
+				new EndsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -64,7 +64,7 @@ public static partial class ThatAsyncEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new EndsWithConstraint<string?, string?>(it, doNotPopulateThisValue, expected.ToArray(),
+				new EndsWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -99,7 +99,7 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new DoesNotEndWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				new DoesNotEndWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);
@@ -135,7 +135,7 @@ public static partial class ThatAsyncEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new DoesNotEndWithConstraint<string?, string?>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				new DoesNotEndWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsContainedIn.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsContainedIn.cs
@@ -24,7 +24,7 @@ public static partial class ThatAsyncEnumerable
 		return new
 			ObjectCollectionBeContainedInResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-					new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+					new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 				source,
 				options,
 				matchOptions);
@@ -45,7 +45,7 @@ public static partial class ThatAsyncEnumerable
 		return new StringCollectionBeContainedInResult<IAsyncEnumerable<string?>,
 			IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<string?, string?>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
@@ -23,7 +23,7 @@ public static partial class ThatAsyncEnumerable
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -42,7 +42,7 @@ public static partial class ThatAsyncEnumerable
 		CollectionMatchOptions matchOptions = new();
 		return new StringCollectionMatchResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<string?, string?>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInAscendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInAscendingOrder.cs
@@ -40,7 +40,7 @@ public static partial class ThatAsyncEnumerable
 		return new CollectionOrderResult<TMember, IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new IsInOrderConstraint<TItem, TMember>(it, memberAccessor, SortOrder.Ascending, options,
-					$" for {doNotPopulateThisValue}")),
+					$" for {doNotPopulateThisValue.TrimCommonWhiteSpace()}")),
 			source,
 			options);
 	}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInDescendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInDescendingOrder.cs
@@ -43,7 +43,7 @@ public static partial class ThatAsyncEnumerable
 		return new CollectionOrderResult<TMember, IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new IsInOrderConstraint<TItem, TMember>(it, memberAccessor, SortOrder.Descending, options,
-					$" for {doNotPopulateThisValue}")),
+					$" for {doNotPopulateThisValue.TrimCommonWhiteSpace()}")),
 			source,
 			options);
 	}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.StartsWith.cs
@@ -31,7 +31,7 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new StartsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected.ToArray(),
+				new StartsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -65,7 +65,7 @@ public static partial class ThatAsyncEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new StartsWithConstraint<string?, string?>(it, doNotPopulateThisValue, expected.ToArray(),
+				new StartsWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -100,7 +100,7 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new DoesNotStartWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				new DoesNotStartWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);
@@ -136,7 +136,7 @@ public static partial class ThatAsyncEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new DoesNotStartWithConstraint<string?, string?>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				new DoesNotStartWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);

--- a/Source/aweXpect/That/Collections/ThatDictionary.AreAllUnique.cs
+++ b/Source/aweXpect/That/Collections/ThatDictionary.AreAllUnique.cs
@@ -67,7 +67,7 @@ public static partial class ThatDictionary
 		return new ObjectEqualityResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TMember>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new AllIsUniqueWithPredicateConstraint<TKey, TValue, TMember, TMember>(it, memberAccessor,
-					doNotPopulateThisValue,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
 			source, options
 		);
@@ -92,7 +92,7 @@ public static partial class ThatDictionary
 		return new StringEqualityResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new AllIsUniqueWithPredicateConstraint<TKey, TValue, string, string>(it, memberAccessor,
-					doNotPopulateThisValue,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
 			source, options
 		);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.AreAllUnique.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.AreAllUnique.cs
@@ -58,7 +58,7 @@ public static partial class ThatEnumerable
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TMember>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new OnlyHasUniqueItemsWithPredicateConstraint<TItem, TMember, TMember>(it, memberAccessor,
-					doNotPopulateThisValue,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
 			source, options
 		);
@@ -78,7 +78,7 @@ public static partial class ThatEnumerable
 		return new StringEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new OnlyHasUniqueItemsWithPredicateConstraint<TItem, string, string>(it, memberAccessor,
-					doNotPopulateThisValue,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
 			source, options
 		);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -72,7 +72,7 @@ public static partial class ThatEnumerable
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new ContainConstraint<TItem>(
 					it,
-					q => $"contains item matching {doNotPopulateThisValue} {q}",
+					q => $"contains item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} {q}",
 					predicate,
 					quantifier)),
 			source,
@@ -92,7 +92,7 @@ public static partial class ThatEnumerable
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
 		return new ObjectCollectionContainResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -110,7 +110,7 @@ public static partial class ThatEnumerable
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
 		return new StringCollectionContainResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<string?, string?>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -164,7 +164,7 @@ public static partial class ThatEnumerable
 		=> new(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new NotContainConstraint<TItem>(it,
-					() => $"does not contain item matching {doNotPopulateThisValue}",
+					() => $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 					predicate)),
 			source);
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEquivalentTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEquivalentTo.cs
@@ -36,8 +36,8 @@ public static partial class ThatEnumerable
 						it,
 						_quantifier,
 						() => grammar == ExpectationGrammars.None
-							? $"is equivalent to {Formatter.Format(expected)}"
-							: $"are equivalent to {Formatter.Format(expected)}",
+							? $"is equivalent to {doNotPopulateThisValue.TrimCommonWhiteSpace()}"
+							: $"are equivalent to {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 						a => equalityOptions.AreConsideredEqual(a, expected),
 						"were")),
 				_subject,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
@@ -25,8 +25,8 @@ public static partial class ThatEnumerable
 						_quantifier,
 						() => grammar.HasFlag(ExpectationGrammars.Nested) switch
 						{
-							true => $"satisfy {doNotPopulateThisValue}",
-							_ => $"satisfies {doNotPopulateThisValue}",
+							true => $"satisfy {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
+							_ => $"satisfies {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 						},
 						predicate,
 						"did")),
@@ -49,8 +49,8 @@ public static partial class ThatEnumerable
 						_quantifier,
 						() => grammar.HasFlag(ExpectationGrammars.Nested) switch
 						{
-							true => $"satisfy {doNotPopulateThisValue}",
-							_ => $"satisfies {doNotPopulateThisValue}",
+							true => $"satisfy {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
+							_ => $"satisfies {doNotPopulateThisValue.TrimCommonWhiteSpace()}",
 						},
 						predicate,
 						"did")),

--- a/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
@@ -27,7 +27,7 @@ public static partial class ThatEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new EndsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected.ToArray(),
+				=> new EndsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -61,7 +61,7 @@ public static partial class ThatEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new EndsWithConstraint<string?, string?>(it, doNotPopulateThisValue, expected.ToArray(),
+				=> new EndsWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -96,7 +96,7 @@ public static partial class ThatEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new NotEndsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				=> new NotEndsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);
@@ -132,7 +132,7 @@ public static partial class ThatEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new NotEndsWithConstraint<string?, string?>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				=> new NotEndsWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsContainedIn.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsContainedIn.cs
@@ -22,7 +22,7 @@ public static partial class ThatEnumerable
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.IsContainedIn);
 		return new ObjectCollectionBeContainedInResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -40,7 +40,7 @@ public static partial class ThatEnumerable
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.IsContainedIn);
 		return new StringCollectionBeContainedInResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsConstraint<string?, string?>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				new IsConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
@@ -22,7 +22,7 @@ public static partial class ThatEnumerable
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				=> new IsConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);
@@ -40,7 +40,7 @@ public static partial class ThatEnumerable
 		CollectionMatchOptions matchOptions = new();
 		return new StringCollectionMatchResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsConstraint<string?, string?>(it, doNotPopulateThisValue, expected, options, matchOptions)),
+				=> new IsConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected, options, matchOptions)),
 			source,
 			options,
 			matchOptions);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsInAscendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsInAscendingOrder.cs
@@ -40,7 +40,7 @@ public static partial class ThatEnumerable
 		return new CollectionOrderResult<TMember, IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new IsInOrderConstraint<TItem, TMember>(it, memberAccessor, SortOrder.Ascending, options,
-					$" for {doNotPopulateThisValue}")),
+					$" for {doNotPopulateThisValue.TrimCommonWhiteSpace()}")),
 			source,
 			options);
 	}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsInDescendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsInDescendingOrder.cs
@@ -40,7 +40,7 @@ public static partial class ThatEnumerable
 		return new CollectionOrderResult<TMember, IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
 				=> new IsInOrderConstraint<TItem, TMember>(it, memberAccessor, SortOrder.Descending, options,
-					$" for {doNotPopulateThisValue}")),
+					$" for {doNotPopulateThisValue.TrimCommonWhiteSpace()}")),
 			source,
 			options);
 	}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
@@ -27,7 +27,7 @@ public static partial class ThatEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new StartsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, expected.ToArray(),
+				=> new StartsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -61,7 +61,7 @@ public static partial class ThatEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new StartsWithConstraint<string?, string?>(it, doNotPopulateThisValue, expected.ToArray(),
+				=> new StartsWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected.ToArray(),
 					options)),
 			source,
 			options);
@@ -96,7 +96,7 @@ public static partial class ThatEnumerable
 		ObjectEqualityOptions<TItem> options = new();
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new NotStartsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				=> new NotStartsWithConstraint<TItem, TItem>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);
@@ -132,7 +132,7 @@ public static partial class ThatEnumerable
 		StringEqualityOptions options = new();
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new NotStartsWithConstraint<string?, string?>(it, doNotPopulateThisValue, unexpected.ToArray(),
+				=> new NotStartsWithConstraint<string?, string?>(it, doNotPopulateThisValue.TrimCommonWhiteSpace(), unexpected.ToArray(),
 					options)),
 			source,
 			options);

--- a/Source/aweXpect/That/Objects/ThatObject.IsEqualTo.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsEqualTo.cs
@@ -20,7 +20,7 @@ public static partial class ThatObject
 		ObjectEqualityOptions<object?> options = new();
 		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsEqualToConstraint<object?, object?>(it, expected, doNotPopulateThisValue, options)),
+				=> new IsEqualToConstraint<object?, object?>(it, expected, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -37,7 +37,7 @@ public static partial class ThatObject
 		ObjectEqualityOptions<T?> options = new();
 		return new ObjectEqualityResult<T?, IThat<T?>, T?>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsNullableEqualToConstraint<T>(it, expected, doNotPopulateThisValue, options)),
+				=> new IsNullableEqualToConstraint<T>(it, expected, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -54,7 +54,7 @@ public static partial class ThatObject
 		ObjectEqualityOptions<T> options = new();
 		return new ObjectEqualityResult<T, IThat<T>, T>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsEqualToConstraint<T>(it, expected, doNotPopulateThisValue, options)),
+				=> new IsEqualToConstraint<T>(it, expected, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -71,7 +71,7 @@ public static partial class ThatObject
 		ObjectEqualityOptions<object?> options = new();
 		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsNotEqualToConstraint(it, unexpected, doNotPopulateThisValue, options)),
+				=> new IsNotEqualToConstraint(it, unexpected, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -89,7 +89,7 @@ public static partial class ThatObject
 		ObjectEqualityOptions<T?> options = new();
 		return new ObjectEqualityResult<T?, IThat<T?>, T?>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsNullableNotEqualToConstraint<T>(it, unexpected, doNotPopulateThisValue, options)),
+				=> new IsNullableNotEqualToConstraint<T>(it, unexpected, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -107,7 +107,7 @@ public static partial class ThatObject
 		ObjectEqualityOptions<T> options = new();
 		return new ObjectEqualityResult<T, IThat<T>, T>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsNotEqualToConstraint<T>(it, unexpected, doNotPopulateThisValue, options)),
+				=> new IsNotEqualToConstraint<T>(it, unexpected, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -130,7 +130,7 @@ public static partial class ThatObject
 		}
 
 		public override string ToString()
-			=> options.GetExpectation(expectedExpression);
+			=> options.GetExpectation(expectedExpression.TrimCommonWhiteSpace());
 	}
 
 	private readonly struct IsEqualToConstraint<T>(

--- a/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
@@ -30,7 +30,7 @@ public static partial class ThatObject
 		equalityOptions.Equivalent(equivalencyOptions);
 		return new AndOrResult<TSubject, IThat<TSubject>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
-				=> new IsEqualToConstraint<TSubject, TExpected>(it, expected, doNotPopulateThisValue, equalityOptions)),
+				=> new IsEqualToConstraint<TSubject, TExpected>(it, expected, doNotPopulateThisValue.TrimCommonWhiteSpace(), equalityOptions)),
 			source);
 	}
 }

--- a/Source/aweXpect/That/Objects/ThatObject.IsSameAs.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsSameAs.cs
@@ -17,7 +17,7 @@ public static partial class ThatObject
 		where T : class
 		=> new(source.ThatIs().ExpectationBuilder
 				.AddConstraint((it, grammar) =>
-					new IsSameAsConstraint<T>(it, expected, doNotPopulateThisValue)),
+					new IsSameAsConstraint<T>(it, expected, doNotPopulateThisValue.TrimCommonWhiteSpace())),
 			source);
 
 	/// <summary>
@@ -29,7 +29,7 @@ public static partial class ThatObject
 		where T : class
 		=> new(source.ThatIs().ExpectationBuilder
 				.AddConstraint((it, grammar) =>
-					new IsNotSameAsConstraint<T>(it, expected, doNotPopulateThisValue)),
+					new IsNotSameAsConstraint<T>(it, expected, doNotPopulateThisValue.TrimCommonWhiteSpace())),
 			source);
 
 	private readonly struct IsSameAsConstraint<T>(

--- a/Source/aweXpect/That/ThatGeneric.Satisfies.cs
+++ b/Source/aweXpect/That/ThatGeneric.Satisfies.cs
@@ -24,7 +24,7 @@ public static partial class ThatGeneric
 		RepeatedCheckOptions options = new();
 		return new RepeatedCheckResult<T, IThat<T>>(source.ThatIs().ExpectationBuilder
 				.AddConstraint((it, grammar) =>
-					new SatisfyConstraint<T>(it, predicate, doNotPopulateThisValue, options)),
+					new SatisfyConstraint<T>(it, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace(), options)),
 			source,
 			options);
 	}
@@ -38,7 +38,7 @@ public static partial class ThatGeneric
 		string doNotPopulateThisValue = "")
 		=> new(source.ThatIs().ExpectationBuilder
 				.AddConstraint((it, grammar) =>
-					new NotSatisfyConstraint<T>(it, predicate, doNotPopulateThisValue)),
+					new NotSatisfyConstraint<T>(it, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace())),
 			source);
 
 	private readonly struct SatisfyConstraint<T>(
@@ -82,7 +82,7 @@ public static partial class ThatGeneric
 		}
 
 		public override string ToString()
-			=> $"satisfy {predicateExpression}{options}";
+			=> $"satisfy {predicateExpression.TrimCommonWhiteSpace()}{options}";
 	}
 
 	private readonly struct NotSatisfyConstraint<T>(

--- a/Tests/aweXpect.Internal.Tests/Helpers/StringExtensionsTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Helpers/StringExtensionsTests.cs
@@ -2,60 +2,158 @@
 
 namespace aweXpect.Internal.Tests.Helpers;
 
-public class StringExtensionsTests
+public sealed class StringExtensionsTests
 {
-	[Fact]
-	public async Task Indent_WhenIndentationIsEmpty_ShouldReturnInput()
+	public sealed class IndentTests
 	{
-		string input = "foo\nbar";
+		[Fact]
+		public async Task WhenIndentationIsEmpty_ShouldReturnInput()
+		{
+			string input = "foo\nbar";
 
-		string result = input.Indent("");
+			string result = input.Indent("");
 
-		await That(result).IsEqualTo(input);
+			await That(result).IsEqualTo(input);
+		}
+
+		[Fact]
+		public async Task WhenIndentationIsNotEmpty_ShouldReturnIndentedInput()
+		{
+			string input = "foo\nbar";
+			string expected = "   foo\n   bar";
+
+			string result = input.Indent("   ");
+
+			await That(result).IsEqualTo(expected);
+		}
+
+		[Fact]
+		public async Task WhenIndentFirstLineIsFalse_ShouldOnlyIndentSubsequentLines()
+		{
+			string input = "foo\nbar";
+			string expected = "foo\n   bar";
+
+			string result = input.Indent("   ", false);
+
+			await That(result).IsEqualTo(expected);
+		}
+
+		[Fact]
+		public async Task WhenNull_ShouldReturnNull()
+		{
+			string? input = null;
+
+			string? result = input.Indent();
+
+			await That(result).IsNull();
+		}
 	}
 
-	[Fact]
-	public async Task Indent_WhenIndentationIsNotEmpty_ShouldReturnIndentedInput()
+	public sealed class PrependAOrAnTests
 	{
-		string input = "foo\nbar";
-		string expected = "   foo\n   bar";
+		[Theory]
+		[InlineData("", "a ")]
+		[InlineData("apple", "an apple")]
+		[InlineData("bee", "a bee")]
+		[InlineData("Exception", "an Exception")]
+		[InlineData("NotSupportedException", "a NotSupportedException")]
+		public async Task ShouldReturnExpectedValue(string input, string expected)
+		{
+			string result = input.PrependAOrAn();
 
-		string result = input.Indent("   ");
-
-		await That(result).IsEqualTo(expected);
+			await That(result).IsEqualTo(expected);
+		}
 	}
 
-	[Fact]
-	public async Task Indent_WhenIndentFirstLineIsFalse_ShouldOnlyIndentSubsequentLines()
+	public sealed class TrimCommonWhiteSpace
 	{
-		string input = "foo\nbar";
-		string expected = "foo\n   bar";
+		[Fact]
+		public async Task WhenAnyLaterLineHasNoWhiteSpace_ShouldReturnUnchangedInput()
+		{
+			string input = """
+			               foo
+			                   bar
+			               baz
+			                  bay
+			               """;
 
-		string result = input.Indent("   ", false);
+			string result = input.TrimCommonWhiteSpace();
 
-		await That(result).IsEqualTo(expected);
-	}
+			await That(result).IsEqualTo(input);
+		}
 
-	[Fact]
-	public async Task Indent_WhenNull_ShouldReturnNull()
-	{
-		string? input = null;
+		[Fact]
+		public async Task WhenEmpty_ShouldReturnEmptyString()
+		{
+			string input = string.Empty;
 
-		string? result = input.Indent();
+			string result = input.TrimCommonWhiteSpace();
 
-		await That(result).IsNull();
-	}
+			await That(result).IsEmpty();
+		}
 
-	[Theory]
-	[InlineData("", "a ")]
-	[InlineData("apple", "an apple")]
-	[InlineData("bee", "a bee")]
-	[InlineData("Exception", "an Exception")]
-	[InlineData("NotSupportedException", "a NotSupportedException")]
-	public async Task PrependAOrAn(string input, string expected)
-	{
-		string result = input.PrependAOrAn();
+		[Fact]
+		public async Task WhenLinesHaveDifferentWhiteSpace_ShouldKeepAllWhiteSpace()
+		{
+			string input = """
+			               foo
+			                   bar
+			               	baz
+			               """;
 
-		await That(result).IsEqualTo(expected);
+			string result = input.TrimCommonWhiteSpace();
+
+			await That(result).IsEqualTo("""
+			                             foo
+			                                 bar
+			                             	baz
+			                             """);
+		}
+
+		[Fact]
+		public async Task WhenLinesHaveSomeCommonWhiteSpace_ShouldTrim()
+		{
+			string input = """
+			               foo
+			                   bar
+			                 baz
+			                  bay
+			               """;
+
+			string result = input.TrimCommonWhiteSpace();
+
+			await That(result).IsEqualTo("""
+			                             foo
+			                               bar
+			                             baz
+			                              bay
+			                             """);
+		}
+
+		[Fact]
+		public async Task WhenOnlyHasOneLine_ShouldReturnLine()
+		{
+			string input = "foo";
+
+			string result = input.TrimCommonWhiteSpace();
+
+			await That(result).IsEqualTo(input);
+		}
+
+		[Fact]
+		public async Task WhenTwoLines_ShouldTrimSecondLine()
+		{
+			string input = """
+			               foo
+			                	 bar
+			               """;
+
+			string result = input.TrimCommonWhiteSpace();
+
+			await That(result).IsEqualTo("""
+			                             foo
+			                             bar
+			                             """);
+		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
@@ -104,7 +104,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is equivalent to 42 for all items,
+						             is equivalent to constantValue for all items,
 						             but it was <null>
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
@@ -93,7 +93,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is equivalent to 42 for all items,
+						             is equivalent to constantValue for all items,
 						             but it was <null>
 						             """);
 				}

--- a/Tests/aweXpect.Tests/ThatGeneric.CompliesWith.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.CompliesWith.Tests.cs
@@ -29,9 +29,9 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             is equivalent to new
-					             					{
-					             						Value = expectedValue,
-					             					},
+					             {
+					             	Value = expectedValue,
+					             },
 					             but it was Other {
 					               Value = 1
 					             }
@@ -56,9 +56,9 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             is equivalent to new
-					             					{
-					             						HasWaitedEnough = true,
-					             					} within 0:30,
+					             {
+					             	HasWaitedEnough = true,
+					             } within 0:30,
 					             but it was MyChangingClass {
 					               HasWaitedEnough = False
 					             }
@@ -131,9 +131,9 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             is equivalent to new
-					             					{
-					             						HasWaitedEnough = true,
-					             					} within 0:00.050,
+					             {
+					             	HasWaitedEnough = true,
+					             } within 0:00.050,
 					             but it was MyChangingClass {
 					               HasWaitedEnough = False
 					             }


### PR DESCRIPTION
All expectation expressions from `CallerArgumentExpression` should trim common white-space after the first line.