### PR TITLE
fix: formatting exception with open generic types

### DIFF
--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
@@ -138,7 +138,10 @@ public static partial class ValueFormatters
 					}
 
 					isFirstArgument = false;
-					FormatType(argument, stringBuilder);
+					if (!argument.ContainsGenericParameters)
+					{
+						FormatType(argument, stringBuilder);
+					}
 				}
 
 				stringBuilder.Append('>');

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -104,6 +104,22 @@ public partial class ValueFormatters
 			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 
+		[Fact]
+		public async Task ShouldSupportOpenGenericTypeDefinitions()
+		{
+			Type value = typeof(IEnumerable<>);
+			string expectedResult = "IEnumerable<>";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
 		[Theory]
 		[MemberData(nameof(SimpleTypes))]
 		public async Task SimpleTypes_ShouldUseSimpleNames(Type value, string expectedResult)
@@ -151,6 +167,7 @@ public partial class ValueFormatters
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
 		}
 
+		// ReSharper disable once UnusedTypeParameter
 		private class NestedGenericType<T>;
 
 		public static TheoryData<Type, string> SimpleTypes


### PR DESCRIPTION
Open generic types result in a `StackOverflowException` because the inner type is recursively formatted.