### PR TITLE
feat: add support for inconclusive tests

### DIFF
--- a/Source/aweXpect.Core/Core/Adapters/ITestFrameworkAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/ITestFrameworkAdapter.cs
@@ -22,5 +22,15 @@ public interface ITestFrameworkAdapter
 	///     Throws a framework-specific exception to indicate a failing unit test.
 	/// </summary>
 	[DoesNotReturn]
-	void Throw(string message);
+	void Fail(string message);
+
+	/// <summary>
+	///     Throws a framework-specific exception to indicate an inconclusive unit test.
+	/// </summary>
+	/// <remarks>
+	///     It should be used in situations where another run with different data or a different environment might run to
+	///     completion, with either a success or failure outcome.
+	/// </remarks>
+	[DoesNotReturn]
+	void Inconclusive(string message);
 }

--- a/Source/aweXpect.Core/Core/Adapters/MsTestAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/MsTestAdapter.cs
@@ -12,5 +12,6 @@ namespace aweXpect.Core.Adapters;
 internal class MsTestAdapter() : TestFrameworkAdapter(
 	"Microsoft.VisualStudio.TestPlatform.TestFramework,",
 	(a, m) => FromType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException", a, m),
+	(a, m) => FromType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertInconclusiveException", a, m),
 	(a, m) => FromType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertInconclusiveException", a, m)
 );

--- a/Source/aweXpect.Core/Core/Adapters/NUnitAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/NUnitAdapter.cs
@@ -11,5 +11,6 @@ namespace aweXpect.Core.Adapters;
 internal class NUnitAdapter() : TestFrameworkAdapter(
 	"nunit.framework,",
 	(a, m) => FromType("NUnit.Framework.AssertionException", a, m),
-	(a, m) => FromType("NUnit.Framework.IgnoreException", a, m)
+	(a, m) => FromType("NUnit.Framework.IgnoreException", a, m),
+	(a, m) => FromType("NUnit.Framework.InconclusiveException", a, m)
 );

--- a/Source/aweXpect.Core/Core/Adapters/TUnitAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/TUnitAdapter.cs
@@ -41,22 +41,10 @@ internal class TUnitAdapter : ITestFrameworkAdapter
 		}
 	}
 
-	/// <inheritdoc cref="ITestFrameworkAdapter.Skip(string)" />
+	/// <inheritdoc cref="ITestFrameworkAdapter.Fail" />
 	[DoesNotReturn]
 	[StackTraceHidden]
-	public void Skip(string message)
-	{
-		Type exceptionType = _coreAssembly?.GetType("TUnit.Core.Exceptions.SkipTestException")
-		                     ?? throw new NotSupportedException(
-			                     "Failed to create the TUnit skip assertion type");
-
-		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
-	}
-
-	/// <inheritdoc cref="ITestFrameworkAdapter.Throw(string)" />
-	[DoesNotReturn]
-	[StackTraceHidden]
-	public void Throw(string message)
+	public void Fail(string message)
 	{
 		if (_assertionsAssembly == null)
 		{
@@ -68,6 +56,30 @@ internal class TUnitAdapter : ITestFrameworkAdapter
 			_assertionsAssembly.GetType("TUnit.Assertions.Exceptions.AssertionException")
 			?? throw new NotSupportedException(
 				"Failed to create the TUnit fail assertion type");
+
+		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
+	}
+
+	/// <inheritdoc cref="ITestFrameworkAdapter.Inconclusive(string)" />
+	[DoesNotReturn]
+	[StackTraceHidden]
+	public void Inconclusive(string message)
+	{
+		Type exceptionType = _coreAssembly?.GetType("TUnit.Core.Exceptions.InconclusiveTestException")
+		                     ?? throw new NotSupportedException(
+			                     "Failed to create the TUnit inconclusive assertion type");
+
+		throw (Exception)Activator.CreateInstance(exceptionType, message, null)!;
+	}
+
+	/// <inheritdoc cref="ITestFrameworkAdapter.Skip(string)" />
+	[DoesNotReturn]
+	[StackTraceHidden]
+	public void Skip(string message)
+	{
+		Type exceptionType = _coreAssembly?.GetType("TUnit.Core.Exceptions.SkipTestException")
+		                     ?? throw new NotSupportedException(
+			                     "Failed to create the TUnit skip assertion type");
 
 		throw (Exception)Activator.CreateInstance(exceptionType, message)!;
 	}

--- a/Source/aweXpect.Core/Core/Adapters/TestFrameworkAdapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/TestFrameworkAdapter.cs
@@ -9,7 +9,8 @@ namespace aweXpect.Core.Adapters;
 internal abstract class TestFrameworkAdapter(
 	string assemblyName,
 	Func<Assembly, string, Exception?> failException,
-	Func<Assembly, string, Exception?> skipException)
+	Func<Assembly, string, Exception?> skipException,
+	Func<Assembly, string, Exception?> inconclusiveException)
 	: ITestFrameworkAdapter
 {
 	private Assembly? _assembly;
@@ -47,6 +48,20 @@ internal abstract class TestFrameworkAdapter(
 		}
 	}
 
