### PR TITLE
coverage: add missing test cases

### DIFF
--- a/Source/aweXpect.Core/Options/StringEqualityOptions.SuffixMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.SuffixMatchType.cs
@@ -56,12 +56,6 @@ public partial class StringEqualityOptions
 			int minCommonLength = Math.Min(actual.Length, expected.Length);
 			StringDifference stringDifference = new(actual, expected, comparer, settings);
 			int indexOfFirstMismatch = stringDifference.IndexOfFirstMismatch(StringDifference.MatchType.Equality);
-			if (indexOfFirstMismatch == 0 && comparer.Equals(actual.TrimStart(), expected))
-			{
-				return
-					$"{prefix} which has unexpected whitespace (\"{actual.Substring(0, GetIndexOfFirstMatch(actual, expected, comparer)).DisplayWhitespace().TruncateWithEllipsis(100)}\" at the beginning)";
-			}
-
 			if (indexOfFirstMismatch == 0 && comparer.Equals(actual, expected.TrimStart()))
 			{
 				return
@@ -84,12 +78,6 @@ public partial class StringEqualityOptions
 			{
 				return
 					$"{prefix} with a length of {actual.Length} which is shorter than the expected length of {expected.Length} and misses:{Environment.NewLine}  \"{expected.Substring(actual.Length).TruncateWithEllipsis(100)}\"";
-			}
-
-			if (actual.Length > expected.Length && indexOfFirstMismatch == expected.Length)
-			{
-				return
-					$"{prefix} with a length of {actual.Length} which is longer than the expected length of {expected.Length} and has superfluous:{Environment.NewLine}  \"{actual.Substring(expected.Length).TruncateWithEllipsis(100)}\"";
 			}
 
 			return $"{prefix} which {stringDifference}";

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Threading;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.Tests.TestHelpers;
+
+namespace aweXpect.Core.Tests.Core;
+
+public class ExpectationBuilderTests
+{
+	[Fact]
+	public async Task ForAsyncMember_WithFailingExpectation_ShouldReturnFailureConstraintResult()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+
+		sut.ForAsyncMember(MemberAccessor<string, Task<int>>.FromFunc(x => Task.FromResult(x.Length), "length "))
+			.AddExpectations(expectationBuilder => expectationBuilder.AddConstraint((_, _)
+				=> new DummyConstraint<int>(v => v == 2, "equal to 2")));
+
+		ConstraintResult constraintResult = await sut.IsMetBy("bar", null!, CancellationToken.None);
+
+		await That(constraintResult.Outcome).IsEqualTo(Outcome.Failure);
+		await That(constraintResult.GetExpectationText()).IsEqualTo("length equal to 2");
+	}
+
+	[Fact]
+	public async Task ForAsyncMember_WithSucceedingExpectation_ShouldReturnSuccessConstraintResult()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+
+		sut.ForAsyncMember(MemberAccessor<string, Task<int>>.FromFunc(x => Task.FromResult(x.Length), "length "))
+			.AddExpectations(expectationBuilder => expectationBuilder.AddConstraint((_, _)
+				=> new DummyConstraint<int>(v => v == 3, "equal to 3")));
+
+		ConstraintResult constraintResult = await sut.IsMetBy("bar", null!, CancellationToken.None);
+
+		await That(constraintResult.Outcome).IsEqualTo(Outcome.Success);
+		await That(constraintResult.GetExpectationText()).IsEqualTo("length equal to 3");
+	}
+
+	[Fact]
+	public async Task ForMember_WithFailingExpectation_ShouldReturnFailureConstraintResult()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+
+		sut.ForMember(MemberAccessor<string, int>.FromFunc(x => x.Length, "length "))
+			.AddExpectations(expectationBuilder => expectationBuilder.AddConstraint((_, _)
+				=> new DummyConstraint<int>(v => v == 2, "equal to 2")));
+
+		ConstraintResult constraintResult = await sut.IsMetBy("bar", null!, CancellationToken.None);
+
+		await That(constraintResult.Outcome).IsEqualTo(Outcome.Failure);
+		await That(constraintResult.GetExpectationText()).IsEqualTo("length equal to 2");
+	}
+
+	[Fact]
+	public async Task ForMember_WithSucceedingExpectation_ShouldReturnSuccessConstraintResult()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+
+		sut.ForMember(MemberAccessor<string, int>.FromFunc(x => x.Length, "length "))
+			.AddExpectations(expectationBuilder => expectationBuilder.AddConstraint((_, _)
+				=> new DummyConstraint<int>(v => v == 3, "equal to 3")));
+
+		ConstraintResult constraintResult = await sut.IsMetBy("bar", null!, CancellationToken.None);
+
+		await That(constraintResult.Outcome).IsEqualTo(Outcome.Success);
+		await That(constraintResult.GetExpectationText()).IsEqualTo("length equal to 3");
+	}
+}

