### PR TITLE
feat!: move contexts to `ExpectationBuilder`

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResult.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResult.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using aweXpect.Core.Helpers;
 
@@ -42,14 +41,6 @@ public abstract class ConstraintResult
 	public abstract void AppendResult(StringBuilder stringBuilder, string? indentation = null);
 
 	/// <summary>
-	///     Gets the contexts for the result.
-	/// </summary>
-	public virtual IEnumerable<Context> GetContexts()
-	{
-		yield break;
-	}
-
-	/// <summary>
 	///     Tries to extract the <paramref name="value" /> that is stored in the constraint result.
 	/// </summary>
 	public virtual bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value)
@@ -85,38 +76,6 @@ public abstract class ConstraintResult
 		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			// Do nothing
-		}
-
-		/// <inheritdoc />
-		public override IEnumerable<Context> GetContexts()
-		{
-			yield break;
-		}
-	}
-
-	/// <summary>
-	///     A result context that is appended to a result error.
-	/// </summary>
-	public record Context(string Title, string Content)
-	{
-		/// <summary>
-		///     The comparer for contexts that only considers the title.
-		/// </summary>
-		public static IEqualityComparer<Context> Comparer { get; } = new ContextComparer();
-
-		private sealed class ContextComparer : IEqualityComparer<Context>
-		{
-			public bool Equals(Context? x, Context? y)
-			{
-				if (x is null || y is null)
-				{
-					return false;
-				}
-
-				return x.Title == y.Title;
-			}
-
-			public int GetHashCode(Context obj) => obj.Title.GetHashCode();
 		}
 	}
 

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text;
 using aweXpect.Core.Helpers;
 
@@ -40,27 +38,6 @@ public static class ConstraintResultExtensions
 		=> new ConstraintResultFailure<T>(inner, failure, value);
 
 	/// <summary>
-	///     Creates a new <see cref="ConstraintResult" /> with a context with
-	///     <paramref name="title" /> and <paramref name="content" />.
-	/// </summary>
-	public static ConstraintResult WithContext(this ConstraintResult inner, string title, string? content)
-	{
-		if (content == null)
-		{
-			return inner;
-		}
-
-		return new ConstraintResultContextWrapper(inner, [new ConstraintResult.Context(title, content),]);
-	}
-
-	/// <summary>
-	///     Creates a new <see cref="ConstraintResult" /> with <paramref name="contexts" />.
-	/// </summary>
-	public static ConstraintResult WithContexts(this ConstraintResult inner,
-		params ConstraintResult.Context?[] contexts)
-		=> new ConstraintResultContextWrapper(inner, contexts);
-
-	/// <summary>
 	///     Checks if the two <see cref="ConstraintResult" />s have the same result text.
 	/// </summary>
 	public static bool HasSameResultTextAs(this ConstraintResult left, ConstraintResult right)
@@ -96,9 +73,6 @@ public static class ConstraintResultExtensions
 		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
 			=> _inner.AppendResult(stringBuilder, indentation);
 
-		public override IEnumerable<Context> GetContexts()
-			=> _inner.GetContexts();
-
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 		{
 			if (_value is TValue typedValue)
@@ -112,34 +86,6 @@ public static class ConstraintResultExtensions
 		}
 	}
 
