### PR TITLE
feat: add custom value formatters

### DIFF
--- a/Source/aweXpect.Core/Formatting/IValueFormatter.cs
+++ b/Source/aweXpect.Core/Formatting/IValueFormatter.cs
@@ -1,0 +1,19 @@
+﻿using System.Text;
+
+namespace aweXpect.Formatting;
+
+/// <summary>
+///     A custom value formatter to use in <see cref="ValueFormatter.Register(IValueFormatter)" />.
+/// </summary>
+public interface IValueFormatter
+{
+	/// <summary>
+	///     Stores the formatted string in the <paramref name="stringBuilder" /> and returns <see langword="true" />,
+	///     if the <paramref name="value" /> can be formatted, otherwise leaves the <paramref name="stringBuilder" />
+	///     untouched and returns <see langword="false" />.
+	/// </summary>
+	public bool TryFormat(
+		StringBuilder stringBuilder,
+		object value,
+		FormattingOptions? options);
+}

--- a/Source/aweXpect.Core/Formatting/ValueFormatter.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatter.cs
@@ -1,10 +1,18 @@
-﻿namespace aweXpect.Formatting;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using aweXpect.Customization;
+
+namespace aweXpect.Formatting;
 
 /// <summary>
 ///     Formatter for arbitrary objects in exception messages.
 /// </summary>
 public class ValueFormatter
 {
+	internal static readonly ConcurrentDictionary<int, IValueFormatter> RegisteredValueFormatters = new();
+	private static int _index;
+
 	/// <summary>
 	///     The default string representation of <see langword="null" />.
 	/// </summary>
@@ -13,4 +21,15 @@ public class ValueFormatter
 #pragma warning disable S1118 // Utility classes should not have public constructors
 	internal ValueFormatter() { }
 #pragma warning restore S1118
+
+	/// <summary>
+	///     Registers a custom <paramref name="formatter" /> to use for formatting <see cref="object" />s.
+	/// </summary>
+	public static IDisposable Register(IValueFormatter formatter)
+	{
+		int index = Interlocked.Increment(ref _index);
+		RegisteredValueFormatters.TryAdd(index, formatter);
+		CustomizationLifetime disposable = new(() => RegisteredValueFormatters.TryRemove(index, out _));
+		return disposable;
+	}
 }

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -37,8 +37,21 @@ public static partial class ValueFormatters
 		if (value is null)
 		{
 			stringBuilder.Append(ValueFormatter.NullString);
+			return;
 		}
-		else if (value is bool boolValue)
+
+		if (ValueFormatter.RegisteredValueFormatters.Count > 0)
+		{
+			foreach (IValueFormatter valueFormatter in ValueFormatter.RegisteredValueFormatters.Values)
+			{
+				if (valueFormatter.TryFormat(stringBuilder, value, options))
+				{
+					return;
+				}
+			}
+		}
+
+		if (value is bool boolValue)
 		{
 			formatter.Format(stringBuilder, boolValue, options);
 		}

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -596,9 +596,14 @@ namespace aweXpect.Formatting
         public static aweXpect.Formatting.FormattingOptions SingleLine { get; }
         public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null) { }
     }
+    public interface IValueFormatter
+    {
+        bool TryFormat(System.Text.StringBuilder stringBuilder, object value, aweXpect.Formatting.FormattingOptions? options);
+    }
     public class ValueFormatter
     {
         public static readonly string NullString;
+        public static System.IDisposable Register(aweXpect.Formatting.IValueFormatter formatter) { }
     }
     public static class ValueFormatters
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -591,9 +591,14 @@ namespace aweXpect.Formatting
         public static aweXpect.Formatting.FormattingOptions SingleLine { get; }
         public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null) { }
     }
+    public interface IValueFormatter
+    {
+        bool TryFormat(System.Text.StringBuilder stringBuilder, object value, aweXpect.Formatting.FormattingOptions? options);
+    }
     public class ValueFormatter
     {
         public static readonly string NullString;
+        public static System.IDisposable Register(aweXpect.Formatting.IValueFormatter formatter) { }
     }
     public static class ValueFormatters
     {

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatterTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Text;
+
+namespace aweXpect.Core.Tests.Formatting;
+
+public class ValueFormatterTests
+{
+	[Fact]
+	public async Task CustomFormatter_ShouldBeUsedDuringLifetime()
+	{
+		MyFormattableClass value = new()
+		{
+			Value = 42,
+		};
+		using (ValueFormatter.Register(new MyCustomFormatter("my-string")))
+		{
+			string customObjectResult = Formatter.Format(value);
+
+			await That(customObjectResult).IsEqualTo("my-string");
+		}
+
+		string objectResult = Formatter.Format(value);
+
+		await That(objectResult).IsEqualTo("""
+		                                   ValueFormatterTests.MyFormattableClass {
+		                                     Value = 42
+		                                   }
+		                                   """);
+	}
+
+	[Fact]
+	public async Task CustomFormatter_WhenNull_ShouldUseDefaultNullString()
+	{
+		using IDisposable lifetime = ValueFormatter.Register(new MyCustomFormatter("my-string"));
+		bool? value = null;
+
+		string objectResult = Formatter.Format((object?)value);
+
+		await That(objectResult).IsEqualTo(ValueFormatter.NullString);
+	}
+
+	[Fact]
+	public async Task CustomFormatter_WhenTypeDoesNotMatch_ShouldDoNothing()
+	{
+		int value = 1;
+		using (ValueFormatter.Register(new MyCustomFormatter("my-string")))
+		{
+			string customObjectResult = Formatter.Format((object?)value);
+
+			await That(customObjectResult).IsEqualTo("1");
+		}
+	}
+
+	private sealed class MyCustomFormatter(string formatString) : IValueFormatter
+	{
+		public bool TryFormat(StringBuilder stringBuilder, object value, FormattingOptions? options)
+		{
+			if (value is MyFormattableClass)
+			{
+				stringBuilder.Append(formatString);
+				return true;
+			}
+
+			return false;
+		}
+	}
+
+	private sealed class MyFormattableClass
+	{
+		public int Value { get; set; }
+	}
+}


### PR DESCRIPTION
Allow registering custom value formatters on the `ValueFormatter` class that are considered during formatting of objects.