### PR TITLE
feat: Add complete string as context

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -43,8 +43,15 @@ public static class ConstraintResultExtensions
 	///     Creates a new <see cref="ConstraintResult" /> with a context with
 	///     <paramref name="title" /> and <paramref name="content" />.
 	/// </summary>
-	public static ConstraintResult WithContext(this ConstraintResult inner, string title, string content)
-		=> new ConstraintResultContextWrapper(inner, [new ConstraintResult.Context(title, content)]);
+	public static ConstraintResult WithContext(this ConstraintResult inner, string title, string? content)
+	{
+		if (content == null)
+		{
+			return inner;
+		}
+
+		return new ConstraintResultContextWrapper(inner, [new ConstraintResult.Context(title, content),]);
+	}
 
 	/// <summary>
 	///     Creates a new <see cref="ConstraintResult" /> with <paramref name="contexts" />.

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.WithMessage.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.WithMessage.cs
@@ -38,7 +38,8 @@ public partial class ThatDelegateThrows<TException>
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				options.GetExtendedFailure(it, actual?.Message, expected));
+					options.GetExtendedFailure(it, actual?.Message, expected))
+				.WithContext("Message", actual?.Message);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Exceptions/ThatException.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.cs
@@ -28,7 +28,7 @@ public static partial class ThatException
 
 			return new ConstraintResult.Failure(ToString(),
 					options.GetExtendedFailure(it, actual?.Message, expected))
-				.WithContext("Message", actual?.Message!);
+				.WithContext("Message", actual?.Message);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Exceptions/ThatException.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.cs
@@ -28,7 +28,7 @@ public static partial class ThatException
 
 			return new ConstraintResult.Failure(ToString(),
 					options.GetExtendedFailure(it, actual?.Message, expected))
-				.WithContext("Message", actual?.Message);
+				.WithContext("Message", actual?.Message!);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Exceptions/ThatException.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.cs
@@ -27,7 +27,8 @@ public static partial class ThatException
 			}
 
 			return new ConstraintResult.Failure(ToString(),
-				options.GetExtendedFailure(it, actual?.Message, expected));
+					options.GetExtendedFailure(it, actual?.Message, expected))
+				.WithContext("Message", actual?.Message);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
@@ -35,7 +35,8 @@ public static partial class ThatString
 			}
 
 			return new ConstraintResult.Failure<string?>(actual, ToString(),
-				options.GetExtendedFailure(it, actual, expected));
+					options.GetExtendedFailure(it, actual, expected))
+				.WithContext("Actual", actual);
 		}
 
 		/// <inheritdoc />

--- a/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
@@ -36,7 +36,7 @@ public static partial class ThatString
 
 			return new ConstraintResult.Failure<string?>(actual, ToString(),
 					options.GetExtendedFailure(it, actual, expected))
-				.WithContext("Actual", actual);
+				.WithContext("Actual", actual!);
 		}
 
 		/// <inheritdoc />

--- a/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
@@ -36,7 +36,7 @@ public static partial class ThatString
 
 			return new ConstraintResult.Failure<string?>(actual, ToString(),
 					options.GetExtendedFailure(it, actual, expected))
-				.WithContext("Actual", actual!);
+				.WithContext("Actual", actual);
 		}
 
 		/// <inheritdoc />

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -67,7 +67,7 @@ namespace aweXpect.Core.Constraints
         public static bool HasSameResultTextAs(this aweXpect.Core.Constraints.ConstraintResult left, aweXpect.Core.Constraints.ConstraintResult right) { }
         public static aweXpect.Core.Constraints.ConstraintResult PrependExpectationText(this aweXpect.Core.Constraints.ConstraintResult inner, System.Action<System.Text.StringBuilder>? prefix) { }
         public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string content) { }
+        public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string? content) { }
         public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context?[] contexts) { }
     }
     public enum FurtherProcessingStrategy

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -67,7 +67,7 @@ namespace aweXpect.Core.Constraints
         public static bool HasSameResultTextAs(this aweXpect.Core.Constraints.ConstraintResult left, aweXpect.Core.Constraints.ConstraintResult right) { }
         public static aweXpect.Core.Constraints.ConstraintResult PrependExpectationText(this aweXpect.Core.Constraints.ConstraintResult inner, System.Action<System.Text.StringBuilder>? prefix) { }
         public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string content) { }
+        public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string? content) { }
         public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context?[] contexts) { }
     }
     public enum FurtherProcessingStrategy

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -372,6 +372,9 @@ public sealed class WhichNodeTests
 			               "foo"
 			               "bar"
 			                ↑ (expected)
