### PR TITLE
fix: forward contexts from `ManualExpectationBuilder`

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -367,7 +367,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Gets the list of <see cref="ResultContext" />.
 	/// </summary>
-	internal virtual IEnumerable<ResultContext> GetContexts() => _contexts ?? [];
+	internal IEnumerable<ResultContext> GetContexts() => _contexts ?? [];
 
 	/// <summary>
 	///     Creates the exception message from the <paramref name="failure" />.

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -357,7 +357,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Update the list of <see cref="ResultContext" /> that is included in the failure message.
 	/// </summary>
-	public ExpectationBuilder UpdateContexts(Action<ResultContexts> callback)
+	public virtual ExpectationBuilder UpdateContexts(Action<ResultContexts> callback)
 	{
 		_contexts ??= new ResultContexts();
 		callback(_contexts);
@@ -367,7 +367,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Gets the list of <see cref="ResultContext" />.
 	/// </summary>
-	internal IEnumerable<ResultContext> GetContexts() => _contexts ?? [];
+	internal virtual IEnumerable<ResultContext> GetContexts() => _contexts ?? [];
 
 	/// <summary>
 	///     Creates the exception message from the <paramref name="failure" />.

--- a/Source/aweXpect.Core/Core/ManualExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ManualExpectationBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,7 +13,9 @@ namespace aweXpect.Core;
 /// <summary>
 ///     A manual expectation builder can be used for manually evaluating inner expectations.
 /// </summary>
-public class ManualExpectationBuilder<TValue>(ExpectationGrammars grammars = ExpectationGrammars.None)
+public class ManualExpectationBuilder<TValue>(
+	ExpectationBuilder? inner,
+	ExpectationGrammars grammars = ExpectationGrammars.None)
 	: ExpectationBuilder("", grammars)
 {
 	/// <summary>
@@ -37,4 +40,12 @@ public class ManualExpectationBuilder<TValue>(ExpectationGrammars grammars = Exp
 		TimeSpan? timeout,
 		CancellationToken cancellationToken)
 		=> throw new NotSupportedException($"Use {nameof(IsMetBy)} for ManualExpectationBuilder!");
+
+	/// <inheritdoc cref="ExpectationBuilder.UpdateContexts(Action{ResultContexts})" />
+	public override ExpectationBuilder UpdateContexts(Action<ResultContexts> callback)
+	{
+		inner?.UpdateContexts(callback);
+		base.UpdateContexts(callback);
+		return this;
+	}
 }

--- a/Source/aweXpect.Core/Options/Quantifier.cs
+++ b/Source/aweXpect.Core/Options/Quantifier.cs
@@ -17,7 +17,7 @@ public class Quantifier
 	/// </summary>
 	public static Quantifier Never()
 	{
-		Quantifier? quantifier = new();
+		Quantifier quantifier = new();
 		quantifier.Exactly(0);
 		return quantifier;
 	}

--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -72,12 +72,12 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder) : Expectat
 	}
 
 	/// <inheritdoc />
-	internal override async Task<Result> GetResult(int index)
+	internal override async Task<Result> GetResult(int index, Dictionary<int, Outcome> outcomes)
 		=> new(++index, $" [{index:00}] Expected that {expectationBuilder.Subject}",
 			await expectationBuilder.IsMet());
 
 	/// <inheritdoc />
-	internal override IEnumerable<ResultContext> GetContexts(int index)
+	internal override IEnumerable<ResultContext> GetContexts(int index, Dictionary<int, Outcome> outcomes)
 		=> expectationBuilder.GetContexts();
 
 	/// <summary>
@@ -173,12 +173,12 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	}
 
 	/// <inheritdoc />
-	internal override async Task<Result> GetResult(int index)
+	internal override async Task<Result> GetResult(int index, Dictionary<int, Outcome> outcomes)
 		=> new(++index, $" [{index:00}] Expected that {expectationBuilder.Subject}",
 			await expectationBuilder.IsMet());
 
 	/// <inheritdoc />
-	internal override IEnumerable<ResultContext> GetContexts(int index)
+	internal override IEnumerable<ResultContext> GetContexts(int index, Dictionary<int, Outcome> outcomes)
 		=> expectationBuilder.GetContexts();
 
 	/// <summary>

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
@@ -24,8 +24,8 @@ public static partial class ThatAsyncEnumerable
 		{
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint((it, grammars)
-					=> new ComplyWithConstraint<TItem>(it, grammars, _quantifier, expectations)),
+				_subject.ThatIs().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+					=> new ComplyWithConstraint<TItem>(expectationBuilder, it, grammars, _quantifier, expectations)),
 				_subject,
 				options);
 		}
