### PR TITLE
fix: formatting of nested types

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
@@ -87,7 +87,7 @@ public abstract partial class ThatDelegate
 			}
 			else
 			{
-				stringBuilder.Append("throws ").Append(exceptionType.Name.PrependAOrAn());
+				stringBuilder.Append("throws ").Append(Formatter.Format(exceptionType).PrependAOrAn());
 			}
 		}
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
@@ -84,7 +84,7 @@ public abstract partial class ThatDelegate
 			}
 			else
 			{
-				stringBuilder.Append("throws exactly ").Append(exceptionType.Name.PrependAOrAn());
+				stringBuilder.Append("throws exactly ").Append(Formatter.Format(exceptionType).PrependAOrAn());
 			}
 		}
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.cs
@@ -25,7 +25,7 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 			return "<null>";
 		}
 
-		string message = exception.GetType().Name.PrependAOrAn();
+		string message = Formatter.Format(exception.GetType()).PrependAOrAn();
 		if (!string.IsNullOrEmpty(exception.Message))
 		{
 			message += ":" + Environment.NewLine + exception.Message.Indent();

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
@@ -116,28 +116,36 @@ public static partial class ValueFormatters
 		{
 			stringBuilder.Append(alias);
 		}
-		else if (value.IsGenericType)
-		{
-			Type genericTypeDefinition = value.GetGenericTypeDefinition();
-			stringBuilder.Append(genericTypeDefinition.Name.SubstringUntilFirst('`'));
-			stringBuilder.Append('<');
-			bool isFirstArgument = true;
-			foreach (Type argument in value.GetGenericArguments())
-			{
-				if (!isFirstArgument)
-				{
-					stringBuilder.Append(", ");
-				}
-
-				isFirstArgument = false;
-				FormatType(argument, stringBuilder);
-			}
-
-			stringBuilder.Append('>');
-		}
 		else
 		{
-			stringBuilder.Append(value.Name);
+			if (value.IsNested && value.DeclaringType is not null)
+			{
+				FormatType(value.DeclaringType, stringBuilder);
+				stringBuilder.Append('.');
+			}
+			if (value.IsGenericType)
+			{
+				Type genericTypeDefinition = value.GetGenericTypeDefinition();
+				stringBuilder.Append(genericTypeDefinition.Name.SubstringUntilFirst('`'));
+				stringBuilder.Append('<');
+				bool isFirstArgument = true;
+				foreach (Type argument in value.GetGenericArguments())
+				{
+					if (!isFirstArgument)
+					{
+						stringBuilder.Append(", ");
+					}
+
+					isFirstArgument = false;
+					FormatType(argument, stringBuilder);
+				}
+
+				stringBuilder.Append('>');
+			}
+			else
+			{
+				stringBuilder.Append(value.Name);
+			}
 		}
 	}
 

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
@@ -123,6 +123,7 @@ public static partial class ValueFormatters
 				FormatType(value.DeclaringType, stringBuilder);
 				stringBuilder.Append('.');
 			}