+			             
+			             Actual:
+			             foo
 			             """);
 	}
 

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.ExactMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.ExactMatchTypeTests.cs
@@ -35,7 +35,11 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo\nbar"
 				               "FOO\nBAR"
 				                ↑ (expected)
-				             """);
+				             
+				             Actual:
+				             foo
+				             bar
+				             """).IgnoringNewlineStyle();
 		}
 
 		[Fact]
@@ -55,6 +59,9 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo"
 				               "bar"
 				                ↑ (expected)
+				             
+				             Actual:
+				             foo
 				             """);
 		}
 
@@ -75,7 +82,11 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo\nbar"
 				               "\tsomething\r\nelse"
 				                ↑ (expected)
-				             """);
+				             
+				             Actual:
+				             foo
+				             bar
+				             """).IgnoringNewlineStyle();
 		}
 
 		[Fact]
@@ -96,6 +107,9 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo"
 				               "bar"
 				                ↑ (expected)
+				             
+				             Message:
+				             foo
 				             """);
 		}
 
@@ -112,6 +126,9 @@ public sealed partial class StringEqualityOptionsTests
 				             Expected that sut
 				             is equal to <null>,
 				             but it was "foo"
+				             
+				             Actual:
+				             foo
 				             """);
 		}
 

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.RegexMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.RegexMatchTypeTests.cs
@@ -35,7 +35,11 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo\nbar"
 				               "FOO\nBAR"
 				               ↑ (regex pattern)
-				             """);
+				             
+				             Actual:
+				             foo
+				             bar
+				             """).IgnoringNewlineStyle();
 		}
 
 		[Fact]
@@ -55,6 +59,9 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo"
 				               "bar"
 				               ↑ (regex pattern)
+				             
+				             Actual:
+				             foo
 				             """);
 		}
 
@@ -75,7 +82,11 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo\nbar"
 				               "\tsomething\r\nelse"
 				               ↑ (regex pattern)
-				             """);
+				             
+				             Actual:
+				             foo
+				             bar
+				             """).IgnoringNewlineStyle();
 		}
 
 		[Fact]
@@ -96,6 +107,9 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo"
 				               "bar"
 				               ↑ (regex pattern)
+				             
+				             Message:
+				             foo
 				             """);
 		}
 
@@ -123,6 +137,9 @@ public sealed partial class StringEqualityOptionsTests
 				             Expected that sut
 				             matches regex <null>,
 				             but could not compare the <null> regex with "foo"
+				             
+				             Actual:
+				             foo
 				             """);
 		}
 

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.WildcardMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.WildcardMatchTypeTests.cs
@@ -35,7 +35,11 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo\nbar"
 				               "FOO\nBAR"
 				               ↑ (wildcard pattern)
-				             """);
+				             
+				             Actual:
+				             foo
+				             bar
+				             """).IgnoringNewlineStyle();
 		}
 
 		[Fact]
@@ -55,6 +59,9 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo"
 				               "bar"
 				               ↑ (wildcard pattern)
+				             
+				             Actual:
+				             foo
 				             """);
 		}
 
@@ -75,7 +82,11 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo\nbar"
 				               "\tsomething\r\nelse"
 				               ↑ (wildcard pattern)
-				             """);
+				             
+				             Actual:
+				             foo
+				             bar
+				             """).IgnoringNewlineStyle();
 		}
 
 		[Fact]
@@ -96,6 +107,9 @@ public sealed partial class StringEqualityOptionsTests
 				               "foo"
 				               "bar"
 				               ↑ (wildcard pattern)
+				             
+				             Message:
+				             foo
 				             """);
 		}
 
@@ -112,6 +126,9 @@ public sealed partial class StringEqualityOptionsTests
 				             Expected that sut
 				             matches <null>,
 				             but could not compare the <null> wildcard pattern with "foo"
+				             
+				             Actual:
+				             foo
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKey.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKey.Tests.cs
@@ -75,6 +75,9 @@ public sealed partial class ThatDictionary
 					               "bar"
 					               "foo"
 					                ↑ (expected)
+					             
+					             Actual:
+					             bar
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerExceptionTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerExceptionTests.cs
@@ -50,6 +50,9 @@ public sealed partial class ThatDelegate
 					               "bar"
 					               "foo"
 					                ↑ (expected)
+					             
+					             Message:
+					             bar
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
@@ -135,6 +135,9 @@ public sealed partial class ThatDelegate
 						               "bar"
 						               "foo"
 						                ↑ (expected)
+						             
+						             Message:
+						             bar
 						             """);
 				}
 