@@ -43,14 +43,14 @@ public static partial class ThatAsyncEnumerable
 		private int _notMatchingCount;
 		private int? _totalCount;
 
-		public ComplyWithConstraint(string it, ExpectationGrammars grammars,
+		public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
 			EnumerableQuantifier quantifier,
 			Action<IThat<TItem>> expectations) : base(grammars)
 		{
 			_it = it;
 			_grammars = grammars;
 			_quantifier = quantifier;
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>();
+			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder);
 			expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -25,8 +25,8 @@ public static partial class ThatEnumerable
 		{
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-				_subject.ThatIs().ExpectationBuilder.AddConstraint((it, grammars)
-					=> new ComplyWithConstraint(it, grammars, _quantifier, expectations)),
+				_subject.ThatIs().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+					=> new ComplyWithConstraint(expectationBuilder, it, grammars, _quantifier, expectations)),
 				_subject,
 				options);
 		}
@@ -41,13 +41,13 @@ public static partial class ThatEnumerable
 			private int _notMatchingCount;
 			private int? _totalCount;
 
-			public ComplyWithConstraint(string it, ExpectationGrammars grammars,
+			public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
 				EnumerableQuantifier quantifier,
 				Action<IThat<TItem>> expectations)
 				: base(it, grammars)
 			{
 				_quantifier = quantifier;
-				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>();
+				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder);
 				expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 			}
 

--- a/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsEqualTo.cs
@@ -51,12 +51,8 @@ public static partial class ThatString
 		{
 			Actual = actual;
 			Outcome = options.AreConsideredEqual(actual, expected) ? Outcome.Success : Outcome.Failure;
-			if (Outcome == Outcome.Failure)
-			{
-				expectationBuilder.UpdateContexts(contexts => contexts
-					.Add(new ResultContext("Actual", actual)));
-			}
-
+			expectationBuilder.UpdateContexts(contexts => contexts
+				.Add(new ResultContext("Actual", actual)));
 			return this;
 		}
 

--- a/Source/aweXpect/That/ThatGeneric.CompliesWith.cs
+++ b/Source/aweXpect/That/ThatGeneric.CompliesWith.cs
@@ -21,8 +21,8 @@ public static partial class ThatGeneric
 	{
 		RepeatedCheckOptions options = new();
 		return new RepeatedCheckResult<T, IThat<T>>(source.ThatIs().ExpectationBuilder
-				.AddConstraint((_, grammars) =>
-					new CompliesWithConstraint<T>(grammars, expectations, options)),
+				.AddConstraint((expectationBuilder, _, grammars) =>
+					new CompliesWithConstraint<T>(expectationBuilder, grammars, expectations, options)),
 			source,
 			options);
 	}
@@ -35,8 +35,8 @@ public static partial class ThatGeneric
 	{
 		RepeatedCheckOptions options = new();
 		return new RepeatedCheckResult<T, IThat<T>>(source.ThatIs().ExpectationBuilder
-				.AddConstraint((_, grammars) =>
-					new CompliesWithConstraint<T>(grammars, expectations, options).Invert()),
+				.AddConstraint((expectationBuilder, _, grammars) =>
+					new CompliesWithConstraint<T>(expectationBuilder, grammars, expectations, options).Invert()),
 			source,
 			options);
 	}
@@ -49,12 +49,12 @@ public static partial class ThatGeneric
 		private readonly RepeatedCheckOptions _options;
 		private bool _isNegated;
 
