### PR TITLE
feat: add customization option for `MinimumNumberOfCharactersAfterStringDifference`

### DIFF
--- a/Docs/pages/docs/expectations/advanced/01-customization.md
+++ b/Docs/pages/docs/expectations/advanced/01-customization.md
@@ -14,6 +14,9 @@ Under `Customize.aweXpect.Formatting()` you have:
 - **MaximumNumberOfCollectionItems**  
   The maximum number of displayed items in a collection.
 
+- **MinimumNumberOfCharactersAfterStringDifference**  
+  The minimum number of characters included after the first mismatch in the string difference.
+
 
 ## Json
 

--- a/Source/aweXpect.Core/Core/StringDifference.cs
+++ b/Source/aweXpect.Core/Core/StringDifference.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using aweXpect.Core.Helpers;
+using aweXpect.Customization;
 
 namespace aweXpect.Core;
 
@@ -260,9 +261,9 @@ public sealed class StringDifference(
 	/// </remarks>
 	private static int GetLengthOfPhraseToShowOrDefaultLength(string value)
 	{
-		const int defaultLength = 50;
-		const int minLength = 45;
-		const int maxLength = 60;
+		int minLength = Customize.aweXpect.Formatting().MinimumNumberOfCharactersAfterStringDifference.Get();
+		int defaultLength  = minLength + 5;
+		int maxLength = minLength + 15;
 		const int lengthOfWhitespace = 1;
 
 		int indexOfWordBoundary = value

--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Formatting.cs
@@ -28,15 +28,23 @@ public partial class AwexpectCustomization
 			_awexpectCustomization = awexpectCustomization;
 			MaximumNumberOfCollectionItems = new CustomizationValue<int>(
 				() => Get().MaximumNumberOfCollectionItems,
-				// ReSharper disable once WithExpressionModifiesAllMembers
 				v => Update(p => p with
 				{
 					MaximumNumberOfCollectionItems = v,
+				}));
+			MinimumNumberOfCharactersAfterStringDifference = new CustomizationValue<int>(
+				() => Get().MinimumNumberOfCharactersAfterStringDifference,
+				v => Update(p => p with
+				{
+					MinimumNumberOfCharactersAfterStringDifference = v,
 				}));
 		}
 
 		/// <inheritdoc cref="FormattingCustomizationValue.MaximumNumberOfCollectionItems" />
 		public ICustomizationValueSetter<int> MaximumNumberOfCollectionItems { get; }
+
+		/// <inheritdoc cref="FormattingCustomizationValue.MinimumNumberOfCharactersAfterStringDifference" />
+		public ICustomizationValueSetter<int> MinimumNumberOfCharactersAfterStringDifference { get; }
 
 		/// <inheritdoc cref="ICustomizationValueUpdater{FormattingCustomizationValue}.Get()" />
 		public FormattingCustomizationValue Get()
@@ -57,5 +65,10 @@ public partial class AwexpectCustomization
 		///     The maximum number of displayed items in a collection.
 		/// </summary>
 		public int MaximumNumberOfCollectionItems { get; init; } = 10;
+
+		/// <summary>
+		///     The minimum number of characters included after the first mismatch in the string difference.
+		/// </summary>
+		public int MinimumNumberOfCharactersAfterStringDifference { get; init; } = 45;
 	}
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -276,6 +276,7 @@ namespace aweXpect.Customization
         public class FormattingCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue>
         {
             public aweXpect.Customization.ICustomizationValueSetter<int> MaximumNumberOfCollectionItems { get; }
+            public aweXpect.Customization.ICustomizationValueSetter<int> MinimumNumberOfCharactersAfterStringDifference { get; }
             public aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue Get() { }
             public aweXpect.Customization.CustomizationLifetime Update(System.Func<aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue, aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue> update) { }
         }
