### PR TITLE
feat: allow specifying multiple contexts in `MemberExpectationBuilder`

### DIFF
--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using aweXpect.Core.Helpers;
 
@@ -49,7 +50,7 @@ public static class ConstraintResultExtensions
 	///     Creates a new <see cref="ConstraintResult" /> with <paramref name="contexts" />.
 	/// </summary>
 	public static ConstraintResult WithContexts(this ConstraintResult inner,
-		params ConstraintResult.Context[] contexts)
+		params ConstraintResult.Context?[] contexts)
 		=> new ConstraintResultContextWrapper(inner, contexts);
 
 	/// <summary>
@@ -106,7 +107,7 @@ public static class ConstraintResultExtensions
 
 	private sealed class ConstraintResultContextWrapper(
 		ConstraintResult inner,
-		ConstraintResult.Context[] contexts)
+		ConstraintResult.Context?[] contexts)
 		: ConstraintResult(inner.Outcome, inner.FurtherProcessingStrategy)
 	{
 		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
@@ -117,9 +118,9 @@ public static class ConstraintResultExtensions
 
 		public override IEnumerable<Context> GetContexts()
 		{
-			foreach (Context c in contexts)
+			foreach (Context? c in contexts.Where(x => x != null))
 			{
-				yield return c;
+				yield return c!;
 			}
 
 			foreach (Context c in inner.GetContexts())

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -31,19 +31,19 @@ internal class AndNode : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddMapping(memberAccessor, expectationTextGenerator, context);
+		=> Current.AddMapping(memberAccessor, expectationTextGenerator, contexts);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, context);
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, contexts);
 
 	public override void AddNode(Node node, string? separator = null)
 	{

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -38,12 +38,12 @@ internal class ExpectationNode : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
 	{
 		MappingNode<TValue, TTarget> mappingNode =
-			new(memberAccessor, expectationTextGenerator, context);
+			new(memberAccessor, expectationTextGenerator, contexts);
 		_inner = mappingNode;
 		_combineResults = mappingNode.CombineResults;
 		return mappingNode;
@@ -53,12 +53,12 @@ internal class ExpectationNode : Node
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
 	{
 		AsyncMappingNode<TValue, TTarget> mappingNode =
-			new(memberAccessor, expectationTextGenerator, context);
+			new(memberAccessor, expectationTextGenerator, contexts);
 		_inner = mappingNode;
 		_combineResults = mappingNode.CombineResults;
 		return mappingNode;

--- a/Source/aweXpect.Core/Core/Nodes/Node.cs
+++ b/Source/aweXpect.Core/Core/Nodes/Node.cs
@@ -21,7 +21,7 @@ internal abstract class Node
 	/// </summary>
 	public abstract Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null);
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null);
 
 	/// <summary>
 	///     Add a mapping constraint which maps the value according to the <paramref name="memberAccessor" /> asynchronously
@@ -30,7 +30,7 @@ internal abstract class Node
 	public abstract Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null);
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null);
 
 	/// <summary>
 	///     Add a node as inner node.

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -31,19 +31,19 @@ internal class OrNode : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddMapping(memberAccessor, expectationTextGenerator, context);
+		=> Current.AddMapping(memberAccessor, expectationTextGenerator, contexts);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, context);
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, contexts);
 
 	public override void AddNode(Node node, string? separator = null)
 	{

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -46,19 +46,19 @@ internal class WhichNode<TSource, TMember> : Node
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
-		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator, context);
+		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator, contexts);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
-		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator, context);
+		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator, contexts);
 
 	/// <inheritdoc />
 	public override void AddNode(Node node, string? separator = null)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -68,7 +68,7 @@ namespace aweXpect.Core.Constraints
         public static aweXpect.Core.Constraints.ConstraintResult PrependExpectationText(this aweXpect.Core.Constraints.ConstraintResult inner, System.Action<System.Text.StringBuilder>? prefix) { }
         public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
         public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string content) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context[] contexts) { }
+        public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context?[] contexts) { }
     }
     public enum FurtherProcessingStrategy
     {
@@ -129,6 +129,7 @@ namespace aweXpect.Core
         public class MemberExpectationBuilder<TSource, TMember>
         {
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContext(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context>> context) { }
+            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContexts(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context?[]>> contexts) { }
             public aweXpect.Core.ExpectationBuilder AddExpectations(System.Action<aweXpect.Core.ExpectationBuilder> expectation, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> Validate(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TSource>> constraintBuilder) { }
         }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -68,7 +68,7 @@ namespace aweXpect.Core.Constraints
         public static aweXpect.Core.Constraints.ConstraintResult PrependExpectationText(this aweXpect.Core.Constraints.ConstraintResult inner, System.Action<System.Text.StringBuilder>? prefix) { }
         public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
         public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string content) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context[] contexts) { }
+        public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context?[] contexts) { }
     }
     public enum FurtherProcessingStrategy
     {
@@ -129,6 +129,7 @@ namespace aweXpect.Core
         public class MemberExpectationBuilder<TSource, TMember>
         {
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContext(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context>> context) { }
+            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContexts(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context?[]>> contexts) { }
             public aweXpect.Core.ExpectationBuilder AddExpectations(System.Action<aweXpect.Core.ExpectationBuilder> expectation, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> Validate(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TSource>> constraintBuilder) { }
         }

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
@@ -82,7 +82,9 @@ public class AsyncMappingNodeTests
 		AsyncMappingNode<string, int> node = new(
 			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "),
 			null,
-			s => Task.FromResult(new ConstraintResult.Context("context", s!)));
+			s => Task.FromResult<ConstraintResult.Context?[]>([
+				new ConstraintResult.Context("context", s!),
+			]));
 		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
 		StringBuilder sb = new();
 

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
@@ -77,7 +77,9 @@ public class MappingNodeTests
 	{
 		MappingNode<string, int> node = new(MemberAccessor<string, int>.FromFunc(s => s.Length, " length "),
 			null,
-			s => Task.FromResult(new ConstraintResult.Context("context", s!)));
+			s => Task.FromResult<ConstraintResult.Context?[]>([
+				new ConstraintResult.Context("context", s!),
+			]));
 		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
 		StringBuilder sb = new();
 

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -125,7 +125,9 @@ public sealed class WhichNodeTests
 		WhichNode<string, int> whichNode = new(node1, s => s.Length);
 		whichNode.AddNode(new ExpectationNode());
 		whichNode.AddMapping(MemberAccessor<int, int>.FromFunc(i => 2 * i, "doubled:"),
-			context: i => Task.FromResult(new ConstraintResult.Context("context", i.ToString())));
+			contexts: i => Task.FromResult<ConstraintResult.Context?[]>([
+				new ConstraintResult.Context("context", i.ToString()),
+			]));
 		whichNode.AddConstraint(new DummyConstraint("c2", () => new ConstraintResult.Success<int>(4, "e2")));
 		StringBuilder sb = new();
 

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -18,7 +18,7 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
 		=> throw new NotSupportedException();
@@ -26,7 +26,7 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
 		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context>>? context = null)
+		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
 		where TValue : default
 		where TTarget : default
 		=> throw new NotSupportedException();


### PR DESCRIPTION
Use case:
- Add "HTTP-Request" and "HTTP-Response" in aweXpect.Web