-		public CompliesWithConstraint(ExpectationGrammars grammars,
+		public CompliesWithConstraint(ExpectationBuilder expectationBuilder, ExpectationGrammars grammars,
 			Action<IThat<T>> expectations, RepeatedCheckOptions options)
 			: base(grammars)
 		{
 			_options = options;
-			_itemExpectationBuilder = new ManualExpectationBuilder<T>(grammars);
+			_itemExpectationBuilder = new ManualExpectationBuilder<T>(expectationBuilder, grammars);
 			expectations.Invoke(new ThatSubject<T>(_itemExpectationBuilder));
 		}
 
@@ -71,7 +71,7 @@ public static partial class ThatGeneric
 
 			if (_options.Timeout > TimeSpan.Zero)
 			{
-				Stopwatch? sw = new();
+				Stopwatch sw = new();
 				sw.Start();
 				do
 				{

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -159,7 +159,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, System.Func<aweXpect.Core.ExpectationGrammars, aweXpect.Core.ExpectationGrammars>? expectationGrammar = null) { }
-        public aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
+        public virtual aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
@@ -238,9 +238,10 @@ namespace aweXpect.Core
     }
     public class ManualExpectationBuilder<TValue> : aweXpect.Core.ExpectationBuilder
     {
-        public ManualExpectationBuilder(aweXpect.Core.ExpectationGrammars grammars = 0) { }
+        public ManualExpectationBuilder(aweXpect.Core.ExpectationBuilder? inner, aweXpect.Core.ExpectationGrammars grammars = 0) { }
         public void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
         public System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult> IsMetBy(TValue value, aweXpect.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken) { }
+        public override aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
     }
     public abstract class MemberAccessor
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -159,7 +159,7 @@ namespace aweXpect.Core
         public aweXpect.Core.ExpectationBuilder.MemberExpectationBuilder<TSource, TTarget> ForMember<TSource, TTarget>(aweXpect.Core.MemberAccessor<TSource, TTarget> memberAccessor, System.Action<aweXpect.Core.MemberAccessor, System.Text.StringBuilder>? expectationTextGenerator = null, bool replaceIt = true) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, System.Threading.Tasks.Task<TTarget?>> asyncMemberAccessor, string? separator = null) { }
         public aweXpect.Core.ExpectationBuilder ForWhich<TSource, TTarget>(System.Func<TSource, TTarget?> memberAccessor, string? separator = null, string? replaceIt = null, System.Func<aweXpect.Core.ExpectationGrammars, aweXpect.Core.ExpectationGrammars>? expectationGrammar = null) { }
-        public aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
+        public virtual aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
         public void WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public void WithTimeout(System.TimeSpan timeout) { }
         public class MemberExpectationBuilder<TSource, TMember>