+	/// <inheritdoc cref="ITestFrameworkAdapter.Fail" />
+	[DoesNotReturn]
+	[StackTraceHidden]
+	public void Fail(string message)
+	{
+		if (_assembly is null)
+		{
+			throw new NotSupportedException("Failed to create the fail assertion type");
+		}
+
+		throw failException(_assembly, message)
+		      ?? new NotSupportedException("Failed to create the fail assertion type");
+	}
+
 	/// <inheritdoc cref="ITestFrameworkAdapter.Skip(string)" />
 	[DoesNotReturn]
 	[StackTraceHidden]
@@ -61,18 +76,18 @@ internal abstract class TestFrameworkAdapter(
 		      ?? new NotSupportedException("Failed to create the skip assertion type");
 	}
 
-	/// <inheritdoc cref="ITestFrameworkAdapter.Throw(string)" />
+	/// <inheritdoc cref="ITestFrameworkAdapter.Inconclusive(string)" />
 	[DoesNotReturn]
 	[StackTraceHidden]
-	public void Throw(string message)
+	public void Inconclusive(string message)
 	{
 		if (_assembly is null)
 		{
-			throw new NotSupportedException("Failed to create the fail assertion type");
+			throw new NotSupportedException("Failed to create the inconclusive assertion type");
 		}
 
-		throw failException(_assembly, message)
-		      ?? new NotSupportedException("Failed to create the fail assertion type");
+		throw inconclusiveException(_assembly, message)
+		      ?? new NotSupportedException("Failed to create the inconclusive assertion type");
 	}
 
 	#endregion

--- a/Source/aweXpect.Core/Core/Adapters/XUnit2Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit2Adapter.cs
@@ -11,5 +11,6 @@ namespace aweXpect.Core.Adapters;
 internal class XUnit2Adapter() : TestFrameworkAdapter(
 	"xunit.assert",
 	(a, m) => FromType("Xunit.Sdk.XunitException", a, m),
-	(_, m) => new SkipException($"SKIPPED: {m} (xunit v2 does not support skipping test)")
+	(_, m) => new SkipException($"SKIPPED: {m} (xunit v2 does not support skipping test)"),
+	(_, m) => new InconclusiveException($"INCONCLUSIVE: {m} (xunit v2 does not support inconclusive tests)")
 );

