### PR TITLE
chore: support pull requests from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
                     dotnet-version: |
                         8.0.x
             -   name: Run mutation tests
-                run: ./build.sh MutationTests
+                run: ./build.sh MutationTests MutationTestDashboard
     
     benchmarks:
         name: "Benchmarks"

--- a/.github/workflows/ci-analysis.yml
+++ b/.github/workflows/ci-analysis.yml
@@ -1,0 +1,52 @@
+name: CI-Analysis
+
+on:
+    workflow_dispatch:
+    workflow_run:
+        workflows: [ "CI" ]
+        types:
+            - completed
+
+jobs:
+    mutation-tests:
+        name: "Mutation tests"
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        env:
+            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Upload mutation dashboard and create comment
+                run: ./build.sh MutationTestDashboard
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+                    WorkflowRunId: ${{ github.event.workflow_run.id }}
+    
+    benchmarks:
+        name: "Benchmarks"
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Create benchmark comment
+                run: ./build.sh BenchmarkComment
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+                    WorkflowRunId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,8 @@ jobs:
     
     mutation-tests:
         name: "Mutation tests"
-        if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
         env:
-            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
             DOTNET_NOLOGO: true
         steps:
             -   uses: actions/checkout@v4
@@ -82,16 +78,17 @@ jobs:
                         8.0.x
             -   name: Run mutation tests
                 run: ./build.sh MutationTests
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: MutationTests
+                    path: |
+                        ./Artifacts/*
     
     benchmarks:
         name: "Benchmarks"
-        if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -105,12 +102,17 @@ jobs:
                         8.0.x
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: Benchmarks
+                    path: |
+                        ./Artifacts/*
     
     static-code-analysis:
         name: "Static code analysis"
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         runs-on: ubuntu-latest
         env:
             REPORTGENERATOR_LICENSE: ${{ secrets.REPORTGENERATOR_LICENSE }}

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -9,7 +9,7 @@ namespace Build;
 	"Build",
 	GitHubActionsImage.UbuntuLatest,
 	AutoGenerate = false,
-	ImportSecrets = [nameof(GithubToken)]
+	ImportSecrets = [nameof(GithubToken),]
 )]
 partial class Build : NukeBuild
 {

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -1,4 +1,10 @@
 ﻿using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.Tools.SonarScanner;
 using Serilog;
@@ -31,5 +37,60 @@ public static class BuildExtensions
 
 		Log.Information("Use branch analysis for '{BranchName}'", branchName);
 		return settings.SetBranchName(branchName);
+	}
+	
+	public static async Task DownloadArtifactTo(this string artifactName, string artifactsDirectory, string githubToken)
+	{
+		string runId = Environment.GetEnvironmentVariable("WorkflowRunId");
+		if (string.IsNullOrEmpty(runId))
+		{
+			Log.Information("Skip downloading artifacts, because no 'WorkflowRunId' environment variable is set.");
+			return;
+		}
+
+		using HttpClient client = new();
+		client.DefaultRequestHeaders.UserAgent.ParseAdd("aweXpect");
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+		HttpResponseMessage response = await client.GetAsync(
+			$"https://api.github.com/repos/aweXpect/aweXpect.Json/actions/runs/{runId}/artifacts");
+
+		string responseContent = await response.Content.ReadAsStringAsync();
+		if (!response.IsSuccessStatusCode)
+		{
+			throw new InvalidOperationException(
+				$"Could not find artifacts for run #{runId}': {responseContent}");
+		}
+
+		try
+		{
+			JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
+			foreach (JsonElement artifact in jsonDocument.RootElement.GetProperty("artifacts").EnumerateArray())
+			{
+				string name = artifact.GetProperty("name").GetString()!;
+				if (name.Equals(artifactName, StringComparison.OrdinalIgnoreCase))
+				{
+					long artifactId = artifact.GetProperty("id").GetInt64();
+					HttpResponseMessage fileResponse = await client.GetAsync(
+						$"https://api.github.com/repos/aweXpect/aweXpect.Json/actions/artifacts/{artifactId}/zip");
+					if (fileResponse.IsSuccessStatusCode)
+					{
+						using ZipArchive archive = new(await fileResponse.Content.ReadAsStreamAsync());
+						archive.ExtractToDirectory(artifactsDirectory);
+						Log.Information(
+							$"Extracted artifact #{artifactId} with {archive.Entries.Count} entries to {artifactsDirectory}:\n - {string.Join("\n - ", archive.Entries.Select(entry => $"{entry.Name} ({entry.Length})"))}");
+					}
+					else
+					{
+						string fileResponseContent = await fileResponse.Content.ReadAsStringAsync();
+						throw new InvalidOperationException(
+							$"Could not download the artifacts with id #{artifactId}': {fileResponseContent}");
+					}
+				}
+			}
+		}
+		catch (JsonException e)
+		{
+			Log.Error($"Could not parse JSON: {e.Message}\n{responseContent}");
+		}
 	}
 }

--- a/aweXpect.sln
+++ b/aweXpect.sln
@@ -49,6 +49,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		.github\workflows\pages.yml = .github\workflows\pages.yml
+		.github\workflows\ci-analysis.yml = .github\workflows\ci-analysis.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Frameworks", "Frameworks", "{97A9E15D-5A21-4BA1-940B-7F42933DE0A5}"


### PR DESCRIPTION
The build pipeline currently does not support pull requests from forks, as the secrets are not available. Follow the [recommendation from Github](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and add a second build step with the `workflow_run` trigger.

As [SonarCloud does not support this](https://community.sonarsource.com/t/code-analysis-on-pull-request-from-forked-repository-with-github-actions/43986/4), disable static code analyis for pull requests from forked repositories.