### PR TITLE
feat: add context with equivalency options

### DIFF
--- a/Source/aweXpect.Core/Equivalency/EquivalencyOptions.cs
+++ b/Source/aweXpect.Core/Equivalency/EquivalencyOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace aweXpect.Equivalency;
 
@@ -8,14 +9,19 @@ namespace aweXpect.Equivalency;
 /// </summary>
 public record EquivalencyOptions : EquivalencyTypeOptions
 {
+	private readonly Func<Type, EquivalencyComparisonType>? _defaultComparisonTypeSelector;
+
 	/// <summary>
 	///     Specifies the selector how types should be compared, if not overwritten in the <see cref="CustomOptions" />.
 	/// </summary>
 	/// <remarks>
 	///     Defaults to use the <see cref="EquivalencyDefaults.DefaultComparisonType" />.
 	/// </remarks>
-	public Func<Type, EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; } =
-		EquivalencyDefaults.DefaultComparisonType;
+	public Func<Type, EquivalencyComparisonType> DefaultComparisonTypeSelector
+	{
+		get => _defaultComparisonTypeSelector ?? EquivalencyDefaults.DefaultComparisonType;
+		init => _defaultComparisonTypeSelector = value;
+	}
 
 	/// <summary>
 	///     Custom type-specific equivalency options.
@@ -31,6 +37,22 @@ public record EquivalencyOptions : EquivalencyTypeOptions
 		EquivalencyTypeOptions typeOptions = options(this);
 		CustomOptions.Add(typeof(TMember), typeOptions);
 		return this;
+	}
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		StringBuilder? sb = new();
+		AppendOptions(sb);
+		foreach (KeyValuePair<Type, EquivalencyTypeOptions> customOption in CustomOptions)
+		{
+			sb.Append(" - for ");
+			Formatter.Format(sb, customOption.Key);
+			sb.AppendLine(":");
+			customOption.Value.AppendOptions(sb, "  ");
+		}
+
+		return sb.ToString().TrimEnd();
 	}
 }
 
@@ -58,4 +80,7 @@ public record EquivalencyOptions<TExpected> : EquivalencyOptions
 		base.For<TMember>(options);
 		return this;
 	}
+
+	/// <inheritdoc />
+	public override string ToString() => base.ToString();
 }

--- a/Source/aweXpect.Core/Equivalency/EquivalencyTypeOptions.cs
+++ b/Source/aweXpect.Core/Equivalency/EquivalencyTypeOptions.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace aweXpect.Equivalency;
 
 /// <summary>
@@ -32,4 +34,49 @@ public record EquivalencyTypeOptions
 	///     Ignores the order of collections when checking for equivalency.
 	/// </summary>
 	public bool IgnoreCollectionOrder { get; init; }
+
+	internal void AppendOptions(StringBuilder sb, string indentation = "")
+	{
+		sb.Append(indentation).Append(" - include").Append(Fields switch
+		{
+			IncludeMembers.Public => " public",
+			IncludeMembers.Private => " private",
+			IncludeMembers.Internal => " internal",
+			_ => " no",
+		}).Append(" fields and");
+
+		if (Fields != Properties)
+		{
+			sb.Append(Properties switch
+			{
+				IncludeMembers.Public => " public",
+				IncludeMembers.Private => " private",
+				IncludeMembers.Internal => " internal",
+				_ => " no",
+			});
+		}
+
+		sb.AppendLine(" properties");
+		if (ComparisonType is not null)
+		{
+			sb.Append(indentation).Append(" - compare types ");
+			sb.AppendLine(ComparisonType switch
+			{
+				EquivalencyComparisonType.ByMembers => "by members",
+				_ => "by value",
+			});
+		}
+
+		if (IgnoreCollectionOrder)
+		{
+			sb.Append(indentation).AppendLine(" - ignore collection order");
+		}
+
+		if (MembersToIgnore.Length > 0)
+		{
+			sb.Append(indentation).Append(" - ignore members: ");
+			Formatter.Format(sb, MembersToIgnore, FormattingOptions.SingleLine);
+			sb.AppendLine();
+		}
+	}
 }

--- a/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -32,4 +33,10 @@ public static class EquivalencyExtensions
 		options.SetMatchType(new EquivalencyComparer(equivalencyOptions));
 		return options;
 	}