+
 			if (value.IsGenericType)
 			{
 				Type genericTypeDefinition = value.GetGenericTypeDefinition();

--- a/Source/aweXpect/Helpers/ExceptionHelpers.cs
+++ b/Source/aweXpect/Helpers/ExceptionHelpers.cs
@@ -7,7 +7,7 @@ internal static class ExceptionHelpers
 {
 	public static string FormatForMessage(this Exception exception)
 	{
-		string message = exception.GetType().Name.PrependAOrAn();
+		string message = Formatter.Format(exception.GetType()).PrependAOrAn();
 		if (!string.IsNullOrEmpty(exception.Message))
 		{
 			message += ":" + Environment.NewLine + exception.Message.Indent();

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -77,7 +77,7 @@ public class ExpectationBuilderTests
 			.WithMessage("""
 			             Expected that this long description for the subject
 			             is null,
-			             but it was MyDescribableSubject { }
+			             but it was ExpectationBuilderTests.MyDescribableSubject { }
 			             """);
 	}
 

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -330,7 +330,7 @@ public sealed class WhichNodeTests
 		await That(Act).Throws<XunitException>()
 			.WithMessage("""
 			             Expected that subject
-			             is type Dummy whose .Value is equal to "bar",
+			             is type WhichNodeTests.Dummy whose .Value is equal to "bar",
 			             but .Value was "foo" which differs at index 0:
 			                ↓ (actual)
 			               "foo"

--- a/Tests/aweXpect.Core.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
@@ -25,7 +25,7 @@ public sealed class EquivalencyOptionsExtensionsTests
 		{
 			await That(result.ToString()).IsEqualTo("""
 			                                         - include public fields and properties
-			                                         - for MyClass:
+			                                         - for EquivalencyOptionsExtensionsTests.MyClass:
 			                                           - include public fields and properties
 			                                           - ignore collection order
 			                                        """);
@@ -51,7 +51,7 @@ public sealed class EquivalencyOptionsExtensionsTests
 			});
 		await That(result.ToString()).IsEqualTo($"""
 		                                          - include public fields and properties
-		                                          - for MyClass:
+		                                          - for EquivalencyOptionsExtensionsTests.MyClass:
 		                                            - include public fields and properties
 		                                            - ignore members: ["{memberToIgnore}"]
 		                                         """);
@@ -82,7 +82,7 @@ public sealed class EquivalencyOptionsExtensionsTests
 			});
 		await That(result.ToString()).IsEqualTo($"""
 		                                          - include public fields and properties
-		                                          - for MyClass:
+		                                          - for EquivalencyOptionsExtensionsTests.MyClass:
 		                                            - include {expectedVisibility} fields and public properties
 		                                         """);
 	}
@@ -112,7 +112,7 @@ public sealed class EquivalencyOptionsExtensionsTests
 			});
 		await That(result.ToString()).IsEqualTo($"""
 		                                          - include public fields and properties
-		                                          - for MyClass:
+		                                          - for EquivalencyOptionsExtensionsTests.MyClass:
 		                                            - include public fields and {expectedVisibility} properties
 		                                         """);
 	}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.ObjectTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.ObjectTests.cs
@@ -18,7 +18,7 @@ public partial class ValueFormatters
 				Value = 2,
 			};
 			string expectedResult = """
-			                        Dummy { Inner = InnerDummy { InnerValue = "foo" }, Value = 2 }
+			                        ValueFormatters.FormatObjectTests.Dummy { Inner = ValueFormatters.FormatObjectTests.InnerDummy { InnerValue = "foo" }, Value = 2 }
 			                        """;
 			StringBuilder sb = new();
 
@@ -38,7 +38,7 @@ public partial class ValueFormatters
 			};
 			value.Inner = value;
 			string expectedResult = """
-			                        RecursiveDummy { Inner = RecursiveDummy { *recursive* }, Value = 1 }
+			                        ValueFormatters.FormatObjectTests.RecursiveDummy { Inner = ValueFormatters.FormatObjectTests.RecursiveDummy { *recursive* }, Value = 1 }
 			                        """;
 			StringBuilder sb = new();
 
@@ -61,8 +61,8 @@ public partial class ValueFormatters
 				Value = 2,
 			};
 			string expectedResult = """
-			                        Dummy {
-			                            Inner = InnerDummy {
+			                        ValueFormatters.FormatObjectTests.Dummy {
+			                            Inner = ValueFormatters.FormatObjectTests.InnerDummy {
 			                              InnerValue = "foo"
 			                            },
 			                            Value = 2
@@ -89,8 +89,8 @@ public partial class ValueFormatters
 				Value = 2,
 			};
 			string expectedResult = """
-			                        Dummy {
-			                          Inner = InnerDummy {
+			                        ValueFormatters.FormatObjectTests.Dummy {
+			                          Inner = ValueFormatters.FormatObjectTests.InnerDummy {
 			                            InnerValue = "foo"
 			                          },
 			                          Value = 2
@@ -143,7 +143,7 @@ public partial class ValueFormatters
 			{
 				Value = 42,
 			};
-			string expectedResult = "ClassWithField { Value = 42 }";
+			string expectedResult = "ValueFormatters.FormatObjectTests.ClassWithField { Value = 42 }";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value, FormattingOptions.SingleLine);
@@ -157,7 +157,7 @@ public partial class ValueFormatters
 		public async Task WhenClassIsEmpty_ShouldDisplayClassName()
 		{
 			object value = new EmptyClass();
-			string expectedResult = "EmptyClass { }";
+			string expectedResult = "ValueFormatters.FormatObjectTests.EmptyClass { }";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value, FormattingOptions.SingleLine);
@@ -172,7 +172,7 @@ public partial class ValueFormatters
 		{
 			Exception exception = new("foo");
 			object value = new ClassWithExceptionProperty(exception);
-			string expectedResult = "ClassWithExceptionProperty { Value = [Member 'Value' threw an exception: 'foo'] }";
+			string expectedResult = "ValueFormatters.FormatObjectTests.ClassWithExceptionProperty { Value = [Member 'Value' threw an exception: 'foo'] }";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value, FormattingOptions.SingleLine);

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -9,7 +9,23 @@ public partial class ValueFormatters
 	public sealed class TypeTests
 	{
 		[Fact]
-		public async Task NestedTypes_ShouldOnlyIncludeTheDeclaringTypeAndName()
+		public async Task NestedGenericTypes_ShouldIncludeTheDeclaringTypeAndName()
+		{
+			Type value = typeof(NestedGenericType<TypeTests>);
+			string expectedResult = "ValueFormatters.TypeTests.NestedGenericType<ValueFormatters.TypeTests>";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task NestedTypes_ShouldIncludeTheDeclaringTypeAndName()
 		{
 			Type value = typeof(TypeTests);
 			string expectedResult = $"{nameof(ValueFormatters)}.{nameof(TypeTests)}";
@@ -134,6 +150,8 @@ public partial class ValueFormatters
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
 		}
+
+		private class NestedGenericType<T>;
 
 		public static TheoryData<Type, string> SimpleTypes
 			=> new()

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -9,6 +9,22 @@ public partial class ValueFormatters
 	public sealed class TypeTests
 	{
 		[Fact]
+		public async Task NestedTypes_ShouldOnlyIncludeTheDeclaringTypeAndName()
+		{
+			Type value = typeof(TypeTests);
+			string expectedResult = $"{nameof(ValueFormatters)}.{nameof(TypeTests)}";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
 		public async Task ShouldSupportArraySyntax()
 		{
 			Type value = typeof(int[]);
@@ -28,7 +44,7 @@ public partial class ValueFormatters
 		public async Task ShouldSupportArraySyntaxWithComplexObjects()
 		{
 			Type value = typeof(TypeTests[]);
-			string expectedResult = $"{nameof(TypeTests)}[]";
+			string expectedResult = $"{nameof(ValueFormatters)}.{nameof(TypeTests)}[]";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);
@@ -60,7 +76,7 @@ public partial class ValueFormatters
 		public async Task ShouldSupportNestedGenericTypeDefinitions()
 		{
 			Type value = typeof(Expression<Func<TypeTests[], bool>>);
-			string expectedResult = $"Expression<Func<{nameof(TypeTests)}[], bool>>";
+			string expectedResult = $"Expression<Func<{nameof(ValueFormatters)}.{nameof(TypeTests)}[], bool>>";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);
@@ -91,8 +107,8 @@ public partial class ValueFormatters
 		[Fact]
 		public async Task Types_ShouldOnlyIncludeTheName()
 		{
-			Type value = typeof(TypeTests);
-			string expectedResult = nameof(TypeTests);
+			Type value = typeof(ValueFormatter);
+			string expectedResult = nameof(ValueFormatter);
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);

--- a/Tests/aweXpect.Core.Tests/Recording/EventRecordingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Recording/EventRecordingTests.cs
@@ -13,7 +13,7 @@ public sealed class EventRecordingTests
 			=> sut.Record().Events("someMissingEventName");
 
 		await That(Act).Throws<NotSupportedException>()
-			.WithMessage("Event someMissingEventName is not supported on CustomEventClass { }");
+			.WithMessage("Event someMissingEventName is not supported on EventRecordingTests.CustomEventClass { }");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Results/AndOrWhichResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Results/AndOrWhichResultTests.cs
@@ -21,7 +21,7 @@ public class AndOrWhichResultTests
 		await That(Act).ThrowsException()
 			.WithMessage("""
 			             Expected that subject
-			              which .Value1 is True and which .Value2 is True and refers to subject MyClass {
+			              which .Value1 is True and which .Value2 is True and refers to subject AndOrWhichResultTests.MyClass {
 			                 Value1 = False,
 			                 Value2 = False
 			               },

--- a/Tests/aweXpect.Core.Tests/Results/AndOrWhoseResultTests.cs
+++ b/Tests/aweXpect.Core.Tests/Results/AndOrWhoseResultTests.cs
@@ -16,7 +16,7 @@ public class AndOrWhoseResultTests
 		await That(Act).ThrowsException()
 			.WithMessage("""
 			             Expected that sut
-			             is type MyClass whose .Value1 is True and whose .Value2 is True and refers to sut MyClass {
+			             is type AndOrWhoseResultTests.MyClass whose .Value1 is True and whose .Value2 is True and refers to sut AndOrWhoseResultTests.MyClass {
 			                 Value1 = False,
 			                 Value2 = False
 			               },
@@ -45,7 +45,7 @@ public class AndOrWhoseResultTests
 		await That(Act).ThrowsException().OnlyIf(!expectSuccess)
 			.WithMessage($"""
 			              Expected that sut
-			              is type MyClass whose .Value1 is True and whose .Value2 is True,
+			              is type AndOrWhoseResultTests.MyClass whose .Value1 is True and whose .Value2 is True,
 			              but {(value1 ? "" : ".Value1 was False")}{(!value1 && !value2 ? " and " : "")}{(value2 ? "" : ".Value2 was False")}
 			              """);
 	}

--- a/Tests/aweXpect.Internal.Tests/Helpers/EquivalencyComparerTests.ComparisonTypeTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Helpers/EquivalencyComparerTests.ComparisonTypeTests.cs
@@ -47,8 +47,8 @@ public sealed partial class EquivalencyComparerTests
 			await That(failure).IsEqualTo("""
 			                              it was not:
 			                                Property Property2 differed:
-			                                     Found: MyClass2 { Value = 1 }
-			                                  Expected: MyClass2 { Value = 1 }
+			                                     Found: EquivalencyComparerTests.ComparisonTypeTests.MyClass2 { Value = 1 }
+			                                  Expected: EquivalencyComparerTests.ComparisonTypeTests.MyClass2 { Value = 1 }
 			                              """);
 		}
 
@@ -75,8 +75,8 @@ public sealed partial class EquivalencyComparerTests
 			await That(failure).IsEqualTo("""
 			                              it was not:
 			                                It differed:
-			                                     Found: MyClass { MyValue = "foo", Nested = <null> }
-			                                  Expected: MyClass { MyValue = "foo", Nested = <null> }
+			                                     Found: EquivalencyComparerTests.MyClass { MyValue = "foo", Nested = <null> }
+			                                  Expected: EquivalencyComparerTests.MyClass { MyValue = "foo", Nested = <null> }
 			                              """);
 		}
 

--- a/Tests/aweXpect.Internal.Tests/Helpers/EquivalencyComparerTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Helpers/EquivalencyComparerTests.cs
@@ -78,7 +78,7 @@ public sealed partial class EquivalencyComparerTests
 
 			await That(result).IsFalse();
 			await That(failure).IsEqualTo("""
-			                              it was <null> instead of MyClass { MyValue = <null>, Nested = <null> }
+			                              it was <null> instead of EquivalencyComparerTests.MyClass { MyValue = <null>, Nested = <null> }
 			                              """);
 		}
 
@@ -94,7 +94,7 @@ public sealed partial class EquivalencyComparerTests
 
 			await That(result).IsFalse();
 			await That(failure).IsEqualTo("""
-			                              it was MyClass { MyValue = <null>, Nested = <null> } instead of <null>
+			                              it was EquivalencyComparerTests.MyClass { MyValue = <null>, Nested = <null> } instead of <null>
 			                              """);
 		}
 	}

--- a/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiedCollectionResult.BeTests.cs
@@ -20,7 +20,7 @@ public sealed partial class QuantifiedCollectionResult
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
 				             Expected that subject
-				             is of type MyClass for all items,
+				             is of type QuantifiedCollectionResult.MyClass for all items,
 				             but only 2 of 3 were
 				             """);
 		}

--- a/Tests/aweXpect.Internal.Tests/ThatTests/DelegateTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/DelegateTests.cs
@@ -81,7 +81,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_Action_WhenThrown)}
 			              """);
 	}
@@ -129,7 +129,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_Action_WithCancellationToken_WhenThrown)}
 			              """);
 	}
@@ -162,7 +162,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_FuncTask_WhenThrown)}
 			              """);
 	}
@@ -210,7 +210,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_FuncTask_WithCancellationToken_WhenThrown)}
 			              """);
 	}
