### PR TITLE
feat: add `IsNotEquivalentTo` for objects

### DIFF
--- a/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsEquivalentTo.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using aweXpect.Core;
+using aweXpect.Core.Constraints;
 using aweXpect.Customization;
 using aweXpect.Equivalency;
 using aweXpect.Helpers;
@@ -36,6 +37,32 @@ public static partial class ThatObject
 			expectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<TSubject, TExpected>(it, grammars, expected,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(), equalityOptions)),
+			source);
+	}
+	/// <summary>
+	///     Verifies that the subject is not equivalent to the <paramref name="unexpected" /> value.
+	/// </summary>
+	public static AndOrResult<TSubject, IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(
+		this IThat<TSubject> source,
+		TExpected unexpected,
+		Func<EquivalencyOptions<TExpected>, EquivalencyOptions>? options = null,
+		[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+	{
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		EquivalencyOptions equivalencyOptions = Customize.aweXpect.Equivalency().DefaultEquivalencyOptions.Get();
+		if (options != null)
+		{
+			equivalencyOptions = options(new EquivalencyOptions<TExpected>(equivalencyOptions));
+		}
+
+		expectationBuilder.AddEquivalencyContext(equivalencyOptions);
+
+		ObjectEqualityOptions<TSubject> equalityOptions = new();
+		equalityOptions.Equivalent(equivalencyOptions);
+		return new AndOrResult<TSubject, IThat<TSubject>>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<TSubject, TExpected>(it, grammars, unexpected,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(), equalityOptions).Invert()),
 			source);
 	}
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -557,6 +557,7 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsNotEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where T :  struct { }
+        public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -632,6 +632,7 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsNotEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where T :  struct { }
+        public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -488,7 +488,7 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
-			public async Task WhenSameEntries_ShouldBeEquivalent()
+			public async Task WhenSameEntries_ShouldSucceed()
 			{
 				Dictionary<int, int> subject = new()
 				{
@@ -510,11 +510,14 @@ public sealed partial class ThatObject
 					},
 				};
 
-				await That(subject).IsEquivalentTo(expected);
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenSameEntriesInDifferentOrder_ShouldBeEquivalent()
+			public async Task WhenSameEntriesInDifferentOrder_ShouldSucceed()
 			{
 				Dictionary<string, string> subject = new(StringComparer.OrdinalIgnoreCase)
 				{
@@ -536,7 +539,10 @@ public sealed partial class ThatObject
 					},
 				};
 