-	private sealed class ConstraintResultContextWrapper(
-		ConstraintResult inner,
-		ConstraintResult.Context?[] contexts)
-		: ConstraintResult(inner.Outcome, inner.FurtherProcessingStrategy)
-	{
-		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> inner.AppendExpectation(stringBuilder, indentation);
-
-		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
-			=> inner.AppendResult(stringBuilder, indentation);
-
-		public override IEnumerable<Context> GetContexts()
-		{
-			foreach (Context? c in contexts.Where(x => x != null))
-			{
-				yield return c!;
-			}
-
-			foreach (Context c in inner.GetContexts())
-			{
-				yield return c;
-			}
-		}
-
-		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
-			=> inner.TryGetValue(out value);
-	}
-
 	private sealed class ConstraintResultFailure<T>(ConstraintResult inner, string failure, T value)
 		: ConstraintResult(Outcome.Failure, inner.FurtherProcessingStrategy)
 	{
@@ -150,9 +96,6 @@ public static class ConstraintResultExtensions
 
 		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append(failure.Indent(indentation));
-
-		public override IEnumerable<Context> GetContexts()
-			=> inner.GetContexts();
 
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 		{
@@ -173,9 +116,6 @@ public static class ConstraintResultExtensions
 		Action<StringBuilder>? suffix)
 		: ConstraintResult(inner.Outcome, inner.FurtherProcessingStrategy)
 	{
-		public override IEnumerable<Context> GetContexts()
-			=> inner.GetContexts();
-
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 			=> inner.TryGetValue(out value);
 

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -30,20 +30,18 @@ internal class AndNode : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddMapping(memberAccessor, expectationTextGenerator, contexts);
+		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, contexts);
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator);
 
 	public override void AddNode(Node node, string? separator = null)
 	{
@@ -151,19 +149,6 @@ internal class AndNode : Node
 			else if (right.Outcome == Outcome.Failure)
 			{
 				right.AppendResult(stringBuilder, indentation);
-			}
-		}
-
-		public override IEnumerable<Context> GetContexts()
-		{
-			foreach (Context context in left.GetContexts())
-			{
-				yield return context;
-			}
-
-			foreach (Context context in right.GetContexts())
-			{
-				yield return context;
 			}
 		}
 

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -37,13 +37,12 @@ internal class ExpectationNode : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
 	{
 		MappingNode<TValue, TTarget> mappingNode =
-			new(memberAccessor, expectationTextGenerator, contexts);
+			new(memberAccessor, expectationTextGenerator);
 		_inner = mappingNode;
 		_combineResults = mappingNode.CombineResults;
 		return mappingNode;
@@ -52,13 +51,12 @@ internal class ExpectationNode : Node
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
 	{
 		AsyncMappingNode<TValue, TTarget> mappingNode =
-			new(memberAccessor, expectationTextGenerator, contexts);
+			new(memberAccessor, expectationTextGenerator);
 		_inner = mappingNode;
 		_combineResults = mappingNode.CombineResults;
 		return mappingNode;

--- a/Source/aweXpect.Core/Core/Nodes/Node.cs
+++ b/Source/aweXpect.Core/Core/Nodes/Node.cs
@@ -20,8 +20,7 @@ internal abstract class Node
 	///     and applies this value to the inner expectations.
 	/// </summary>
 	public abstract Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null);
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
 
 	/// <summary>
 	///     Add a mapping constraint which maps the value according to the <paramref name="memberAccessor" /> asynchronously
@@ -29,8 +28,7 @@ internal abstract class Node
 	/// </summary>
 	public abstract Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null);
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null);
 
 	/// <summary>
 	///     Add a node as inner node.

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -30,20 +30,18 @@ internal class OrNode : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddMapping(memberAccessor, expectationTextGenerator, contexts);
+		=> Current.AddMapping(memberAccessor, expectationTextGenerator);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
-		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator, contexts);
+		=> Current.AddAsyncMapping(memberAccessor, expectationTextGenerator);
 
 	public override void AddNode(Node node, string? separator = null)
 	{
@@ -146,19 +144,6 @@ internal class OrNode : Node
 			         _furtherProcessingStrategy != FurtherProcessingStrategy.IgnoreResult)
 			{
 				right.AppendResult(stringBuilder, indentation);
-			}
-		}
-
-		public override IEnumerable<Context> GetContexts()
-		{
-			foreach (Context context in left.GetContexts())
-			{
-				yield return context;
-			}
-
-			foreach (Context context in right.GetContexts())
-			{
-				yield return context;
 			}
 		}
 

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -45,20 +45,18 @@ internal class WhichNode<TSource, TMember> : Node
 
 	/// <inheritdoc />
 	public override Node? AddMapping<TValue, TTarget>(MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
-		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator, contexts);
+		=> _inner?.AddMapping(memberAccessor, expectationTextGenerator);
 
 	/// <inheritdoc />
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
-		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator, contexts);
+		=> _inner?.AddAsyncMapping(memberAccessor, expectationTextGenerator);
 
 	/// <inheritdoc />
 	public override void AddNode(Node node, string? separator = null)
@@ -165,19 +163,6 @@ internal class WhichNode<TSource, TMember> : Node
 			else if (right.Outcome == Outcome.Failure)
 			{
 				right.AppendResult(stringBuilder, indentation);
-			}
-		}
-
-		public override IEnumerable<Context> GetContexts()
-		{
-			foreach (Context context in left.GetContexts())
-			{
-				yield return context;
-			}
-
-			foreach (Context context in right.GetContexts())
-			{
-				yield return context;
 			}
 		}
 

--- a/Source/aweXpect.Core/Core/ResultContext.cs
+++ b/Source/aweXpect.Core/Core/ResultContext.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace aweXpect.Core;
+
+/// <summary>
+///     A result context that is appended to a result error.
+/// </summary>
+public class ResultContext
+{
+	private readonly Func<CancellationToken, Task<string?>>? _contentFunc;
+
+	private readonly string? _fixedContent;
+
+	/// <summary>
+	///     A result context that is appended to a result error.
+	/// </summary>
+	public ResultContext(string title, string? content)
+	{
+		Title = title;
+		_fixedContent = content;
+	}
+
+	/// <summary>
+	///     A result context that is appended to a result error.
+	/// </summary>
+	public ResultContext(string title, Func<CancellationToken, Task<string?>> asyncContent)
+	{
+		Title = title;
+		_contentFunc = asyncContent;
+	}
+
+	/// <summary>
+	///     The title of the context.
+	/// </summary>
+	public string Title { get; set; }
+
+	/// <summary>
+	///     The content of the context.
+	/// </summary>
+	public async Task<string?> GetContent(CancellationToken cancellationToken = default)
+	{
+		if (_fixedContent is not null)
+		{
+			return _fixedContent;
+		}
+
+		if (_contentFunc is not null)
+		{
+			return await _contentFunc(cancellationToken);
+		}
+
+		return null;
+	}
+}

