### PR TITLE
fix: missing expectation text in collections `ComplyWith` constraint

### DIFF
--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
@@ -50,7 +50,7 @@ public static partial class ThatAsyncEnumerable
 			_it = it;
 			_grammars = grammars;
 			_quantifier = quantifier;
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder);
+			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder, grammars);
 			expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 		}
 
@@ -137,8 +137,7 @@ public static partial class ThatAsyncEnumerable
 			}
 			else
 			{
-				_quantifier.AppendResult(stringBuilder, _grammars.Negate(), _matchingCount, _notMatchingCount,
-					_totalCount);
+				_quantifier.AppendResult(stringBuilder, _grammars, _matchingCount, _notMatchingCount, _totalCount);
 			}
 		}
 	}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -47,7 +47,7 @@ public static partial class ThatEnumerable
 				: base(it, grammars)
 			{
 				_quantifier = quantifier;
-				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder);
+				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder, grammars);
 				expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 			}
 
@@ -118,7 +118,7 @@ public static partial class ThatEnumerable
 			}
 
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
-				=> _quantifier.AppendResult(stringBuilder, Grammars.Negate(), _matchingCount, _notMatchingCount,
+				=> _quantifier.AppendResult(stringBuilder, Grammars, _matchingCount, _notMatchingCount,
 					_totalCount);
 		}
 	}

--- a/Source/aweXpect/That/ThatGeneric.CompliesWith.cs
+++ b/Source/aweXpect/That/ThatGeneric.CompliesWith.cs
@@ -98,6 +98,7 @@ public static partial class ThatGeneric
 
 		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
+			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
 		}
 
 		private ConstraintResult NegateIfNegated(ConstraintResult constraintResult)

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.ComplyWith.Tests.cs
@@ -114,6 +114,25 @@ public sealed partial class ThatAsyncEnumerable
 						             """);
 				}
 			}
+
+			public sealed class NegatedTests
+			{
+				[Fact]
+				public async Task WhenEnumerableOnlyContainsEqualValues_ShouldFail()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 1, 1, 1, 1, 1, 1,]);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.DoesNotComplyWith(it => it.IsEqualTo(1)));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not equal to 1 for all items,
+						             but not all were
+						             """);
+				}
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
@@ -113,6 +113,25 @@ public sealed partial class ThatEnumerable
 						             """);
 				}
 			}
+
+			public sealed class NegatedTests
+			{
+				[Fact]
+				public async Task WhenEnumerableOnlyContainsEqualValues_ShouldFail()
+				{
+					IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 1, 1, 1,]);
+
+					async Task Act()
+						=> await That(subject).All().ComplyWith(x => x.DoesNotComplyWith(it => it.IsEqualTo(1)));
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not equal to 1 for all items,
+						             but not all were
+						             """);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
The following test fails with incorrect message
> ```
> Expected that subject
>  for all items,
> but not all were
> ```

but it should succeed with the given message.
```csharp
[Fact]
public async Task WhenEnumerableOnlyContainsEqualValues_ShouldFail()
{
    IEnumerable<int> subject = ToEnumerable([1, 1, 1, 1, 1, 1, 1,]);

    async Task Act()
        => await That(subject).All().ComplyWith(x => x.DoesNotComplyWith(it => it.IsEqualTo(1)));

    await That(Act).Throws<XunitException>()
        .WithMessage("""
                     Expected that subject
                     is not equal to 1 for all items,
                     but not all were
                     """);
}
```