### PR TITLE
fix: catch `ReflectionTypeLoadException` during initialization

### DIFF
--- a/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
+++ b/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
@@ -63,7 +63,7 @@ internal static class AweXpectInitialization
 	private static void ExecuteCustomInitializers()
 	{
 		Type initializerInterface = typeof(IAweXpectInitializer);
-		foreach (Assembly? assembly in AppDomain.CurrentDomain.GetAssemblies()
+		foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()
 			         .Where(assembly => Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
 				         .All(excludedAssemblyPrefix => !assembly.FullName!.StartsWith(excludedAssemblyPrefix))))
 		{
@@ -88,6 +88,7 @@ internal static class AweXpectInitialization
 			}
 			catch (ReflectionTypeLoadException)
 			{
+				// Ignore any ReflectionTypeLoadException and continue with the next assembly.
 			}
 		}
 	}


### PR DESCRIPTION
If types cannot be loaded in an assembly, the initialization should skip this assembly and continue.