### PR TITLE
Add numeric expectations on `INumber<T>`

### DIFF
--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -87,7 +87,7 @@ public static class ConstraintResultExtensions
 			}
 
 			value = default;
-			return _value is null;
+			return typeof(TValue).IsAssignableFrom(typeof(T));
 		}
 
 		public override ConstraintResult Negate() => _inner.Negate();
@@ -123,7 +123,7 @@ public static class ConstraintResultExtensions
 			}
 
 			value = default;
-			return _value is null;
+			return typeof(TValue).IsAssignableFrom(typeof(T));
 		}
 
 		public override ConstraintResult Negate() => _inner.Negate();

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -209,7 +209,7 @@ internal class WhichNode<TSource, TMember> : Node
 			}
 
 			value = default;
-			return false;
+			return typeof(TValue).IsAssignableFrom(typeof(TMember));
 		}
 
 		public override ConstraintResult Negate()

--- a/Source/aweXpect.Core/Results/NullableNumberToleranceResult.cs
+++ b/Source/aweXpect.Core/Results/NullableNumberToleranceResult.cs
@@ -1,6 +1,10 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Options;
+#if NET8_0_OR_GREATER
+using System.Numerics;
+#else
+using System;
+#endif
 
 namespace aweXpect.Results;
 
@@ -19,7 +23,11 @@ public class NullableNumberToleranceResult<TType, TThat>(
 		expectationBuilder,
 		returnValue,
 		options)
+#if NET8_0_OR_GREATER
+	where TType : struct, INumber<TType>;
+#else
 	where TType : struct, IComparable<TType>;
+#endif
 
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TType" />?.
@@ -33,7 +41,11 @@ public class NullableNumberToleranceResult<TType, TThat, TSelf>(
 	NumberTolerance<TType> options)
 	: AndOrResult<TType?, TThat, TSelf>(expectationBuilder, returnValue)
 	where TSelf : NullableNumberToleranceResult<TType, TThat, TSelf>
+#if NET8_0_OR_GREATER
+	where TType : struct, INumber<TType>
+#else
 	where TType : struct, IComparable<TType>
+#endif
 {
 	/// <summary>
 	///     Specifies a <paramref name="tolerance" /> to apply on the number comparison.

--- a/Source/aweXpect.Core/Results/NumberToleranceResult.cs
+++ b/Source/aweXpect.Core/Results/NumberToleranceResult.cs
@@ -1,6 +1,10 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Options;
+#if NET8_0_OR_GREATER
+using System.Numerics;
+#else
+using System;
+#endif
 
 namespace aweXpect.Results;
 
@@ -19,7 +23,11 @@ public class NumberToleranceResult<TType, TThat>(
 		expectationBuilder,
 		returnValue,
 		options)
+#if NET8_0_OR_GREATER
+	where TType : struct, INumber<TType>;
+#else
 	where TType : struct, IComparable<TType>;
+#endif
 
 /// <summary>
 ///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
@@ -33,7 +41,11 @@ public class NumberToleranceResult<TType, TThat, TSelf>(
 	NumberTolerance<TType> options)
 	: AndOrResult<TType, TThat, TSelf>(expectationBuilder, returnValue)
 	where TSelf : NumberToleranceResult<TType, TThat, TSelf>
+#if NET8_0_OR_GREATER
+	where TType : struct, INumber<TType>
+#else
 	where TType : struct, IComparable<TType>
+#endif
 {
 	/// <summary>
 	///     Specifies a <paramref name="tolerance" /> to apply on the number comparison.

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsEqualTo.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsEqualTo.cs
@@ -1,9 +1,11 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
@@ -13,81 +15,14 @@ public static partial class ThatNumber
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static NumberToleranceResult<float, IThat<float>> IsEqualTo(
-		this IThat<float> source,
-		float? expected)
-	{
-		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NumberToleranceResult<float, IThat<float>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<float>(it, grammars, expected, options)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<double, IThat<double>> IsEqualTo(
-		this IThat<double> source,
-		double? expected)
-	{
-		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NumberToleranceResult<double, IThat<double>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<double>(it, grammars, expected, options)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
 	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsEqualTo<TNumber>(
 		this IThat<TNumber> source, TNumber? expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(
-			(a, e, t) => a < e
-				? e - a <= (t ?? default(TNumber))
-				: a - e <= (t ?? default(TNumber)));
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsEqualToConstraint<TNumber>(it, grammars, expected, options)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NullableNumberToleranceResult<float, IThat<float?>> IsEqualTo(
-		this IThat<float?> source,
-		float? expected)
-	{
-		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NullableNumberToleranceResult<float, IThat<float?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsEqualToConstraint<float>(it, grammars, expected, options)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
-	/// </summary>
-	public static NullableNumberToleranceResult<double, IThat<double?>> IsEqualTo(
-		this IThat<double?> source,
-		double? expected)
-	{
-		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NullableNumberToleranceResult<double, IThat<double?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsEqualToConstraint<double>(it, grammars, expected, options)),
 			source,
 			options);
 	}
@@ -99,45 +34,10 @@ public static partial class ThatNumber
 		this IThat<TNumber?> source, TNumber? expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(
-			(a, e, t) => a < e
-				? e - a <= (t ?? default(TNumber))
-				: a - e <= (t ?? default(TNumber)));
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsEqualToConstraint<TNumber>(it, grammars, expected, options)),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<float, IThat<float>> IsNotEqualTo(
-		this IThat<float> source,
-		float? unexpected)
-	{
-		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NumberToleranceResult<float, IThat<float>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<float>(it, grammars, unexpected, options).Invert()),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
-	/// </summary>
-	public static NumberToleranceResult<double, IThat<double>> IsNotEqualTo(
-		this IThat<double> source,
-		double? unexpected)
-	{
-		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NumberToleranceResult<double, IThat<double>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<double>(it, grammars, unexpected, options).Invert()),
 			source,
 			options);
 	}
@@ -149,45 +49,10 @@ public static partial class ThatNumber
 		this IThat<TNumber> source, TNumber? unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(
-			(a, e, t) => a < e
-				? e - a <= (t ?? default(TNumber))
-				: a - e <= (t ?? default(TNumber)));
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsEqualToConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
-	/// </summary>
-	public static NullableNumberToleranceResult<float, IThat<float?>> IsNotEqualTo(
-		this IThat<float?> source,
-		float? unexpected)
-	{
-		NumberTolerance<float> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NullableNumberToleranceResult<float, IThat<float?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsEqualToConstraint<float>(it, grammars, unexpected, options).Invert()),
-			source,
-			options);
-	}
-
-	/// <summary>
-	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
-	/// </summary>
-	public static NullableNumberToleranceResult<double, IThat<double?>> IsNotEqualTo(
-		this IThat<double?> source,
-		double? unexpected)
-	{
-		NumberTolerance<double> options = new(
-			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
-		return new NullableNumberToleranceResult<double, IThat<double?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsEqualToConstraint<double>(it, grammars, unexpected, options).Invert()),
 			source,
 			options);
 	}