--- a/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
@@ -15,12 +15,14 @@ namespace aweXpect.Core.Adapters;
 internal class XUnit3Adapter() : TestFrameworkAdapter(
 	"xunit.v3.assert",
 	(a, m) => FromType("Xunit.Sdk.XunitException", a, m),
-	(_, m) => new SkipException($"$XunitDynamicSkip${m}"))
+	(_, m) => new SkipException($"$XunitDynamicSkip${m}"),
+	(_, m) => new XunitTimeoutException(m))
 {
 	internal class XUnit3CoreAdapter() : TestFrameworkAdapter(
 		"xunit.v3.core",
 		(_, m) => new XunitException(m),
-		(_, m) => new SkipException($"$XunitDynamicSkip${m}"))
+		(_, m) => new SkipException($"$XunitDynamicSkip${m}"),
+		(_, m) => new XunitTimeoutException(m))
 	{
 		/// <summary>
 		///     Interface is required by xunit v3 to identify an assertion exception.
@@ -28,8 +30,14 @@ internal class XUnit3Adapter() : TestFrameworkAdapter(
 		private interface IAssertionException;
 
 #pragma warning disable S3871 // Exception types should be "public"
-		private sealed class XunitException(string message)
+		private class XunitException(string message)
 			: Exception(message), IAssertionException;
 #pragma warning restore S3871 // Exception types should be "public"
 	}
+
+#pragma warning disable S3871 // Exception types should be "public"
+	private sealed class XunitTimeoutException(string message)
+		: InconclusiveException(message), ITestTimeoutException ;
+#pragma warning restore S3871 // Exception types should be "public"
+	private interface ITestTimeoutException;
 }

--- a/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
+++ b/Source/aweXpect.Core/Core/Adapters/XUnit3Adapter.cs
@@ -30,7 +30,7 @@ internal class XUnit3Adapter() : TestFrameworkAdapter(
 		private interface IAssertionException;
 
 #pragma warning disable S3871 // Exception types should be "public"
-		private class XunitException(string message)
+		private sealed class XunitException(string message)
 			: Exception(message), IAssertionException;
 #pragma warning restore S3871 // Exception types should be "public"
 	}

--- a/Source/aweXpect.Core/Core/Ambient/Initialization.cs
+++ b/Source/aweXpect.Core/Core/Ambient/Initialization.cs
@@ -16,7 +16,7 @@ internal static class Initialization
 	{
 		Type frameworkInterface = typeof(ITestFrameworkAdapter);
 		foreach (Type frameworkType in types
-			         .Where(x => x is { IsClass: true, IsAbstract: false })
+			         .Where(x => x is { IsClass: true, IsAbstract: false, })
 			         .Where(frameworkInterface.IsAssignableFrom))
 		{
 			try
@@ -64,8 +64,16 @@ internal static class Initialization
 		/// </summary>
 		[DoesNotReturn]
 		[StackTraceHidden]
-		public void Throw(string message)
-			=> testFramework.Throw(message);
+		public void Fail(string message)
+			=> testFramework.Fail(message);
+
+		/// <summary>
+		///     Throws a framework-specific exception to indicate an inconclusive unit test.
+		/// </summary>
+		[DoesNotReturn]
+		[StackTraceHidden]
+		public void Inconclusive(string message)
+			=> testFramework.Inconclusive(message);
 	}
 
 	private sealed class FallbackTestFramework : ITestFrameworkAdapter
@@ -76,13 +84,18 @@ internal static class Initialization
 
 		[DoesNotReturn]
 		[StackTraceHidden]
+		public void Fail(string message)
+			=> throw new FailException(message);
+
+		[DoesNotReturn]
+		[StackTraceHidden]
 		public void Skip(string message)
 			=> throw new SkipException(message);
 
 		[DoesNotReturn]
 		[StackTraceHidden]
-		public void Throw(string message)
-			=> throw new FailException(message);
+		public void Inconclusive(string message)
+			=> throw new InconclusiveException(message);
 
 		#endregion
 	}

--- a/Source/aweXpect.Core/Core/Exceptions/InconclusiveException.cs
+++ b/Source/aweXpect.Core/Core/Exceptions/InconclusiveException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace aweXpect;
+
+/// <summary>
+///     Represents the default inconclusive exception in case no test framework is configured.
+/// </summary>
+public class InconclusiveException(string message) : Exception(message);

--- a/Source/aweXpect.Core/Fail.cs
+++ b/Source/aweXpect.Core/Fail.cs
@@ -33,6 +33,14 @@ public static class Fail
 	/// <param name="reason">The reason why the test was failed</param>
 	public static void When([DoesNotReturnIf(true)] bool condition, string reason)
 		=> FailIf(condition, reason);