--- a/Source/aweXpect.Core/Core/ResultContexts.cs
+++ b/Source/aweXpect.Core/Core/ResultContexts.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace aweXpect.Core;
+
+/// <summary>
+///     The list of <see cref="ResultContext" /> that is appended to the failure message.
+/// </summary>
+public class ResultContexts : IEnumerable<ResultContext>
+{
+	private readonly List<ResultContext> _results = new();
+
+	/// <inheritdoc cref="IEnumerable{ResultContext}.GetEnumerator()" />
+	public IEnumerator<ResultContext> GetEnumerator() => _results.GetEnumerator();
+
+	/// <inheritdoc cref="IEnumerable.GetEnumerator()" />
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	/// <summary>
+	///     Adds the <paramref name="context" /> to the context list.
+	/// </summary>
+	public ResultContexts Add(ResultContext context)
+	{
+		_results.Add(context);
+		return this;
+	}
+
+	/// <summary>
+	///     Removes all contexts from the context list.
+	/// </summary>
+	public ResultContexts Clear()
+	{
+		_results.Clear();
+		return this;
+	}
+
+	/// <summary>
+	///     Removes all contexts with the given <paramref name="title" />.
+	/// </summary>
+	public ResultContexts Remove(string title, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
+	{
+		_results.RemoveAll(x => x.Title.Equals(title, stringComparison));
+		return this;
+	}
+
+	/// <summary>
+	///     Removes all contexts that match the <paramref name="predicate" />.
+	/// </summary>
+	public ResultContexts Remove(Predicate<ResultContext> predicate)
+	{
+		_results.RemoveAll(predicate);
+		return this;
+	}
+}

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.WithMessage.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.WithMessage.cs
@@ -18,12 +18,13 @@ public partial class ThatDelegateThrows<TException>
 		return new StringEqualityTypeResult<TException, ThatDelegateThrows<TException>>(
 			ExpectationBuilder.AddConstraint((it, grammar)
 				=> new HasMessageValueConstraint(
-					it, "with", expected, options)),
+					ExpectationBuilder, it, "with", expected, options)),
 			this,
 			options);
 	}
 
 	internal readonly struct HasMessageValueConstraint(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		string verb,
 		string expected,
@@ -37,9 +38,10 @@ public partial class ThatDelegateThrows<TException>
 				return new ConstraintResult.Success<TException?>(actual as TException, ToString());
 			}
 
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("Message", actual?.Message)));
 			return new ConstraintResult.Failure(ToString(),
-					options.GetExtendedFailure(it, actual?.Message, expected))
-				.WithContext("Message", actual?.Message);
+					options.GetExtendedFailure(it, actual?.Message, expected));
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -75,6 +76,10 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 		=> new(++index, $" [{index:00}] Expected that {expectationBuilder.Subject}",
 			await expectationBuilder.IsMet());
 
+	/// <inheritdoc />
+	internal override IEnumerable<ResultContext> GetContexts(int index)
+		=> expectationBuilder.GetContexts();
+
 	/// <summary>
 	///     Specifies a <see cref="ITimeSystem" /> to use for the expectation.
 	/// </summary>
@@ -93,8 +98,7 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 			return;
 		}
 
-		Fail.Test(ExpectationBuilder.FromFailure(
-			expectationBuilder.Subject, result));
+		Fail.Test(await expectationBuilder.FromFailure(result));
 	}
 }
 
@@ -173,6 +177,10 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 		=> new(++index, $" [{index:00}] Expected that {expectationBuilder.Subject}",
 			await expectationBuilder.IsMet());
 
+	/// <inheritdoc />
+	internal override IEnumerable<ResultContext> GetContexts(int index)
+		=> expectationBuilder.GetContexts();
+
 	/// <summary>
 	///     Specifies a <see cref="ITimeSystem" /> to use for the expectation.
 	/// </summary>
@@ -195,7 +203,7 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 
 		if (result.Outcome == Outcome.Failure)
 		{
-			Fail.Test(ExpectationBuilder.FromFailure(expectationBuilder.Subject, result));
+			Fail.Test(await expectationBuilder.FromFailure(result));
 		}
 
 		throw new FailException(

--- a/Source/aweXpect/That/Exceptions/ThatException.HasMessage.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.HasMessage.cs
@@ -17,9 +17,9 @@ public static partial class ThatException
 	{
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<Exception?, IThat<Exception?>>(
-			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar)
+			source.ThatIs().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammar)
 				=> new HasMessageValueConstraint<Exception>(
-					it, grammar, expected, options)),
+					expectationBuilder, it, grammar, expected, options)),
 			source,
 			options);
 	}

--- a/Source/aweXpect/That/Exceptions/ThatException.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.cs
@@ -12,6 +12,7 @@ namespace aweXpect;
 public static partial class ThatException
 {
 	private readonly struct HasMessageValueConstraint<TException>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammar,
 		string expected,
@@ -26,9 +27,10 @@ public static partial class ThatException
 				return new ConstraintResult.Success<TException?>(actual as TException, ToString());
 			}
 
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("Message", actual?.Message)));
 			return new ConstraintResult.Failure(ToString(),
-					options.GetExtendedFailure(it, actual?.Message, expected))
-				.WithContext("Message", actual?.Message);
+					options.GetExtendedFailure(it, actual?.Message, expected));
 		}
 
 		public override string ToString()

--- a/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
@@ -17,13 +17,17 @@ public static partial class ThatString
 	{
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<string?, IThat<string?>>(
-			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
-				new IsEqualToConstraint(it, expected, options)),
+			source.ThatIs().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammar) =>
+				new IsEqualToConstraint(expectationBuilder, it, expected, options)),
 			source,
 			options);
 	}
 
-	private readonly struct IsEqualToConstraint(string it, string? expected, StringEqualityOptions options)
+	private readonly struct IsEqualToConstraint(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		string? expected,
+		StringEqualityOptions options)
 		: IValueConstraint<string?>
 	{
 		/// <inheritdoc />
@@ -34,9 +38,10 @@ public static partial class ThatString
 				return new ConstraintResult.Success<string?>(actual, ToString());
 			}
 
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("Actual", actual)));
 			return new ConstraintResult.Failure<string?>(actual, ToString(),
-					options.GetExtendedFailure(it, actual, expected))
-				.WithContext("Actual", actual);
+					options.GetExtendedFailure(it, actual, expected));
 		}
 
 		/// <inheritdoc />

--- a/Tests/aweXpect.Core.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Core.Api.Tests/ApiApprovalTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Threading.Tasks;
+using aweXpect.Customization;
 using NUnit.Framework;
 
 namespace aweXpect.Core.Api.Tests;