-				await That(subject).IsEquivalentTo(expected);
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
@@ -1,0 +1,566 @@
+﻿using System.Collections.Generic;
+using aweXpect.Equivalency;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatObject
+{
+	public sealed class IsNotEquivalentTo
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task BasicEquivalentObjects_ShouldFail()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+				};
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to ThatObject.OuterClass {
+					                 Inner = <null>,
+					                 Value = "Foo"
+					               }
+
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+
+			[Fact]
+			public async Task MismatchedObjects_ShouldSucceed()
+			{
+				OuterClass subject = new();
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task
+				ObjectsWithNestedEnumerableMismatch_WithIgnoreRule_ShouldFail()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3",],
+						},
+					},
+				};
+
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3", "4",],
+						},
+					},
+				};
+
+				async Task Act()
+					=> await That(subject)
+						.IsNotEquivalentTo(unexpected, o => o.IgnoringMember("Inner.Inner.Collection[3]"));
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to ThatObject.OuterClass {
+					                 Inner = ThatObject.InnerClass {
+					                   Collection = <null>,
+					                   Inner = ThatObject.InnerClass {
+					                     Collection = [
+					                     "1",
+					                     "2",
+					                     "3"
+					                   ],
+					                     Inner = <null>,
+					                     Value = "Baz"
+					                   },
+					                   Value = "Bar"
+					                 },
+					                 Value = "Foo"
+					               }
+
+					             Equivalency options:
+					              - include public fields and properties
+					              - ignore members: ["Inner.Inner.Collection[3]"]
+					             """);
+			}
+
+			[Fact]
+			public async Task
+				ObjectsWithNestedEnumerableMismatch_WithIncorrectIgnoreRule_ShouldSucceed()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3",],
+						},
+					},
+				};
+
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Bart",
+							Collection = ["1", "2", "3", "4",],
+						},
+					},
+				};
+
+				async Task Act()
+					=> await That(subject)
+						.IsNotEquivalentTo(unexpected, o => o.IgnoringMember("Inner.Inner.Collection.[3]"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ObjectsWithNestedMatches_ShouldFail()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+						},
+					},
+				};
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+						},
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to ThatObject.OuterClass {
+					                 Inner = ThatObject.InnerClass {
+					                   Collection = <null>,
+					                   Inner = ThatObject.InnerClass {
+					                     Collection = <null>,
+					                     Inner = <null>,
+					                     Value = "Baz"
+					                   },
+					                   Value = "Bar"
+					                 },
+					                 Value = "Foo"
+					               }
+
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+
+			[Fact]
+			public async Task ObjectsWithNestedMatchingEnumerable_ShouldFail()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3",],
+						},
+					},
+				};
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3",],
+						},
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to ThatObject.OuterClass {
+					                 Inner = ThatObject.InnerClass {
+					                   Collection = <null>,
+					                   Inner = ThatObject.InnerClass {
+					                     Collection = [
+					                     "1",
+					                     "2",
+					                     "3"
+					                   ],
+					                     Inner = <null>,
+					                     Value = "Baz"
+					                   },
+					                   Value = "Bar"
+					                 },
+					                 Value = "Foo"
+					               }
+
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+
+			[Fact]
+			public async Task ObjectsWithNestedMismatch_ShouldSucceed()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass(),
+					},
+				};
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+						},
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ObjectsWithNestedMismatchingEnumerable_ShouldSucceed()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3",],
+						},
+					},
+				};
+
+				OuterClass unexpected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						Value = "Bar",
+						Inner = new InnerClass
+						{
+							Value = "Baz",
+							Collection = ["1", "2", "3", "4",],
+						},
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class CollectionTests
+		{
+			[Fact]
+			public async Task WhenDifferentValues_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] unexpected = [4, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInDifferentOrder_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] unexpected = [1, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInDifferentOrder_WhenIgnoringCollectionOrder_ShouldFail()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] unexpected = [1, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to [
+					               1,
+					               2,
+					               3
+					             ]
+					             
+					             Equivalency options:
+					              - include public fields and properties
+					              - ignore collection order
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInSameOrder_ShouldFail()
+			{
+				int[] subject = [1, 2, 3,];
+				int[] unexpected = [1, 2, 3,];
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to [
+					               1,
+					               2,
+					               3
+					             ]
+					             
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+		}
+
+		public sealed class DictionaryTests
+		{
+			[Fact]
+			public async Task WhenDifferentKeys_ShouldSucceed()
+			{
+				Dictionary<int, int> subject = new()
+				{
+					{
+						1, 2
+					},
+					{
+						2, 3
+					},
+					{
+						3, 4
+					},
+				};
+				Dictionary<int, int> unexpected = new()
+				{
+					{
+						1, 2
+					},
+					{
+						3, 3
+					},
+					{
+						4, 4
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDifferentValues_ShouldSucceed()
+			{
+				Dictionary<int, int> subject = new()
+				{
+					{
+						1, 2
+					},
+					{
+						2, 3
+					},
+					{
+						3, 4
+					},
+				};
+				Dictionary<int, int> unexpected = new()
+				{
+					{
+						1, 2
+					},
+					{
+						2, 4
+					},
+					{
+						3, 5
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected, o => o.IgnoringCollectionOrder());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSameEntries_ShouldFail()
+			{
+				Dictionary<int, int> subject = new()
+				{
+					{
+						2, 3
+					},
+					{
+						1, 4
+					},
+				};
+
+				Dictionary<int, int> unexpected = new()
+				{
+					{
+						2, 3
+					},
+					{
+						1, 4
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+				
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to [
+					               [2, 3],
+					               [1, 4]
+					             ]
+					             
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSameEntriesInDifferentOrder_ShouldFail()
+			{
+				Dictionary<string, string> subject = new(StringComparer.OrdinalIgnoreCase)
+				{
+					{
+						"A", "A"
+					},
+					{
+						"B", "B"
+					},
+				};
+
+				Dictionary<string, string> unexpected = new(StringComparer.OrdinalIgnoreCase)
+				{
+					{
+						"B", "B"
+					},
+					{
+						"A", "A"
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsNotEquivalentTo(unexpected);
+				
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to unexpected,
+					             but it was considered equivalent to [
+					               [A, A],
+					               [B, B]
+					             ]
+					             
+					             Equivalency options:
+					              - include public fields and properties
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add negated expectation `IsNotEquivalentTo` for objects, that ensures that the subject is not equivalent to the unexpected value.