### PR TITLE
feat: add customization option for `DefaultCheckInterval`

### DIFF
--- a/Docs/pages/docs/expectations/advanced/01-customization.md
+++ b/Docs/pages/docs/expectations/advanced/01-customization.md
@@ -42,6 +42,9 @@ Under `Customize.aweXpect.Settings()` you have:
   - `FromCancellationToken(Func<CancellationToken> cancellationTokenFactory)`  
     This will use the returned `CancellationToken` internally and also forward it to the [delegates](/docs/expectations/delegates).
 
+- **DefaultCheckInterval**  
+  The default interval for repeatedly checking the condition on an object.
+
 - **DefaultSignalerTimeout**  
   The default timeout for the [`Signaler`](/docs/expectations/advanced/callbacks).
 

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Settings.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Settings.cs
@@ -27,6 +27,12 @@ public partial class AwexpectCustomization
 		internal SettingsCustomization(IAwexpectCustomization awexpectCustomization)
 		{
 			_awexpectCustomization = awexpectCustomization;
+			DefaultCheckInterval = new CustomizationValue<TimeSpan>(
+				() => Get().DefaultCheckInterval,
+				v => Update(p => p with
+				{
+					DefaultCheckInterval = v,
+				}));
 			DefaultSignalerTimeout = new CustomizationValue<TimeSpan>(
 				() => Get().DefaultSignalerTimeout,
 				v => Update(p => p with
@@ -46,6 +52,9 @@ public partial class AwexpectCustomization
 					TestCancellation = v,
 				}));
 		}
+
+		/// <inheritdoc cref="SettingsCustomizationValue.DefaultCheckInterval" />
+		public ICustomizationValueSetter<TimeSpan> DefaultCheckInterval { get; }
 
 		/// <inheritdoc cref="SettingsCustomizationValue.DefaultSignalerTimeout" />
 		public ICustomizationValueSetter<TimeSpan> DefaultSignalerTimeout { get; }
@@ -75,6 +84,11 @@ public partial class AwexpectCustomization
 		///     If set, applies the cancellation logic for all test.
 		/// </summary>
 		public TestCancellation? TestCancellation { get; init; }
+
+		/// <summary>
+		///     The default interval for repeatedly checking the condition on an object.
+		/// </summary>
+		public TimeSpan DefaultCheckInterval { get; init; } = TimeSpan.FromMilliseconds(100);
 
 		/// <summary>
 		///     The default timeout for the <see cref="Signaler" />.

--- a/Source/aweXpect/Options/RepeatedCheckOptions.cs
+++ b/Source/aweXpect/Options/RepeatedCheckOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using aweXpect.Customization;
 using aweXpect.Results;
 
 namespace aweXpect.Options;
@@ -13,10 +14,20 @@ public class RepeatedCheckOptions
 	/// </summary>
 	public static readonly TimeSpan DefaultInterval = TimeSpan.FromMilliseconds(100);
 
+	private ICheckInterval? _interval;
+
 	/// <summary>
 	///     The interval in which the condition should be checked.
 	/// </summary>
-	public ICheckInterval Interval { get; private set; } = new FixedCheckInterval(DefaultInterval);
+	public ICheckInterval Interval
+	{
+		get
+		{
+			_interval ??= new FixedCheckInterval(Customize.aweXpect.Settings().DefaultCheckInterval.Get());
+			return _interval;
+		}
+		private set => _interval = value;
+	}
 
 	/// <summary>
 	///     The timeout until the condition must be met.

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -297,6 +297,7 @@ namespace aweXpect.Customization
         }
         public class SettingsCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
+            public aweXpect.Customization.ICustomizationValueSetter<System.TimeSpan> DefaultCheckInterval { get; }
             public aweXpect.Customization.ICustomizationValueSetter<System.TimeSpan> DefaultSignalerTimeout { get; }
             public aweXpect.Customization.ICustomizationValueSetter<System.TimeSpan> DefaultTimeComparisonTolerance { get; }
             public aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.TestCancellation?> TestCancellation { get; }
@@ -306,6 +307,7 @@ namespace aweXpect.Customization
         public class SettingsCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
             public SettingsCustomizationValue() { }
+            public System.TimeSpan DefaultCheckInterval { get; init; }
             public System.TimeSpan DefaultSignalerTimeout { get; init; }
             public System.TimeSpan DefaultTimeComparisonTolerance { get; init; }
             public aweXpect.Customization.TestCancellation? TestCancellation { get; init; }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -297,6 +297,7 @@ namespace aweXpect.Customization
         }
         public class SettingsCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
+            public aweXpect.Customization.ICustomizationValueSetter<System.TimeSpan> DefaultCheckInterval { get; }
             public aweXpect.Customization.ICustomizationValueSetter<System.TimeSpan> DefaultSignalerTimeout { get; }
             public aweXpect.Customization.ICustomizationValueSetter<System.TimeSpan> DefaultTimeComparisonTolerance { get; }
             public aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.TestCancellation?> TestCancellation { get; }