@@ -9,8 +11,13 @@ namespace aweXpect.Core.Api.Tests;
 ///     If the change was intentional, execute the <see cref="ApiAcceptance.AcceptApiChanges()" /> test to take over the
 ///     current public API surface. The changes will become part of the pull request and will be reviewed accordingly.
 /// </summary>
-public sealed class ApiApprovalTests
+public sealed class ApiApprovalTests : IDisposable
 {
+	private readonly CustomizationLifetime _settings = Customize.aweXpect
+		.Formatting().MinimumNumberOfCharactersAfterStringDifference.Set(200);
+
+	public void Dispose() => _settings.Dispose();
+
 	[TestCaseSource(typeof(TargetFrameworksTheoryData))]
 	public async Task VerifyPublicApiForAweXpectCore(string framework)
 	{

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -21,15 +21,7 @@ namespace aweXpect.Core.Constraints
         public aweXpect.Core.Constraints.Outcome Outcome { get; }
         public abstract void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null);
         public abstract void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null);
-        public virtual System.Collections.Generic.IEnumerable<aweXpect.Core.Constraints.ConstraintResult.Context> GetContexts() { }
         public virtual bool TryGetValue<TValue>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue? value) { }
-        public class Context : System.IEquatable<aweXpect.Core.Constraints.ConstraintResult.Context>
-        {
-            public Context(string Title, string Content) { }
-            public string Content { get; init; }
-            public string Title { get; init; }
-            public static System.Collections.Generic.IEqualityComparer<aweXpect.Core.Constraints.ConstraintResult.Context> Comparer { get; }
-        }
         public class Failure : aweXpect.Core.Constraints.ConstraintResult.TextBasedConstraintResult
         {
             public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
@@ -57,7 +49,6 @@ namespace aweXpect.Core.Constraints
             protected TextBasedConstraintResult(aweXpect.Core.Constraints.Outcome outcome, string expectationText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy) { }
             public override void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
             public override void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
-            public override System.Collections.Generic.IEnumerable<aweXpect.Core.Constraints.ConstraintResult.Context> GetContexts() { }
         }
     }
     public static class ConstraintResultExtensions
