### PR TITLE
feat: support `Open`/`Close` for context list

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -344,10 +344,11 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Update the list of <see cref="ResultContext" /> that is included in the failure message.
 	/// </summary>
-	public void UpdateContexts(Action<ResultContexts> callback)
+	public ExpectationBuilder UpdateContexts(Action<ResultContexts> callback)
 	{
 		_contexts ??= new();
 		callback(_contexts);
+		return this;
 	}
 
 	/// <summary>

--- a/Source/aweXpect.Core/Core/ResultContexts.cs
+++ b/Source/aweXpect.Core/Core/ResultContexts.cs
@@ -10,7 +10,7 @@ namespace aweXpect.Core;
 public class ResultContexts : IEnumerable<ResultContext>
 {
 	private readonly List<ResultContext> _results = new();
-	private bool _isClosed;
+	private bool _isOpen = true;
 
 	/// <inheritdoc cref="IEnumerable{ResultContext}.GetEnumerator()" />
 	public IEnumerator<ResultContext> GetEnumerator() => _results.GetEnumerator();
@@ -23,7 +23,7 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Close()
 	{
-		_isClosed = true;
+		_isOpen = false;
 		return this;
 	}
 
@@ -32,7 +32,7 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Open()
 	{
-		_isClosed = false;
+		_isOpen = true;
 		return this;
 	}
 
@@ -41,7 +41,7 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Add(ResultContext context)
 	{
-		if (!_isClosed)
+		if (_isOpen)
 		{
 			_results.Add(context);
 		}
@@ -54,7 +54,7 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Clear()
 	{
-		if (!_isClosed)
+		if (_isOpen)
 		{
 			_results.Clear();
 		}
@@ -67,7 +67,7 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Remove(string title, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
 	{
-		if (!_isClosed)
+		if (_isOpen)
 		{
 			_results.RemoveAll(x => x.Title.Equals(title, stringComparison));
 		}
@@ -80,7 +80,7 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Remove(Predicate<ResultContext> predicate)
 	{
-		if (!_isClosed)
+		if (_isOpen)
 		{
 			_results.RemoveAll(predicate);
 		}

--- a/Source/aweXpect.Core/Core/ResultContexts.cs
+++ b/Source/aweXpect.Core/Core/ResultContexts.cs
@@ -10,6 +10,7 @@ namespace aweXpect.Core;
 public class ResultContexts : IEnumerable<ResultContext>
 {
 	private readonly List<ResultContext> _results = new();
+	private bool _isClosed;
 
 	/// <inheritdoc cref="IEnumerable{ResultContext}.GetEnumerator()" />
 	public IEnumerator<ResultContext> GetEnumerator() => _results.GetEnumerator();
@@ -18,11 +19,33 @@ public class ResultContexts : IEnumerable<ResultContext>
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	/// <summary>
+	///     Closes the context list for further modifications.
+	/// </summary>
+	public ResultContexts Close()
+	{
+		_isClosed = true;
+		return this;
+	}
+
+	/// <summary>
+	///     Opens the context list for further modifications.
+	/// </summary>
+	public ResultContexts Open()
+	{
+		_isClosed = false;
+		return this;
+	}
+
+	/// <summary>
 	///     Adds the <paramref name="context" /> to the context list.
 	/// </summary>
 	public ResultContexts Add(ResultContext context)
 	{
-		_results.Add(context);
+		if (!_isClosed)
+		{
+			_results.Add(context);
+		}
+
 		return this;
 	}
 
@@ -31,7 +54,11 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Clear()
 	{
-		_results.Clear();
+		if (!_isClosed)
+		{
+			_results.Clear();
+		}
+
 		return this;
 	}
 
@@ -40,7 +67,11 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Remove(string title, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
 	{
-		_results.RemoveAll(x => x.Title.Equals(title, stringComparison));
+		if (!_isClosed)
+		{
+			_results.RemoveAll(x => x.Title.Equals(title, stringComparison));
+		}
+
 		return this;
 	}
 
@@ -49,7 +80,11 @@ public class ResultContexts : IEnumerable<ResultContext>
 	/// </summary>
 	public ResultContexts Remove(Predicate<ResultContext> predicate)
 	{
-		_results.RemoveAll(predicate);
+		if (!_isClosed)
+		{
+			_results.RemoveAll(predicate);
+		}
+
 		return this;
 	}
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -117,7 +117,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
-        public void UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
+        public aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
@@ -212,7 +212,9 @@ namespace aweXpect.Core
         public ResultContexts() { }
         public aweXpect.Core.ResultContexts Add(aweXpect.Core.ResultContext context) { }
         public aweXpect.Core.ResultContexts Clear() { }
+        public aweXpect.Core.ResultContexts Close() { }
         public System.Collections.Generic.IEnumerator<aweXpect.Core.ResultContext> GetEnumerator() { }
+        public aweXpect.Core.ResultContexts Open() { }
         public aweXpect.Core.ResultContexts Remove(System.Predicate<aweXpect.Core.ResultContext> predicate) { }
         public aweXpect.Core.ResultContexts Remove(string title, System.StringComparison stringComparison = 5) { }
     }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -117,7 +117,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, aweXpect.Core.ExpectationGrammars? expectationGrammar = default) { }
         public override string? ToString() { }
-        public void UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
+        public aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
@@ -212,7 +212,9 @@ namespace aweXpect.Core
         public ResultContexts() { }
         public aweXpect.Core.ResultContexts Add(aweXpect.Core.ResultContext context) { }
         public aweXpect.Core.ResultContexts Clear() { }
+        public aweXpect.Core.ResultContexts Close() { }
         public System.Collections.Generic.IEnumerator<aweXpect.Core.ResultContext> GetEnumerator() { }
+        public aweXpect.Core.ResultContexts Open() { }
         public aweXpect.Core.ResultContexts Remove(System.Predicate<aweXpect.Core.ResultContext> predicate) { }
         public aweXpect.Core.ResultContexts Remove(string title, System.StringComparison stringComparison = 5) { }
     }

--- a/Tests/aweXpect.Core.Tests/Core/ResultContextsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ResultContextsTests.cs
@@ -44,6 +44,118 @@ public sealed class ResultContextsTests
 	}
 
 	[Fact]
+	public async Task Close_ShouldRestrictAdd()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+
+		sut.Close();
+
+		sut.Add(new ResultContext("bar", "2"));
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "foo",
+		});
+	}
+
+	[Fact]
+	public async Task Close_ShouldRestrictClear()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+
+		sut.Close();
+
+		sut.Clear();
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "foo",
+		});
+	}
+
+	[Fact]
+	public async Task Close_ShouldRestrictRemoveWithPredicate()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+
+		sut.Close();
+
+		sut.Remove(_ => true);
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "foo",
+		});
+	}
+
+	[Fact]
+	public async Task Close_ShouldRestrictRemoveWithTitle()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+
+		sut.Close();
+
+		sut.Remove("foo");
+		await That(sut).HasSingle().Which.IsEquivalentTo(new
+		{
+			Title = "foo",
+		});
+	}
+
+	[Fact]
+	public async Task Open_ShouldRestrictAdd()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+		sut.Close();
+
+		sut.Open();
+
+		sut.Add(new ResultContext("bar", "2"));
+		await That(sut).HasCount().EqualTo(2);
+	}
+
+	[Fact]
+	public async Task Open_ShouldRestrictClear()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+		sut.Close();
+
+		sut.Open();
+
+		sut.Clear();
+		await That(sut).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Open_ShouldRestrictRemoveWithPredicate()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+		sut.Close();
+
+		sut.Open();
+
+		sut.Remove(_ => true);
+		await That(sut).IsEmpty();
+	}
+
+	[Fact]
+	public async Task Open_ShouldRestrictRemoveWithTitle()
+	{
+		ResultContexts sut = new();
+		sut.Add(new ResultContext("foo", "1"));
+		sut.Close();
+
+		sut.Open();
+
+		sut.Remove("foo");
+		await That(sut).IsEmpty();
+	}
+
+	[Fact]
 	public async Task Remove_WithPredicate_ShouldRemoveAllMatchingContexts()
 	{
 		ResultContexts sut =


### PR DESCRIPTION
`Close()` will freeze the context collection, but can be re-opened with `Open()`.