+	
+	/// <summary>
+	///     Explicitly fails the current test as inconclusive.
+	/// </summary>
+	/// <param name="reason">The reason why the test failed</param>
+	[DoesNotReturn]
+	public static void Inconclusive(string reason)
+		=> Initialization.State.Value.Inconclusive(reason);
 
 	private static void FailIf([DoesNotReturnIf(true)] bool condition, string reason)
 	{
@@ -41,6 +49,6 @@ public static class Fail
 			return;
 		}
 
-		Initialization.State.Value.Throw(reason);
+		Initialization.State.Value.Fail(reason);
 	}
 }

--- a/Tests/Frameworks/aweXpect.Frameworks.Fallback.Tests/FallbackTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.Fallback.Tests/FallbackTests.cs
@@ -14,6 +14,18 @@ public sealed class FallbackTests
 		Assert.That(exception!.Message, Is.EqualTo("my message"));
 	}
 
+#if DEBUG // TODO remove after next core update
+	[Test]
+	public void OnInconclusive_WhenNotSpecifyingAnyTestFramework_ShouldFallbackToThrowingAnInconclusiveException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		InconclusiveException? exception = Assert.Throws<InconclusiveException>(Act);
+		Assert.That(exception!.Message, Is.EqualTo("my message"));
+	}
+#endif
+
 	[Test]
 	public void OnSkip_WhenNotSpecifyingAnyTestFramework_ShouldFallbackToThrowingASkipException()
 	{

--- a/Tests/Frameworks/aweXpect.Frameworks.MsTest.Tests/MsTestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.MsTest.Tests/MsTestFrameworkTests.cs
@@ -7,16 +7,29 @@ namespace aweXpect.Frameworks.MsTest.Tests;
 public sealed class MsTestFrameworkTests
 {
 	[TestMethod]
-	public async Task OnFail_WhenUsingMsTestAsTestFramework_ShouldThrowXunitException()
+	public async Task OnFail_WhenUsingMsTestAsTestFramework_ShouldThrowAssertFailedException()
 	{
 		void Act()
 			=> Fail.Test("my message");
 
-		await Expect.That(Act).Throws<AssertFailedException>();
+		await Expect.That(Act).Throws<AssertFailedException>()
+			.WithMessage("my message");
 	}
 
+#if DEBUG // TODO remove after next core update
 	[TestMethod]
-	public async Task OnSkip_WhenUsingMsTestAsTestFramework_ShouldThrowSkipException()
+	public async Task OnInconclusive_WhenUsingMsTestAsTestFramework_ShouldThrowAssertInconclusiveException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		await Expect.That(Act).Throws<AssertInconclusiveException>()
+			.WithMessage("my message");
+	}
+#endif
+
+	[TestMethod]
+	public async Task OnSkip_WhenUsingMsTestAsTestFramework_ShouldThrowAssertInconclusiveException()
 	{
 		void Act()
 			=> Skip.Test("my message");

--- a/Tests/Frameworks/aweXpect.Frameworks.NUnit3.Tests/NUnit3TestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.NUnit3.Tests/NUnit3TestFrameworkTests.cs
@@ -11,8 +11,21 @@ public sealed class NUnit3TestFrameworkTests
 		void Act()
 			=> Fail.Test("my message");
 
-		await Expect.That(Act).Throws<AssertionException>();
+		await Expect.That(Act).Throws<AssertionException>()
+			.WithMessage("my message");
 	}
+
+#if DEBUG // TODO remove after next core update
+	[Test]
+	public async Task OnInconclusive_WhenUsingNUnit3AsTestFramework_ShouldThrowAssertionException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		await Expect.That(Act).Throws<NUnit.Framework.InconclusiveException>()
+			.WithMessage("my message");
+	}
+#endif
 
 	[Test]
 	public async Task OnSkip_WhenUsingNUnit3AsTestFramework_ShouldThrowIgnoreException()
