### PR TITLE
refactor: solve sonar issues

### DIFF
--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.cs
@@ -11,7 +11,6 @@ public partial class ThatDelegateThrows<TException>
 	: ExpectationResult<TException, ThatDelegateThrows<TException>>, IThatDelegateThrows<TException>
 	where TException : Exception?
 {
-	private const string ExceptionString = "exception";
 	private readonly ThatDelegate.ThrowsOption _throwOptions;
 
 	internal ThatDelegateThrows(ExpectationBuilder expectationBuilder, ThatDelegate.ThrowsOption throwOptions)

--- a/Tests/aweXpect.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Tests/ExpectTests.cs
@@ -322,7 +322,7 @@ public class ExpectTests
 				             """);
 		}
 
-		[Fact(Skip = "TODO: Check later")]
+		[Fact]
 		public async Task WhenNested_ShouldIndentMultiLineResults()
 		{
 			async Task Act()

--- a/Tests/aweXpect.Tests/TestHelpers/MyConstraintExtensions.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/MyConstraintExtensions.cs
@@ -29,10 +29,10 @@ public static class MyConstraintExtensions
 		}
 
 		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(expectation);
+			=> stringBuilder.Append(expectation.Indent(indentation, false));
 
 		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(failureMessage);
+			=> stringBuilder.Append(failureMessage.Indent(indentation, false));
 
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 		{

--- a/Tests/aweXpect.Tests/TestHelpers/StringExtensions.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/StringExtensions.cs
@@ -7,4 +7,17 @@ internal static class StringExtensions
 	[return: NotNullIfNotNull(nameof(value))]
 	public static string? DisplayWhitespace(this string? value)
 		=> value?.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+	
+	[return: NotNullIfNotNull(nameof(value))]
+	public static string? Indent(this string? value, string? indentation = "  ",
+		bool indentFirstLine = true)
+	{
+		if (value == null || string.IsNullOrEmpty(indentation))
+		{
+			return value;
+		}
+
+		return (indentFirstLine ? indentation : "")
+		       + value.Replace("\n", $"\n{indentation}");
+	}
 }


### PR DESCRIPTION
- Remove unused private field 'ExceptionString'
- Test method should not be skipped. Remove the Skip property to start running the test again.