@@ -67,8 +58,6 @@ namespace aweXpect.Core.Constraints
         public static bool HasSameResultTextAs(this aweXpect.Core.Constraints.ConstraintResult left, aweXpect.Core.Constraints.ConstraintResult right) { }
         public static aweXpect.Core.Constraints.ConstraintResult PrependExpectationText(this aweXpect.Core.Constraints.ConstraintResult inner, System.Action<System.Text.StringBuilder>? prefix) { }
         public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string? content) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context?[] contexts) { }
     }
     public enum FurtherProcessingStrategy
     {
@@ -118,18 +107,21 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IAsyncContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IAsyncConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IAsyncContextConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForAsyncMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, System.Threading.Tasks.Task<TTarget?>> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
+        public void UpdateContexts(System.Action<System.Collections.Generic.List<aweXpect.Core.ResultContext>> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
         {
-            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContext(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context>> context) { }
-            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContexts(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context?[]>> contexts) { }
             public aweXpect.Core.ExpectationBuilder AddExpectations(System.Action<aweXpect.Core.ExpectationBuilder> expectation, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> Validate(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TSource>> constraintBuilder) { }
         }
@@ -207,6 +199,13 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
         public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFunc(System.Func<TSource, TTarget> func, string name) { }
+    }
+    public class ResultContext
+    {
+        public ResultContext(string title, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string?>> asyncContent) { }
+        public ResultContext(string title, string? content) { }
+        public string Title { get; set; }
+        public System.Threading.Tasks.Task<string?> GetContent(System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class StringDifference
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -117,7 +117,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
-        public void UpdateContexts(System.Action<System.Collections.Generic.List<aweXpect.Core.ResultContext>> callback) { }
+        public void UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
@@ -206,6 +206,15 @@ namespace aweXpect.Core
         public ResultContext(string title, string? content) { }
         public string Title { get; set; }
         public System.Threading.Tasks.Task<string?> GetContent(System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public class ResultContexts : System.Collections.Generic.IEnumerable<aweXpect.Core.ResultContext>, System.Collections.IEnumerable
+    {
+        public ResultContexts() { }
+        public aweXpect.Core.ResultContexts Add(aweXpect.Core.ResultContext context) { }
+        public aweXpect.Core.ResultContexts Clear() { }
+        public System.Collections.Generic.IEnumerator<aweXpect.Core.ResultContext> GetEnumerator() { }
+        public aweXpect.Core.ResultContexts Remove(System.Predicate<aweXpect.Core.ResultContext> predicate) { }
+        public aweXpect.Core.ResultContexts Remove(string title, System.StringComparison stringComparison = 5) { }
     }
     public sealed class StringDifference
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -21,15 +21,7 @@ namespace aweXpect.Core.Constraints
         public aweXpect.Core.Constraints.Outcome Outcome { get; }
         public abstract void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null);
         public abstract void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null);
-        public virtual System.Collections.Generic.IEnumerable<aweXpect.Core.Constraints.ConstraintResult.Context> GetContexts() { }
         public virtual bool TryGetValue<TValue>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TValue? value) { }
-        public class Context : System.IEquatable<aweXpect.Core.Constraints.ConstraintResult.Context>
-        {
-            public Context(string Title, string Content) { }
-            public string Content { get; init; }
-            public string Title { get; init; }
-            public static System.Collections.Generic.IEqualityComparer<aweXpect.Core.Constraints.ConstraintResult.Context> Comparer { get; }
-        }
         public class Failure : aweXpect.Core.Constraints.ConstraintResult.TextBasedConstraintResult
         {
             public Failure(string expectationText, string resultText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy = 0) { }
@@ -57,7 +49,6 @@ namespace aweXpect.Core.Constraints
             protected TextBasedConstraintResult(aweXpect.Core.Constraints.Outcome outcome, string expectationText, aweXpect.Core.Constraints.FurtherProcessingStrategy furtherProcessingStrategy) { }
             public override void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
             public override void AppendResult(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
-            public override System.Collections.Generic.IEnumerable<aweXpect.Core.Constraints.ConstraintResult.Context> GetContexts() { }
         }
     }
     public static class ConstraintResultExtensions
@@ -67,8 +58,6 @@ namespace aweXpect.Core.Constraints
         public static bool HasSameResultTextAs(this aweXpect.Core.Constraints.ConstraintResult left, aweXpect.Core.Constraints.ConstraintResult right) { }
         public static aweXpect.Core.Constraints.ConstraintResult PrependExpectationText(this aweXpect.Core.Constraints.ConstraintResult inner, System.Action<System.Text.StringBuilder>? prefix) { }
         public static aweXpect.Core.Constraints.ConstraintResult UseValue<T>(this aweXpect.Core.Constraints.ConstraintResult inner, T value) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContext(this aweXpect.Core.Constraints.ConstraintResult inner, string title, string? content) { }
-        public static aweXpect.Core.Constraints.ConstraintResult WithContexts(this aweXpect.Core.Constraints.ConstraintResult inner, params aweXpect.Core.Constraints.ConstraintResult.Context?[] contexts) { }
     }
     public enum FurtherProcessingStrategy
     {
@@ -118,18 +107,21 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IAsyncContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IAsyncConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IAsyncContextConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IContextConstraint<TValue>> constraintBuilder) { }
+        public aweXpect.Core.ExpectationBuilder AddConstraint<TValue>(System.Func<aweXpect.Core.ExpectationBuilder, string, aweXpect.Core.ExpectationGrammars, aweXpect.Core.Constraints.IValueConstraint<TValue>> constraintBuilder) { }
         public aweXpect.Core.ExpectationBuilder And(string textSeparator = " and ") { }
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForAsyncMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, System.Threading.Tasks.Task<TTarget?>> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
+        public void UpdateContexts(System.Action<System.Collections.Generic.List<aweXpect.Core.ResultContext>> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
         {
-            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContext(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context>> context) { }
-            public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> AddContexts(System.Func<TSource?, System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult.Context?[]>> contexts) { }
             public aweXpect.Core.ExpectationBuilder AddExpectations(System.Action<aweXpect.Core.ExpectationBuilder> expectation, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
             public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TMember> Validate(System.Func<string, aweXpect.Core.Constraints.IValueConstraint<TSource>> constraintBuilder) { }
         }
@@ -207,6 +199,13 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
         public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFunc(System.Func<TSource, TTarget> func, string name) { }
+    }
+    public class ResultContext
+    {
+        public ResultContext(string title, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string?>> asyncContent) { }
+        public ResultContext(string title, string? content) { }
+        public string Title { get; set; }
+        public System.Threading.Tasks.Task<string?> GetContent(System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class StringDifference
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -117,7 +117,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
-        public void UpdateContexts(System.Action<System.Collections.Generic.List<aweXpect.Core.ResultContext>> callback) { }
+        public void UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
@@ -206,6 +206,15 @@ namespace aweXpect.Core
         public ResultContext(string title, string? content) { }
         public string Title { get; set; }
         public System.Threading.Tasks.Task<string?> GetContent(System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public class ResultContexts : System.Collections.Generic.IEnumerable<aweXpect.Core.ResultContext>, System.Collections.IEnumerable
+    {
+        public ResultContexts() { }
+        public aweXpect.Core.ResultContexts Add(aweXpect.Core.ResultContext context) { }
+        public aweXpect.Core.ResultContexts Clear() { }
+        public System.Collections.Generic.IEnumerator<aweXpect.Core.ResultContext> GetEnumerator() { }
+        public aweXpect.Core.ResultContexts Remove(System.Predicate<aweXpect.Core.ResultContext> predicate) { }
+        public aweXpect.Core.ResultContexts Remove(string title, System.StringComparison stringComparison = 5) { }
     }
     public sealed class StringDifference
     {

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultExtensionsTests.cs
@@ -88,33 +88,6 @@ public sealed class ConstraintResultExtensionsTests
 		}
 	}
 
-	public sealed class WithContextTests
-	{
-		[Fact]
-		public async Task NestedContexts_ShouldIncludeBoth()
-		{
-			ConstraintResult sut = new ConstraintResult.Failure<string>("value", "foo", "bar");
-			sut = sut.WithContext("t1", "c1");
-			sut = sut.WithContext("t2", "c2");
-
-			List<ConstraintResult.Context> result = sut.GetContexts().ToList();
-
-			await That(result).HasCount().EqualTo(2);
-		}
-
-		[Fact]
-		public async Task TryGetValue_ShouldForwardToWrappedConstraintResult()
-		{
-			ConstraintResult sut = new ConstraintResult.Failure<string>("value1", "foo", "bar");
-			sut = sut.WithContext("t1", "c1");
-
-			bool result = sut.TryGetValue(out string? value);
-
-			await That(result).IsTrue();
-			await That(value).IsEqualTo("value1");
-		}
-	}
-
 	public sealed class AppendExpectationTextTests
 	{
 		[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.cs
@@ -8,47 +8,6 @@ namespace aweXpect.Core.Tests.Core.Constraints;
 public class ConstraintResultTests
 {
 	[Fact]
-	public async Task Context_Comparer_WhenItem1IsNull_ShouldReturnFalse()
-	{
-		ConstraintResult.Context context = new("foo", "baz");
-
-		bool result = ConstraintResult.Context.Comparer.Equals(null!, context);
-
-		await That(result).IsFalse();
-	}
-
-	[Fact]
-	public async Task Context_Comparer_WhenItem2IsNull_ShouldReturnFalse()
-	{
-		ConstraintResult.Context context = new("foo", "baz");
-
-		bool result = ConstraintResult.Context.Comparer.Equals(context, null!);
-
-		await That(result).IsFalse();
-	}
-
-	[Fact]
-	public async Task Context_Comparer_WhenTitleIsEqual_ShouldReturnTrue()
-	{
-		ConstraintResult.Context context1 = new("foo", "bar");
-		ConstraintResult.Context context2 = new("foo", "baz");
-
-		bool result = ConstraintResult.Context.Comparer.Equals(context1, context2);
-
-		await That(result).IsTrue();
-	}
-
-	[Fact]
-	public async Task Failure_GetContexts_ShouldBeEmpty()
-	{
-		ConstraintResult.Failure<int> sut = new(1, "foo", "bar");
-
-		List<ConstraintResult.Context> contexts = sut.GetContexts().ToList();
-
-		await That(contexts).IsEmpty();
-	}
-
-	[Fact]
 	public async Task Failure_ShouldHaveFailureOutcome()
 	{
 		ConstraintResult.Failure<int> sut = new(1, "foo", "bar");
@@ -98,16 +57,6 @@ public class ConstraintResultTests
 		sut.AppendResult(sb);
 
 		await That(sb.ToString()).IsEmpty();
-	}
-
-	[Fact]
-	public async Task Success_GetContexts_ShouldBeEmpty()
-	{
-		ConstraintResult.Success<int> sut = new(1, "foo");
-
-		List<ConstraintResult.Context> contexts = sut.GetContexts().ToList();
-
-		await That(contexts).IsEmpty();
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
@@ -8,6 +8,73 @@ namespace aweXpect.Core.Tests.Core;
 public class ManualExpectationBuilderTests
 {
 	[Fact]
+	public async Task AddAsyncContextValueConstraint_ShouldAllowGettingExpectationBuilder()
+	{
+		ManualExpectationBuilder<int> sut = new();
+		ExpectationBuilder? expectationBuilder = null;
+		sut.AddConstraint((e, _, _) =>
+		{
+			expectationBuilder = e;
+			return new DummyAsyncContextConstraint<int>(_
+				=> Task.FromResult<ConstraintResult>(new ConstraintResult.Success("")));
+		});
+
+		await sut.IsMetBy(1, null!, CancellationToken.None);
+
+		await That(expectationBuilder).IsSameAs(sut);
+	}
+
+	[Fact]
+	public async Task AddAsyncValueConstraint_ShouldAllowGettingExpectationBuilder()
+	{
+		ManualExpectationBuilder<int> sut = new();
+		ExpectationBuilder? expectationBuilder = null;
+		sut.AddConstraint((e, _, _) =>
+		{
+			expectationBuilder = e;
+			return new DummyAsyncConstraint<int>(_
+				=> Task.FromResult<ConstraintResult>(new ConstraintResult.Success("")));
+		});
+
+		await sut.IsMetBy(1, null!, CancellationToken.None);
+
+		await That(expectationBuilder).IsSameAs(sut);
+	}
+
+	[Fact]
+	public async Task AddContextValueConstraint_ShouldAllowGettingExpectationBuilder()
+	{
+		ManualExpectationBuilder<int> sut = new();
+		ExpectationBuilder? expectationBuilder = null;
+		sut.AddConstraint((e, _, _) =>
+		{
+			expectationBuilder = e;
+			return new DummyContextConstraint<int>(_ => new ConstraintResult.Success(""));
+		});
+
+		await sut.IsMetBy(1, null!, CancellationToken.None);
+
+		await That(expectationBuilder).IsSameAs(sut);
+	}
+
+	[Fact]
+	public async Task AddValueConstraint_ShouldAllowGettingExpectationBuilder()
+	{
+		ManualExpectationBuilder<int> sut = new();
+		ExpectationBuilder? expectationBuilder = null;
+		sut.AddConstraint((e, _, _) =>
+		{
+			expectationBuilder = e;
+			return new DummyConstraint("");
+		});
+
+		await sut.IsMetBy(1, null!, CancellationToken.None);
+
+		await That(expectationBuilder).IsSameAs(sut);
+	}
+
+
+	[Fact]
 	public async Task IsMet_ShouldThrowNotSupportedException()
 	{
 		ManualExpectationBuilder<int> sut = new();

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AndNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AndNodeTests.cs
@@ -10,25 +10,6 @@ namespace aweXpect.Core.Tests.Core.Nodes;
 
 public sealed class AndNodeTests
 {
-	[Fact]
-	public async Task GetContexts_ShouldIncludeContextsFromLeftAndRight()
-	{
-		DummyNode node1 = new("", () => new ConstraintResult.Success("").WithContext("t1", "c1"));
-		DummyNode node2 = new("", () => new ConstraintResult.Success("").WithContext("t2", "c2"));
-		AndNode andNode = new(node1);
-		andNode.AddNode(node2);
-		ConstraintResult constraintResult = await andNode.IsMetBy(0, null!, CancellationToken.None);
-
-		List<ConstraintResult.Context> contexts = constraintResult.GetContexts().ToList();
-
-		await That(contexts)
-			.IsEqualTo([
-				new ConstraintResult.Context("t1", "c1"),
-				new ConstraintResult.Context("t2", "c2"),
-			])
-			.InAnyOrder();
-	}
-
 	[Theory]
 	[InlineData(Outcome.Success, Outcome.Success, Outcome.Success)]
 	[InlineData(Outcome.Failure, Outcome.Success, Outcome.Failure)]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
@@ -75,23 +75,4 @@ public class AsyncMappingNodeTests
 		await That(sb.ToString()).IsEqualTo("yeah!");
 		await That(result.GetResultText()).IsEqualTo("it was <null>");
 	}
-
-	[Fact]
-	public async Task WithContext_ShouldAddContext()
-	{
-		AsyncMappingNode<string, int> node = new(
-			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "),
-			null,
-			s => Task.FromResult<ConstraintResult.Context?[]>([
-				new ConstraintResult.Context("context", s!),
-			]));
-		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
-		StringBuilder sb = new();
-
-		ConstraintResult result = await node.IsMetBy("foobar", null!, CancellationToken.None);
-
-		result.AppendExpectation(sb);
-		await That(sb.ToString()).IsEqualTo("yeah: 6");
-		await That(result.GetContexts()).Contains(x => x is { Title: "context", Content: "foobar", });
-	}
 }

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/ExpectationNodeTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using System.Threading;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Helpers;
@@ -58,48 +56,6 @@ public class ExpectationNodeTests
 
 		await That(Act).Throws<NotSupportedException>()
 			.WithMessage("Don't specify the inner node for Expectation nodes directly. Use AddMapping() instead!");
-	}
-
-	[Fact]
-	public async Task GetContexts_WithAsyncMapping_ShouldIncludeContextsFromLeftAndRight()
-	{
-		DummyConstraint constraint1 = new("", () => new ConstraintResult.Success("").WithContext("t1", "c1"));
-		DummyConstraint constraint2 = new("", () => new ConstraintResult.Success<int>(2, "").WithContext("t2", "c2"));
-		ExpectationNode node = new();
-		node.AddConstraint(constraint1);
-		node.AddAsyncMapping(MemberAccessor<int, Task<int>>.FromFunc(_ => Task.FromResult(0), "length"));
-		node.AddConstraint(constraint2);
-		ConstraintResult constraintResult = await node.IsMetBy(3, null!, CancellationToken.None);
-
-		List<ConstraintResult.Context> contexts = constraintResult.GetContexts().ToList();
-
-		await That(contexts)
-			.IsEqualTo([
-				new ConstraintResult.Context("t1", "c1"),
-				new ConstraintResult.Context("t2", "c2"),
-			])
-			.InAnyOrder();
-	}
-
-	[Fact]
-	public async Task GetContexts_WithMapping_ShouldIncludeContextsFromLeftAndRight()
-	{
-		DummyConstraint constraint1 = new("", () => new ConstraintResult.Success("").WithContext("t1", "c1"));
-		DummyConstraint constraint2 = new("", () => new ConstraintResult.Success<int>(2, "").WithContext("t2", "c2"));
-		ExpectationNode node = new();
-		node.AddConstraint(constraint1);
-		node.AddMapping(MemberAccessor<int, int>.FromFunc(_ => 0, "length"));
-		node.AddConstraint(constraint2);
-		ConstraintResult constraintResult = await node.IsMetBy(3, null!, CancellationToken.None);
-
-		List<ConstraintResult.Context> contexts = constraintResult.GetContexts().ToList();
-
-		await That(contexts)
-			.IsEqualTo([
-				new ConstraintResult.Context("t1", "c1"),
-				new ConstraintResult.Context("t2", "c2"),
-			])
-			.InAnyOrder();
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
@@ -71,22 +71,4 @@ public class MappingNodeTests
 		await That(sb.ToString()).IsEqualTo("yeah!");
 		await That(result.GetResultText()).IsEqualTo("it was <null>");
 	}
-
-	[Fact]
-	public async Task WithContext_ShouldAddContext()
-	{
-		MappingNode<string, int> node = new(MemberAccessor<string, int>.FromFunc(s => s.Length, " length "),
-			null,
-			s => Task.FromResult<ConstraintResult.Context?[]>([
-				new ConstraintResult.Context("context", s!),
-			]));
-		node.AddConstraint(new DummyValueConstraint<int>(v => new ConstraintResult.Success<int>(v, $"yeah: {v}")));
-		StringBuilder sb = new();
-
-		ConstraintResult result = await node.IsMetBy("foobar", null!, CancellationToken.None);
-
-		result.AppendExpectation(sb);
-		await That(sb.ToString()).IsEqualTo("yeah: 6");
-		await That(result.GetContexts()).Contains(x => x is { Title: "context", Content: "foobar", });
-	}
 }

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/OrNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/OrNodeTests.cs
@@ -10,25 +10,6 @@ namespace aweXpect.Core.Tests.Core.Nodes;
 
 public sealed class OrNodeTests
 {
-	[Fact]
-	public async Task GetContexts_ShouldIncludeContextsFromLeftAndRight()
-	{
-		DummyNode node1 = new("", () => new ConstraintResult.Success("").WithContext("t1", "c1"));
-		DummyNode node2 = new("", () => new ConstraintResult.Success("").WithContext("t2", "c2"));
-		OrNode orNode = new(node1);
-		orNode.AddNode(node2);
-		ConstraintResult constraintResult = await orNode.IsMetBy(0, null!, CancellationToken.None);
-
-		List<ConstraintResult.Context> contexts = constraintResult.GetContexts().ToList();
-
-		await That(contexts)
-			.IsEqualTo([
-				new ConstraintResult.Context("t1", "c1"),
-				new ConstraintResult.Context("t2", "c2"),
-			])
-			.InAnyOrder();
-	}
-
 	[Theory]
 	[InlineData(Outcome.Success, Outcome.Success, Outcome.Success)]
 	[InlineData(Outcome.Failure, Outcome.Success, Outcome.Success)]

--- a/Tests/aweXpect.Core.Tests/Core/ResultContextsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ResultContextsTests.cs
@@ -1,0 +1,89 @@
+﻿namespace aweXpect.Core.Tests.Core;
+
+public sealed class ResultContextsTests
+{
+	[Fact]
+	public async Task Add_ShouldAddContext()
+	{
+		ResultContexts sut = new();
+
+		sut.Add(new ResultContext("foo", "bar"));
+
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "foo",
+		});
+	}
+
+	[Fact]
+	public async Task AddMultiple_ShouldAddContext()
+	{
+		ResultContexts sut = new();
+
+		sut.Add(new ResultContext("foo", "1"));
+		sut.Add(new ResultContext("foo", "2"));
+		sut.Add(new ResultContext("foo", "2"));
+		sut.Add(new ResultContext("bar", "3"));
+		sut.Add(new ResultContext("foo", "4"));
+
+		await That(sut).HasCount().EqualTo(5);
+	}
+
+	[Fact]
+	public async Task Clear_ShouldRemoveAllContexts()
+	{
+		ResultContexts sut =
+		[
+			new ResultContext("foo", "bar"),
+			new ResultContext("foo", "bar"),
+		];
+
+		sut.Clear();
+
+		await That(sut).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Remove_WithPredicate_ShouldRemoveAllMatchingContexts()
+	{
+		ResultContexts sut =
+		[
+			new ResultContext("foo", "bar"),
+			new ResultContext("bar", "baz"),
+			new ResultContext("foo", "bar"),
+		];
+
+		sut.Remove(c => c.Title == "foo");
+
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "bar",
+		});
+	}
+
+	[Fact]
+	public async Task Remove_WithTitle_ShouldRemoveAllMatchingContexts()
+	{
+		ResultContexts sut =
+		[
+			new ResultContext("foo", "bar"),
+			new ResultContext("bar", "baz"),
+			new ResultContext("foo", "bar"),
+		];
+
+		sut.Remove("foo");
+
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "bar",
+		});
+	}
+
+	[Fact]
+	public async Task ShouldInitializeEmpty()
+	{
+		ResultContexts sut = new();
+
+		await That(sut).IsEmpty();
+	}
+}

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.ExactMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.ExactMatchTypeTests.cs
@@ -90,7 +90,7 @@ public sealed partial class StringEqualityOptionsTests
 		}
 
 		[Fact]
-		public async Task ShouldSupportPassiveGrammaticVoice()
+		public async Task ShouldSupportPassiveGrammaticalVoice()
 		{
 			Exception exception = new("foo");
 

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.RegexMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.RegexMatchTypeTests.cs
@@ -90,7 +90,7 @@ public sealed partial class StringEqualityOptionsTests
 		}
 
 		[Fact]
-		public async Task ShouldSupportPassiveGrammaticVoice()
+		public async Task ShouldSupportPassiveGrammaticalVoice()
 		{
 			Exception exception = new("foo");
 

--- a/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.WildcardMatchTypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/StringEqualityOptionsTests.WildcardMatchTypeTests.cs
@@ -90,7 +90,7 @@ public sealed partial class StringEqualityOptionsTests
 		}
 
 		[Fact]
-		public async Task ShouldSupportPassiveGrammaticVoice()
+		public async Task ShouldSupportPassiveGrammaticalVoice()
 		{
 			Exception exception = new("foo");
 

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -17,16 +17,14 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 
 	public override Node? AddMapping<TValue, TTarget>(
 		MemberAccessor<TValue, TTarget> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
 		=> throw new NotSupportedException();
 
 	public override Node? AddAsyncMapping<TValue, TTarget>(
 		MemberAccessor<TValue, Task<TTarget>> memberAccessor,
-		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null,
-		Func<TValue?, Task<ConstraintResult.Context?[]>>? contexts = null)
+		Action<MemberAccessor, StringBuilder>? expectationTextGenerator = null)
 		where TValue : default
 		where TTarget : default
 		=> throw new NotSupportedException();

--- a/Tests/aweXpect.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Tests/ExpectTests.cs
@@ -55,8 +55,11 @@ public class ExpectTests
 				                     "subject C"
 				                              ↑ (expected)
 				             
-				             Actual:
+				             [02] Actual:
 				             subject C
+				             
+				             [03] Actual:
+				             subject B
 				             """);
 		}
 
@@ -131,8 +134,11 @@ public class ExpectTests
 				                       "subject C"
 				                                ↑ (expected)
 				             
-				             Actual:
+				             [03] Actual:
 				             some unexpected value
+				             
+				             [04] Actual:
+				             subject B
 				             """);
 		}
 
@@ -239,8 +245,14 @@ public class ExpectTests
 				                     "subject C"
 				                              ↑ (expected)
 				             
-				             Actual:
+				             [01] Actual:
 				             subject X
+				             
+				             [02] Actual:
+				             subject Y
+				             
+				             [03] Actual:
+				             subject Z
 				             """);
 		}
 
@@ -299,8 +311,14 @@ public class ExpectTests
 				                       "subject C"
 				                                ↑ (expected)
 				             
-				             Actual:
+				             [02] Actual:
 				             subject X
+				             
+				             [03] Actual:
+				             some unexpected value
+				             
+				             [04] Actual:
+				             subject Z
 				             """);
 		}
 


### PR DESCRIPTION
Move the registration of contexts to the expectation builder, so that it is also possible to manipulate previous contexts.