@@ -243,7 +243,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_FuncTaskValue_WhenThrown)}
 			              """);
 	}
@@ -292,7 +292,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_FuncTaskValue_WithCancellationToken_WhenThrown)}
 			              """);
 	}
@@ -325,7 +325,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_FuncValue_WhenThrown)}
 			              """);
 	}
@@ -376,7 +376,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that @delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_FuncValue_WithCancellationToken_WhenThrown)}
 			              """);
 	}
@@ -431,7 +431,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that Delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_ValueTask_WhenThrown)}
 			              """);
 	}
@@ -450,7 +450,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that Delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_ValueTask_WithCancellationToken_WhenThrown)}
 			              """);
 	}
@@ -487,7 +487,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that Delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_ValueTaskValue_WhenThrown)}
 			              """);
 	}
@@ -524,7 +524,7 @@ public sealed class DelegateTests
 			.WithMessage($"""
 			              Expected that Delegate
 			              does not throw any exception,
-			              but it did throw a MyException:
+			              but it did throw a DelegateTests.MyException:
 			                {nameof(ShouldSupportDelegate_ValueTaskValue_WithCancellationToken_WhenThrown)}
 			              """);
 	}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Are.Tests.cs
@@ -26,7 +26,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is of type MyClass for all items,
+						             is of type ThatAsyncEnumerable.All.Are.MyClass for all items,
 						             but not all were
 						             """);
 				}
