### PR TITLE
feat: add `IAweXpectInitializer` for extension configuration

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Helpers;
+using aweXpect.Core.Initialization;
 using aweXpect.Core.Nodes;
 using aweXpect.Core.Sources;
 using aweXpect.Core.TimeSystem;
@@ -41,6 +42,7 @@ public abstract class ExpectationBuilder
 	/// </summary>
 	protected ExpectationBuilder(string subjectExpression, ExpectationGrammars grammars = ExpectationGrammars.None)
 	{
+		AweXpectInitialization.EnsureInitialized();
 		Subject = subjectExpression;
 		ExpectationGrammars = grammars;
 	}

--- a/Source/aweXpect.Core/Core/Initialization/IAweXpectInitializer.cs
+++ b/Source/aweXpect.Core/Core/Initialization/IAweXpectInitializer.cs
@@ -1,0 +1,13 @@
+﻿namespace aweXpect.Core.Initialization;
+
+/// <summary>
+///     aweXpect will call <see cref="IAweXpectInitializer.Initialize()" /> on all classes that implement this interface
+///     before the first expectation is executed.
+/// </summary>
+public interface IAweXpectInitializer
+{
+	/// <summary>
+	///     Can be used to initialize and customize aweXpect.
+	/// </summary>
+	void Initialize();
+}

--- a/Source/aweXpect.Core/Fail.cs
+++ b/Source/aweXpect.Core/Fail.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using aweXpect.Core.Ambient;
+using aweXpect.Core.Initialization;
 
 namespace aweXpect;
 
@@ -40,7 +40,7 @@ public static class Fail
 	/// <param name="reason">The reason why the test failed</param>
 	[DoesNotReturn]
 	public static void Inconclusive(string reason)
-		=> Initialization.State.Value.Inconclusive(reason);
+		=> AweXpectInitialization.State.Value.Inconclusive(reason);
 
 	private static void FailIf([DoesNotReturnIf(true)] bool condition, string reason)
 	{
@@ -49,6 +49,6 @@ public static class Fail
 			return;
 		}
 
-		Initialization.State.Value.Fail(reason);
+		AweXpectInitialization.State.Value.Fail(reason);
 	}
 }

--- a/Source/aweXpect.Core/Formatting/Format.cs
+++ b/Source/aweXpect.Core/Formatting/Format.cs
@@ -1,4 +1,4 @@
-using aweXpect.Core.Ambient;
+using aweXpect.Core.Initialization;
 
 namespace aweXpect.Formatting;
 
@@ -10,5 +10,5 @@ public static class Format
 	/// <summary>
 	///     The formatter to use for formatting values.
 	/// </summary>
-	public static ValueFormatter Formatter { get; } = Initialization.State.Value.Formatter;
+	public static ValueFormatter Formatter { get; } = AweXpectInitialization.State.Value.Formatter;
 }

--- a/Source/aweXpect.Core/Skip.cs
+++ b/Source/aweXpect.Core/Skip.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using aweXpect.Core.Ambient;
+using aweXpect.Core.Initialization;
 
 namespace aweXpect;
 
@@ -43,6 +43,6 @@ public static class Skip
 			return;
 		}
 
-		Initialization.State.Value.Skip(reason);
+		AweXpectInitialization.State.Value.Skip(reason);
 	}
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -311,6 +311,13 @@ namespace aweXpect.Core.Helpers
         ExplicitlyImplemented = 4,
     }
 }
+namespace aweXpect.Core.Initialization
+{
+    public interface IAweXpectInitializer
+    {
+        void Initialize();
+    }
+}
 namespace aweXpect.Core.Sources
 {
     public class DelegateValue

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -311,6 +311,13 @@ namespace aweXpect.Core.Helpers
         ExplicitlyImplemented = 4,
     }
 }
+namespace aweXpect.Core.Initialization
+{
+    public interface IAweXpectInitializer
+    {
+        void Initialize();
+    }
+}
 namespace aweXpect.Core.Sources
 {
     public class DelegateValue


### PR DESCRIPTION
Add an interface `IAweXpectInitializer` which can be used by extensions to execute initialization logic. Ensure that the initialization is executed before the first expectation is evaluated by adding a corresponding call to the `ExpectationBuilder` constructor.