### PR TITLE
feat: allow overriding the subject description

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -385,7 +385,11 @@ public abstract class ExpectationBuilder
 		CancellationToken cancellationToken)
 	{
 		StringBuilder sb = new();
-		sb.Append("Expected that ").Append(subject).AppendLine();
+		sb.Append("Expected that ");
+		sb.Append(failure.TryGetValue(out IDescribableSubject? describableSubject)
+			? describableSubject.GetDescription()
+			: subject);
+		sb.AppendLine();
 		failure.AppendExpectation(sb);
 		sb.AppendLine(",");
 		sb.Append("but ");

--- a/Source/aweXpect.Core/Core/IDescribableSubject.cs
+++ b/Source/aweXpect.Core/Core/IDescribableSubject.cs
@@ -1,0 +1,12 @@
+﻿namespace aweXpect.Core;
+
+/// <summary>
+///     Allows overriding the subject string in the expectation message.
+/// </summary>
+public interface IDescribableSubject
+{
+	/// <summary>
+	///     Get the description of the subject.
+	/// </summary>
+	string GetDescription();
+}

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -196,6 +196,10 @@ namespace aweXpect.Core
         bool Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options, int maximumNumber, out string? error);
         bool VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options, int maximumNumber, out string? error);
     }
+    public interface IDescribableSubject
+    {
+        string GetDescription();
+    }
     public interface IExpectThat<out T> : aweXpect.Core.IThat<T>
     {
         aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -196,6 +196,10 @@ namespace aweXpect.Core
         bool Verify(string it, T value, aweXpect.Core.IOptionsEquality<T2> options, int maximumNumber, out string? error);
         bool VerifyComplete(string it, aweXpect.Core.IOptionsEquality<T2> options, int maximumNumber, out string? error);
     }
+    public interface IDescribableSubject
+    {
+        string GetDescription();
+    }
     public interface IExpectThat<out T> : aweXpect.Core.IThat<T>
     {
         aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -65,4 +65,25 @@ public class ExpectationBuilderTests
 		await That(constraintResult.Outcome).IsEqualTo(Outcome.Success);
 		await That(constraintResult.GetExpectationText()).IsEqualTo("length equal to 3");
 	}
+
+	[Fact]
+	public async Task WhenTypeImplementsIDescribableSubject_ShouldUseToStringFromIt()
+	{
+		MyDescribableSubject subject = new("this long description for the subject");
+
+		async Task Act() => await That(subject).IsNull();
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that this long description for the subject
+			             is null,
+			             but it was MyDescribableSubject { }
+			             """);
+	}
+
+	private sealed class MyDescribableSubject(string subject) : IDescribableSubject
+	{
+		public string GetDescription()
+			=> subject;
+	}
 }


### PR DESCRIPTION
By implementing `IDescribableSubject`, a custom type can override how the subject description in the expectation message should look.