@@ -306,6 +307,7 @@ namespace aweXpect.Customization
         public class SettingsCustomizationValue : System.IEquatable<aweXpect.Customization.AwexpectCustomization.SettingsCustomizationValue>
         {
             public SettingsCustomizationValue() { }
+            public System.TimeSpan DefaultCheckInterval { get; init; }
             public System.TimeSpan DefaultSignalerTimeout { get; init; }
             public System.TimeSpan DefaultTimeComparisonTolerance { get; init; }
             public aweXpect.Customization.TestCancellation? TestCancellation { get; init; }

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -15,7 +15,7 @@ public sealed class CustomizeSettingsTests
 #if DEBUG
 		TimeSpan timeout = 500.Milliseconds();
 #else
-		TimeSpan timeout = 5.Seconds();
+		TimeSpan timeout = 3.Seconds();
 #endif
 		List<int> list = new();
 		Stopwatch sw = new();

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -12,11 +12,7 @@ public sealed class CustomizeSettingsTests
 	[Fact]
 	public async Task DefaultCheckInterval_ShouldBeUsedInTimeComparisons()
 	{
-#if DEBUG
-		TimeSpan timeout = 500.Milliseconds();
-#else
-		TimeSpan timeout = 3.Seconds();
-#endif
+		TimeSpan timeout = 2.Seconds();
 		List<int> list = new();
 		Stopwatch sw = new();
 		sw.Start();

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using aweXpect.Chronology;
 using aweXpect.Customization;
@@ -8,6 +9,31 @@ namespace aweXpect.Core.Tests.Customization;
 
 public sealed class CustomizeSettingsTests
 {
+	[Fact]
+	public async Task DefaultCheckInterval_ShouldBeUsedInTimeComparisons()
+	{
+		List<int> list = new();
+		Stopwatch sw = new();
+		sw.Start();
+		Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
+
+		await That(list).Satisfies(l => l.Count > 0).Within(5.Seconds());
+		sw.Stop();
+		await That(sw.Elapsed).IsGreaterThanOrEqualTo(100.Milliseconds()).And.IsLessThan(1.Seconds());
+
+		using (IDisposable __ = Customize.aweXpect.Settings().DefaultCheckInterval.Set(1.Seconds()))
+		{
+			list.Clear();
+			sw.Reset();
+			sw.Start();
+			Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
+
+			await That(list).Satisfies(l => l.Count > 0).Within(5.Seconds());
+			sw.Stop();
+			await That(sw.Elapsed).IsGreaterThanOrEqualTo(1.Seconds()).And.IsLessThan(5.Seconds());
+		}
+	}
+
 	[Fact]
 	public async Task DefaultSignalerTimeout_ShouldBeUsedInSignaler()
 	{

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -12,25 +12,30 @@ public sealed class CustomizeSettingsTests
 	[Fact]
 	public async Task DefaultCheckInterval_ShouldBeUsedInTimeComparisons()
 	{
+#if DEBUG
+		TimeSpan timeout = 500.Milliseconds();
+#else
+		TimeSpan timeout = 5.Seconds();
+#endif
 		List<int> list = new();
 		Stopwatch sw = new();
 		sw.Start();
 		_ = Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
 
-		await That(list).Satisfies(l => l.Count > 0).Within(5.Seconds());
+		await That(list).Satisfies(l => l.Count > 0).Within(30.Seconds());
 		sw.Stop();
-		await That(sw.Elapsed).IsGreaterThanOrEqualTo(100.Milliseconds()).And.IsLessThan(1.Seconds());
+		await That(sw.Elapsed).IsGreaterThanOrEqualTo(100.Milliseconds()).And.IsLessThan(timeout);
 
-		using (IDisposable __ = Customize.aweXpect.Settings().DefaultCheckInterval.Set(1.Seconds()))
+		using (IDisposable __ = Customize.aweXpect.Settings().DefaultCheckInterval.Set(timeout))
 		{
 			list.Clear();
 			sw.Reset();
 			sw.Start();
 			_ = Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
 
-			await That(list).Satisfies(l => l.Count > 0).Within(5.Seconds());
+			await That(list).Satisfies(l => l.Count > 0).Within(30.Seconds());
 			sw.Stop();
-			await That(sw.Elapsed).IsGreaterThanOrEqualTo(1.Seconds()).And.IsLessThan(5.Seconds());
+			await That(sw.Elapsed).IsGreaterThanOrEqualTo(timeout).And.IsLessThan(20.Seconds());
 		}
 	}
 

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -15,7 +15,7 @@ public sealed class CustomizeSettingsTests
 		List<int> list = new();
 		Stopwatch sw = new();
 		sw.Start();
-		Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
+		_ = Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
 
 		await That(list).Satisfies(l => l.Count > 0).Within(5.Seconds());
 		sw.Stop();
@@ -26,7 +26,7 @@ public sealed class CustomizeSettingsTests
 			list.Clear();
 			sw.Reset();
 			sw.Start();
-			Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
+			_ = Task.Delay(50.Milliseconds()).ContinueWith(_ => list.Add(1));
 
 			await That(list).Satisfies(l => l.Count > 0).Within(5.Seconds());
 			sw.Stop();


### PR DESCRIPTION
- `Settings().DefaultCheckInterval`
  The default interval for repeatedly checking a condition.