### PR TITLE
fix: ignore order in dictionary equivalency

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -104,11 +104,46 @@ public partial class ValueFormatters
 			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 
+		[Theory]
+		[InlineData(typeof(IDictionary<,>), 0, "IDictionary<, >.TKey")]
+		[InlineData(typeof(IDictionary<,>), 1, "IDictionary<, >.TValue")]
+		[InlineData(typeof(IEnumerable<>), 0, "IEnumerable<>.T")]
+		public async Task ShouldSupportOpenGenericParametersOfIDictionary(
+			Type genericType, int argumentIndex, string expectedResult)
+		{
+			Type value = genericType.GetGenericArguments()[argumentIndex];
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
 		[Fact]
 		public async Task ShouldSupportOpenGenericTypeDefinitions()
 		{
 			Type value = typeof(IEnumerable<>);
 			string expectedResult = "IEnumerable<>";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task ShouldSupportOpenGenericTypeWithMultipleParametersDefinitions()
+		{
+			Type value = typeof(IDictionary<,>);
+			string expectedResult = "IDictionary<, >";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.WhoseTests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.WhoseTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatObject
 
 				async Task Act()
 					=> await That(subject).Is<MyClass>()
-						.Whose(x => x.Value, x => x.IsLessThan(42));
+						.Whose(it => it.Value, value => value.IsLessThan(42));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -35,7 +35,7 @@ public sealed partial class ThatObject
 				};
 
 				async Task Act()
-					=> await That(subject).Is<MyClass>().Whose(x => x.Value, x => x.IsEqualTo(42));
+					=> await That(subject).Is<MyClass>().Whose(it => it.Value, value => value.IsEqualTo(42));
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Equivalency;
+﻿using System.Collections.Generic;
+using aweXpect.Equivalency;
 
 namespace aweXpect.Tests;
 
@@ -333,7 +334,7 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
-			public async Task WhenInDifferentOrderOrder_ShouldFail()
+			public async Task WhenInDifferentOrder_ShouldFail()
 			{
 				int[] subject = [1, 2, 3,];
 				int[] expected = [1, 3, 2,];
@@ -360,7 +361,7 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
-			public async Task WhenInDifferentOrderOrder_WhenIgnoringCollectionOrder_ShouldSucceed()
+			public async Task WhenInDifferentOrder_WhenIgnoringCollectionOrder_ShouldSucceed()
 			{
 				int[] subject = [1, 2, 3,];
 				int[] expected = [1, 3, 2,];
@@ -381,6 +382,161 @@ public sealed partial class ThatObject
 					=> await That(subject).IsEquivalentTo(expected);
 
 				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class DictionaryTests
+		{
+			[Fact]
+			public async Task WhenDifferentKeys_ShouldFail()
+			{
+				Dictionary<int, int> subject = new()
+				{
+					{
+						1, 2
+					},
+					{
+						2, 3
+					},
+					{
+						3, 4
+					},
+				};
+				Dictionary<int, int> expected = new()
+				{
+					{
+						1, 2
+					},
+					{
+						3, 3
+					},
+					{
+						4, 4
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to expected,
+					             but it was not:
+					               Element [2] had superfluous 3
+					             and
+					               Element [3] differed:
+					                    Found: 4
+					                 Expected: 3
+					             and
+					               Element [4] was missing 4
+
+					             Equivalency options:
+					              - include public fields and properties
+					              - ignore collection order
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenDifferentValues_ShouldFail()
+			{
+				Dictionary<int, int> subject = new()
+				{
+					{
+						1, 2
+					},
+					{
+						2, 3
+					},
+					{
+						3, 4
+					},
+				};
+				Dictionary<int, int> expected = new()
+				{
+					{
+						1, 2
+					},
+					{
+						2, 4
+					},
+					{
+						3, 5
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equivalent to expected,
+					             but it was not:
+					               Element [2] differed:
+					                    Found: 3
+					                 Expected: 4
+					             and
+					               Element [3] differed:
+					                    Found: 4
+					                 Expected: 5
+
+					             Equivalency options:
+					              - include public fields and properties
+					              - ignore collection order
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSameEntries_ShouldBeEquivalent()
+			{
+				Dictionary<int, int> subject = new()
+				{
+					{
+						2, 3
+					},
+					{
+						1, 4
+					},
+				};
+
+				Dictionary<int, int> expected = new()
+				{
+					{
+						2, 3
+					},
+					{
+						1, 4
+					},
+				};
+
+				await That(subject).IsEquivalentTo(expected);
+			}
+
+			[Fact]
+			public async Task WhenSameEntriesInDifferentOrder_ShouldBeEquivalent()
+			{
+				Dictionary<string, string> subject = new(StringComparer.OrdinalIgnoreCase)
+				{
+					{
+						"A", "A"
+					},
+					{
+						"B", "B"
+					},
+				};
+
+				Dictionary<string, string> expected = new(StringComparer.OrdinalIgnoreCase)
+				{
+					{
+						"B", "B"
+					},
+					{
+						"A", "A"
+					},
+				};
+
+				await That(subject).IsEquivalentTo(expected);
 			}
 		}
 


### PR DESCRIPTION
When comparing dictionaries for equivalency, always ignore the order of the key-value-pairs.

* Add edge-case tests for type formatting