### PR TITLE
feat: add `IsPrefix` and `IsSuffix` as string equality option

### DIFF
--- a/Docs/pages/docs/expectations/02-string.md
+++ b/Docs/pages/docs/expectations/02-string.md
@@ -59,6 +59,17 @@ The regex comparison uses the following [
 - `Multiline` (always)
 - `IgnoreCase` (if the `IgnoringCase` method is also used)
 
+### Prefix / Suffix
+
+You can also verify that the subject starts with or ends with a given string.
+
+```csharp
+string subject = "some text";
+
+await Expect.That(subject).IsEqualTo("some").AsPrefix();
+await Expect.That(subject).IsEqualTo("text").AsSuffix();
+```
+
 ## One of
 
 You can verify, that the `string` is one of many alternatives.  

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.RegexMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.RegexMatchType.cs
@@ -7,6 +7,8 @@ namespace aweXpect.Options;
 
 public partial class StringEqualityOptions
 {
+	private static readonly IStringMatchType RegexMatch = new RegexMatchType();
+
 	/// <summary>
 	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
 	/// </summary>

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.SuffixMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.SuffixMatchType.cs
@@ -7,18 +7,18 @@ namespace aweXpect.Options;
 
 public partial class StringEqualityOptions
 {
-	private static readonly IStringMatchType ExactMatch = new ExactMatchType();
+	private static readonly IStringMatchType SuffixMatch = new SuffixMatchType();
 
 	/// <summary>
-	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	///     Interprets the expected <see langword="string" /> to be a suffix for the actual string.
 	/// </summary>
-	public StringEqualityOptions Exactly()
+	public StringEqualityOptions AsSuffix()
 	{
-		_matchType = ExactMatch;
+		_matchType = SuffixMatch;
 		return this;
 	}
 
-	private sealed class ExactMatchType : IStringMatchType
+	private sealed class SuffixMatchType : IStringMatchType
 	{
 		private static int GetIndexOfFirstMatch(string stringWithLeadingWhitespace, string value,
 			IEqualityComparer<string> comparer)
@@ -109,7 +109,7 @@ public partial class StringEqualityOptions
 				return false;
 			}
 
-			return comparer.Equals(actual, expected);
+			return actual.Length >= expected.Length && comparer.Equals(actual[^expected.Length..], expected);
 		}
 
 		/// <inheritdoc cref="IStringMatchType.GetExpectation(string?, ExpectationGrammars)" />
@@ -117,18 +117,18 @@ public partial class StringEqualityOptions
 			=> (grammars.HasFlag(ExpectationGrammars.Active), grammars.HasFlag(ExpectationGrammars.Negated)) switch
 			{
 				(true, false) =>
-					$"is equal to {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
+					$"ends with {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
 				(false, false) =>
-					$"equal to {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
+					$"end with {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
 				(true, true) =>
-					$"is not equal to {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
+					$"does not end with {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
 				(false, true) =>
-					$"not equal to {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
+					$"not end with {Formatter.Format(expected.TruncateWithEllipsisOnWord(DefaultMaxLength).ToSingleLine())}",
 			};
 
 		/// <inheritdoc cref="IStringMatchType.GetTypeString()" />
 		public string GetTypeString()
-			=> "";
+			=> " as suffix";
 
 		/// <inheritdoc cref="IStringMatchType.GetOptionString(bool, IEqualityComparer{string})" />
 		public string GetOptionString(bool ignoreCase, IEqualityComparer<string>? comparer)

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.WildcardMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.WildcardMatchType.cs
@@ -7,6 +7,8 @@ namespace aweXpect.Options;
 
 public partial class StringEqualityOptions
 {
+	private static readonly IStringMatchType WildcardMatch = new WildcardMatchType();
+
 	/// <summary>
 	///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
 	///     Supports * to match zero or more characters and ? to match exactly one character.

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.cs
@@ -12,11 +12,8 @@ namespace aweXpect.Options;
 public partial class StringEqualityOptions : IOptionsEquality<string?>
 {
 	private const int DefaultMaxLength = 30;
-	private static readonly IStringMatchType ExactMatch = new ExactMatchType();
-	private static readonly IStringMatchType RegexMatch = new RegexMatchType();
 
 	private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(1000);
-	private static readonly IStringMatchType WildcardMatch = new WildcardMatchType();
 	private IEqualityComparer<string>? _comparer;
 	private bool _ignoreCase;
 	private bool _ignoreLeadingWhiteSpace;

--- a/Source/aweXpect.Core/Results/StringEqualityTypeCountResult.cs
+++ b/Source/aweXpect.Core/Results/StringEqualityTypeCountResult.cs
@@ -17,11 +17,38 @@ public class StringEqualityTypeCountResult<TType, TThat>(
 	private readonly StringEqualityOptions _options = options;
 
 	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public StringCountResult<TType, TThat> Exactly()
+	{
+		_options.Exactly();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as a prefix, so that the actual value starts with it.
+	/// </summary>
+	public StringCountResult<TType, TThat> AsPrefix()
+	{
+		_options.AsPrefix();
+		return this;
+	}
+
+	/// <summary>
 	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
 	/// </summary>
 	public StringCountResult<TType, TThat> AsRegex()
 	{
 		_options.AsRegex();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as a suffix, so that the actual value ends with it.
+	/// </summary>
+	public StringCountResult<TType, TThat> AsSuffix()
+	{
+		_options.AsSuffix();
 		return this;
 	}
 
@@ -32,15 +59,6 @@ public class StringEqualityTypeCountResult<TType, TThat>(
 	public StringCountResult<TType, TThat> AsWildcard()
 	{
 		_options.AsWildcard();
-		return this;
-	}
-
-	/// <summary>
-	///     Interprets the expected <see langword="string" /> to be exactly equal.
-	/// </summary>
-	public StringCountResult<TType, TThat> Exactly()
-	{
-		_options.Exactly();
 		return this;
 	}
 }

--- a/Source/aweXpect.Core/Results/StringEqualityTypeResult.cs
+++ b/Source/aweXpect.Core/Results/StringEqualityTypeResult.cs
@@ -33,11 +33,38 @@ public class StringEqualityTypeResult<TType, TThat, TSelf>(
 	private readonly StringEqualityOptions _options = options;
 
 	/// <summary>
+	///     Interprets the expected <see langword="string" /> to be exactly equal.
+	/// </summary>
+	public TSelf Exactly()
+	{
+		_options.Exactly();
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as a prefix, so that the actual value starts with it.
+	/// </summary>
+	public TSelf AsPrefix()
+	{
+		_options.AsPrefix();
+		return (TSelf)this;
+	}
+
+	/// <summary>
 	///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
 	/// </summary>
 	public TSelf AsRegex()
 	{
 		_options.AsRegex();
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Interprets the expected <see langword="string" /> as a suffix, so that the actual value ends with it.
+	/// </summary>
+	public TSelf AsSuffix()
+	{
+		_options.AsSuffix();
 		return (TSelf)this;
 	}
 
@@ -48,15 +75,6 @@ public class StringEqualityTypeResult<TType, TThat, TSelf>(
 	public TSelf AsWildcard()
 	{
 		_options.AsWildcard();
-		return (TSelf)this;
-	}
-
-	/// <summary>
-	///     Interprets the expected <see langword="string" /> to be exactly equal.
-	/// </summary>
-	public TSelf Exactly()
-	{
-		_options.Exactly();
 		return (TSelf)this;
 	}
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -770,7 +770,9 @@ namespace aweXpect.Options
     {
         public StringEqualityOptions() { }
         public bool AreConsideredEqual<TExpected>(string? actual, TExpected expected) { }
+        public aweXpect.Options.StringEqualityOptions AsPrefix() { }
         public aweXpect.Options.StringEqualityOptions AsRegex() { }
+        public aweXpect.Options.StringEqualityOptions AsSuffix() { }
         public aweXpect.Options.StringEqualityOptions AsWildcard() { }
         public aweXpect.Options.StringEqualityOptions Exactly() { }
         public string GetExpectation(string? expected, aweXpect.Core.ExpectationGrammars grammars) { }
@@ -1044,7 +1046,9 @@ namespace aweXpect.Results
     public class StringEqualityTypeCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat>
     {
         public StringEqualityTypeCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsPrefix() { }
         public aweXpect.Results.StringCountResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsSuffix() { }
         public aweXpect.Results.StringCountResult<TType, TThat> AsWildcard() { }
         public aweXpect.Results.StringCountResult<TType, TThat> Exactly() { }
     }
@@ -1056,7 +1060,9 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringEqualityTypeResult<TType, TThat, TSelf>
     {
         public StringEqualityTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
+        public TSelf AsPrefix() { }
         public TSelf AsRegex() { }
+        public TSelf AsSuffix() { }
         public TSelf AsWildcard() { }
         public TSelf Exactly() { }
     }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -757,7 +757,9 @@ namespace aweXpect.Options
     {
         public StringEqualityOptions() { }
         public bool AreConsideredEqual<TExpected>(string? actual, TExpected expected) { }
+        public aweXpect.Options.StringEqualityOptions AsPrefix() { }
         public aweXpect.Options.StringEqualityOptions AsRegex() { }
+        public aweXpect.Options.StringEqualityOptions AsSuffix() { }
         public aweXpect.Options.StringEqualityOptions AsWildcard() { }
         public aweXpect.Options.StringEqualityOptions Exactly() { }
         public string GetExpectation(string? expected, aweXpect.Core.ExpectationGrammars grammars) { }
@@ -1031,7 +1033,9 @@ namespace aweXpect.Results
     public class StringEqualityTypeCountResult<TType, TThat> : aweXpect.Results.StringCountResult<TType, TThat>
     {
         public StringEqualityTypeCountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsPrefix() { }
         public aweXpect.Results.StringCountResult<TType, TThat> AsRegex() { }
+        public aweXpect.Results.StringCountResult<TType, TThat> AsSuffix() { }
         public aweXpect.Results.StringCountResult<TType, TThat> AsWildcard() { }
         public aweXpect.Results.StringCountResult<TType, TThat> Exactly() { }
     }
@@ -1043,7 +1047,9 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.StringEqualityTypeResult<TType, TThat, TSelf>
     {
         public StringEqualityTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options) { }
+        public TSelf AsPrefix() { }
         public TSelf AsRegex() { }
+        public TSelf AsSuffix() { }
         public TSelf AsWildcard() { }
         public TSelf Exactly() { }
     }

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsPrefixTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsPrefixTests.cs
@@ -1,0 +1,203 @@
+﻿#if DEBUG // Remove after next core update
+namespace aweXpect.Tests;
+
+public sealed partial class ThatString
+{
+	public sealed partial class IsEqualTo
+	{
+		public sealed class AsPrefixTests
+		{
+			[Fact]
+			public async Task WhenActualAndExpectedAreNull_ShouldSucceed()
+			{
+				string? subject = null;
+				string? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenActualIsNull_ShouldFail()
+			{
+				string? subject = null;
+				string expected = "some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "some text",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string subject = "some text";
+				string? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with <null>,
+					             but it was "some text"
+
+					             Actual:
+					             some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringHasAdditionalTrailingWhitespace_ShouldSucceed()
+			{
+				string subject = "some text \t ";
+				string expected = "some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringHasMissingLeadingWhitespace_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = " \t some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with " \t some text",
+					             but it was "some text" which misses some whitespace (" \t " at the beginning)
+
+					             Actual:
+					             some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringHasMissingTrailingWhitespace_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = "some text \t ";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "some text \t ",
+					             but it was "some text" with a length of 9 which is shorter than the expected length of 12 and misses:
+					               " 	 "
+
+					             Actual:
+					             some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringHasUnexpectedLeadingWhitespace_ShouldFail()
+			{
+				string subject = " \t some text";
+				string expected = "some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "some text",
+					             but it was " \t some text" which has unexpected whitespace (" \t " at the beginning)
+
+					             Actual:
+					              	 some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringIsShorter_ShouldFail()
+			{
+				string subject = "some text with";
+				string expected = "some text without out";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "some text without out",
+					             but it was "some text with" with a length of 14 which is shorter than the expected length of 21 and misses:
+					               "out out"
+
+					             Actual:
+					             some text with
+					             """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenStringsAreTheSame_ShouldSucceed(string subject)
+			{
+				string expected = subject;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringsDiffer_ShouldFail()
+			{
+				string subject = "actual text";
+				string expected = "expected other text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "expected other text",
+					             but it was "actual text" which differs at index 0:
+					                ↓ (actual)
+					               "actual text"
+					               "expected other text"
+					                ↑ (expected)
+
+					             Actual:
+					             actual text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringStartsWithExpected_ShouldSucceed()
+			{
+				string subject = "some text without out";
+				string expected = "some text with";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsSuffixTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsSuffixTests.cs
@@ -1,0 +1,202 @@
+﻿#if DEBUG // Remove after next core update
+namespace aweXpect.Tests;
+
+public sealed partial class ThatString
+{
+	public sealed partial class IsEqualTo
+	{
+		public sealed class AsSuffixTests
+		{
+			[Fact]
+			public async Task WhenActualAndExpectedAreNull_ShouldSucceed()
+			{
+				string? subject = null;
+				string? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenActualIsNull_ShouldFail()
+			{
+				string? subject = null;
+				string expected = "some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "some text",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string subject = "some text";
+				string? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with <null>,
+					             but it was "some text"
+
+					             Actual:
+					             some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringEndsWithExpected_ShouldSucceed()
+			{
+				string subject = "some text without out";
+				string expected = "text without out";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringHasAdditionalLeadingWhitespace_ShouldSucceed()
+			{
+				string subject = " \t some text";
+				string expected = "some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringHasMissingLeadingWhitespace_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = " \t some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with " \t some text",
+					             but it was "some text" which misses some whitespace (" \t " at the beginning)
+
+					             Actual:
+					             some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringHasMissingTrailingWhitespace_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = "some text \t ";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "some text \t ",
+					             but it was "some text" which misses some whitespace (" \t " at the end)
+
+					             Actual:
+					             some text
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringHasUnexpectedTrailingWhitespace_ShouldFail()
+			{
+				string subject = "some text \t ";
+				string expected = "some text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "some text",
+					             but it was "some text \t " which has unexpected whitespace (" \t " at the end)
+
+					             Actual:
+					             some text 	 
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringIsShorter_ShouldFail()
+			{
+				string subject = "some text with";
+				string expected = "some text without out";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "some text without out",
+					             but it was "some text with" with a length of 14 which is shorter than the expected length of 21 and misses:
+					               "out out"
+
+					             Actual:
+					             some text with
+					             """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenStringsAreTheSame_ShouldSucceed(string subject)
+			{
+				string expected = subject;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringsDiffer_ShouldFail()
+			{
+				string subject = "actual text";
+				string expected = "expected other text";
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected).AsSuffix();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             ends with "expected other text",
+					             but it was "actual text" which differs at index 0:
+					                ↓ (actual)
+					               "actual text"
+					               "expected other text"
+					                ↑ (expected)
+
+					             Actual:
+					             actual text
+					             """);
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
With this you can now verify that the subject starts with or ends with a given string.

```csharp
string subject = "some text";

await Expect.That(subject).IsEqualTo("some").AsPrefix();
await Expect.That(subject).IsEqualTo("text").AsSuffix();
```

*Implement #438*