@@ -199,10 +64,7 @@ public static partial class ThatNumber
 		this IThat<TNumber?> source, TNumber? unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(
-			(a, e, t) => a < e
-				? e - a <= (t ?? default(TNumber))
-				: a - e <= (t ?? default(TNumber)));
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsEqualToConstraint<TNumber>(it, grammars, unexpected, options).Invert()),

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsEqualTo.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsEqualTo.cs
@@ -9,6 +9,291 @@ namespace aweXpect;
 
 public static partial class ThatNumber
 {
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<float, IThat<float>> IsEqualTo(
+		this IThat<float> source,
+		float? expected)
+	{
+		NumberTolerance<float> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NumberToleranceResult<float, IThat<float>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<float>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<double, IThat<double>> IsEqualTo(
+		this IThat<double> source,
+		double? expected)
+	{
+		NumberTolerance<double> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NumberToleranceResult<double, IThat<double>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<double>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsEqualTo<TNumber>(
+		this IThat<TNumber> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(
+			(a, e, t) => a < e
+				? e - a <= (t ?? default(TNumber))
+				: a - e <= (t ?? default(TNumber)));
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NullableNumberToleranceResult<float, IThat<float?>> IsEqualTo(
+		this IThat<float?> source,
+		float? expected)
+	{
+		NumberTolerance<float> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NullableNumberToleranceResult<float, IThat<float?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsEqualToConstraint<float>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NullableNumberToleranceResult<double, IThat<double?>> IsEqualTo(
+		this IThat<double?> source,
+		double? expected)
+	{
+		NumberTolerance<double> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NullableNumberToleranceResult<double, IThat<double?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsEqualToConstraint<double>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsEqualTo<TNumber>(
+		this IThat<TNumber?> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(
+			(a, e, t) => a < e
+				? e - a <= (t ?? default(TNumber))
+				: a - e <= (t ?? default(TNumber)));
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsEqualToConstraint<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<float, IThat<float>> IsNotEqualTo(
+		this IThat<float> source,
+		float? unexpected)
+	{
+		NumberTolerance<float> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NumberToleranceResult<float, IThat<float>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<float>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<double, IThat<double>> IsNotEqualTo(
+		this IThat<double> source,
+		double? unexpected)
+	{
+		NumberTolerance<double> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NumberToleranceResult<double, IThat<double>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<double>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsNotEqualTo<TNumber>(
+		this IThat<TNumber> source, TNumber? unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(
+			(a, e, t) => a < e
+				? e - a <= (t ?? default(TNumber))
+				: a - e <= (t ?? default(TNumber)));
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NullableNumberToleranceResult<float, IThat<float?>> IsNotEqualTo(
+		this IThat<float?> source,
+		float? unexpected)
+	{
+		NumberTolerance<float> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NullableNumberToleranceResult<float, IThat<float?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsEqualToConstraint<float>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NullableNumberToleranceResult<double, IThat<double?>> IsNotEqualTo(
+		this IThat<double?> source,
+		double? unexpected)
+	{
+		NumberTolerance<double> options = new(
+			(a, e, t) => a.Equals(e) || Math.Abs(a - e) <= (t ?? 0));
+		return new NullableNumberToleranceResult<double, IThat<double?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsEqualToConstraint<double>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not equal to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsNotEqualTo<TNumber>(
+		this IThat<TNumber?> source, TNumber? unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(
+			(a, e, t) => a < e
+				? e - a <= (t ?? default(TNumber))
+				: a - e <= (t ?? default(TNumber)));
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsEqualToConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	private sealed class IsEqualToConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber? expected,
+		NumberTolerance<TNumber> options)
+		: ConstraintResult.WithEqualToValue<TNumber>(it, grammars, expected is null),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber actual)
+		{
+			Actual = actual;
+			Outcome = options.IsWithinTolerance(actual, expected)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is equal to ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not equal to ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsEqualToConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber? expected,
+		NumberTolerance<TNumber> options)
+		: ConstraintResult.WithEqualToValue<TNumber?>(it, grammars, expected is null),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber? actual)
+		{
+			Actual = actual;
+			Outcome = options.IsWithinTolerance(actual, expected)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is equal to ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not equal to ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is equal to the <paramref name="expected" /> value.
 	/// </summary>
@@ -792,4 +1077,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsFinite.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsFinite.cs
@@ -157,7 +157,9 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(float? actual)
 		{
 			Actual = actual;
-			Outcome = actual is not null && !float.IsInfinity(actual.Value) && !float.IsNaN(actual.Value) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual is not null && !float.IsInfinity(actual.Value) && !float.IsNaN(actual.Value)
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 
@@ -186,7 +188,9 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(double? actual)
 		{
 			Actual = actual;
-			Outcome = actual is not null && !double.IsInfinity(actual.Value) && !double.IsNaN(actual.Value) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual is not null && !double.IsInfinity(actual.Value) && !double.IsNaN(actual.Value)
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThan.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThan.cs
@@ -1,13 +1,111 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
 public static partial class ThatNumber
 {
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is greater than the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T, IThat<T>> IsGreaterThan<T>(
+		this IThat<T> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsGreaterThanConstraint<T>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is greater than the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T?, IThat<T?>> IsGreaterThan<T>(
+		this IThat<T?> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsGreaterThanConstraint<T>(it, grammars, expected)),
+			source);
+
+	private sealed class IsGreaterThanConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
+		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
+			IValueConstraint<T>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual > expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is greater than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not greater than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsGreaterThanConstraint<T>(
+		string it,
+		ExpectationGrammars grammars,
+		T? expected)
+		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
+			IValueConstraint<T?>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual > expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is greater than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not greater than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is greater than the <paramref name="expected" /> value.
 	/// </summary>
@@ -302,4 +400,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThan.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThan.cs
@@ -14,29 +14,29 @@ public static partial class ThatNumber
 	/// <summary>
 	///     Verifies that the subject is greater than the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T, IThat<T>> IsGreaterThan<T>(
-		this IThat<T> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber, IThat<TNumber>> IsGreaterThan<TNumber>(
+		this IThat<TNumber> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsGreaterThanConstraint<T>(it, grammars, expected)),
+				new IsGreaterThanConstraint<TNumber>(it, grammars, expected)),
 			source);
 
 	/// <summary>
 	///     Verifies that the subject is greater than the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T?, IThat<T?>> IsGreaterThan<T>(
-		this IThat<T?> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber?, IThat<TNumber?>> IsGreaterThan<TNumber>(
+		this IThat<TNumber?> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsGreaterThanConstraint<T>(it, grammars, expected)),
+				new NullableIsGreaterThanConstraint<TNumber>(it, grammars, expected)),
 			source);
 
-	private sealed class IsGreaterThanConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
-		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
-			IValueConstraint<T>
-		where T : struct, INumber<T>
+	private sealed class IsGreaterThanConstraint<TNumber>(string it, ExpectationGrammars grammars, TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber>(it, grammars, expected is null),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T actual)
+		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual > expected
@@ -67,15 +67,15 @@ public static partial class ThatNumber
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
 
-	private sealed class NullableIsGreaterThanConstraint<T>(
+	private sealed class NullableIsGreaterThanConstraint<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		T? expected)
-		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
-			IValueConstraint<T?>
-		where T : struct, INumber<T>
+		TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber?>(it, grammars, expected is null),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T? actual)
+		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual > expected

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThanOrEqualTo.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThanOrEqualTo.cs
@@ -1,13 +1,111 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
 public static partial class ThatNumber
 {
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is greater than or equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T, IThat<T>> IsGreaterThanOrEqualTo<T>(
+		this IThat<T> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsGreaterThanOrEqualToConstraint<T>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is greater than or equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T?, IThat<T?>> IsGreaterThanOrEqualTo<T>(
+		this IThat<T?> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsGreaterThanOrEqualToConstraint<T>(it, grammars, expected)),
+			source);
+
+	private sealed class IsGreaterThanOrEqualToConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
+		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
+			IValueConstraint<T>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual >= expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is greater than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not greater than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsGreaterThanOrEqualToConstraint<T>(
+		string it,
+		ExpectationGrammars grammars,
+		T? expected)
+		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
+			IValueConstraint<T?>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual >= expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is greater than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not greater than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is greater than or equal to the <paramref name="expected" /> value.
 	/// </summary>
@@ -302,4 +400,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThanOrEqualTo.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsGreaterThanOrEqualTo.cs
@@ -14,29 +14,32 @@ public static partial class ThatNumber
 	/// <summary>
 	///     Verifies that the subject is greater than or equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T, IThat<T>> IsGreaterThanOrEqualTo<T>(
-		this IThat<T> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber, IThat<TNumber>> IsGreaterThanOrEqualTo<TNumber>(
+		this IThat<TNumber> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsGreaterThanOrEqualToConstraint<T>(it, grammars, expected)),
+				new IsGreaterThanOrEqualToConstraint<TNumber>(it, grammars, expected)),
 			source);
 
 	/// <summary>
 	///     Verifies that the subject is greater than or equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T?, IThat<T?>> IsGreaterThanOrEqualTo<T>(
-		this IThat<T?> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber?, IThat<TNumber?>> IsGreaterThanOrEqualTo<TNumber>(
+		this IThat<TNumber?> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsGreaterThanOrEqualToConstraint<T>(it, grammars, expected)),
+				new NullableIsGreaterThanOrEqualToConstraint<TNumber>(it, grammars, expected)),
 			source);
 
-	private sealed class IsGreaterThanOrEqualToConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
-		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
-			IValueConstraint<T>
-		where T : struct, INumber<T>
+	private sealed class IsGreaterThanOrEqualToConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber>(it, grammars, expected is null),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T actual)
+		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual >= expected
@@ -67,15 +70,15 @@ public static partial class ThatNumber
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
 
-	private sealed class NullableIsGreaterThanOrEqualToConstraint<T>(
+	private sealed class NullableIsGreaterThanOrEqualToConstraint<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		T? expected)
-		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
-			IValueConstraint<T?>
-		where T : struct, INumber<T>
+		TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber?>(it, grammars, expected is null),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T? actual)
+		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual >= expected

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsLessThan.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsLessThan.cs
@@ -1,13 +1,111 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
 public static partial class ThatNumber
 {
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is less than the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T, IThat<T>> IsLessThan<T>(
+		this IThat<T> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsLessThanConstraint<T>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is less than the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T?, IThat<T?>> IsLessThan<T>(
+		this IThat<T?> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsLessThanConstraint<T>(it, grammars, expected)),
+			source);
+
+	private sealed class IsLessThanConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
+		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
+			IValueConstraint<T>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual < expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is less than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not less than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsLessThanConstraint<T>(
+		string it,
+		ExpectationGrammars grammars,
+		T? expected)
+		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
+			IValueConstraint<T?>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual < expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is less than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not less than ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is less than the <paramref name="expected" /> value.
 	/// </summary>
@@ -302,4 +400,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsLessThan.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsLessThan.cs
@@ -14,29 +14,29 @@ public static partial class ThatNumber
 	/// <summary>
 	///     Verifies that the subject is less than the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T, IThat<T>> IsLessThan<T>(
-		this IThat<T> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber, IThat<TNumber>> IsLessThan<TNumber>(
+		this IThat<TNumber> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsLessThanConstraint<T>(it, grammars, expected)),
+				new IsLessThanConstraint<TNumber>(it, grammars, expected)),
 			source);
 
 	/// <summary>
 	///     Verifies that the subject is less than the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T?, IThat<T?>> IsLessThan<T>(
-		this IThat<T?> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber?, IThat<TNumber?>> IsLessThan<TNumber>(
+		this IThat<TNumber?> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsLessThanConstraint<T>(it, grammars, expected)),
+				new NullableIsLessThanConstraint<TNumber>(it, grammars, expected)),
 			source);
 
-	private sealed class IsLessThanConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
-		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
-			IValueConstraint<T>
-		where T : struct, INumber<T>
+	private sealed class IsLessThanConstraint<TNumber>(string it, ExpectationGrammars grammars, TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber>(it, grammars, expected is null),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T actual)
+		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual < expected
@@ -67,15 +67,15 @@ public static partial class ThatNumber
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
 
-	private sealed class NullableIsLessThanConstraint<T>(
+	private sealed class NullableIsLessThanConstraint<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		T? expected)
-		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
-			IValueConstraint<T?>
-		where T : struct, INumber<T>
+		TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber?>(it, grammars, expected is null),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T? actual)
+		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual < expected

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsLessThanOrEqualTo.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsLessThanOrEqualTo.cs
@@ -1,13 +1,111 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
 public static partial class ThatNumber
 {
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is less than or equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T, IThat<T>> IsLessThanOrEqualTo<T>(
+		this IThat<T> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsLessThanOrEqualToConstraint<T>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is less than or equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<T?, IThat<T?>> IsLessThanOrEqualTo<T>(
+		this IThat<T?> source, T? expected)
+		where T : struct, INumber<T>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsLessThanOrEqualToConstraint<T>(it, grammars, expected)),
+			source);
+
+	private sealed class IsLessThanOrEqualToConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
+		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
+			IValueConstraint<T>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual <= expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is less than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not less than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsLessThanOrEqualToConstraint<T>(
+		string it,
+		ExpectationGrammars grammars,
+		T? expected)
+		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
+			IValueConstraint<T?>
+		where T : struct, INumber<T>
+	{
+		public ConstraintResult IsMetBy(T? actual)
+		{
+			Actual = actual;
+			Outcome = IsFinite(expected) && IsFinite(actual) && actual <= expected
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is less than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not less than or equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is less than or equal to the <paramref name="expected" /> value.
 	/// </summary>
@@ -302,4 +400,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsLessThanOrEqualTo.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsLessThanOrEqualTo.cs
@@ -14,29 +14,32 @@ public static partial class ThatNumber
 	/// <summary>
 	///     Verifies that the subject is less than or equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T, IThat<T>> IsLessThanOrEqualTo<T>(
-		this IThat<T> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber, IThat<TNumber>> IsLessThanOrEqualTo<TNumber>(
+		this IThat<TNumber> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsLessThanOrEqualToConstraint<T>(it, grammars, expected)),
+				new IsLessThanOrEqualToConstraint<TNumber>(it, grammars, expected)),
 			source);
 
 	/// <summary>
 	///     Verifies that the subject is less than or equal to the <paramref name="expected" /> value.
 	/// </summary>