@@ -20,6 +33,7 @@ public sealed class NUnit3TestFrameworkTests
 		void Act()
 			=> Skip.Test("my message");
 
-		await Expect.That(Act).Throws<IgnoreException>();
+		await Expect.That(Act).Throws<IgnoreException>()
+			.WithMessage("my message");
 	}
 }

--- a/Tests/Frameworks/aweXpect.Frameworks.NUnit4.Tests/NUnit4TestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.NUnit4.Tests/NUnit4TestFrameworkTests.cs
@@ -11,8 +11,21 @@ public sealed class NUnit4TestFrameworkTests
 		void Act()
 			=> Fail.Test("my message");
 
-		await Expect.That(Act).Throws<AssertionException>();
+		await Expect.That(Act).Throws<AssertionException>()
+			.WithMessage("my message");
 	}
+
+#if DEBUG // TODO remove after next core update
+	[Test]
+	public async Task OnInconclusive_WhenUsingNUnit3AsTestFramework_ShouldThrowAssertionException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		await Expect.That(Act).Throws<NUnit.Framework.InconclusiveException>()
+			.WithMessage("my message");
+	}
+#endif
 
 	[Test]
 	public async Task OnSkip_WhenUsingNUnit4AsTestFramework_ShouldThrowIgnoreException()
@@ -20,6 +33,7 @@ public sealed class NUnit4TestFrameworkTests
 		void Act()
 			=> Skip.Test("my message");
 
-		await Expect.That(Act).Throws<IgnoreException>();
+		await Expect.That(Act).Throws<IgnoreException>()
+			.WithMessage("my message");
 	}
 }

--- a/Tests/Frameworks/aweXpect.Frameworks.TUnit.Tests/TUnitTestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.TUnit.Tests/TUnitTestFrameworkTests.cs
@@ -12,8 +12,21 @@ public sealed class TUnitTestFrameworkTests
 		void Act()
 			=> Fail.Test("my message");
 
-		await Expect.That(Act).Throws<AssertionException>();
+		await Expect.That(Act).Throws<AssertionException>()
+			.WithMessage("my message");
 	}
+
+#if DEBUG // TODO remove after next core update
+	[Test]
+	public async Task OnInconclusive_WhenUsingXunit2AsTestFramework_ShouldThrowXunitException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		await Expect.That(Act).Throws<InconclusiveTestException>()
+			.WithMessage("my message");
+	}
+#endif
 
 	[Test]
 	public async Task OnSkip_WhenUsingXunit2AsTestFramework_ShouldThrowSkipException()
@@ -21,6 +34,7 @@ public sealed class TUnitTestFrameworkTests
 		void Act()
 			=> Skip.Test("my message");
 
-		await Expect.That(Act).Throws<SkipTestException>();
+		await Expect.That(Act).Throws<SkipTestException>()
+			.Whose(e => e.Reason, r => r.IsEqualTo("my message"));
 	}
 }

--- a/Tests/Frameworks/aweXpect.Frameworks.XUnit2.Tests/XUnit2TestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.XUnit2.Tests/XUnit2TestFrameworkTests.cs
@@ -15,6 +15,18 @@ public sealed class XUnit2TestFrameworkTests
 		await Expect.That(Act).Throws<XunitException>();
 	}
 
+#if DEBUG // TODO remove after next core update
+	[Fact]
+	public async Task OnInconclusive_WhenUsingXunit2AsTestFramework_ShouldThrowInconclusiveException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		await Expect.That(Act).Throws<InconclusiveException>()
+			.WithMessage("INCONCLUSIVE: my message (xunit v2 does not support inconclusive tests)");
+	}
+#endif
+
 	[Fact]
 	public async Task OnSkip_WhenUsingXunit2AsTestFramework_ShouldThrowSkipException()
 	{

--- a/Tests/Frameworks/aweXpect.Frameworks.XUnit3.Core.Tests/XUnit3CoreTestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.XUnit3.Core.Tests/XUnit3CoreTestFrameworkTests.cs
@@ -19,6 +19,20 @@ public class XUnit3TestFrameworkTests
 			.Contains("IAssertionException");
 	}
 