+
+
+	internal static void AddEquivalencyContext(this ExpectationBuilder expectationBuilder,
+		EquivalencyOptions equivalencyOptions)
+		=> expectationBuilder.UpdateContexts(contexts => contexts.Add(
+			new ResultContext("Equivalency options", _ => Task.FromResult<string?>(equivalencyOptions.ToString()))));
 }

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEquivalentTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEquivalentTo.cs
@@ -23,16 +23,19 @@ public static partial class ThatAsyncEnumerable
 				Func<EquivalencyOptions<TExpected>, EquivalencyOptions>? options = null,
 				[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		{
+			ExpectationBuilder expectationBuilder = _subject.Get().ExpectationBuilder;
 			EquivalencyOptions equivalencyOptions = Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get();
 			if (options != null)
 			{
 				equivalencyOptions = options(new EquivalencyOptions<TExpected>(equivalencyOptions));
 			}
 
+			expectationBuilder.AddEquivalencyContext(equivalencyOptions);
+
 			ObjectEqualityOptions<TItem> equalityOptions = new();
 			equalityOptions.Equivalent(equivalencyOptions);
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				expectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<TItem>(
 						it, grammars,
 						_quantifier,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEquivalentTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEquivalentTo.cs
@@ -22,16 +22,19 @@ public static partial class ThatEnumerable
 				Func<EquivalencyOptions<TExpected>, EquivalencyOptions>? options = null,
 				[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 		{
+			ExpectationBuilder expectationBuilder = _subject.Get().ExpectationBuilder;
 			EquivalencyOptions equivalencyOptions = Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get();
 			if (options != null)
 			{
 				equivalencyOptions = options(new EquivalencyOptions<TExpected>(equivalencyOptions));
 			}
 
+			expectationBuilder.AddEquivalencyContext(equivalencyOptions);
+
 			ObjectEqualityOptions<TItem> equalityOptions = new();
 			equalityOptions.Equivalent(equivalencyOptions);
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				expectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<TItem>(
 						it, grammars,
 						_quantifier,

--- a/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Customization;
 using aweXpect.Equivalency;
@@ -20,16 +21,19 @@ public static partial class ThatObject
 		Func<EquivalencyOptions<TExpected>, EquivalencyOptions>? options = null,
 		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		EquivalencyOptions equivalencyOptions = Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get();
 		if (options != null)
 		{
 			equivalencyOptions = options(new EquivalencyOptions<TExpected>(equivalencyOptions));
 		}
 
+		expectationBuilder.AddEquivalencyContext(equivalencyOptions);
+
 		ObjectEqualityOptions<TSubject> equalityOptions = new();
 		equalityOptions.Equivalent(equivalencyOptions);
 		return new AndOrResult<TSubject, IThat<TSubject>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+			expectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<TSubject, TExpected>(it, grammars, expected,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(), equalityOptions)),
 			source);

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -481,6 +481,7 @@ namespace aweXpect.Equivalency
     {
         public EquivalencyOptions(aweXpect.Equivalency.EquivalencyOptions inner) { }
         public new aweXpect.Equivalency.EquivalencyOptions<TExpected> For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
+        public override string ToString() { }
     }
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -475,6 +475,7 @@ namespace aweXpect.Equivalency
         public System.Collections.Generic.Dictionary<System.Type, aweXpect.Equivalency.EquivalencyTypeOptions> CustomOptions { get; init; }
         public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; }
         public aweXpect.Equivalency.EquivalencyOptions For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
+        public override string ToString() { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -481,6 +481,7 @@ namespace aweXpect.Equivalency
     {
         public EquivalencyOptions(aweXpect.Equivalency.EquivalencyOptions inner) { }
         public new aweXpect.Equivalency.EquivalencyOptions<TExpected> For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
+        public override string ToString() { }
     }
     public class EquivalencyTypeOptions : System.IEquatable<aweXpect.Equivalency.EquivalencyTypeOptions>
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -475,6 +475,7 @@ namespace aweXpect.Equivalency
         public System.Collections.Generic.Dictionary<System.Type, aweXpect.Equivalency.EquivalencyTypeOptions> CustomOptions { get; init; }
         public System.Func<System.Type, aweXpect.Equivalency.EquivalencyComparisonType> DefaultComparisonTypeSelector { get; init; }
         public aweXpect.Equivalency.EquivalencyOptions For<TMember>(System.Func<aweXpect.Equivalency.EquivalencyTypeOptions, aweXpect.Equivalency.EquivalencyTypeOptions> options) { }
+        public override string ToString() { }
     }
     public class EquivalencyOptions<TExpected> : aweXpect.Equivalency.EquivalencyOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions<TExpected>>
     {

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeEquivalencyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeEquivalencyTests.cs
@@ -35,6 +35,9 @@ public sealed class CustomizeEquivalencyTests
 			               Element [1] differed:
 			                    Found: 2
 			                 Expected: 1
+			             
+			             Equivalency options:
+			              - include public fields and properties
 			             """);
 	}
 

--- a/Tests/aweXpect.Core.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
@@ -20,6 +20,16 @@ public sealed class EquivalencyOptionsExtensionsTests
 			{
 				IgnoreCollectionOrder = ignoreCollectionOrder,
 			});
+
+		if (ignoreCollectionOrder)
+		{
+			await That(result.ToString()).IsEqualTo("""
+			                                         - include public fields and properties
+			                                         - for MyClass:
+			                                           - include public fields and properties
+			                                           - ignore collection order
+			                                        """);
+		}
 	}
 
 	[Theory]
@@ -39,16 +49,28 @@ public sealed class EquivalencyOptionsExtensionsTests
 					memberToIgnore,
 				},
 			});
+		await That(result.ToString()).IsEqualTo($"""
+		                                          - include public fields and properties
+		                                          - for MyClass:
+		                                            - include public fields and properties
+		                                            - ignore members: ["{memberToIgnore}"]
+		                                         """);
 	}
 
 	[Theory]
 	[InlineData(IncludeMembers.None)]
-	[InlineData(IncludeMembers.Public)]
 	[InlineData(IncludeMembers.Internal)]
 	[InlineData(IncludeMembers.Private)]
 	public async Task Generic_For_IncludingFields_ShouldSetOptionForType(IncludeMembers fieldsToInclude)
 	{
 		EquivalencyOptions options = new();
+		string expectedVisibility = fieldsToInclude switch
+		{
+			IncludeMembers.Public => "public",
+			IncludeMembers.Internal => "internal",
+			IncludeMembers.Private => "private",
+			_ => "no",
+		};
 
 		EquivalencyOptions result = options.For<MyClass>(o => o.IncludingFields(fieldsToInclude));
 
@@ -58,16 +80,27 @@ public sealed class EquivalencyOptionsExtensionsTests
 			{
 				Fields = fieldsToInclude,
 			});
+		await That(result.ToString()).IsEqualTo($"""
+		                                          - include public fields and properties
+		                                          - for MyClass:
+		                                            - include {expectedVisibility} fields and public properties
+		                                         """);
 	}
 
 	[Theory]
 	[InlineData(IncludeMembers.None)]
-	[InlineData(IncludeMembers.Public)]
 	[InlineData(IncludeMembers.Internal)]
 	[InlineData(IncludeMembers.Private)]
 	public async Task Generic_For_IncludingProperties_ShouldSetOptionForType(IncludeMembers propertiesToInclude)
 	{
 		EquivalencyOptions options = new();
+		string expectedVisibility = propertiesToInclude switch
+		{
+			IncludeMembers.Public => "public",
+			IncludeMembers.Internal => "internal",
+			IncludeMembers.Private => "private",
+			_ => "no",
+		};
 
 		EquivalencyOptions result = options.For<MyClass>(o => o.IncludingProperties(propertiesToInclude));
 
@@ -77,6 +110,11 @@ public sealed class EquivalencyOptionsExtensionsTests
 			{
 				Properties = propertiesToInclude,
 			});
+		await That(result.ToString()).IsEqualTo($"""
+		                                          - include public fields and properties
+		                                          - for MyClass:
+		                                            - include public fields and {expectedVisibility} properties
+		                                         """);
 	}
 
 	private sealed class MyClass;

--- a/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
@@ -40,6 +40,9 @@ public sealed partial class QuantifiableCollectionItems
 				             Expected that subject
 				             is equivalent to expected for all items,
 				             but only 3 of 4 were
+				             
+				             Equivalency options:
+				              - include public fields and properties
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
@@ -39,6 +39,9 @@ public sealed partial class ThatAsyncEnumerable
 						             Expected that subject
 						             is equivalent to 1 for all items,
 						             but not all were
+						             
+						             Equivalency options:
+						              - include public fields and properties
 						             """);
 				}
 
@@ -77,6 +80,9 @@ public sealed partial class ThatAsyncEnumerable
 						             Expected that subject
 						             is equivalent to 5 for all items,
 						             but not all were
+						             
+						             Equivalency options:
+						              - include public fields and properties
 						             """);
 				}
 
@@ -106,6 +112,9 @@ public sealed partial class ThatAsyncEnumerable
 						             Expected that subject
 						             is equivalent to constantValue for all items,
 						             but it was <null>
+						             
+						             Equivalency options:
+						              - include public fields and properties
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
@@ -39,6 +39,9 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equivalent to 1 for all items,
 						             but not all were
+						             
+						             Equivalency options:
+						              - include public fields and properties
 						             """);
 				}
 