--- a/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Nodes;
 using aweXpect.Core.Tests.TestHelpers;
@@ -117,38 +115,5 @@ public class ManualExpectationBuilderTests
 		ManualExpectationBuilder<int> sut = new(null);
 
 		await That(sut.Subject).IsEmpty();
-	}
-
-	private sealed class DummyConstraint<T>(
-		Func<T, bool> predicate)
-		: ConstraintResult(ExpectationGrammars.None), IValueConstraint<T>
-	{
-		private T? _actual;
-
-		public ConstraintResult IsMetBy(T actual)
-		{
-			_actual = actual;
-			Outcome = predicate(actual) ? Outcome.Success : Outcome.Failure;
-			return this;
-		}
-
-		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null) { }
-
-		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null) { }
-
-		public override ConstraintResult Negate()
-			=> this;
-
-		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
-		{
-			if (_actual is TValue typedValue)
-			{
-				value = typedValue;
-				return true;
-			}
-
-			value = default;
-			return false;
-		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyConstraint.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyConstraint.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using aweXpect.Core.Constraints;
 
 namespace aweXpect.Core.Tests.TestHelpers;
@@ -13,4 +14,44 @@ internal class DummyConstraint(string expectationText, Func<ConstraintResult>? c
 
 	public void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
 		=> stringBuilder.Append(expectationText);
+}
+
+internal class DummyConstraint<T>(
+	Func<T, bool> predicate,
+	string? expectationText = null)
+	: ConstraintResult(ExpectationGrammars.None), IValueConstraint<T>
+{
+	private T? _actual;
+
+	public ConstraintResult IsMetBy(T actual)
+	{
+		_actual = actual;
+		Outcome = predicate(actual) ? Outcome.Success : Outcome.Failure;
+		return this;
+	}
+
+	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
+	{
+		if (expectationText != null)
+		{
+			stringBuilder.Append(expectationText);
+		}
+	}
+
+	public override void AppendResult(StringBuilder stringBuilder, string? indentation = null) { }
+
+	public override ConstraintResult Negate()
+		=> this;
+
+	public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+	{
+		if (_actual is TValue typedValue)
+		{
+			value = typedValue;
+			return true;
+		}
+
+		value = default;
+		return false;
+	}
 }

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsPrefixTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsPrefixTests.cs
@@ -197,5 +197,49 @@ public sealed partial class ThatString
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+		public sealed class AsPrefixNegatedTests
+		{
+			[Fact]
+			public async Task WhenStringEndsWithExpected_ShouldFail()
+			{
+				string subject = "some text without out";
+				string expected = "some text without";
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsEqualTo(expected).AsPrefix().IgnoringCase());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not start with "some text without" ignoring case,
+					             but it was "some text without out"
+
+					             Actual:
+					             some text without out
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringEndsWithExpected_UsingCustomComparer_ShouldFail()
+			{
+				string subject = "some text without out";
+				string expected = "sOmE text wIthOUt";
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsEqualTo(expected).AsPrefix().Using(new IgnoreCaseForVocalsComparer()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not start with "sOmE text wIthOUt" using IgnoreCaseForVocalsComparer,
+					             but it was "some text without out"
+
+					             Actual:
+					             some text without out
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsSuffixTests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsEqualTo.AsSuffixTests.cs
@@ -196,5 +196,49 @@ public sealed partial class ThatString
 					             """);
 			}
 		}
+
+		public sealed class AsSuffixNegatedTests
+		{
+			[Fact]
+			public async Task WhenStringEndsWithExpected_ShouldFail()
+			{
+				string subject = "some text without out";
+				string expected = "text without out";
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsEqualTo(expected).AsSuffix().IgnoringCase());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not end with "text without out" ignoring case,
+					             but it was "some text without out"
+
+					             Actual:
+					             some text without out
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringEndsWithExpected_UsingCustomComparer_ShouldFail()
+			{
+				string subject = "some text without out";
+				string expected = "text wIthOUt OUt";
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsEqualTo(expected).AsSuffix().Using(new IgnoreCaseForVocalsComparer()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not end with "text wIthOUt OUt" using IgnoreCaseForVocalsComparer,
+					             but it was "some text without out"
+
+					             Actual:
+					             some text without out
+					             """);
+			}
+		}
 	}
 }


### PR DESCRIPTION
- For `ExpectationBuilder` methods `ForMember` and `ForAsyncMember`
- For negated `AsSuffix` and `AsPrefix` scenarios