+#if DEBUG // TODO remove after next core update
+	[Fact]
+	public async Task OnInconclusive_WhenUsingXunit3AsTestFramework_ShouldThrowXunitException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		Exception exception = await Expect.That(Act).ThrowsException()
+			.WithMessage("my message");
+		await Expect.That(exception.GetType().GetInterfaces().Select(e => e.Name))
+			.Contains("ITestTimeoutException");
+	}
+#endif
+
 	[Fact]
 	public async Task OnSkip_WhenUsingXunit3AsTestFramework_ShouldThrowSkipException()
 	{

--- a/Tests/Frameworks/aweXpect.Frameworks.XUnit3.Tests/XUnit3TestFrameworkTests.cs
+++ b/Tests/Frameworks/aweXpect.Frameworks.XUnit3.Tests/XUnit3TestFrameworkTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
@@ -14,6 +15,20 @@ public class XUnit3TestFrameworkTests
 
 		await Expect.That(Act).Throws<XunitException>();
 	}
+
+#if DEBUG // TODO remove after next core update
+	[Fact]
+	public async Task OnInconclusive_WhenUsingXunit3AsTestFramework_ShouldThrowXunitException()
+	{
+		void Act()
+			=> Fail.Inconclusive("my message");
+
+		InconclusiveException exception = await Expect.That(Act).Throws<InconclusiveException>()
+			.WithMessage("my message");
+		await Expect.That(exception.GetType().GetInterfaces().Select(e => e.Name))
+			.Contains("ITestTimeoutException");
+	}
+#endif
 
 	[Fact]
 	public async Task OnSkip_WhenUsingXunit3AsTestFramework_ShouldThrowSkipException()

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -7,9 +7,11 @@ namespace aweXpect.Core.Adapters
     {
         bool IsAvailable { get; }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        void Skip(string message);
+        void Fail(string message);
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        void Throw(string message);
+        void Inconclusive(string message);
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        void Skip(string message);
     }
 }
 namespace aweXpect.Core.Constraints
@@ -481,6 +483,8 @@ namespace aweXpect
     public static class Fail
     {
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void Inconclusive(string reason) { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public static void Test(string reason) { }
         public static void Unless([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] bool condition, string reason) { }
         public static void When([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] bool condition, string reason) { }
@@ -488,6 +492,10 @@ namespace aweXpect
     public class FailException : System.Exception
     {
         public FailException(string message) { }
+    }
+    public class InconclusiveException : System.Exception
+    {
+        public InconclusiveException(string message) { }
     }
     [System.Diagnostics.StackTraceHidden]
     public static class Skip

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -7,9 +7,11 @@ namespace aweXpect.Core.Adapters
     {
         bool IsAvailable { get; }
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        void Skip(string message);
+        void Fail(string message);
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        void Throw(string message);
+        void Inconclusive(string message);
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        void Skip(string message);
     }
 }
 namespace aweXpect.Core.Constraints
@@ -476,6 +478,8 @@ namespace aweXpect
     public static class Fail
     {
         [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void Inconclusive(string reason) { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public static void Test(string reason) { }
         public static void Unless([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] bool condition, string reason) { }
         public static void When([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] bool condition, string reason) { }
@@ -483,6 +487,10 @@ namespace aweXpect
     public class FailException : System.Exception
     {
         public FailException(string message) { }
+    }
+    public class InconclusiveException : System.Exception
+    {
+        public InconclusiveException(string message) { }
     }
     [System.Diagnostics.StackTraceHidden]
     public static class Skip

--- a/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
@@ -63,7 +63,7 @@ public sealed class TestFrameworkAdapterTests
 		MyTestFrameworkAdapter adapter = new(MissingAssembly, new MyException());
 		_ = adapter.IsAvailable;
 
-		await That(() => adapter.Throw("foo")).Throws<NotSupportedException>()
+		await That(() => adapter.Fail("foo")).Throws<NotSupportedException>()
 			.WithMessage("Failed to create the fail assertion type");
 	}
 
@@ -73,7 +73,7 @@ public sealed class TestFrameworkAdapterTests
 		MyTestFrameworkAdapter adapter = new(ExistingAssembly);
 		_ = adapter.IsAvailable;
 
-		await That(() => adapter.Throw("foo")).Throws<NotSupportedException>()
+		await That(() => adapter.Fail("foo")).Throws<NotSupportedException>()
 			.WithMessage("Failed to create the fail assertion type");
 	}
 
@@ -84,7 +84,7 @@ public sealed class TestFrameworkAdapterTests
 		MyTestFrameworkAdapter adapter = new(ExistingAssembly, exception);
 		_ = adapter.IsAvailable;
 
-		await That(() => adapter.Throw("foo")).Throws<MyException>()
+		await That(() => adapter.Fail("foo")).Throws<MyException>()
 			.WithMessage("my-message");
 	}
 
@@ -109,10 +109,12 @@ public sealed class TestFrameworkAdapterTests
 
 		public MyTestFrameworkAdapter(string assemblyName,
 			Exception? failException = null,
-			Exception? skipException = null)
+			Exception? skipException = null,
+			Exception? inconclusiveException = null)
 			: base(assemblyName,
 				(_, _) => failException,
-				(_, _) => skipException)
+				(_, _) => skipException,
+				(_, _) => inconclusiveException)
 		{
 		}
 