@@ -66,6 +69,9 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equivalent to 5 for all items,
 						             but only 1 of 20 were
+						             
+						             Equivalency options:
+						              - include public fields and properties
 						             """);
 				}
 
@@ -95,6 +101,9 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equivalent to constantValue for all items,
 						             but it was <null>
+						             
+						             Equivalency options:
+						              - include public fields and properties
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -44,7 +44,7 @@ public sealed partial class ThatObject
 					             is equivalent to expected,
 					             but it was not:
 					               Property Value was <null> instead of "Foo"
-					             
+
 					             Equivalency options:
 					              - include public fields and properties
 					             """);
@@ -126,7 +126,7 @@ public sealed partial class ThatObject
 					             is equivalent to expected,
 					             but it was not:
 					               Element Inner.Inner.Collection[3] was missing "4"
-					             
+
 					             Equivalency options:
 					              - include public fields and properties
 					             """);
@@ -216,7 +216,7 @@ public sealed partial class ThatObject
 					               Property Inner.Inner.Value differed:
 					                    Found: "Baz"
 					                 Expected: "Bart"
-					             
+
 					             Equivalency options:
 					              - include public fields and properties
 					              - ignore members: ["Inner.Inner.Collection.[3]"]
@@ -291,10 +291,407 @@ public sealed partial class ThatObject
 					             is equivalent to expected,
 					             but it was not:
 					               Property Inner.Inner.Value was <null> instead of "Baz"
-					             
+
 					             Equivalency options:
 					              - include public fields and properties
 					             """);