@@ -157,6 +160,9 @@ public sealed partial class ThatDelegate
 						               "bar"
 						               "foo"
 						                ↑ (expected)
+						             
+						             Message:
+						             bar
 						             """);
 				}
 
@@ -194,6 +200,9 @@ public sealed partial class ThatDelegate
 						               "bar"
 						               "foo"
 						                ↑ (expected)
+						             
+						             Message:
+						             bar
 						             """);
 				}
 
@@ -397,6 +406,9 @@ public sealed partial class ThatDelegate
 						               "bar"
 						               "foo"
 						                ↑ (expected)
+						             
+						             Message:
+						             bar
 						             """);
 				}
 
@@ -420,6 +432,9 @@ public sealed partial class ThatDelegate
 						               "bar"
 						               "foo"
 						                ↑ (expected)
+						             
+						             Message:
+						             bar
 						             """);
 				}
 
@@ -443,6 +458,9 @@ public sealed partial class ThatDelegate
 						               "bar"
 						               "foo"
 						                ↑ (expected)
+						             
+						             Message:
+						             bar
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithMessageTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithMessageTests.cs
@@ -57,6 +57,9 @@ public sealed partial class ThatDelegate
 					               "FOO"
 					               "foo"
 					                ↑ (expected)
+					             
+					             Message:
+					             FOO
 					             """);
 			}
 
@@ -80,6 +83,9 @@ public sealed partial class ThatDelegate
 					               "FOO"
 					               "foo"
 					                ↑ (expected)
+					             
+					             Message:
+					             FOO
 					             """);
 			}
 
@@ -116,6 +122,9 @@ public sealed partial class ThatDelegate
 					               "actual text"
 					               "expected other text"
 					                ↑ (expected)
+					             
+					             Message:
+					             actual text
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.GenericTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.GenericTests.cs
@@ -53,6 +53,9 @@ public sealed partial class ThatException
 					               "inner"
 					               "some other message"
 					                ↑ (expected)
+					             
+					             Message:
+					             inner
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.TypeTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.TypeTests.cs
@@ -53,6 +53,9 @@ public sealed partial class ThatException
 					               "inner"
 					               "some other message"
 					                ↑ (expected)
+					             
+					             Message:
+					             inner
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInnerException.Tests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInnerException.Tests.cs
@@ -36,6 +36,9 @@ public sealed partial class ThatException
 					               "inner"
 					               "some other message"
 					                ↑ (expected)
+					             
+					             Message:
+					             inner
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasMessage.Tests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasMessage.Tests.cs
@@ -37,6 +37,9 @@ public sealed partial class ThatException
 					               "actual text"
 					               "expected other text"
 					                ↑ (expected)
+					             
+					             Message:
+					             actual text
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Tests/ExpectTests.cs
@@ -54,6 +54,9 @@ public class ExpectTests
 				                     "subject B"
 				                     "subject C"
 				                              ↑ (expected)
+				             
+				             Actual:
+				             subject C
 				             """);
 		}
 
@@ -127,6 +130,9 @@ public class ExpectTests
 				                       "subject B"
 				                       "subject C"
 				                                ↑ (expected)
+				             
+				             Actual:
+				             some unexpected value
 				             """);
 		}
 
@@ -232,6 +238,9 @@ public class ExpectTests
 				                     "subject Z"
 				                     "subject C"
 				                              ↑ (expected)
+				             
+				             Actual:
+				             subject X
 				             """);
 		}
 
@@ -289,6 +298,9 @@ public class ExpectTests
 				                       "subject Z"
 				                       "subject C"
 				                                ↑ (expected)
+				             
+				             Actual:
+				             subject X
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsRegexTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsRegexTests.cs
@@ -24,6 +24,9 @@ public sealed partial class ThatString
 					                {Formatter.Format(subject)}
 					                {Formatter.Format(pattern)}
 					                ↑ (regex pattern)
+					              
+					              Actual:
+					              some message
 					              """);
 			}
 
@@ -49,6 +52,9 @@ public sealed partial class ThatString
 					               "some message"
 					               ".*ME ME.*"
 					               ↑ (regex pattern)
+					             
+					             Actual:
+					             some message
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsWildcardTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsWildcardTests.cs
@@ -28,6 +28,9 @@ public sealed partial class ThatString
 					                {Formatter.Format(subject)}
 					                {Formatter.Format(pattern)}
 					                ↑ (wildcard pattern)