--- a/Tests/aweXpect.Core.Tests/Core/Ambient/InitializationTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Ambient/InitializationTests.cs
@@ -9,7 +9,7 @@ public sealed class InitializationTests
 	[Fact]
 	public async Task DetectFramework_WhenAllFrameworksAreNotAvailable_ShouldUseFallbackAdapter()
 	{
-		ITestFrameworkAdapter result = Initialization.DetectFramework([typeof(UnavailableFrameworkAdapter)]);
+		ITestFrameworkAdapter result = Initialization.DetectFramework([typeof(UnavailableFrameworkAdapter),]);
 
 		await That(result.IsAvailable).IsFalse();
 		await That(result.GetType().Name).IsEqualTo("FallbackTestFramework");
@@ -18,7 +18,7 @@ public sealed class InitializationTests
 	[Fact]
 	public async Task DetectFramework_WhenFrameworkAdapterThrows_ShouldThrowInvalidOperationException()
 	{
-		void Act() => Initialization.DetectFramework([typeof(IncorrectFrameworkAdapter)]);
+		void Act() => Initialization.DetectFramework([typeof(IncorrectFrameworkAdapter),]);
 
 		await That(Act).Throws<InvalidOperationException>()
 			.WithMessage($"Could not instantiate test framework '{nameof(IncorrectFrameworkAdapter)}'!");
@@ -30,10 +30,13 @@ public sealed class InitializationTests
 
 #pragma warning disable CS0436
 		[DoesNotReturn]
-		public void Skip(string message) => throw new NotSupportedException();
+		public void Fail(string message) => throw new NotSupportedException();
 
 		[DoesNotReturn]
-		public void Throw(string message) => throw new NotSupportedException();
+		public void Inconclusive(string message) => throw new NotSupportedException();
+
+		[DoesNotReturn]
+		public void Skip(string message) => throw new NotSupportedException();
 #pragma warning restore CS0436
 	}
 
@@ -43,10 +46,13 @@ public sealed class InitializationTests
 
 #pragma warning disable CS0436
 		[DoesNotReturn]
-		public void Skip(string message) => throw new NotSupportedException();
+		public void Fail(string message) => throw new NotSupportedException();
 
 		[DoesNotReturn]
-		public void Throw(string message) => throw new NotSupportedException();
+		public void Inconclusive(string message) => throw new NotSupportedException();
+
+		[DoesNotReturn]
+		public void Skip(string message) => throw new NotSupportedException();
 #pragma warning restore CS0436
 	}
 }


### PR DESCRIPTION
Add new method in `ITestFrameworkAdapter` that throws a framework specific exception for inconclusive tests.