@@ -283,6 +284,7 @@ namespace aweXpect.Customization
         {
             public FormattingCustomizationValue() { }
             public int MaximumNumberOfCollectionItems { get; init; }
+            public int MinimumNumberOfCharactersAfterStringDifference { get; init; }
         }
         public class ReflectionCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.ReflectionCustomizationValue>
         {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -276,6 +276,7 @@ namespace aweXpect.Customization
         public class FormattingCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue>
         {
             public aweXpect.Customization.ICustomizationValueSetter<int> MaximumNumberOfCollectionItems { get; }
+            public aweXpect.Customization.ICustomizationValueSetter<int> MinimumNumberOfCharactersAfterStringDifference { get; }
             public aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue Get() { }
             public aweXpect.Customization.CustomizationLifetime Update(System.Func<aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue, aweXpect.Customization.AwexpectCustomization.FormattingCustomizationValue> update) { }
         }
@@ -283,6 +284,7 @@ namespace aweXpect.Customization
         {
             public FormattingCustomizationValue() { }
             public int MaximumNumberOfCollectionItems { get; init; }
+            public int MinimumNumberOfCharactersAfterStringDifference { get; init; }
         }
         public class ReflectionCustomization : aweXpect.Customization.ICustomizationValueUpdater<aweXpect.Customization.AwexpectCustomization.ReflectionCustomizationValue>
         {

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeFormattingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeFormattingTests.cs
@@ -30,4 +30,45 @@ public sealed class CustomizeFormattingTests
 
 		await That(Formatter.Format(items)).IsEqualTo("[1, 2, 3, 4, 5, 6]");
 	}
+
+	[Fact]
+	public async Task MinimumNumberOfCharactersAfterStringDifference_ShouldBeUsedInStringDifference()
+	{
+		string actual =
+			"this is some text with lots of words after the first difference to verify the customization setting";
+		string expected =
+			"this is another text with lots of words after the first difference to verify the customization setting";
+
+		async Task Act() => await That(actual).IsEqualTo(expected);
+		using (IDisposable _ = Customize.aweXpect.Formatting().MinimumNumberOfCharactersAfterStringDifference.Set(3))
+		{
+			await That(Act).ThrowsException()
+				.WithMessage("""
+				             Expected that actual
+				             is equal to "this is another text with…",
+				             but it was "this is some text with lots…" which differs at index 8:
+				                        ↓ (actual)
+				               "this is some text…"
+				               "this is another…"
+				                        ↑ (expected)
+
+				             Actual:
+				             this is some text with lots of words after the first difference to verify the customization setting
+				             """);
+		}
+
+		await That(Act).ThrowsException()
+			.WithMessage("""
+			             Expected that actual
+			             is equal to "this is another text with…",
+			             but it was "this is some text with lots…" which differs at index 8:
+			                        ↓ (actual)
+			               "this is some text with lots of words after the first…"
+			               "this is another text with lots of words after the first…"
+			                        ↑ (expected)
+
+			             Actual:
+			             this is some text with lots of words after the first difference to verify the customization setting
+			             """);
+	}
 }

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -16,11 +16,11 @@ public sealed class CustomizeSettingsTests
 		ChangingClass sut2 = new();
 
 		await That(sut1).Satisfies(x => x.HasMeasuredInterval).Within(30.Seconds());
-		await That(sut1.Interval).IsGreaterThanOrEqualTo(100.Milliseconds()).And.IsLessThan(timeout);
+		await That(sut1.Interval).IsGreaterThanOrEqualTo(50.Milliseconds()).And.IsLessThan(timeout);
 		using (IDisposable __ = Customize.aweXpect.Settings().DefaultCheckInterval.Set(timeout))
 		{
 			await That(sut2).Satisfies(x => x.HasMeasuredInterval).Within(30.Seconds());
-			await That(sut2.Interval).IsGreaterThanOrEqualTo(timeout).And.IsLessThan(20.Seconds());
+			await That(sut2.Interval).IsGreaterThanOrEqualTo(timeout).Within(50.Milliseconds()).And.IsLessThan(20.Seconds());
 		}
 	}
 


### PR DESCRIPTION
- `Formatting().MinimumNumberOfCharactersAfterStringDifference` The minimum number of characters included after the first mismatch in the string difference.