-	public static AndOrResult<T?, IThat<T?>> IsLessThanOrEqualTo<T>(
-		this IThat<T?> source, T? expected)
-		where T : struct, INumber<T>
+	public static AndOrResult<TNumber?, IThat<TNumber?>> IsLessThanOrEqualTo<TNumber>(
+		this IThat<TNumber?> source, TNumber? expected)
+		where TNumber : struct, INumber<TNumber>
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new NullableIsLessThanOrEqualToConstraint<T>(it, grammars, expected)),
+				new NullableIsLessThanOrEqualToConstraint<TNumber>(it, grammars, expected)),
 			source);
 
-	private sealed class IsLessThanOrEqualToConstraint<T>(string it, ExpectationGrammars grammars, T? expected)
-		: ConstraintResult.WithEqualToValue<T>(it, grammars, expected is null),
-			IValueConstraint<T>
-		where T : struct, INumber<T>
+	private sealed class IsLessThanOrEqualToConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber>(it, grammars, expected is null),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T actual)
+		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual <= expected
@@ -67,15 +70,15 @@ public static partial class ThatNumber
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
 
-	private sealed class NullableIsLessThanOrEqualToConstraint<T>(
+	private sealed class NullableIsLessThanOrEqualToConstraint<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		T? expected)
-		: ConstraintResult.WithEqualToValue<T?>(it, grammars, expected is null),
-			IValueConstraint<T?>
-		where T : struct, INumber<T>
+		TNumber? expected)
+		: ConstraintResult.WithEqualToValue<TNumber?>(it, grammars, expected is null),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
 	{
-		public ConstraintResult IsMetBy(T? actual)
+		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
 			Outcome = IsFinite(expected) && IsFinite(actual) && actual <= expected

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsNegative.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsNegative.cs
@@ -2,7 +2,6 @@
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
-using aweXpect.Options;
 using aweXpect.Results;
 
 namespace aweXpect;
@@ -138,7 +137,10 @@ public static partial class ThatNumber
 				new NullableIsNegativeConstraint<decimal>(it, grammars, a => a < 0)),
 			source);
 
-	private sealed class IsNegativeConstraint<TNumber>(string it, ExpectationGrammars grammars, Func<TNumber, bool> predicate)
+	private sealed class IsNegativeConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		Func<TNumber, bool> predicate)
 		: ConstraintResult.WithValue<TNumber>(grammars),
 			IValueConstraint<TNumber>
 		where TNumber : struct, IComparable<TNumber>
@@ -151,9 +153,7 @@ public static partial class ThatNumber
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(ExpectIsNegative);
-		}
+			=> stringBuilder.Append(ExpectIsNegative);
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -162,15 +162,16 @@ public static partial class ThatNumber
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(ExpectIsNotNegative);
-		}
+			=> stringBuilder.Append(ExpectIsNotNegative);
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
 
-	private sealed class NullableIsNegativeConstraint<TNumber>(string it, ExpectationGrammars grammars, Func<TNumber, bool> predicate)
+	private sealed class NullableIsNegativeConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		Func<TNumber, bool> predicate)
 		: ConstraintResult.WithValue<TNumber?>(grammars),
 			IValueConstraint<TNumber?>
 		where TNumber : struct, IComparable<TNumber>
@@ -183,9 +184,7 @@ public static partial class ThatNumber
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(ExpectIsNegative);
-		}
+			=> stringBuilder.Append(ExpectIsNegative);
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -194,9 +193,7 @@ public static partial class ThatNumber
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(ExpectIsNotNegative);
-		}
+			=> stringBuilder.Append(ExpectIsNotNegative);
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsNegative.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsNegative.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
@@ -11,6 +13,89 @@ public static partial class ThatNumber
 	private const string ExpectIsNegative = "is negative";
 	private const string ExpectIsNotNegative = "is not negative";
 
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<TNumber, IThat<TNumber>> IsNegative<TNumber>(
+		this IThat<TNumber> source)
+		where TNumber : struct, INumber<TNumber>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsNegativeConstraint<TNumber>(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is negative.
+	/// </summary>
+	public static AndOrResult<TNumber?, IThat<TNumber?>> IsNegative<TNumber>(
+		this IThat<TNumber?> source)
+		where TNumber : struct, INumber<TNumber>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsNegativeConstraint<TNumber>(it, grammars)),
+			source);
+
+	private sealed class IsNegativeConstraint<TNumber>(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<TNumber>(grammars),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber actual)
+		{
+			Actual = actual;
+			Outcome = actual < default(TNumber)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsNegative);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsNotNegative);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsNegativeConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<TNumber?>(grammars),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber? actual)
+		{
+			Actual = actual;
+			Outcome = actual is not null && actual < default(TNumber)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsNegative);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsNotNegative);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is negative.
 	/// </summary>