@@ -70,7 +70,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is of type MyClass for all items,
+						             is of type ThatAsyncEnumerable.All.Are.MyClass for all items,
 						             but not all were
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreExactly.Tests.cs
@@ -26,7 +26,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyClass for all items,
+						             is exactly of type ThatAsyncEnumerable.All.AreExactly.MyClass for all items,
 						             but not all were
 						             """);
 				}
@@ -43,7 +43,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyBaseClass for all items,
+						             is exactly of type ThatAsyncEnumerable.All.AreExactly.MyBaseClass for all items,
 						             but not all were
 						             """);
 				}
@@ -75,7 +75,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyClass for all items,
+						             is exactly of type ThatAsyncEnumerable.All.AreExactly.MyClass for all items,
 						             but not all were
 						             """);
 				}
@@ -92,7 +92,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyBaseClass for all items,
+						             is exactly of type ThatAsyncEnumerable.All.AreExactly.MyBaseClass for all items,
 						             but not all were
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
@@ -68,38 +68,38 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not contain MyClass {
+					             does not contain ThatAsyncEnumerable.MyClass {
 					               Value = 5
 					             } equivalent,
 					             but it contained it at least 1 times in [
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 2
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 3
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 5
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 8
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 13
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 21
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 34
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 55
 					               },
 					               …

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotEndWith.Tests.cs
@@ -58,24 +58,24 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not end with [MyClass { Value = 3 }, MyClass { Value = 5 }, MyClass { Value = 8 }] equivalent,
+					             does not end with [ThatAsyncEnumerable.MyClass { Value = 3 }, ThatAsyncEnumerable.MyClass { Value = 5 }, ThatAsyncEnumerable.MyClass { Value = 8 }] equivalent,
 					             but it did end with [
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 2
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 3
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 5
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 8
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotStartWith.Tests.cs
@@ -67,13 +67,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             does not start with unexpected equivalent,
 					             but it did start with [
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatAsyncEnumerable.MyClass {
 					                 Value = 2
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInAscendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInAscendingOrder.Tests.cs
@@ -191,19 +191,19 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is in ascending order for x => x.Value,
 					             but it had 3 before 1 which is not in ascending order in [
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               }
 					             ]
@@ -248,13 +248,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is not in ascending order for x => x.Value,
 					             but it was in [
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 3
 					               }
 					             ]
@@ -277,10 +277,10 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is in ascending order for x => x.Value,
 					             but it had "a" before "A" which is not in ascending order in [
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "A"
 					               }
 					             ]
@@ -313,16 +313,16 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is in ascending order for x => x.Value,
 					             but it had "c" before "a" which is not in ascending order in [
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "b"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInDescendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInDescendingOrder.Tests.cs
@@ -191,19 +191,19 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is in descending order for x => x.Value,
 					             but it had 1 before 3 which is not in descending order in [
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               }
 					             ]
@@ -248,13 +248,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is not in descending order for x => x.Value,
 					             but it was in [
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 1
 					               }
 					             ]
@@ -277,10 +277,10 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is in descending order for x => x.Value,
 					             but it had "A" before "a" which is not in descending order in [
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "A"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               }
 					             ]
@@ -313,16 +313,16 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is in descending order for x => x.Value,
 					             but it had "a" before "c" which is not in descending order in [
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "b"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
-					               MyStringClass {
+					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is of type MyClass for all items,
+						             is of type ThatEnumerable.All.Are.MyClass for all items,
 						             but not all were
 						             """);
 				}
@@ -65,7 +65,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is of type MyClass for all items,
+						             is of type ThatEnumerable.All.Are.MyClass for all items,
 						             but not all were
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyClass for all items,
+						             is exactly of type ThatEnumerable.All.AreExactly.MyClass for all items,
 						             but not all were
 						             """);
 				}
@@ -40,7 +40,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyBaseClass for all items,
+						             is exactly of type ThatEnumerable.All.AreExactly.MyBaseClass for all items,
 						             but not all were
 						             """);
 				}
