### PR TITLE
refactor: remove obsolete `ToString` overloads

### DIFF
--- a/Source/aweXpect.Core/Core/StringDifference.cs
+++ b/Source/aweXpect.Core/Core/StringDifference.cs
@@ -60,7 +60,6 @@ public sealed class StringDifference(
 		return _indexOfFirstMismatch.Value;
 	}
 
-
 	/// <inheritdoc />
 	public override string ToString() => ToString("differs");
 

--- a/Source/aweXpect.Core/Results/PropertyResult.cs
+++ b/Source/aweXpect.Core/Results/PropertyResult.cs
@@ -418,10 +418,6 @@ public static class PropertyResult
 			return this;
 		}
 
-
-		public override string ToString()
-			=> expectation;
-
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append(expectation);
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsEmpty.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsEmpty.cs
@@ -67,13 +67,6 @@ public static partial class ThatEnumerable
 			return this;
 		}
 
-		public override string ToString()
-			=> Grammars.HasFlag(ExpectationGrammars.Nested) switch
-			{
-				true => "are empty",
-				_ => "is empty",
-			};
-
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			if (Grammars.HasFlag(ExpectationGrammars.Nested))


### PR DESCRIPTION
A `ToString` overload is no longer necessary for constraints. As it is now dead code, remove it.