@@ -238,9 +238,10 @@ namespace aweXpect.Core
     }
     public class ManualExpectationBuilder<TValue> : aweXpect.Core.ExpectationBuilder
     {
-        public ManualExpectationBuilder(aweXpect.Core.ExpectationGrammars grammars = 0) { }
+        public ManualExpectationBuilder(aweXpect.Core.ExpectationBuilder? inner, aweXpect.Core.ExpectationGrammars grammars = 0) { }
         public void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
         public System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult> IsMetBy(TValue value, aweXpect.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken) { }
+        public override aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
     }
     public abstract class MemberAccessor
     {

--- a/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
@@ -12,7 +12,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task AddAsyncContextValueConstraint_ShouldAllowGettingExpectationBuilder()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		ExpectationBuilder? expectationBuilder = null;
 		sut.AddConstraint((e, _, _) =>
 		{
@@ -29,7 +29,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task AddAsyncValueConstraint_ShouldAllowGettingExpectationBuilder()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		ExpectationBuilder? expectationBuilder = null;
 		sut.AddConstraint((e, _, _) =>
 		{
@@ -46,7 +46,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task AddContextValueConstraint_ShouldAllowGettingExpectationBuilder()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		ExpectationBuilder? expectationBuilder = null;
 		sut.AddConstraint((e, _, _) =>
 		{
@@ -62,7 +62,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task AddValueConstraint_ShouldAllowGettingExpectationBuilder()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		ExpectationBuilder? expectationBuilder = null;
 		sut.AddConstraint((e, _, _) =>
 		{
@@ -79,7 +79,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task IsMet_ShouldThrowNotSupportedException()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		sut.AddConstraint((_, _) => new DummyConstraint<int>(_ => true));
 
 		async Task Act() => await sut.IsMet(
@@ -92,7 +92,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task IsMetBy_FailingConstraint_ShouldReturnFailure()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		sut.AddConstraint((_, _) => new DummyConstraint<int>(_ => false));
 
 		ConstraintResult result = await sut.IsMetBy(1, null!, CancellationToken.None);
@@ -103,7 +103,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task IsMetBy_SucceedingConstraint_ShouldReturnSuccess()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 		sut.AddConstraint((_, _) => new DummyConstraint<int>(_ => true));
 
 		ConstraintResult result = await sut.IsMetBy(1, null!, CancellationToken.None);
@@ -114,7 +114,7 @@ public class ManualExpectationBuilderTests
 	[Fact]
 	public async Task Subject_ShouldBeEmpty()
 	{
-		ManualExpectationBuilder<int> sut = new();
+		ManualExpectationBuilder<int> sut = new(null);
 
 		await That(sut.Subject).IsEmpty();
 	}

--- a/Tests/aweXpect.Core.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Core.Tests/ExpectTests.cs
@@ -27,9 +27,6 @@ public class ExpectTests
 			             but
 			              [01] result1
 
-			             [01] context-title1:
-			             contest-content1
-
 			             [02] context-title2:
 			             contest-content2
 			             """);

--- a/Tests/aweXpect.Core.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Core.Tests/ExpectTests.cs
@@ -116,7 +116,9 @@ public class ExpectTests
 #endif
 	private sealed class MyExpectation(Expectation.Result result, params ResultContext[] contexts) : Expectation
 	{
-		internal override Task<Result> GetResult(int index) => Task.FromResult(result);
-		internal override IEnumerable<ResultContext> GetContexts(int index) => contexts;
+		internal override Task<Result> GetResult(int index, Dictionary<int, Outcome> outcomes)
+			=> Task.FromResult(result);
+		internal override IEnumerable<ResultContext> GetContexts(int index, Dictionary<int, Outcome> outcomes)
+			=> contexts;
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
@@ -42,7 +42,7 @@ public partial class ValueFormatters
 		public async Task NullableShouldUseRoundtripFormat()
 		{
 			Guid? value = Guid.NewGuid();
-			string expectedResult = value.ToString();
+			string? expectedResult = value.ToString();
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
@@ -42,7 +42,7 @@ public partial class ValueFormatters
 		public async Task NullableShouldUseRoundtripFormat()
 		{
 			Guid? value = Guid.NewGuid();
-			string? expectedResult = value.ToString();
+			string expectedResult = value.ToString();
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);

--- a/Tests/aweXpect.Core.Tests/Results/ExpectationResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Results/ExpectationResultTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Nodes;
 using aweXpect.Core.Tests.TestHelpers;
@@ -14,7 +15,7 @@ public class ExpectationResultTests
 	{
 		ExpectationResult sut = new(new MyExpectationBuilder("my-subject"));
 
-		Expectation.Result result = await sut.GetResult(3);
+		Expectation.Result result = await sut.GetResult(3, new Dictionary<int, Outcome>());
 
 		await That(result.Index).IsEqualTo(4);
 		await That(result.SubjectLine).IsEqualTo(" [04] Expected that my-subject");

--- a/Tests/aweXpect.Core.Tests/Results/PropertyResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Results/PropertyResultTests.cs
@@ -301,7 +301,7 @@ public sealed class PropertyResultTests
 
 	private sealed class Dummy : IThat<string>, IThatIs<string>
 	{
-		public ExpectationBuilder ExpectationBuilder { get; } = new ManualExpectationBuilder<string>();
+		public ExpectationBuilder ExpectationBuilder { get; } = new ManualExpectationBuilder<string>(null);
 	}
 
 	private sealed class MyClass

--- a/Tests/aweXpect.Internal.Tests/Helpers/ExpectHelpersTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Helpers/ExpectHelpersTests.cs
@@ -122,30 +122,30 @@ public class ExpectHelpersTests
 	private sealed class ThatWithThatIs : IThat<int>, IThatIs<int>
 	{
 		public ExpectationBuilder ExpectationBuilder { get; }
-			= new ManualExpectationBuilder<int>();
+			= new ManualExpectationBuilder<int>(null);
 	}
 
 	private sealed class ThatWithThatHas : IThat<int>, IThatHas<int>
 	{
 		public ExpectationBuilder ExpectationBuilder { get; }
-			= new ManualExpectationBuilder<int>();
+			= new ManualExpectationBuilder<int>(null);
 	}
 
 	private sealed class ThatIs : IThatIs<int>
 	{
 		public ExpectationBuilder ExpectationBuilder { get; }
-			= new ManualExpectationBuilder<int>();
+			= new ManualExpectationBuilder<int>(null);
 	}
 
 	private sealed class ThatHas : IThatHas<int>
 	{
 		public ExpectationBuilder ExpectationBuilder { get; }
-			= new ManualExpectationBuilder<int>();
+			= new ManualExpectationBuilder<int>(null);
 	}
 
 	private sealed class ThatWithThatVerb : IThat<int>, IThatVerb<int>
 	{
 		public ExpectationBuilder ExpectationBuilder { get; }
-			= new ManualExpectationBuilder<int>();
+			= new ManualExpectationBuilder<int>(null);
 	}
 }

--- a/Tests/aweXpect.Tests/ThatGeneric.DoesNotComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.DoesNotComplyWith.Tests.cs
@@ -24,6 +24,9 @@ public sealed partial class ThatGeneric
 					              Expected that subject
 					              is not equal to "{expectedValue}",
 					              but it was "foo"
+					              
+					              Actual:
+					              foo
 					              """);
 			}
 		}


### PR DESCRIPTION
When using `DoesNotComplyWith` and the expectations add a context to the expectation builder, the context is not displayed in a test error.

Root cause is, that the inner `ManualExpectationBuilder` does not forward the contexts to the outer expectation builder, so that they get lost.

Fixes #458 