### PR TITLE
fix: pipeline when scope is not default

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -139,6 +139,7 @@ partial class Build
 
 	Target MutationTestDashboard => _ => _
 		.After(MutationTestExecution)
+		.OnlyWhenDynamic(() => BuildScope == BuildScope.Default)
 		.Executes(async () =>
 		{
 			await "MutationTests".DownloadArtifactTo(ArtifactsDirectory, GithubToken);


### PR DESCRIPTION
The MutationTestDashboard target should not be executed when the build scope is not `Default`