+			}
+		}
+
+		public sealed class CollectionTests
+		{
+			[Fact]
+			public async Task WhenDifferentValues_ShouldFail()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] expected = [4, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to expected,
+					             but it was not:
+					               Element [0] differed:
+					                    Found: 1
+					                 Expected: 2
+					             and
+					               Element [1] differed:
+					                    Found: 2
+					                 Expected: 3
+					             and
+					               Element [2] differed:
+					                    Found: 3
+					                 Expected: 4
+
+					             Equivalency options:
+					              - include public fields and properties
+					              - ignore collection order
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInDifferentOrderOrder_ShouldFail()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] expected = [1, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to expected,
+					             but it was not:
+					               Element [1] differed:
+					                    Found: 2
+					                 Expected: 3
+					             and
+					               Element [2] differed:
+					                    Found: 3
+					                 Expected: 2
+
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInDifferentOrderOrder_WhenIgnoringCollectionOrder_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] expected = [1, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInSameOrder_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] expected = [1, 2, 3,];
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class FieldTests
+		{
+			[Theory]
+			[InlineData(0, 0, 0, true)]
+			[InlineData(0, 0, 1, true)]
+			[InlineData(0, 1, 0, true)]
+			[InlineData(1, 0, 0, false)]
+			[InlineData(0, 1, 1, true)]
+			[InlineData(1, 0, 1, false)]
+			[InlineData(1, 1, 0, false)]
+			[InlineData(1, 1, 1, false)]
+			public async Task ShouldIgnoreInternalAndPrivateFields(int publicDifference, int internalDifference,
+				int privateDifference, bool expectSuccess)
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(
+					1 + publicDifference,
+					2 + internalDifference,
+					3 + privateDifference);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+					.WithMessage($"""
+					              Expected that subject
+					              is equivalent to expected,
+					              but it was not:
+					                Field PublicValue differed:
+					                     Found: 1
+					                  Expected: {1 + publicDifference}
+
+					              Equivalency options:
+					               - include public fields and properties
+					              """);
+			}
+
+			[Theory]
+			[InlineData(0, 0, 0, true)]
+			[InlineData(0, 0, 1, true)]
+			[InlineData(0, 1, 0, false)]
+			[InlineData(1, 0, 0, true)]
+			[InlineData(0, 1, 1, false)]
+			[InlineData(1, 0, 1, true)]
+			[InlineData(1, 1, 0, false)]
+			[InlineData(1, 1, 1, false)]
+			public async Task WithInternalFields_ShouldFailWhenInternalFieldIsDifferent(int publicDifference,
+				int internalDifference, int privateDifference,
+				bool expectSuccess)
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(
+					1 + publicDifference,
+					2 + internalDifference,
+					3 + privateDifference);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingFields(IncludeMembers.Internal));
+
+				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+					.WithMessage($"""
+					              Expected that subject
+					              is equivalent to expected,
+					              but it was not:
+					                Field InternalValue differed:
+					                     Found: 2
+					                  Expected: {2 + internalDifference}
+
+					              Equivalency options:
+					               - include internal fields and public properties
+					              """);
+			}
+
+			[Fact]
+			public async Task WithNoFields_ShouldConsiderProperties()
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(4, 5, 6);
+
+				expected.MyProperty = !subject.MyProperty;
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingFields(IncludeMembers.None));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to expected,
+					             but it was not:
+					               Property MyProperty differed:
+					                    Found: False
+					                 Expected: True
+
+					             Equivalency options:
+					              - include no fields and public properties
+					             """);
+			}
+
+			[Fact]
+			public async Task WithNoFields_ShouldSucceed()
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(4, 5, 6);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingFields(IncludeMembers.None));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(0, 0, 0, true)]
+			[InlineData(0, 0, 1, false)]
+			[InlineData(0, 1, 0, true)]
+			[InlineData(1, 0, 0, true)]
+			[InlineData(0, 1, 1, false)]
+			[InlineData(1, 0, 1, false)]
+			[InlineData(1, 1, 0, true)]
+			[InlineData(1, 1, 1, false)]
+			public async Task WithPrivateFields_ShouldFailWhenPrivateFieldIsDifferent(int publicDifference,
+				int internalDifference, int privateDifference,
+				bool expectSuccess)
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(
+					1 + publicDifference,
+					2 + internalDifference,
+					3 + privateDifference);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingFields(IncludeMembers.Private));
+
+				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+					.WithMessage($"""
+					              Expected that subject
+					              is equivalent to expected,
+					              but it was not:
+					                Field PrivateValue differed:
+					                     Found: 3
+					                  Expected: {3 + privateDifference}
+
+					              Equivalency options:
+					               - include private fields and public properties
+					              """);
+			}
+
+			private sealed class MyClass(int publicValue, int internalValue, int privateValue)
+			{
+				internal int InternalValue = internalValue;
+				private int PrivateValue = privateValue;
+				public int PublicValue = publicValue;
+				public bool MyProperty { get; set; }
+			}
+		}
+
+		public sealed class PropertyTests
+		{
+			[Theory]
+			[InlineData(0, 0, 0, true)]
+			[InlineData(0, 0, 1, true)]
+			[InlineData(0, 1, 0, true)]
+			[InlineData(1, 0, 0, false)]
+			[InlineData(0, 1, 1, true)]
+			[InlineData(1, 0, 1, false)]
+			[InlineData(1, 1, 0, false)]
+			[InlineData(1, 1, 1, false)]
+			public async Task ShouldIgnoreInternalAndPrivateProperties(int publicDifference, int internalDifference,
+				int privateDifference, bool expectSuccess)
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(
+					1 + publicDifference,
+					2 + internalDifference,
+					3 + privateDifference);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+					.WithMessage($"""
+					              Expected that subject
+					              is equivalent to expected,
+					              but it was not:
+					                Property PublicValue differed:
+					                     Found: 1
+					                  Expected: {1 + publicDifference}
+
+					              Equivalency options:
+					               - include public fields and properties
+					              """);
+			}
+
+			[Theory]
+			[InlineData(0, 0, 0, true)]
+			[InlineData(0, 0, 1, true)]
+			[InlineData(0, 1, 0, false)]
+			[InlineData(1, 0, 0, true)]
+			[InlineData(0, 1, 1, false)]
+			[InlineData(1, 0, 1, true)]
+			[InlineData(1, 1, 0, false)]
+			[InlineData(1, 1, 1, false)]
+			public async Task WithInternalProperties_ShouldFailWhenInternalPropertyIsDifferent(int publicDifference,
+				int internalDifference, int privateDifference,
+				bool expectSuccess)
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(
+					1 + publicDifference,
+					2 + internalDifference,
+					3 + privateDifference);
+
+				async Task Act()
+					=> await That(subject)
+						.IsEquivalentTo(expected, o => o.IncludingProperties(IncludeMembers.Internal));
+
+				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+					.WithMessage($"""
+					              Expected that subject
+					              is equivalent to expected,
+					              but it was not:
+					                Property InternalValue differed:
+					                     Found: 2
+					                  Expected: {2 + internalDifference}
+
+					              Equivalency options:
+					               - include public fields and internal properties
+					              """);
+			}
+
+			[Fact]
+			public async Task WithNoProperties_ShouldConsiderFields()
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(4, 5, 6);
+
+				expected.MyField = !subject.MyField;
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingProperties(IncludeMembers.None));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to expected,
+					             but it was not:
+					               Field MyField differed:
+					                    Found: False
+					                 Expected: True
+
+					             Equivalency options:
+					              - include public fields and no properties
+					             """);
+			}
+
+			[Fact]
+			public async Task WithNoProperties_ShouldSucceed()
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(4, 5, 6);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingProperties(IncludeMembers.None));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(0, 0, 0, true)]
+			[InlineData(0, 0, 1, false)]
+			[InlineData(0, 1, 0, true)]
+			[InlineData(1, 0, 0, true)]
+			[InlineData(0, 1, 1, false)]
+			[InlineData(1, 0, 1, false)]
+			[InlineData(1, 1, 0, true)]
+			[InlineData(1, 1, 1, false)]
+			public async Task WithPrivateProperties_ShouldFailWhenPrivatePropertyIsDifferent(int publicDifference,
+				int internalDifference, int privateDifference,
+				bool expectSuccess)
+			{
+				MyClass subject = new(1, 2, 3);
+				MyClass expected = new(
+					1 + publicDifference,
+					2 + internalDifference,
+					3 + privateDifference);
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IncludingProperties(IncludeMembers.Private));
+
+				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+					.WithMessage($"""
+					              Expected that subject
+					              is equivalent to expected,
+					              but it was not:
+					                Property PrivateValue differed:
+					                     Found: 3
+					                  Expected: {3 + privateDifference}
+
+					              Equivalency options:
+					               - include public fields and private properties
+					              """);
+			}
+
+			private sealed class MyClass(int publicValue, int internalValue, int privateValue)
+			{
+				public bool MyField;
+				internal int InternalValue { get; set; } = internalValue;
+				private int PrivateValue { get; set; } = privateValue;
+				public int PublicValue { get; set; } = publicValue;
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -44,6 +44,9 @@ public sealed partial class ThatObject
 					             is equivalent to expected,
 					             but it was not:
 					               Property Value was <null> instead of "Foo"
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 
@@ -123,6 +126,9 @@ public sealed partial class ThatObject
 					             is equivalent to expected,
 					             but it was not:
 					               Element Inner.Inner.Collection[3] was missing "4"
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 
@@ -210,6 +216,10 @@ public sealed partial class ThatObject
 					               Property Inner.Inner.Value differed:
 					                    Found: "Baz"
 					                 Expected: "Bart"
+					             
+					             Equivalency options:
+					              - include public fields and properties
+					              - ignore members: ["Inner.Inner.Collection.[3]"]
 					             """);
 			}
 
@@ -281,6 +291,9 @@ public sealed partial class ThatObject
 					             is equivalent to expected,
 					             but it was not:
 					               Property Inner.Inner.Value was <null> instead of "Baz"
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/ThatGeneric.CompliesWith.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.CompliesWith.Tests.cs
@@ -36,6 +36,9 @@ public sealed partial class ThatGeneric
 					               Property Value differed:
 					                    Found: 1
 					                 Expected: 2
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 		}
@@ -64,6 +67,9 @@ public sealed partial class ThatGeneric
 					               Property HasWaitedEnough differed:
 					                    Found: False
 					                 Expected: True
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 
@@ -140,6 +146,9 @@ public sealed partial class ThatGeneric
 					               Property HasWaitedEnough differed:
 					                    Found: False
 					                 Expected: True
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/ThatGeneric.DoesNotComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.DoesNotComplyWith.Tests.cs
@@ -89,6 +89,9 @@ public sealed partial class ThatGeneric
 					             but it was considered equivalent to MyChangingClass {
 					                 HasWaitedEnough = False
 					               }
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 
@@ -164,6 +167,9 @@ public sealed partial class ThatGeneric
 					             but it was considered equivalent to MyChangingClass {
 					                 HasWaitedEnough = False
 					               }
+					             
+					             Equivalency options:
+					              - include public fields and properties
 					             """);
 			}
 


### PR DESCRIPTION
Include the relevant information of the equivalency options in a specific context entry.

*part of #331*