+					              
+					              Actual:
+					              some message
 					              """);
 			}
 
@@ -53,6 +56,9 @@ public sealed partial class ThatString
 					               "some message"
 					               "*ME ME*"
 					               ↑ (wildcard pattern)
+					             
+					             Actual:
+					             some message
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.Tests.cs
@@ -49,6 +49,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             is equal to <null>,
 					             but it was "some text"
+
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -66,6 +69,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             is equal to " \t some text",
 					             but it was "some text" which misses some whitespace (" \t " at the beginning)
+
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -83,6 +89,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             is equal to "some text \t ",
 					             but it was "some text" which misses some whitespace (" \t " at the end)
+
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -100,6 +109,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             is equal to "some text",
 					             but it was " \t some text" which has unexpected whitespace (" \t " at the beginning)
+
+					             Actual:
+					              	 some text
 					             """);
 			}
 
@@ -117,6 +129,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             is equal to "some text",
 					             but it was "some text \t " which has unexpected whitespace (" \t " at the end)
+
+					             Actual:
+					             some text 	 
 					             """);
 			}
 
@@ -135,6 +150,9 @@ public sealed partial class ThatString
 					             is equal to "some text with",
 					             but it was "some text without out" with a length of 21 which is longer than the expected length of 14 and has superfluous:
 					               "out out"
+
+					             Actual:
+					             some text without out
 					             """);
 			}
 
@@ -153,6 +171,9 @@ public sealed partial class ThatString
 					             is equal to "some text without out",
 					             but it was "some text with" with a length of 14 which is shorter than the expected length of 21 and misses:
 					               "out out"
+
+					             Actual:
+					             some text with
 					             """);
 			}
 
@@ -186,6 +207,9 @@ public sealed partial class ThatString
 					               "actual text"
 					               "expected other text"
 					                ↑ (expected)
+
+					             Actual:
+					             actual text
 					             """);
 			}
 		}
@@ -211,6 +235,9 @@ public sealed partial class ThatString
 					                "foo"
 					                "bar"
 					                 ↑ (expected)
+
+					              Actual:
+					              {subject}
 					              """);
 			}
 
@@ -233,6 +260,9 @@ public sealed partial class ThatString
 					                {Formatter.Format(subject.TrimStart())}
 					                {Formatter.Format(expected.TrimStart())}
 					                 ↑ (expected)
+
+					              Actual:
+					              {subject}
 					              """);
 			}
 
@@ -264,15 +294,18 @@ public sealed partial class ThatString
 					=> await That(subject).IsEqualTo(expected).IgnoringNewlineStyle();
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is equal to "foo\r\nbaz" ignoring newline style,
-					             but it was "foo\nbar" which differs on line 2 and column 3:
-					                       ↓ (actual)
-					               "foo\nbar"
-					               "foo\nbaz"
-					                       ↑ (expected)
-					             """);
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to "foo\r\nbaz" ignoring newline style,
+					              but it was "foo\nbar" which differs on line 2 and column 3:
+					                        ↓ (actual)
+					                "foo\nbar"
+					                "foo\nbaz"
+					                        ↑ (expected)
+
+					              Actual:
+					              {subject}
+					              """);
 			}
 
 			[Theory]
@@ -304,15 +337,18 @@ public sealed partial class ThatString
 					=> await That(subject).IsEqualTo(expected).IgnoringTrailingWhiteSpace();
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is equal to "foo-bar" ignoring trailing white-space,
-					             but it was "foo-boo\nbaz" which differs on line 1 and column 6:
-					                     ↓ (actual)
-					               "foo-boo\nbaz"
-					               "foo-bar"
-					                     ↑ (expected)
-					             """);
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to "foo-bar" ignoring trailing white-space,
+					              but it was "foo-boo\nbaz" which differs on line 1 and column 6:
+					                      ↓ (actual)
+					                "foo-boo\nbaz"
+					                "foo-bar"
+					                      ↑ (expected)
+
+					              Actual:
+					              {subject}
+					              """);
 			}
 
 			[Fact]
@@ -333,6 +369,9 @@ public sealed partial class ThatString
 					               "foo-boo"
 					               "foo-bar"
 					                     ↑ (expected)
+
+					             Actual:
+					             foo-boo	
 					             """);
 			}
 


### PR DESCRIPTION
When comparing strings in the failure case add the actual string as context value so that it is included in the failure message.