### PR TITLE
fix: allow local Release build

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -65,4 +65,10 @@
 			  Link="Docs\README.md"/>
 	</ItemGroup>
 
+	<PropertyGroup>
+		<!-- The version is only set to support local builds.
+		In the build pipeline it is overwritten with the actual version in the `nuke Compile` step -->
+		<Version>255.255.255.255</Version>
+	</PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Set a dummy version so that a local build `dotnet build --configuration "Release"` is successful.

In the build pipeline this version is overwritten by nuke with the `--property:Version=2.0.1.0-DEV` parameter