@@ -70,7 +70,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyClass for all items,
+						             is exactly of type ThatEnumerable.All.AreExactly.MyClass for all items,
 						             but not all were
 						             """);
 				}
@@ -86,7 +86,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is exactly of type MyBaseClass for all items,
+						             is exactly of type ThatEnumerable.All.AreExactly.MyBaseClass for all items,
 						             but not all were
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
@@ -70,48 +70,48 @@ public sealed partial class ThatEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not contain MyClass {
+					             does not contain ThatEnumerable.MyClass {
 					               Inner = <null>,
 					               Value = 5
 					             },
 					             but it contained it at least 1 times in [
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 2
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 3
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 5
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 8
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 13
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 21
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 34
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 55
 					               },

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotEndWith.Tests.cs
@@ -57,17 +57,17 @@ public sealed partial class ThatEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not end with [MyClass { Inner = <null>, Value = 3 }, MyClass { Inner = <null>, Value = 5 }, MyClass { Inner = <null>, Value = 8 }] equivalent,
+					             does not end with [ThatEnumerable.MyClass { Inner = <null>, Value = 3 }, ThatEnumerable.MyClass { Inner = <null>, Value = 5 }, ThatEnumerable.MyClass { Inner = <null>, Value = 8 }] equivalent,
 					             but it did end with [
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 3
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 5
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 8
 					               }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotStartWith.Tests.cs
@@ -66,15 +66,15 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             does not start with unexpected equivalent,
 					             but it did start with [
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 1
 					               },
-					               MyClass {
+					               ThatEnumerable.MyClass {
 					                 Inner = <null>,
 					                 Value = 2
 					               }

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInAscendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInAscendingOrder.Tests.cs
@@ -190,19 +190,19 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is in ascending order for x => x.Value,
 					             but it had 3 before 1 which is not in ascending order in [
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               }
 					             ]
@@ -247,13 +247,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is not in ascending order for x => x.Value,
 					             but it was in [
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 3
 					               }
 					             ]
@@ -276,10 +276,10 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is in ascending order for x => x.Value,
 					             but it had "a" before "A" which is not in ascending order in [
-					               MyStringClass {
+					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "A"
 					               }
 					             ]
@@ -311,16 +311,16 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is in ascending order for x => x.Value,
 					             but it had "c" before "a" which is not in ascending order in [
-					               MyStringClass {
+					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "b"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInDescendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInDescendingOrder.Tests.cs
@@ -190,19 +190,19 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is in descending order for x => x.Value,
 					             but it had 1 before 3 which is not in descending order in [
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 1
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               }
 					             ]
@@ -247,13 +247,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is not in descending order for x => x.Value,
 					             but it was in [
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 2
 					               },
-					               MyIntClass {
+					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 1
 					               }
 					             ]
@@ -276,10 +276,10 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is in descending order for x => x.Value,
 					             but it had "A" before "a" which is not in descending order in [
-					               MyStringClass {
+					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "A"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               }
 					             ]
@@ -311,16 +311,16 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is in descending order for x => x.Value,
 					             but it had "a" before "c" which is not in descending order in [
-					               MyStringClass {
+					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "b"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
-					               MyStringClass {
+					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.DoesNotThrow.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.DoesNotThrow.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatDelegate
 					.WithMessage($"""
 					              Expected that @delegate
 					              does not throw any exception,
-					              but it did throw a CustomException:
+					              but it did throw a ThatDelegate.CustomException:
 					                {message}
 					              """);
 			}
@@ -91,7 +91,7 @@ public sealed partial class ThatDelegate
 					.WithMessage($"""
 					              Expected that @delegate
 					              does not throw any exception,
-					              but it did throw a CustomException:
+					              but it did throw a ThatDelegate.CustomException:
 					                {message}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Tests.cs
@@ -80,8 +80,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws a CustomException,
-					              but it did throw an OtherException:
+					              throws a ThatDelegate.CustomException,
+					              but it did throw a ThatDelegate.OtherException:
 					                {message}
 					              """);
 			}
@@ -109,7 +109,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             throws a CustomException,
+					             throws a ThatDelegate.CustomException,
 					             but it was <null>
 					             """);
 			}
@@ -127,8 +127,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws a SubCustomException,
-					              but it did throw a CustomException:
+					              throws a ThatDelegate.SubCustomException,
+					              but it did throw a ThatDelegate.CustomException:
 					                {message}
 					              """);
 			}
@@ -209,8 +209,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws a CustomException,
-					              but it did throw an OtherException:
+					              throws a ThatDelegate.CustomException,
+					              but it did throw a ThatDelegate.OtherException:
 					                {message}
 					              """);
 			}
@@ -238,7 +238,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             throws a CustomException,
+					             throws a ThatDelegate.CustomException,
 					             but it was <null>
 					             """);
 			}
@@ -256,8 +256,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws a SubCustomException,
-					              but it did throw a CustomException:
+					              throws a ThatDelegate.SubCustomException,
+					              but it did throw a ThatDelegate.CustomException:
 					                {message}
 					              """);
 			}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Tests.cs
@@ -62,7 +62,7 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that action
-					             throws exactly a CustomException,
+					             throws exactly a ThatDelegate.CustomException,
 					             but it did not throw any exception
 					             """);
 			}
@@ -80,8 +80,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws exactly a CustomException,
-					              but it did throw an OtherException:
+					              throws exactly a ThatDelegate.CustomException,
+					              but it did throw a ThatDelegate.OtherException:
 					                {message}
 					              """);
 			}
@@ -99,8 +99,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws exactly a CustomException,
-					              but it did throw a SubCustomException:
+					              throws exactly a ThatDelegate.CustomException,
+					              but it did throw a ThatDelegate.SubCustomException:
 					                {message}
 					              """);
 			}
@@ -116,7 +116,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             throws exactly a CustomException,
+					             throws exactly a ThatDelegate.CustomException,
 					             but it was <null>
 					             """);
 			}
@@ -179,7 +179,7 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that action
-					             throws exactly a CustomException,
+					             throws exactly a ThatDelegate.CustomException,
 					             but it did not throw any exception
 					             """);
 			}
@@ -197,8 +197,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws exactly a CustomException,
-					              but it did throw an OtherException:
+					              throws exactly a ThatDelegate.CustomException,
+					              but it did throw a ThatDelegate.OtherException:
 					                {message}
 					              """);
 			}
@@ -216,8 +216,8 @@ public sealed partial class ThatDelegate
 				await That(Act).ThrowsException()
 					.WithMessage($"""
 					              Expected that action
-					              throws exactly a CustomException,
-					              but it did throw a SubCustomException:
+					              throws exactly a ThatDelegate.CustomException,
+					              but it did throw a ThatDelegate.SubCustomException:
 					                {message}
 					              """);
 			}
