### PR TITLE
chore: reset Microsoft.CodeAnalysis.* to v4.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,11 +20,11 @@
 	<ItemGroup>
 		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis" Version="4.13.0"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0"/>
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.11.0"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0"/>
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2"/>
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2"/>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "9.0.201",
+		"version": "8.0.407",
 		"rollForward": "latestMinor"
 	}
 }


### PR DESCRIPTION
In order to be compatible with the [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).