### PR TITLE
feat: make properties of `FormattingOptions` public

### DIFF
--- a/Source/aweXpect.Core/Formatting/FormattingOptions.cs
+++ b/Source/aweXpect.Core/Formatting/FormattingOptions.cs
@@ -21,9 +21,15 @@ public record FormattingOptions
 	/// </summary>
 	public static FormattingOptions SingleLine { get; } = new(false);
 
-	internal bool UseLineBreaks { get; }
+	/// <summary>
+	///     Flag indicating, if line-breaks should be used during formatting.
+	/// </summary>
+	public bool UseLineBreaks { get; }
 
-	internal string Indentation { get; }
+	/// <summary>
+	///     The indentation prefix for subsequent lines when <see cref="UseLineBreaks" /> is <see langword="true" />
+	/// </summary>
+	public string Indentation { get; }
 
 	/// <summary>
 	///     Format the objects on multiple lines with the given <paramref name="indentation" />.

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -582,6 +582,8 @@ namespace aweXpect.Formatting
     }
     public class FormattingOptions : System.IEquatable<aweXpect.Formatting.FormattingOptions>
     {
+        public string Indentation { get; }
+        public bool UseLineBreaks { get; }
         public static aweXpect.Formatting.FormattingOptions MultipleLines { get; }
         public static aweXpect.Formatting.FormattingOptions SingleLine { get; }
         public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -577,6 +577,8 @@ namespace aweXpect.Formatting
     }
     public class FormattingOptions : System.IEquatable<aweXpect.Formatting.FormattingOptions>
     {
+        public string Indentation { get; }
+        public bool UseLineBreaks { get; }
         public static aweXpect.Formatting.FormattingOptions MultipleLines { get; }
         public static aweXpect.Formatting.FormattingOptions SingleLine { get; }
         public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null) { }


### PR DESCRIPTION
This allows extensions to specify custom formatters while taking the options into account.