### PR TITLE
refactor: disable code analysis when build scope is not default

### DIFF
--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -32,7 +32,7 @@ partial class Build
 		.Unlisted()
 		.DependsOn(Compile)
 		.DependsOn(CodeCoverage)
-		.OnlyWhenDynamic(() => IsServerBuild)
+		.OnlyWhenDynamic(() => IsServerBuild && BuildScope == BuildScope.Default)
 		.Executes(() =>
 		{
 			SonarScannerTasks.SonarScannerEnd(s => s

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -11,7 +11,7 @@ public sealed class CustomizeSettingsTests
 	[Fact]
 	public async Task DefaultCheckInterval_ShouldBeUsedInTimeComparisons()
 	{
-		TimeSpan timeout = 1.Seconds();
+		TimeSpan timeout = 2.Seconds();
 		ChangingClass sut1 = new();
 		ChangingClass sut2 = new();
 


### PR DESCRIPTION
When the `BuildScope` is not default, the code analysis is incorrect (missing code coverage, as some tests are not run). In this case, it should be disabled.