@@ -198,4 +283,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
@@ -1,15 +1,306 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
 public static partial class ThatNumber
 {
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsOneOf<TNumber>(
+		this IThat<TNumber> source,
+		params TNumber?[] expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsOneOf<TNumber>(
+		this IThat<TNumber?> source,
+		params TNumber?[] expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsOneOf<TNumber>(
+		this IThat<TNumber> source,
+		params TNumber[] expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsOneOf<TNumber>(
+		this IThat<TNumber?> source,
+		params TNumber[] expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsOneOfConstraint<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsNotOneOf<TNumber>(
+		this IThat<TNumber> source,
+		params TNumber?[] unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsNotOneOf<TNumber>(
+		this IThat<TNumber?> source,
+		params TNumber?[] unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsNotOneOf<TNumber>(
+		this IThat<TNumber> source,
+		params TNumber[] unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsNotOneOf<TNumber>(
+		this IThat<TNumber?> source,
+		params TNumber[] unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsOneOfConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	private sealed class IsOneOfConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber[] expected,
+		NumberTolerance<TNumber> options)
+		: ConstraintResult.WithValue<TNumber>(grammars),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsOneOfConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber[] expected,
+		NumberTolerance<TNumber> options)
+		: ConstraintResult.WithValue<TNumber?>(grammars),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber? actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class IsOneOfConstraintWithNullable<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber?[] expected,
+		NumberTolerance<TNumber> options)
+		: ConstraintResult.WithValue<TNumber>(grammars),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsOneOfConstraintWithNullable<TNumber>(
+		string it,
+		ExpectationGrammars grammars,
+		TNumber?[] expected,
+		NumberTolerance<TNumber> options)
+		: ConstraintResult.WithValue<TNumber?>(grammars),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber? actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is one of the <paramref name="expected" /> values.
 	/// </summary>
@@ -1577,4 +1868,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
@@ -1437,7 +1437,7 @@ public static partial class ThatNumber
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1450,7 +1450,7 @@ public static partial class ThatNumber
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is not one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1477,7 +1477,7 @@ public static partial class ThatNumber
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1490,7 +1490,7 @@ public static partial class ThatNumber
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is not one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1517,7 +1517,7 @@ public static partial class ThatNumber
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1530,7 +1530,7 @@ public static partial class ThatNumber
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is not one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1557,7 +1557,7 @@ public static partial class ThatNumber
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 
@@ -1570,7 +1570,7 @@ public static partial class ThatNumber
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append("is not one of ");
-			ValueFormatters.Format(Formatter, stringBuilder, expected);
+			Formatter.Format(stringBuilder, expected);
 			stringBuilder.Append(options);
 		}
 

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsPositive.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsPositive.cs
@@ -1,8 +1,10 @@
-﻿using System;
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
+#if !NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
@@ -11,6 +13,89 @@ public static partial class ThatNumber
 	private const string ExpectIsPositive = "is positive";
 	private const string ExpectIsNotPositive = "is not positive";
 
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<TNumber, IThat<TNumber>> IsPositive<TNumber>(
+		this IThat<TNumber> source)
+		where TNumber : struct, INumber<TNumber>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsPositiveConstraint<TNumber>(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is positive.
+	/// </summary>
+	public static AndOrResult<TNumber?, IThat<TNumber?>> IsPositive<TNumber>(
+		this IThat<TNumber?> source)
+		where TNumber : struct, INumber<TNumber>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsPositiveConstraint<TNumber>(it, grammars)),
+			source);
+
+	private sealed class IsPositiveConstraint<TNumber>(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<TNumber>(grammars),
+			IValueConstraint<TNumber>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber actual)
+		{
+			Actual = actual;
+			Outcome = actual > default(TNumber)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsPositive);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsNotPositive);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+
+	private sealed class NullableIsPositiveConstraint<TNumber>(
+		string it,
+		ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<TNumber?>(grammars),
+			IValueConstraint<TNumber?>
+		where TNumber : struct, INumber<TNumber>
+	{
+		public ConstraintResult IsMetBy(TNumber? actual)
+		{
+			Actual = actual;
+			Outcome = actual is not null && actual > default(TNumber)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsPositive);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(ExpectIsNotPositive);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+#else
 	/// <summary>
 	///     Verifies that the subject is positive.
 	/// </summary>
@@ -198,4 +283,5 @@ public static partial class ThatNumber
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);
 	}
+#endif
 }

--- a/Source/aweXpect/That/Numbers/ThatNumber.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.cs
@@ -1,4 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+#if NET8_0_OR_GREATER
+using System;
+#endif
 
 namespace aweXpect;
 
@@ -12,6 +15,29 @@ public static partial class ThatNumber
 		null => false,
 		double d => !double.IsNaN(d),
 		float f => !float.IsNaN(f),
-		_ => true,
+#if NET8_0_OR_GREATER
+		Half h => !Half.IsNaN(h),
+#endif
+		_ => true
 	};
+
+#if NET8_0_OR_GREATER
+	private static bool IsWithinTolerance<TNumber>(TNumber actual, TNumber expected, TNumber? tolerance)
+		where TNumber : struct, INumber<TNumber>
+	{
+		if (actual == expected)
+		{
+			return true;
+		}
+
+		if (!IsFinite(actual))
+		{
+			return !IsFinite(expected);
+		}
+
+		return actual < expected
+			? expected - actual <= (tolerance ?? default(TNumber))
+			: actual - expected <= (tolerance ?? default(TNumber));
+	}
+#endif
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -463,124 +463,38 @@ namespace aweXpect
     }
     public static class ThatNumber
     {
-        public static aweXpect.Results.NumberToleranceResult<byte, aweXpect.Core.IThat<byte>> IsEqualTo(this aweXpect.Core.IThat<byte> source, byte? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<byte, aweXpect.Core.IThat<byte?>> IsEqualTo(this aweXpect.Core.IThat<byte?> source, byte? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<decimal, aweXpect.Core.IThat<decimal>> IsEqualTo(this aweXpect.Core.IThat<decimal> source, decimal? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<decimal, aweXpect.Core.IThat<decimal?>> IsEqualTo(this aweXpect.Core.IThat<decimal?> source, decimal? expected) { }
         public static aweXpect.Results.NumberToleranceResult<double, aweXpect.Core.IThat<double>> IsEqualTo(this aweXpect.Core.IThat<double> source, double? expected) { }
         public static aweXpect.Results.NullableNumberToleranceResult<double, aweXpect.Core.IThat<double?>> IsEqualTo(this aweXpect.Core.IThat<double?> source, double? expected) { }
         public static aweXpect.Results.NumberToleranceResult<float, aweXpect.Core.IThat<float>> IsEqualTo(this aweXpect.Core.IThat<float> source, float? expected) { }
         public static aweXpect.Results.NullableNumberToleranceResult<float, aweXpect.Core.IThat<float?>> IsEqualTo(this aweXpect.Core.IThat<float?> source, float? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<int, aweXpect.Core.IThat<int>> IsEqualTo(this aweXpect.Core.IThat<int> source, int? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<int, aweXpect.Core.IThat<int?>> IsEqualTo(this aweXpect.Core.IThat<int?> source, int? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<long, aweXpect.Core.IThat<long>> IsEqualTo(this aweXpect.Core.IThat<long> source, long? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<long, aweXpect.Core.IThat<long?>> IsEqualTo(this aweXpect.Core.IThat<long?> source, long? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<sbyte, aweXpect.Core.IThat<sbyte>> IsEqualTo(this aweXpect.Core.IThat<sbyte> source, sbyte? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<sbyte, aweXpect.Core.IThat<sbyte?>> IsEqualTo(this aweXpect.Core.IThat<sbyte?> source, sbyte? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<short, aweXpect.Core.IThat<short>> IsEqualTo(this aweXpect.Core.IThat<short> source, short? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<short, aweXpect.Core.IThat<short?>> IsEqualTo(this aweXpect.Core.IThat<short?> source, short? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<uint, aweXpect.Core.IThat<uint>> IsEqualTo(this aweXpect.Core.IThat<uint> source, uint? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<uint, aweXpect.Core.IThat<uint?>> IsEqualTo(this aweXpect.Core.IThat<uint?> source, uint? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<ulong, aweXpect.Core.IThat<ulong>> IsEqualTo(this aweXpect.Core.IThat<ulong> source, ulong? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<ulong, aweXpect.Core.IThat<ulong?>> IsEqualTo(this aweXpect.Core.IThat<ulong?> source, ulong? expected) { }
-        public static aweXpect.Results.NumberToleranceResult<ushort, aweXpect.Core.IThat<ushort>> IsEqualTo(this aweXpect.Core.IThat<ushort> source, ushort? expected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<ushort, aweXpect.Core.IThat<ushort?>> IsEqualTo(this aweXpect.Core.IThat<ushort?> source, ushort? expected) { }
+        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsFinite(this aweXpect.Core.IThat<double> source) { }
         public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double?>> IsFinite(this aweXpect.Core.IThat<double?> source) { }
         public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsFinite(this aweXpect.Core.IThat<float> source) { }
         public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float?>> IsFinite(this aweXpect.Core.IThat<float?> source) { }
-        public static aweXpect.Results.AndOrResult<byte, aweXpect.Core.IThat<byte>> IsGreaterThan(this aweXpect.Core.IThat<byte> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<byte?, aweXpect.Core.IThat<byte?>> IsGreaterThan(this aweXpect.Core.IThat<byte?> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal, aweXpect.Core.IThat<decimal>> IsGreaterThan(this aweXpect.Core.IThat<decimal> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal?, aweXpect.Core.IThat<decimal?>> IsGreaterThan(this aweXpect.Core.IThat<decimal?> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsGreaterThan(this aweXpect.Core.IThat<double> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsGreaterThan(this aweXpect.Core.IThat<double?> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsGreaterThan(this aweXpect.Core.IThat<float> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<float?, aweXpect.Core.IThat<float?>> IsGreaterThan(this aweXpect.Core.IThat<float?> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<int, aweXpect.Core.IThat<int>> IsGreaterThan(this aweXpect.Core.IThat<int> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<int?, aweXpect.Core.IThat<int?>> IsGreaterThan(this aweXpect.Core.IThat<int?> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<long, aweXpect.Core.IThat<long>> IsGreaterThan(this aweXpect.Core.IThat<long> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<long?, aweXpect.Core.IThat<long?>> IsGreaterThan(this aweXpect.Core.IThat<long?> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte, aweXpect.Core.IThat<sbyte>> IsGreaterThan(this aweXpect.Core.IThat<sbyte> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>> IsGreaterThan(this aweXpect.Core.IThat<sbyte?> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>> IsGreaterThan(this aweXpect.Core.IThat<short> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>> IsGreaterThan(this aweXpect.Core.IThat<short?> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<uint, aweXpect.Core.IThat<uint>> IsGreaterThan(this aweXpect.Core.IThat<uint> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<uint?, aweXpect.Core.IThat<uint?>> IsGreaterThan(this aweXpect.Core.IThat<uint?> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong, aweXpect.Core.IThat<ulong>> IsGreaterThan(this aweXpect.Core.IThat<ulong> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong?, aweXpect.Core.IThat<ulong?>> IsGreaterThan(this aweXpect.Core.IThat<ulong?> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort, aweXpect.Core.IThat<ushort>> IsGreaterThan(this aweXpect.Core.IThat<ushort> source, ushort? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort?, aweXpect.Core.IThat<ushort?>> IsGreaterThan(this aweXpect.Core.IThat<ushort?> source, ushort? expected) { }
-        public static aweXpect.Results.AndOrResult<byte, aweXpect.Core.IThat<byte>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<byte> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<byte?, aweXpect.Core.IThat<byte?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<byte?> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal, aweXpect.Core.IThat<decimal>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<decimal> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal?, aweXpect.Core.IThat<decimal?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<decimal?> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<double> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<double?> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<float> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<float?, aweXpect.Core.IThat<float?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<float?> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<int, aweXpect.Core.IThat<int>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<int> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<int?, aweXpect.Core.IThat<int?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<int?> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<long, aweXpect.Core.IThat<long>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<long> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<long?, aweXpect.Core.IThat<long?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<long?> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte, aweXpect.Core.IThat<sbyte>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<sbyte> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<sbyte?> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<short> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<short?> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<uint, aweXpect.Core.IThat<uint>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<uint> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<uint?, aweXpect.Core.IThat<uint?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<uint?> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong, aweXpect.Core.IThat<ulong>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<ulong> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong?, aweXpect.Core.IThat<ulong?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<ulong?> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort, aweXpect.Core.IThat<ushort>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<ushort> source, ushort? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort?, aweXpect.Core.IThat<ushort?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<ushort?> source, ushort? expected) { }
+        public static aweXpect.Results.AndOrResult<TNumber, aweXpect.Core.IThat<TNumber>> IsGreaterThan<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>> IsGreaterThan<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.AndOrResult<TNumber, aweXpect.Core.IThat<TNumber>> IsGreaterThanOrEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>> IsGreaterThanOrEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsInfinite(this aweXpect.Core.IThat<double> source) { }
         public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsInfinite(this aweXpect.Core.IThat<double?> source) { }
         public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsInfinite(this aweXpect.Core.IThat<float> source) { }
         public static aweXpect.Results.AndOrResult<float?, aweXpect.Core.IThat<float?>> IsInfinite(this aweXpect.Core.IThat<float?> source) { }
-        public static aweXpect.Results.AndOrResult<byte, aweXpect.Core.IThat<byte>> IsLessThan(this aweXpect.Core.IThat<byte> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<byte?, aweXpect.Core.IThat<byte?>> IsLessThan(this aweXpect.Core.IThat<byte?> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal, aweXpect.Core.IThat<decimal>> IsLessThan(this aweXpect.Core.IThat<decimal> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal?, aweXpect.Core.IThat<decimal?>> IsLessThan(this aweXpect.Core.IThat<decimal?> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsLessThan(this aweXpect.Core.IThat<double> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsLessThan(this aweXpect.Core.IThat<double?> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsLessThan(this aweXpect.Core.IThat<float> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<float?, aweXpect.Core.IThat<float?>> IsLessThan(this aweXpect.Core.IThat<float?> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<int, aweXpect.Core.IThat<int>> IsLessThan(this aweXpect.Core.IThat<int> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<int?, aweXpect.Core.IThat<int?>> IsLessThan(this aweXpect.Core.IThat<int?> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<long, aweXpect.Core.IThat<long>> IsLessThan(this aweXpect.Core.IThat<long> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<long?, aweXpect.Core.IThat<long?>> IsLessThan(this aweXpect.Core.IThat<long?> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte, aweXpect.Core.IThat<sbyte>> IsLessThan(this aweXpect.Core.IThat<sbyte> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>> IsLessThan(this aweXpect.Core.IThat<sbyte?> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>> IsLessThan(this aweXpect.Core.IThat<short> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>> IsLessThan(this aweXpect.Core.IThat<short?> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<uint, aweXpect.Core.IThat<uint>> IsLessThan(this aweXpect.Core.IThat<uint> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<uint?, aweXpect.Core.IThat<uint?>> IsLessThan(this aweXpect.Core.IThat<uint?> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong, aweXpect.Core.IThat<ulong>> IsLessThan(this aweXpect.Core.IThat<ulong> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong?, aweXpect.Core.IThat<ulong?>> IsLessThan(this aweXpect.Core.IThat<ulong?> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort, aweXpect.Core.IThat<ushort>> IsLessThan(this aweXpect.Core.IThat<ushort> source, ushort? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort?, aweXpect.Core.IThat<ushort?>> IsLessThan(this aweXpect.Core.IThat<ushort?> source, ushort? expected) { }
-        public static aweXpect.Results.AndOrResult<byte, aweXpect.Core.IThat<byte>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<byte> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<byte?, aweXpect.Core.IThat<byte?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<byte?> source, byte? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal, aweXpect.Core.IThat<decimal>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<decimal> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<decimal?, aweXpect.Core.IThat<decimal?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<decimal?> source, decimal? expected) { }
-        public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<double> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<double?> source, double? expected) { }
-        public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<float> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<float?, aweXpect.Core.IThat<float?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<float?> source, float? expected) { }
-        public static aweXpect.Results.AndOrResult<int, aweXpect.Core.IThat<int>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<int> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<int?, aweXpect.Core.IThat<int?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<int?> source, int? expected) { }
-        public static aweXpect.Results.AndOrResult<long, aweXpect.Core.IThat<long>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<long> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<long?, aweXpect.Core.IThat<long?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<long?> source, long? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte, aweXpect.Core.IThat<sbyte>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<sbyte> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<sbyte?> source, sbyte? expected) { }
-        public static aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<short> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<short?> source, short? expected) { }
-        public static aweXpect.Results.AndOrResult<uint, aweXpect.Core.IThat<uint>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<uint> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<uint?, aweXpect.Core.IThat<uint?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<uint?> source, uint? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong, aweXpect.Core.IThat<ulong>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<ulong> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ulong?, aweXpect.Core.IThat<ulong?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<ulong?> source, ulong? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort, aweXpect.Core.IThat<ushort>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<ushort> source, ushort? expected) { }
-        public static aweXpect.Results.AndOrResult<ushort?, aweXpect.Core.IThat<ushort?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<ushort?> source, ushort? expected) { }
+        public static aweXpect.Results.AndOrResult<TNumber, aweXpect.Core.IThat<TNumber>> IsLessThan<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>> IsLessThan<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.AndOrResult<TNumber, aweXpect.Core.IThat<TNumber>> IsLessThanOrEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>> IsLessThanOrEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsNaN(this aweXpect.Core.IThat<double> source) { }
         public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsNaN(this aweXpect.Core.IThat<double?> source) { }
         public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsNaN(this aweXpect.Core.IThat<float> source) { }
@@ -599,28 +513,14 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>> IsNegative(this aweXpect.Core.IThat<sbyte?> source) { }
         public static aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>> IsNegative(this aweXpect.Core.IThat<short> source) { }
         public static aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>> IsNegative(this aweXpect.Core.IThat<short?> source) { }
-        public static aweXpect.Results.NumberToleranceResult<byte, aweXpect.Core.IThat<byte>> IsNotEqualTo(this aweXpect.Core.IThat<byte> source, byte? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<byte, aweXpect.Core.IThat<byte?>> IsNotEqualTo(this aweXpect.Core.IThat<byte?> source, byte? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<decimal, aweXpect.Core.IThat<decimal>> IsNotEqualTo(this aweXpect.Core.IThat<decimal> source, decimal? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<decimal, aweXpect.Core.IThat<decimal?>> IsNotEqualTo(this aweXpect.Core.IThat<decimal?> source, decimal? unexpected) { }
         public static aweXpect.Results.NumberToleranceResult<double, aweXpect.Core.IThat<double>> IsNotEqualTo(this aweXpect.Core.IThat<double> source, double? unexpected) { }
         public static aweXpect.Results.NullableNumberToleranceResult<double, aweXpect.Core.IThat<double?>> IsNotEqualTo(this aweXpect.Core.IThat<double?> source, double? unexpected) { }
         public static aweXpect.Results.NumberToleranceResult<float, aweXpect.Core.IThat<float>> IsNotEqualTo(this aweXpect.Core.IThat<float> source, float? unexpected) { }
         public static aweXpect.Results.NullableNumberToleranceResult<float, aweXpect.Core.IThat<float?>> IsNotEqualTo(this aweXpect.Core.IThat<float?> source, float? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<int, aweXpect.Core.IThat<int>> IsNotEqualTo(this aweXpect.Core.IThat<int> source, int? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<int, aweXpect.Core.IThat<int?>> IsNotEqualTo(this aweXpect.Core.IThat<int?> source, int? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<long, aweXpect.Core.IThat<long>> IsNotEqualTo(this aweXpect.Core.IThat<long> source, long? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<long, aweXpect.Core.IThat<long?>> IsNotEqualTo(this aweXpect.Core.IThat<long?> source, long? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<sbyte, aweXpect.Core.IThat<sbyte>> IsNotEqualTo(this aweXpect.Core.IThat<sbyte> source, sbyte? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<sbyte, aweXpect.Core.IThat<sbyte?>> IsNotEqualTo(this aweXpect.Core.IThat<sbyte?> source, sbyte? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<short, aweXpect.Core.IThat<short>> IsNotEqualTo(this aweXpect.Core.IThat<short> source, short? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<short, aweXpect.Core.IThat<short?>> IsNotEqualTo(this aweXpect.Core.IThat<short?> source, short? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<uint, aweXpect.Core.IThat<uint>> IsNotEqualTo(this aweXpect.Core.IThat<uint> source, uint? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<uint, aweXpect.Core.IThat<uint?>> IsNotEqualTo(this aweXpect.Core.IThat<uint?> source, uint? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<ulong, aweXpect.Core.IThat<ulong>> IsNotEqualTo(this aweXpect.Core.IThat<ulong> source, ulong? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<ulong, aweXpect.Core.IThat<ulong?>> IsNotEqualTo(this aweXpect.Core.IThat<ulong?> source, ulong? unexpected) { }
-        public static aweXpect.Results.NumberToleranceResult<ushort, aweXpect.Core.IThat<ushort>> IsNotEqualTo(this aweXpect.Core.IThat<ushort> source, ushort? unexpected) { }
-        public static aweXpect.Results.NullableNumberToleranceResult<ushort, aweXpect.Core.IThat<ushort?>> IsNotEqualTo(this aweXpect.Core.IThat<ushort?> source, ushort? unexpected) { }
+        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsNotEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? unexpected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsNotEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? unexpected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>> IsNotFinite(this aweXpect.Core.IThat<double> source) { }
         public static aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>> IsNotFinite(this aweXpect.Core.IThat<double?> source) { }
         public static aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>> IsNotFinite(this aweXpect.Core.IThat<float> source) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -942,24 +942,24 @@ namespace aweXpect.Results
         public TSelf WithTimeout(System.TimeSpan timeout) { }
     }
     public class NullableNumberToleranceResult<TType, TThat> : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, aweXpect.Results.NullableNumberToleranceResult<TType, TThat>>
-        where TType :  struct, System.IComparable<TType>
+        where TType :  struct, System.Numerics.INumber<TType>
     {
         public NullableNumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
     }
     public class NullableNumberToleranceResult<TType, TThat, TSelf> : aweXpect.Results.AndOrResult<TType?, TThat, TSelf>
-        where TType :  struct, System.IComparable<TType>
+        where TType :  struct, System.Numerics.INumber<TType>
         where TSelf : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, TSelf>
     {
         public NullableNumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
         public TSelf Within(TType tolerance) { }
     }
     public class NumberToleranceResult<TType, TThat> : aweXpect.Results.NumberToleranceResult<TType, TThat, aweXpect.Results.NumberToleranceResult<TType, TThat>>
-        where TType :  struct, System.IComparable<TType>
+        where TType :  struct, System.Numerics.INumber<TType>
     {
         public NumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }
     }
     public class NumberToleranceResult<TType, TThat, TSelf> : aweXpect.Results.AndOrResult<TType, TThat, TSelf>
-        where TType :  struct, System.IComparable<TType>
+        where TType :  struct, System.Numerics.INumber<TType>
         where TSelf : aweXpect.Results.NumberToleranceResult<TType, TThat, TSelf>
     {
         public NumberToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.NumberTolerance<TType> options) { }

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.WithEqualToValueTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.WithEqualToValueTests.cs
@@ -176,9 +176,9 @@ public partial class ConstraintResultTests
 		}
 
 		[Fact]
-		public async Task TryGetValue_ShouldReturnFalseWhenTypeIsSupertypeAndValueIsNull()
+		public async Task TryGetValue_ShouldReturnFalseWhenTypeIsSupertype()
 		{
-			ConstraintResult sut = new MyWithEqualToValueDummy<MyBaseClass?>(null, false);
+			ConstraintResult sut = new MyWithEqualToValueDummy<MyBaseClass?>(new MyBaseClass(), false);
 
 			bool result = sut.TryGetValue(out MyDerivedClass? value);
 

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.WithNotNullValueTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.WithNotNullValueTests.cs
@@ -150,9 +150,9 @@ public partial class ConstraintResultTests
 		}
 
 		[Fact]
-		public async Task TryGetValue_ShouldReturnFalseWhenTypeIsSupertypeAndValueIsNull()
+		public async Task TryGetValue_ShouldReturnFalseWhenTypeIsSupertype()
 		{
-			ConstraintResult sut = new MyWithNotNullValueDummy<MyBaseClass?>(null);
+			ConstraintResult sut = new MyWithNotNullValueDummy<MyBaseClass?>(new MyBaseClass());
 
 			bool result = sut.TryGetValue(out MyDerivedClass? value);
 

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.WithValueTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.WithValueTests.cs
@@ -124,9 +124,9 @@ public partial class ConstraintResultTests
 		}
 
 		[Fact]
-		public async Task TryGetValue_ShouldReturnFalseWhenTypeIsSupertypeAndValueIsNull()
+		public async Task TryGetValue_ShouldReturnFalseWhenTypeIsSupertype()
 		{
-			ConstraintResult sut = new MyWithValueDummy<MyBaseClass?>(null);
+			ConstraintResult sut = new MyWithValueDummy<MyBaseClass?>(new MyBaseClass());
 
 			bool result = sut.TryGetValue(out MyDerivedClass? value);
 

--- a/Tests/aweXpect.Internal.Tests/ThatTests/NumberTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/NumberTests.cs
@@ -4,8 +4,10 @@ public sealed class NumberTests
 {
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_byte(byte subject, byte expected)
+	public async Task ShouldSupportValues_byte(byte subject)
 	{
+		byte expected = subject == 0 ? (byte)1 : (byte)0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -19,8 +21,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_decimal(decimal subject, decimal expected)
+	public async Task ShouldSupportValues_decimal(decimal subject)
 	{
+		decimal expected = subject == 0 ? 1 : 0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -34,8 +38,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_double(double subject, double expected)
+	public async Task ShouldSupportValues_double(double subject)
 	{
+		double expected = subject == 0.0 ? 1.0 : 0.0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -49,8 +55,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_float(float subject, float expected)
+	public async Task ShouldSupportValues_float(float subject)
 	{
+		float expected = subject == 0.0F ? 1.0F : 0.0F;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -64,8 +72,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_int(int subject, int expected)
+	public async Task ShouldSupportValues_int(int subject)
 	{
+		int expected = subject == 0 ? 1 : 0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -79,8 +89,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_long(long subject, long expected)
+	public async Task ShouldSupportValues_long(long subject)
 	{
+		long expected = subject == 0 ? 1 : 0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -94,8 +106,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_sbyte(sbyte subject, sbyte expected)
+	public async Task ShouldSupportValues_sbyte(sbyte subject)
 	{
+		sbyte expected = subject == 0 ? (sbyte)1 : (sbyte)0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -109,8 +123,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_short(short subject, short expected)
+	public async Task ShouldSupportValues_short(short subject)
 	{
+		short expected = subject == 0 ? (short)1 : (short)0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -124,8 +140,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_uint(uint subject, uint expected)
+	public async Task ShouldSupportValues_uint(uint subject)
 	{
+		uint expected = subject == 0 ? 1 : (uint)0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -139,8 +157,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_ulong(ulong subject, ulong expected)
+	public async Task ShouldSupportValues_ulong(ulong subject)
 	{
+		ulong expected = subject == 0 ? 1 : (ulong)0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 
@@ -154,8 +174,10 @@ public sealed class NumberTests
 
 	[Theory]
 	[AutoData]
-	public async Task ShouldSupportValues_ushort(ushort subject, ushort expected)
+	public async Task ShouldSupportValues_ushort(ushort subject)
 	{
+		ushort expected = subject == 0 ? (ushort)1 : (ushort)0;
+
 		async Task Act()
 			=> await That(subject).IsEqualTo(expected);
 

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
@@ -27,7 +27,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((byte)1, (byte)2)]
 			[InlineData((byte)1, (byte)0)]
-			public async Task ForByte_WhenValueIsDifferentToExpected_ShouldFail(byte subject,
+			public async Task ForByte_WhenValueIsDifferentFromExpected_ShouldFail(byte subject,
 				byte? expected)
 			{
 				async Task Act()
@@ -72,7 +72,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForDecimal_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForDecimal_WhenValueIsDifferentFromExpected_ShouldFail(
 				double subjectValue, double expectedValue)
 			{
 				decimal subject = new(subjectValue);
@@ -161,7 +161,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForDouble_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForDouble_WhenValueIsDifferentFromExpected_ShouldFail(
 				double subject, double expected)
 			{
 				async Task Act()
@@ -233,7 +233,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((float)1.1, (float)2.1)]
 			[InlineData((float)1.1, (float)0.1)]
-			public async Task ForFloat_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForFloat_WhenValueIsDifferentFromExpected_ShouldFail(
 				float subject, float expected)
 			{
 				async Task Act()
@@ -279,7 +279,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1, 2)]
 			[InlineData(2, 1)]
-			public async Task ForInt_WhenValueIsDifferentToExpected_ShouldFail(int subject,
+			public async Task ForInt_WhenValueIsDifferentFromExpected_ShouldFail(int subject,
 				int? expected)
 			{
 				async Task Act()
@@ -303,6 +303,63 @@ public sealed partial class ThatNumber
 
 				await That(Act).DoesNotThrow();
 			}
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(2, 1)]
+			public async Task ForInt128_WhenValueIsDifferentFromExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 1)]
+			public async Task ForInt128_WhenValueIsEqualToExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
 
 			[Theory]
 			[InlineData(1L, 1)]
@@ -335,7 +392,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((long)1, (long)2)]
 			[InlineData((long)1, (long)0)]
-			public async Task ForLong_WhenValueIsDifferentToExpected_ShouldFail(long subject,
+			public async Task ForLong_WhenValueIsDifferentFromExpected_ShouldFail(long subject,
 				long? expected)
 			{
 				async Task Act()
@@ -363,7 +420,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((byte)1, (byte)2)]
 			[InlineData((byte)1, (byte)0)]
-			public async Task ForNullableByte_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableByte_WhenValueIsDifferentFromExpected_ShouldFail(
 				byte? subject, byte? expected)
 			{
 				async Task Act()
@@ -426,7 +483,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForNullableDecimal_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableDecimal_WhenValueIsDifferentFromExpected_ShouldFail(
 				double? subjectValue, double? expectedValue)
 			{
 				decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
@@ -477,7 +534,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForNullableDouble_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableDouble_WhenValueIsDifferentFromExpected_ShouldFail(
 				double? subject, double? expected)
 			{
 				async Task Act()
@@ -522,7 +579,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((float)1.1, (float)2.1)]
 			[InlineData((float)1.1, (float)0.1)]
-			public async Task ForNullableFloat_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableFloat_WhenValueIsDifferentFromExpected_ShouldFail(
 				float? subject, float? expected)
 			{
 				async Task Act()
@@ -550,7 +607,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1, 2)]
 			[InlineData(1, 0)]
-			public async Task ForNullableInt_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableInt_WhenValueIsDifferentFromExpected_ShouldFail(
 				int? subject, int? expected)
 			{
 				async Task Act()
@@ -593,10 +650,68 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForNullableInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(2, 1)]
+			public async Task ForNullableInt128_WhenValueIsDifferentFromExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is equal to {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 1)]
+			public async Task ForNullableInt128_WhenValueIsEqualToExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
 			[Theory]
 			[InlineData((long)1, (long)2)]
 			[InlineData((long)1, (long)0)]
-			public async Task ForNullableLong_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableLong_WhenValueIsDifferentFromExpected_ShouldFail(
 				long? subject, long? expected)
 			{
 				async Task Act()
@@ -642,7 +757,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((sbyte)1, (sbyte)2)]
 			[InlineData((sbyte)1, (sbyte)0)]
-			public async Task ForNullableSbyte_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableSbyte_WhenValueIsDifferentFromExpected_ShouldFail(
 				sbyte? subject, sbyte? expected)
 			{
 				async Task Act()
@@ -688,7 +803,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((short)1, (short)2)]
 			[InlineData((short)1, (short)0)]
-			public async Task ForNullableShort_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableShort_WhenValueIsDifferentFromExpected_ShouldFail(
 				short? subject, short? expected)
 			{
 				async Task Act()
@@ -734,7 +849,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((uint)1, (uint)2)]
 			[InlineData((uint)1, (uint)0)]
-			public async Task ForNullableUint_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableUint_WhenValueIsDifferentFromExpected_ShouldFail(
 				uint? subject, uint? expected)
 			{
 				async Task Act()
@@ -780,7 +895,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ulong)1, (ulong)2)]
 			[InlineData((ulong)1, (ulong)0)]
-			public async Task ForNullableUlong_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableUlong_WhenValueIsDifferentFromExpected_ShouldFail(
 				ulong? subject, ulong? expected)
 			{
 				async Task Act()
@@ -826,7 +941,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ushort)1, (ushort)2)]
 			[InlineData((ushort)1, (ushort)0)]
-			public async Task ForNullableUshort_WhenValueIsDifferentToExpected_ShouldFail(
+			public async Task ForNullableUshort_WhenValueIsDifferentFromExpected_ShouldFail(
 				ushort? subject, ushort? expected)
 			{
 				async Task Act()
@@ -890,7 +1005,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((sbyte)1, (sbyte)2)]
 			[InlineData((sbyte)1, (sbyte)0)]
-			public async Task ForSbyte_WhenValueIsDifferentToExpected_ShouldFail(sbyte subject,
+			public async Task ForSbyte_WhenValueIsDifferentFromExpected_ShouldFail(sbyte subject,
 				sbyte? expected)
 			{
 				async Task Act()
@@ -936,7 +1051,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((short)1, (short)2)]
 			[InlineData((short)1, (short)0)]
-			public async Task ForShort_WhenValueIsDifferentToExpected_ShouldFail(short subject,
+			public async Task ForShort_WhenValueIsDifferentFromExpected_ShouldFail(short subject,
 				short? expected)
 			{
 				async Task Act()
@@ -982,7 +1097,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((uint)1, (uint)2)]
 			[InlineData((uint)1, (uint)0)]
-			public async Task ForUint_WhenValueIsDifferentToExpected_ShouldFail(uint subject,
+			public async Task ForUint_WhenValueIsDifferentFromExpected_ShouldFail(uint subject,
 				uint? expected)
 			{
 				async Task Act()
@@ -1028,7 +1143,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ulong)1, (ulong)2)]
 			[InlineData((ulong)1, (ulong)0)]
-			public async Task ForUlong_WhenValueIsDifferentToExpected_ShouldFail(ulong subject,
+			public async Task ForUlong_WhenValueIsDifferentFromExpected_ShouldFail(ulong subject,
 				ulong? expected)
 			{
 				async Task Act()
@@ -1074,7 +1189,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ushort)1, (ushort)2)]
 			[InlineData((ushort)1, (ushort)0)]
-			public async Task ForUshort_WhenValueIsDifferentToExpected_ShouldFail(ushort subject,
+			public async Task ForUshort_WhenValueIsDifferentFromExpected_ShouldFail(ushort subject,
 				ushort? expected)
 			{
 				async Task Act()

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsGreaterThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsGreaterThan.Tests.cs
@@ -285,6 +285,64 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			public async Task ForInt128_WhenValueIsGreaterThanExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(0, 0)]
+			public async Task ForInt128_WhenValueIsLessThanOrEqualToExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
 			[Theory]
 			[AutoData]
 			public async Task ForLong_WhenExpectedIsNull_ShouldFail(
@@ -576,6 +634,64 @@ public sealed partial class ThatNumber
 					              but it was <null>
 					              """);
 			}
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForNullableInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			public async Task ForNullableInt128_WhenValueIsGreaterThanExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(0, 0)]
+			public async Task ForNullableInt128_WhenValueIsLessThanOrEqualToExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
 
 			[Theory]
 			[InlineData((long)2, (long)1)]

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsGreaterThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsGreaterThanOrEqualTo.Tests.cs
@@ -286,6 +286,64 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than or equal to <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			[InlineData(0, 0)]
+			public async Task ForInt128_WhenValueIsGreaterThanOrEqualToExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			public async Task ForInt128_WhenValueIsLessThanExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than or equal to {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
 			[Theory]
 			[AutoData]
 			public async Task ForLong_WhenExpectedIsNull_ShouldFail(
@@ -578,6 +636,64 @@ public sealed partial class ThatNumber
 					              but it was <null>
 					              """);
 			}
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForNullableInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than or equal to <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			[InlineData(0, 0)]
+			public async Task ForNullableInt128_WhenValueIsGreaterThanOrEqualToExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			public async Task ForNullableInt128_WhenValueIsLessThanExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsGreaterThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is greater than or equal to {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
 
 			[Theory]
 			[InlineData((long)2, (long)1)]

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsLessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsLessThan.Tests.cs
@@ -285,6 +285,64 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			[InlineData(0, 0)]
+			public async Task ForInt128_WhenValueIsGreaterThanOrEqualToExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			public async Task ForInt128_WhenValueIsLessThanExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
 			[Theory]
 			[InlineData(1L, 2)]
 			public async Task ForLong_WhenExpectedIsLargerInt_ShouldSucceed(long subject, int expected)
@@ -576,6 +634,63 @@ public sealed partial class ThatNumber
 					              but it was <null>
 					              """);
 			}
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForNullableInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			[InlineData(0, 0)]
+			public async Task ForNullableInt128_WhenValueIsGreaterThanOrEqualToExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			public async Task ForNullableInt128_WhenValueIsLessThanExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThan(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
 
 			[Theory]
 			[InlineData((long)-1, (long)-2)]

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsLessThanOrEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsLessThanOrEqualTo.Tests.cs
@@ -285,6 +285,64 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than or equal to <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			public async Task ForInt128_WhenValueIsGreaterThanExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than or equal to {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(0, 0)]
+			public async Task ForInt128_WhenValueIsLessThanOrEqualToExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
 			[Theory]
 			[InlineData(1L, 2)]
 			public async Task ForLong_WhenExpectedIsLargerInt_ShouldSucceed(long subject, int expected)
@@ -576,6 +634,63 @@ public sealed partial class ThatNumber
 					              but it was <null>
 					              """);
 			}
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForNullableInt128_WhenExpectedIsNull_ShouldFail(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than or equal to <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1)]
+			public async Task ForNullableInt128_WhenValueIsGreaterThanExpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is less than or equal to {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(0, 0)]
+			public async Task ForNullableInt128_WhenValueIsLessThanOrEqualToExpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? expected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsLessThanOrEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
 
 			[Theory]
 			[InlineData((long)-1, (long)-2)]

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNegative.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNegative.Tests.cs
@@ -196,6 +196,42 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1)]
+			[InlineData(0)]
+			public async Task ForInt128_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsNegative();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is negative,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(-1)]
+			public async Task ForInt128_WhenValueIsLessThanZero_ShouldSucceed(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsNegative();
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
 			[Theory]
 			[InlineData(1)]
 			[InlineData(0)]
@@ -485,6 +521,41 @@ public sealed partial class ThatNumber
 					             but it was <null>
 					             """);
 			}
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1)]
+			[InlineData(0)]
+			public async Task ForNullableInt128_WhenValueIsGreaterThanOrEqualToZero_ShouldFail(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsNegative();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is negative,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(-1)]
+			public async Task ForNullableInt128_WhenValueIsLessThanZero_ShouldSucceed(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsNegative();
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
 
 			[Theory]
 			[InlineData(1L)]

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotEqualTo.Tests.cs
@@ -22,7 +22,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((byte)1, (byte)2)]
 			[InlineData((byte)1, (byte)0)]
-			public async Task ForByte_WhenValueIsDifferentToUnexpected_ShouldSucceed(byte subject,
+			public async Task ForByte_WhenValueIsDifferentFromUnexpected_ShouldSucceed(byte subject,
 				byte? unexpected)
 			{
 				async Task Act()
@@ -62,7 +62,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForDecimal_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForDecimal_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				double subjectValue, double unexpectedValue)
 			{
 				decimal subject = new(subjectValue);
@@ -151,7 +151,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForDouble_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForDouble_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				double subject, double unexpected)
 			{
 				async Task Act()
@@ -218,7 +218,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((float)1.1, (float)2.1)]
 			[InlineData((float)1.1, (float)0.1)]
-			public async Task ForFloat_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForFloat_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				float subject, float unexpected)
 			{
 				async Task Act()
@@ -259,7 +259,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1, 2)]
 			[InlineData(2, 1)]
-			public async Task ForInt_WhenValueIsDifferentToUnexpected_ShouldSucceed(int subject,
+			public async Task ForInt_WhenValueIsDifferentFromUnexpected_ShouldSucceed(int subject,
 				int? unexpected)
 			{
 				async Task Act()
@@ -283,6 +283,59 @@ public sealed partial class ThatNumber
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForInt128_WhenUnexpectedIsNull_ShouldSucceed(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? unexpected = null;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(2, 1)]
+			public async Task ForInt128_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? unexpected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 1)]
+			public async Task ForInt128_WhenValueIsEqualToUnexpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? unexpected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not equal to {Formatter.Format(unexpected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
 
 			[Theory]
 			[InlineData(1L, 1)]
@@ -316,7 +369,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((long)1, (long)2)]
 			[InlineData((long)1, (long)0)]
-			public async Task ForLong_WhenValueIsDifferentToUnexpected_ShouldSucceed(long subject,
+			public async Task ForLong_WhenValueIsDifferentFromUnexpected_ShouldSucceed(long subject,
 				long? unexpected)
 			{
 				async Task Act()
@@ -344,7 +397,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((byte)1, (byte)2)]
 			[InlineData((byte)1, (byte)0)]
-			public async Task ForNullableByte_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableByte_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				byte? subject, byte? unexpected)
 			{
 				async Task Act()
@@ -375,11 +428,11 @@ public sealed partial class ThatNumber
 				byte? unexpected)
 			{
 				byte? subject = null;
-				var result = await That(subject).IsNotEqualTo(unexpected);
-				async Task Act()
-					=> 
+				byte? result = await That(subject).IsNotEqualTo(unexpected);
 
-				await That(Act).DoesNotThrow();
+				async Task Act()
+					=>
+						await That(Act).DoesNotThrow();
 			}
 
 			[Theory]
@@ -397,7 +450,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForNullableDecimal_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableDecimal_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				double? subjectValue, double? unexpectedValue)
 			{
 				decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
@@ -445,7 +498,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
-			public async Task ForNullableDouble_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableDouble_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				double? subject, double? unexpected)
 			{
 				async Task Act()
@@ -485,7 +538,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((float)1.1, (float)2.1)]
 			[InlineData((float)1.1, (float)0.1)]
-			public async Task ForNullableFloat_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableFloat_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				float? subject, float? unexpected)
 			{
 				async Task Act()
@@ -513,7 +566,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData(1, 2)]
 			[InlineData(1, 0)]
-			public async Task ForNullableInt_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableInt_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				int? subject, int? unexpected)
 			{
 				async Task Act()
@@ -551,10 +604,63 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[AutoData]
+			public async Task ForNullableInt128_WhenUnexpectedIsNull_ShouldSucceed(int subjectValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? unexpected = null;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 2)]
+			[InlineData(2, 1)]
+			public async Task ForNullableInt128_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? unexpected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1, 1)]
+			public async Task ForNullableInt128_WhenValueIsEqualToUnexpected_ShouldFail(
+				int subjectValue, int expectedValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? unexpected = expectedValue;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not equal to {Formatter.Format(unexpected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
 			[Theory]
 			[InlineData((long)1, (long)2)]
 			[InlineData((long)1, (long)0)]
-			public async Task ForNullableLong_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableLong_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				long? subject, long? unexpected)
 			{
 				async Task Act()
@@ -595,7 +701,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((sbyte)1, (sbyte)2)]
 			[InlineData((sbyte)1, (sbyte)0)]
-			public async Task ForNullableSbyte_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableSbyte_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				sbyte? subject, sbyte? unexpected)
 			{
 				async Task Act()
@@ -636,7 +742,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((short)1, (short)2)]
 			[InlineData((short)1, (short)0)]
-			public async Task ForNullableShort_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableShort_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				short? subject, short? unexpected)
 			{
 				async Task Act()
@@ -677,7 +783,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((uint)1, (uint)2)]
 			[InlineData((uint)1, (uint)0)]
-			public async Task ForNullableUint_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableUint_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				uint? subject, uint? unexpected)
 			{
 				async Task Act()
@@ -718,7 +824,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ulong)1, (ulong)2)]
 			[InlineData((ulong)1, (ulong)0)]
-			public async Task ForNullableUlong_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableUlong_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				ulong? subject, ulong? unexpected)
 			{
 				async Task Act()
@@ -759,7 +865,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ushort)1, (ushort)2)]
 			[InlineData((ushort)1, (ushort)0)]
-			public async Task ForNullableUshort_WhenValueIsDifferentToUnexpected_ShouldSucceed(
+			public async Task ForNullableUshort_WhenValueIsDifferentFromUnexpected_ShouldSucceed(
 				ushort? subject, ushort? unexpected)
 			{
 				async Task Act()
@@ -813,7 +919,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((sbyte)1, (sbyte)2)]
 			[InlineData((sbyte)1, (sbyte)0)]
-			public async Task ForSbyte_WhenValueIsDifferentToUnexpected_ShouldSucceed(sbyte subject,
+			public async Task ForSbyte_WhenValueIsDifferentFromUnexpected_ShouldSucceed(sbyte subject,
 				sbyte? unexpected)
 			{
 				async Task Act()
@@ -854,7 +960,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((short)1, (short)2)]
 			[InlineData((short)1, (short)0)]
-			public async Task ForShort_WhenValueIsDifferentToUnexpected_ShouldSucceed(short subject,
+			public async Task ForShort_WhenValueIsDifferentFromUnexpected_ShouldSucceed(short subject,
 				short? unexpected)
 			{
 				async Task Act()
@@ -895,7 +1001,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((uint)1, (uint)2)]
 			[InlineData((uint)1, (uint)0)]
-			public async Task ForUint_WhenValueIsDifferentToUnexpected_ShouldSucceed(uint subject,
+			public async Task ForUint_WhenValueIsDifferentFromUnexpected_ShouldSucceed(uint subject,
 				uint? unexpected)
 			{
 				async Task Act()
@@ -936,7 +1042,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ulong)1, (ulong)2)]
 			[InlineData((ulong)1, (ulong)0)]
-			public async Task ForUlong_WhenValueIsDifferentToUnexpected_ShouldSucceed(ulong subject,
+			public async Task ForUlong_WhenValueIsDifferentFromUnexpected_ShouldSucceed(ulong subject,
 				ulong? unexpected)
 			{
 				async Task Act()
@@ -977,7 +1083,7 @@ public sealed partial class ThatNumber
 			[Theory]
 			[InlineData((ushort)1, (ushort)2)]
 			[InlineData((ushort)1, (ushort)0)]
-			public async Task ForUshort_WhenValueIsDifferentToUnexpected_ShouldSucceed(ushort subject,
+			public async Task ForUshort_WhenValueIsDifferentFromUnexpected_ShouldSucceed(ushort subject,
 				ushort? unexpected)
 			{
 				async Task Act()

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotEqualTo.Tests.cs
@@ -375,9 +375,9 @@ public sealed partial class ThatNumber
 				byte? unexpected)
 			{
 				byte? subject = null;
-
+				var result = await That(subject).IsNotEqualTo(unexpected);
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected);
+					=> 
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsPositive.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsPositive.Tests.cs
@@ -196,6 +196,42 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1)]
+			public async Task ForInt128_WhenValueIsGreaterThanZero_ShouldSucceed(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsPositive();
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(-1)]
+			[InlineData(0)]
+			public async Task ForInt128_WhenValueIsLessThanOrEqualZero_ShouldFail(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsPositive();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is positive,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
 			[Theory]
 			[InlineData(1)]
 			public async Task ForLong_WhenValueIsGreaterThanZero_ShouldSucceed(long subject)
@@ -484,6 +520,41 @@ public sealed partial class ThatNumber
 					             but it was <null>
 					             """);
 			}
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(1)]
+			public async Task ForNullableInt128_WhenValueIsGreaterThanZero_ShouldSucceed(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsPositive();
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(-1)]
+			[InlineData(0)]
+			public async Task ForNullableInt128_WhenValueIsLessThanOrEqualToZero_ShouldFail(
+				int subjectValue)
+			{
+				Int128 subject = subjectValue;
+
+				async Task Act()
+					=> await That(subject).IsPositive();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is positive,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
 
 			[Theory]
 			[InlineData(1L)]

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.Tests.cs
@@ -71,7 +71,10 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task SubjectToItself_ShouldSucceed()
 			{
-				char subject = 'c';
+				MyStruct subject = new()
+				{
+					Value = 1,
+				};
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(subject);
@@ -82,8 +85,14 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task SubjectToSomeOtherValue_ShouldFail()
 			{
-				char subject = 'x';
-				char expected = 'y';
+				MyStruct subject = new()
+				{
+					Value = 1,
+				};
+				MyStruct expected = new()
+				{
+					Value = 2,
+				};
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected)
@@ -93,7 +102,9 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is equal to expected, because we want to test the failure,
-					             but it was 'x'
+					             but it was MyStruct {
+					                 Value = 1
+					               }
 					             """);
 			}
 		}
@@ -103,7 +114,10 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task SubjectToItself_ShouldSucceed()
 			{
-				char? subject = 'c';
+				MyStruct? subject = new()
+				{
+					Value = 1,
+				};
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(subject);
@@ -114,8 +128,14 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task SubjectToSomeOtherValue_ShouldFail()
 			{
-				char? subject = 'x';
-				char? expected = 'y';
+				MyStruct? subject = new()
+				{
+					Value = 1,
+				};
+				MyStruct? expected = new()
+				{
+					Value = 2,
+				};
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected)
@@ -125,15 +145,17 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is equal to expected, because we want to test the failure,
-					             but it was 'x'
+					             but it was MyStruct {
+					                 Value = 1
+					               }
 					             """);
 			}
 
 			[Fact]
 			public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
 			{
-				char? subject = null;
-				char? expected = null;
+				MyStruct? subject = null;
+				MyStruct? expected = null;
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -144,15 +166,15 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				char? subject = null;
+				MyStruct? subject = null;
 
 				async Task Act()
-					=> await That(subject).IsEqualTo('c');
+					=> await That(subject).IsEqualTo(new MyStruct());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equal to 'c',
+					             is equal to new MyStruct(),
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.Tests.cs
@@ -71,8 +71,14 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task SubjectToItself_ShouldFail()
 			{
-				char subject = 'c';
-				char unexpected = 'c';
+				MyStruct? subject = new()
+				{
+					Value = 1,
+				};
+				MyStruct? unexpected = new()
+				{
+					Value = 1,
+				};
 
 				async Task Act()
 					=> await That(subject).IsNotEqualTo(unexpected)
@@ -82,18 +88,26 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is not equal to unexpected, because we want to test the failure,
-					             but it was 'c'
+					             but it was MyStruct {
+					                 Value = 1
+					               }
 					             """);
 			}
 
 			[Fact]
 			public async Task SubjectToSomeOtherValue_ShouldSucceed()
 			{
-				char subject = 'x';
-				char expected = 'y';
+				MyStruct? subject = new()
+				{
+					Value = 1,
+				};
+				MyStruct? unexpected = new()
+				{
+					Value = 2,
+				};
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -104,8 +118,14 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task SubjectToItself_ShouldFail()
 			{
-				char? subject = 'c';
-				char? unexpected = 'c';
+				MyStruct? subject = new()
+				{
+					Value = 1,
+				};
+				MyStruct? unexpected = new()
+				{
+					Value = 1,
+				};
 
 				async Task Act()
 					=> await That(subject).IsNotEqualTo(unexpected)
@@ -115,18 +135,26 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is not equal to unexpected, because we want to test the failure,
-					             but it was 'c'
+					             but it was MyStruct {
+					                 Value = 1
+					               }
 					             """);
 			}
 
 			[Fact]
 			public async Task SubjectToSomeOtherValue_ShouldSucceed()
 			{
-				char? subject = 'x';
-				char? expected = 'y';
+				MyStruct? subject = new()
+				{
+					Value = 1,
+				};
+				MyStruct? unexpected = new()
+				{
+					Value = 2,
+				};
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -134,16 +162,16 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
 			{
-				char? subject = null;
-				char? expected = null;
+				MyStruct? subject = null;
+				MyStruct? unexpected = null;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not equal to expected,
+					             is not equal to unexpected,
 					             but it was <null>
 					             """);
 			}
@@ -151,10 +179,10 @@ public sealed partial class ThatObject
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				char? subject = null;
+				MyStruct? subject = null;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo('c');
+					=> await That(subject).IsNotEqualTo(new MyStruct());
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.cs
@@ -28,4 +28,9 @@ public sealed partial class ThatObject
 		public InnerClass? Inner { get; set; }
 		public string? Value { get; set; }
 	}
+
+	private struct MyStruct
+	{
+		public int Value { get; set; }
+	}
 }


### PR DESCRIPTION
Use [`INumber<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.numerics.inumber-1) when targeting .NET 8 or greater for
- `IsGreaterThan`
- `IsGreaterThanOrEqualTo`
- `IsLessThan`
- `IsLessThanOrEqualTo`
- `IsEqualTo` / `IsNotEqualTo`
- `IsPositive`
- `IsNegative`
- `IsOneOf`

*Fixes #450*