@@ -233,7 +233,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             throws exactly a CustomException,
+					             throws exactly a ThatDelegate.CustomException,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithInnerTests.cs
@@ -33,8 +33,8 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that action
-						              throws an exception with an inner SubCustomException,
-						              but it was a CustomException:
+						              throws an exception with an inner ThatDelegate.SubCustomException,
+						              but it was a ThatDelegate.CustomException:
 						                {message}
 						              """);
 				}
@@ -52,8 +52,8 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that action
-						              throws an exception with an inner CustomException,
-						              but it was an OtherException:
+						              throws an exception with an inner ThatDelegate.CustomException,
+						              but it was a ThatDelegate.OtherException:
 						                {message}
 						              """);
 				}
@@ -108,7 +108,7 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that action
-						             throws an exception with an inner CustomException,
+						             throws an exception with an inner ThatDelegate.CustomException,
 						             but it was <null>
 						             """);
 				}
@@ -129,7 +129,7 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that action
-						             throws an exception with an inner CustomException whose Message is equal to "foo",
+						             throws an exception with an inner ThatDelegate.CustomException whose Message is equal to "foo",
 						             but it was "bar" which differs at index 0:
 						                ↓ (actual)
 						               "bar"
@@ -220,7 +220,7 @@ public sealed partial class ThatDelegate
 						.WithMessage("""
 						             Expected that action
 						             throws an exception with an inner MyException whose Message is equal to "foo",
-						             but it was a CustomException:
+						             but it was a ThatDelegate.CustomException:
 						               foo
 						             """);
 				}
@@ -254,7 +254,7 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that action
-						             throws an exception with an inner CustomException whose Message is equal to "foo",
+						             throws an exception with an inner ThatDelegate.CustomException whose Message is equal to "foo",
 						             but it did not throw any exception
 						             """);
 				}
@@ -303,8 +303,8 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that action
-						              throws an exception with an inner SubCustomException,
-						              but it was a CustomException:
+						              throws an exception with an inner ThatDelegate.SubCustomException,
+						              but it was a ThatDelegate.CustomException:
 						                {message}
 						              """);
 				}
@@ -322,8 +322,8 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that action
-						              throws an exception with an inner CustomException,
-						              but it was an OtherException:
+						              throws an exception with an inner ThatDelegate.CustomException,
+						              but it was a ThatDelegate.OtherException:
 						                {message}
 						              """);
 				}
@@ -378,7 +378,7 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that action
-						             throws an exception with an inner CustomException,
+						             throws an exception with an inner ThatDelegate.CustomException,
 						             but it was <null>
 						             """);
 				}
@@ -400,7 +400,7 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that action
-						             throws an exception with an inner CustomException whose Message is equal to "foo",
+						             throws an exception with an inner ThatDelegate.CustomException whose Message is equal to "foo",
 						             but it was "bar" which differs at index 0:
 						                ↓ (actual)
 						               "bar"
@@ -478,7 +478,7 @@ public sealed partial class ThatDelegate
 						.WithMessage("""
 						             Expected that action
 						             throws an exception with an inner MyException whose Message is equal to "foo",
-						             but it was a CustomException:
+						             but it was a ThatDelegate.CustomException:
 						               foo
 						             """);
 				}
@@ -512,7 +512,7 @@ public sealed partial class ThatDelegate
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that action
-						             throws an exception with an inner CustomException whose Message is equal to "foo",
+						             throws an exception with an inner ThatDelegate.CustomException whose Message is equal to "foo",
 						             but it did not throw any exception
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithMessageTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithMessageTests.cs
@@ -77,7 +77,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that Delegate
-					             throws a CustomException with Message equal to "foo",
+					             throws a ThatDelegate.CustomException with Message equal to "foo",
 					             but it was "FOO" which differs at index 0:
 					                ↓ (actual)
 					               "FOO"

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
@@ -26,7 +26,7 @@ public sealed partial class ThatDelegate
 				await That(Act).Throws<XunitException>().OnlyIf(shouldThrow)
 					.WithMessage($"""
 					              Expected that action
-					              throws an exception with recursive inner exceptions which at least {minimum} are of type CustomException,
+					              throws an exception with recursive inner exceptions which at least {minimum} are of type ThatDelegate.CustomException,
 					              but only 1 of 5 were
 					              """);
 			}

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.GenericTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.GenericTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException whose Message is equal to "inner",
+						             has an inner ThatException.CustomException whose Message is equal to "inner",
 						             but it was an Exception:
 						               inner
 						             """);
@@ -49,7 +49,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException whose Message is equal to "some other message",
+						             has an inner ThatException.CustomException whose Message is equal to "some other message",
 						             but it was "inner" which differs at index 0:
 						                ↓ (actual)
 						               "inner"
@@ -76,7 +76,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException,
+						             has an inner ThatException.CustomException,
 						             but it was an Exception:
 						               inner
 						             """);
@@ -106,7 +106,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException,
+						             has an inner ThatException.CustomException,
 						             but it was <null>
 						             """);
 				}
@@ -139,7 +139,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not have an inner CustomException whose Message is equal to "inner",
+						             does not have an inner ThatException.CustomException whose Message is equal to "inner",
 						             but it had
 						             """);
 				}
@@ -195,7 +195,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not have an inner CustomException,
+						             does not have an inner ThatException.CustomException,
 						             but it had
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.TypeTests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasInner.TypeTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException whose Message is equal to "inner",
+						             has an inner ThatException.CustomException whose Message is equal to "inner",
 						             but it was an Exception:
 						               inner
 						             """);
@@ -50,7 +50,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException whose Message is equal to "some other message",
+						             has an inner ThatException.CustomException whose Message is equal to "some other message",
 						             but it was "inner" which differs at index 0:
 						                ↓ (actual)
 						               "inner"
