### PR TITLE
fix: incorrect project in build pipeline

### DIFF
--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -52,7 +52,7 @@ public static class BuildExtensions
 		client.DefaultRequestHeaders.UserAgent.ParseAdd("aweXpect");
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
 		HttpResponseMessage response = await client.GetAsync(
-			$"https://api.github.com/repos/aweXpect/aweXpect.Json/actions/runs/{runId}/artifacts");
+			$"https://api.github.com/repos/aweXpect/aweXpect/actions/runs/{runId}/artifacts");
 
 		string responseContent = await response.Content.ReadAsStringAsync();
 		if (!response.IsSuccessStatusCode)
@@ -71,7 +71,7 @@ public static class BuildExtensions
 				{
 					long artifactId = artifact.GetProperty("id").GetInt64();
 					HttpResponseMessage fileResponse = await client.GetAsync(
-						$"https://api.github.com/repos/aweXpect/aweXpect.Json/actions/artifacts/{artifactId}/zip");
+						$"https://api.github.com/repos/aweXpect/aweXpect/actions/artifacts/{artifactId}/zip");
 					if (fileResponse.IsSuccessStatusCode)
 					{
 						using ZipArchive archive = new(await fileResponse.Content.ReadAsStreamAsync());


### PR DESCRIPTION
The `DownloadArtifactTo` method uses an incorrect project in the URL.