@@ -77,7 +77,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException,
+						             has an inner ThatException.CustomException,
 						             but it was an Exception:
 						               inner
 						             """);
@@ -107,7 +107,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             has an inner CustomException,
+						             has an inner ThatException.CustomException,
 						             but it was <null>
 						             """);
 				}
@@ -140,7 +140,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not have an inner CustomException whose Message is equal to "inner",
+						             does not have an inner ThatException.CustomException whose Message is equal to "inner",
 						             but it had
 						             """);
 				}
@@ -196,7 +196,7 @@ public sealed partial class ThatException
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not have an inner CustomException,
+						             does not have an inner ThatException.CustomException,
 						             but it had
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is type MyClass,
+					             is type ThatObject.MyClass,
 					             but it was <null>
 					             """);
 			}
@@ -52,8 +52,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is type OtherClass, because we want to test the failure,
-					               but it was MyClass {
+					               is type ThatObject.OtherClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -86,8 +86,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is type MyClass, because {{reason}},
-					               but it was MyBaseClass {
+					               is type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyBaseClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -132,7 +132,7 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is type MyClass,
+					             is type ThatObject.MyClass,
 					             but it was <null>
 					             """);
 			}
@@ -153,8 +153,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is type OtherClass, because we want to test the failure,
-					               but it was MyClass {
+					               is type ThatObject.OtherClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -187,8 +187,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is type MyClass, because {{reason}},
-					               but it was MyBaseClass {
+					               is type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyBaseClass {
 					                   Value = {{value}}
 					                 }
 					               """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.WhoseTests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.WhoseTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is type MyClass whose .Value is less than 42,
+					             is type ThatObject.MyClass whose .Value is less than 42,
 					             but .Value was 42
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is equal to expected, because we want to test the failure,
-					             but it was MyClass {
+					             but it was ThatObject.MyClass {
 					                 Value = 0
 					               }
 					             """);
@@ -102,7 +102,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is equal to expected, because we want to test the failure,
-					             but it was MyStruct {
+					             but it was ThatObject.MyStruct {
 					                 Value = 1
 					               }
 					             """);
@@ -145,7 +145,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is equal to expected, because we want to test the failure,
-					             but it was MyStruct {
+					             but it was ThatObject.MyStruct {
 					                 Value = 1
 					               }
 					             """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.UsingTests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.UsingTests.cs
@@ -23,8 +23,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equal to expected using MyComparer,
-					             but it was OuterClass {
+					             is equal to expected using ThatObject.IsEqualTo.UsingTests.MyComparer,
+					             but it was ThatObject.OuterClass {
 					                 Inner = <null>,
 					                 Value = "Foo"
 					               }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is exactly type MyClass,
+					             is exactly type ThatObject.MyClass,
 					             but it was <null>
 					             """);
 			}
@@ -52,8 +52,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is exactly type OtherClass, because we want to test the failure,
-					               but it was MyClass {
+					               is exactly type ThatObject.OtherClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -75,8 +75,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is exactly type MyBaseClass, because we want to test the failure,
-					               but it was MyClass {
+					               is exactly type ThatObject.MyBaseClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -98,8 +98,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is exactly type MyClass, because {{reason}},
-					               but it was MyBaseClass {
+					               is exactly type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyBaseClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -144,7 +144,7 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is exactly type MyClass,
+					             is exactly type ThatObject.MyClass,
 					             but it was <null>
 					             """);
 			}
@@ -165,8 +165,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is exactly type OtherClass, because we want to test the failure,
-					               but it was MyClass {
+					               is exactly type ThatObject.OtherClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -188,8 +188,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is exactly type MyBaseClass, because we want to test the failure,
-					               but it was MyClass {
+					               is exactly type ThatObject.MyBaseClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -211,8 +211,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is exactly type MyClass, because {{reason}},
-					               but it was MyBaseClass {
+					               is exactly type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyBaseClass {
 					                   Value = {{value}}
 					                 }
 					               """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Whose.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Whose.Tests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is exactly type MyClass whose .Value is less than 42,
+					             is exactly type ThatObject.MyClass whose .Value is less than 42,
 					             but .Value was 42
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
@@ -58,8 +58,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is not type MyBaseClass, because we want to test the failure,
-					               but it was MyClass {
+					               is not type ThatObject.MyBaseClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -92,8 +92,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is not type MyClass, because {{reason}},
-					               but it was MyClass {
+					               is not type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -154,8 +154,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is not type MyBaseClass, because we want to test the failure,
-					               but it was MyClass {
+					               is not type ThatObject.MyBaseClass, because we want to test the failure,
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -188,8 +188,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is not type MyClass, because {{reason}},
-					               but it was MyClass {
+					               is not type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is not equal to subject, because we want to test the failure,
-					             but it was MyClass {
+					             but it was ThatObject.MyClass {
 					                 Value = 0
 					               }
 					             """);
@@ -88,7 +88,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is not equal to unexpected, because we want to test the failure,
-					             but it was MyStruct {
+					             but it was ThatObject.MyStruct {
 					                 Value = 1
 					               }
 					             """);
@@ -135,7 +135,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is not equal to unexpected, because we want to test the failure,
-					             but it was MyStruct {
+					             but it was ThatObject.MyStruct {
 					                 Value = 1
 					               }
 					             """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.UsingTests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.UsingTests.cs
@@ -41,8 +41,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not equal to expected using MyComparer,
-					             but it was OuterClass {
+					             is not equal to expected using ThatObject.IsNotEqualTo.UsingTests.MyComparer,
+					             but it was ThatObject.OuterClass {
 					                 Inner = <null>,
 					                 Value = "Foo"
 					               }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotExactly.Tests.cs
@@ -80,8 +80,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is not exactly type MyClass, because {{reason}},
-					               but it was MyClass {
+					               is not exactly type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);
@@ -164,8 +164,8 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage($$"""
 					               Expected that subject
-					               is not exactly type MyClass, because {{reason}},
-					               but it was MyClass {
+					               is not exactly type ThatObject.MyClass, because {{reason}},
+					               but it was ThatObject.MyClass {
 					                   Value = {{value}}
 					                 }
 					               """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNull.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNull.Tests.cs
@@ -30,7 +30,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is null, because we want to test the failure,
-					             but it was MyClass {
+					             but it was ThatObject.MyClass {
 					                 Value = 0
 					               }
 					             """);

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChanged.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChanged.Tests.cs
@@ -41,7 +41,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has never recorded the PropertyChanged event on sut,
 					             but it was recorded once in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 422
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "SomeArbitraryProperty"

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChangedFor.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.DidNotTriggerPropertyChangedFor.Tests.cs
@@ -41,7 +41,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has never recorded the PropertyChanged event on sut for property MyValue,
 					             but it was recorded once in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 421
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "MyValue"

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithSenderTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithSenderTests.cs
@@ -33,7 +33,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has recorded the PropertyChanged event on sut with sender s => s == sender at least once,
 					             but it was never recorded in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 2
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "MyValue"

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithTests.cs
@@ -29,7 +29,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has recorded the PropertyChanged event on sut with PropertyChangedEventArgs e => e.PropertyName == "SomethingElse" at least once,
 					             but it was never recorded in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 2
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "MyValue"

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
@@ -47,7 +47,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has recorded the PropertyChanged event on sut at least 2 times,
 					             but it was recorded once in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 42
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "MyValue"
@@ -93,12 +93,12 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has recorded the PropertyChanged event on sut with PropertyChangedEventArgs e => e.PropertyName == "foo" at least 2 times,
 					             but it was recorded once in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 0
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "foo"
 					                 }),
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 0
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "bar"

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.Tests.cs
@@ -27,7 +27,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has recorded the PropertyChanged event on sut for property MyValue at least once,
 					             but it was never recorded in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 2
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "foo"
@@ -103,7 +103,7 @@ public sealed partial class ThatEventRecording
 					             Expected that recording
 					             has never recorded the PropertyChanged event on sut,
 					             but it was recorded once in [
-					               PropertyChanged(PropertyChangedClass {
+					               PropertyChanged(ThatEventRecording.PropertyChangedClass {
 					                   MyValue = 422
 					                 }, PropertyChangedEventArgs {
 					                   PropertyName = "SomeArbitraryProperty"

--- a/Tests/aweXpect.Tests/ThatGeneric.DoesNotComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.DoesNotComplyWith.Tests.cs
@@ -86,7 +86,7 @@ public sealed partial class ThatGeneric
 					             {
 					             	HasWaitedEnough = false,
 					             } within 0:30,
-					             but it was considered equivalent to MyChangingClass {
+					             but it was considered equivalent to ThatGeneric.DoesNotComplyWith.WithinTests.MyChangingClass {
 					                 HasWaitedEnough = False
 					               }
 					             
@@ -164,7 +164,7 @@ public sealed partial class ThatGeneric
 					             {
 					             	HasWaitedEnough = false,
 					             } within 0:00.050,
-					             but it was considered equivalent to MyChangingClass {
+					             but it was considered equivalent to ThatGeneric.DoesNotComplyWith.WithinTests.MyChangingClass {
 					                 HasWaitedEnough = False
 					               }
 					             

--- a/Tests/aweXpect.Tests/ThatGeneric.DoesNotSatisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.DoesNotSatisfy.Tests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             does not satisfy _ => predicateResult,
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					               Value = 0
 					             }
 					             """);

--- a/Tests/aweXpect.Tests/ThatGeneric.IsNotSameAs.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.IsNotSameAs.Tests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatGeneric
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not refer to expected Other {
+					             does not refer to expected ThatGeneric.Other {
 					                 Value = 1
 					               },
 					             but it did
@@ -93,7 +93,7 @@ public sealed partial class ThatGeneric
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not refer to expected Other {
+					             does not refer to expected ThatGeneric.Other {
 					                 Value = 1
 					               },
 					             but it was <null>
@@ -121,10 +121,10 @@ public sealed partial class ThatGeneric
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             refers to expected Other {
+					             refers to expected ThatGeneric.Other {
 					                 Value = 1
 					               },
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					                 Value = 1
 					               }
 					             """);

--- a/Tests/aweXpect.Tests/ThatGeneric.IsSameAs.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.IsSameAs.Tests.cs
@@ -39,10 +39,10 @@ public sealed partial class ThatGeneric
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             refers to expected Other {
+					             refers to expected ThatGeneric.Other {
 					                 Value = 1
 					               },
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					                 Value = 1
 					               }
 					             """);
@@ -64,7 +64,7 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             refers to expected <null>,
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					                 Value = 1
 					               }
 					             """);
@@ -102,7 +102,7 @@ public sealed partial class ThatGeneric
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             refers to expected Other {
+					             refers to expected ThatGeneric.Other {
 					                 Value = 1
 					               },
 					             but it was <null>
@@ -127,7 +127,7 @@ public sealed partial class ThatGeneric
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not refer to expected Other {
+					             does not refer to expected ThatGeneric.Other {
 					                 Value = 1
 					               },
 					             but it did

--- a/Tests/aweXpect.Tests/ThatGeneric.Satisfies.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.Satisfies.Tests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             satisfies _ => predicateResult,
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					               Value = 0
 					             }
 					             """);
@@ -44,7 +44,7 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             satisfies _ => ++count > 42 within 0:30,
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					               Value = 0
 					             }
 					             """);
@@ -112,7 +112,7 @@ public sealed partial class ThatGeneric
 					.WithMessage("""
 					             Expected that subject
 					             satisfies _ => ++count > 42 within 0:00.050,
-					             but it was Other {
+					             but it was ThatGeneric.Other {
 					               Value = 0
 					             }
 					             """);


### PR DESCRIPTION
Include the declaring type when formatting nested types.

- Fixes #494 