### PR TITLE
feat: Add options for `HasSingle` with predicate

### DIFF
--- a/Docs/pages/docs/expectations/01-boolean.md
+++ b/Docs/pages/docs/expectations/01-boolean.md
@@ -4,7 +4,7 @@ Describes the possible expectations for boolean values.
 
 ## Equality
 
-You can verify, that the `bool` is equal to another one or not:
+You can verify that the `bool` is equal to another one or not:
 
 ```csharp
 bool subject = false;
@@ -15,7 +15,7 @@ await Expect.That(subject).IsNotEqualTo(true);
 
 ## True / False
 
-You can verify, that the `bool` is `true` or `false`:
+You can verify that the `bool` is `true` or `false`:
 
 ```csharp
 await Expect.That(false).IsFalse();
@@ -35,7 +35,7 @@ await Expect.That(subject).IsNotTrue()
 
 ## Implication
 
-You can verify, that `a` implies `b` (*find [here](https://mathworld.wolfram.com/Implies.html) a mathematical
+You can verify that `a` implies `b` (*find [here](https://mathworld.wolfram.com/Implies.html) a mathematical
 explanation*):
 
 ```csharp

--- a/Docs/pages/docs/expectations/02-string.md
+++ b/Docs/pages/docs/expectations/02-string.md
@@ -4,7 +4,7 @@ Describes the possible expectations for strings.
 
 ## Equality
 
-You can verify, that the `string` is equal to another one.  
+You can verify that the `string` is equal to another one.  
 This expectation can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or
 use a custom `IEqualityComparer<string>`:
 
@@ -72,7 +72,7 @@ await Expect.That(subject).IsEqualTo("text").AsSuffix();
 
 ## One of
 
-You can verify, that the `string` is one of many alternatives.  
+You can verify that the `string` is one of many alternatives.  
 This expectation can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or
 use a custom `IEqualityComparer<string>`:
 
@@ -88,7 +88,7 @@ await Expect.That(subject).IsOneOf("NONE", "SOME", "MANY").Using(StringComparer.
 
 ## Null, empty or white-space
 
-You can verify, that the `string` is null, empty or contains only whitespace:
+You can verify that the `string` is null, empty or contains only whitespace:
 
 ```csharp
 string? subject = null;
@@ -108,7 +108,7 @@ await Expect.That("foo").IsNotNullOrWhiteSpace();
 
 ## Length
 
-You can verify, that the `string` has the expected length:
+You can verify that the `string` has the expected length:
 
 ```csharp
 string subject = "some value";
@@ -124,7 +124,7 @@ await Expect.That(subject).HasLength().LessThan(12);
 
 ## String start / end
 
-You can verify, that the `string` starts or ends with a given string.  
+You can verify that the `string` starts or ends with a given string.  
 These expectations can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or
 use a custom `IEqualityComparer<string>`:
 
@@ -146,7 +146,7 @@ await Expect.That(subject).EndsWith("TEXT").Using(StringComparer.OrdinalIgnoreCa
 
 ## Contains
 
-You can verify, that the `string` contains a given substring.  
+You can verify that the `string` contains a given substring.  
 These expectations can be configured to ignore case, ignore newline style, ignoring leading or trailing white-space, or
 use a custom `IEqualityComparer<string>`:
 
@@ -177,7 +177,7 @@ await Expect.That(subject).Contains("in").Between(1).And(5)
 
 ## Character casing
 
-You can verify, that the characters in a `string` are all upper or lower cased:
+You can verify that the characters in a `string` are all upper or lower cased:
 
 ```csharp
 await Expect.That("1ST PLACE").IsUpperCased()

--- a/Docs/pages/docs/expectations/03-number.md
+++ b/Docs/pages/docs/expectations/03-number.md
@@ -4,7 +4,7 @@ Describes the possible expectations for numbers.
 
 ## Equality
 
-You can verify, that the number is equal to another one or not:
+You can verify that the number is equal to another one or not:
 
 ```csharp
 int subject = 42;
@@ -23,7 +23,7 @@ await Expect.That(subject).IsEqualTo(42).Within(0.2)
 
 ## One of
 
-You can verify, that the number is one of many alternatives:
+You can verify that the number is one of many alternatives:
 
 ```csharp
 int subject = 42;
@@ -42,7 +42,7 @@ await Expect.That(subject).IsOneOf(40, 42, 44).Within(0.2)
 
 ## Greater than
 
-You can verify, that the number is greater than (or equal to) another number:
+You can verify that the number is greater than (or equal to) another number:
 
 ```csharp
 int subject = 42;
@@ -62,7 +62,7 @@ await Expect.That(subject).IsGreaterThan(42).Within(0.2)
 
 ## Less than
 
-You can verify, that the number is less than (or equal to) another number:
+You can verify that the number is less than (or equal to) another number:
 
 ```csharp
 int subject = 42;
@@ -82,7 +82,7 @@ await Expect.That(subject).IsLessThan(42).Within(0.2)
 
 ## Positive / negative
 
-You can verify, that the number is positive or negative:
+You can verify that the number is positive or negative:
 
 ```csharp
 await Expect.That(42).IsPositive();
@@ -93,7 +93,7 @@ await Expect.That(-3).IsNegative();
 
 ## NaN
 
-For floating point numbers you can verify, that the number is `NaN` or not:
+For floating point numbers you can verify that the number is `NaN` or not:
 
 ```csharp
 await Expect.That(float.NaN).IsNaN();
@@ -102,7 +102,7 @@ await Expect.That(42.0).IsNotNaN();
 
 ## Infinity
 
-For floating point numbers you can verify, that the number is finite or infinite:
+For floating point numbers you can verify that the number is finite or infinite:
 
 ```csharp
 await Expect.That(float.PositiveInfinity).IsInfinite();

--- a/Docs/pages/docs/expectations/04-enum.md
+++ b/Docs/pages/docs/expectations/04-enum.md
@@ -4,7 +4,7 @@ Describes the possible expectations for `enum` values.
 
 ## Equality
 
-You can verify, that the `enum` is equal to another one or not:
+You can verify that the `enum` is equal to another one or not:
 
 ```csharp
 enum Colors { Red = 1, Green = 2, Blue = 3}
@@ -17,7 +17,7 @@ await Expect.That(Colors.Red).IsNotEqualTo(Colors.Blue)
 
 ## Value
 
-You can verify, that the `enum` has a given value or not:
+You can verify that the `enum` has a given value or not:
 
 ```csharp
 enum Colors { Red = 1, Green = 2, Blue = 3}
@@ -30,7 +30,7 @@ await Expect.That(Colors.Red).DoesNotHaveValue(2)
 
 ## Defined
 
-You can verify, that the `enum` has a defined value or not:
+You can verify that the `enum` has a defined value or not:
 
 ```csharp
 enum Colors { Red = 1, Green = 2, Blue = 3}
@@ -43,7 +43,7 @@ await Expect.That((Colors)4).IsNotDefined()
 
 ## Flags
 
-You can verify, that the `enum` has a specific flag or not:
+You can verify that the `enum` has a specific flag or not:
 
 ```csharp
 RegexOptions subject = RegexOptions.Multiline | RegexOptions.IgnoreCase;

--- a/Docs/pages/docs/expectations/05-delegates.md
+++ b/Docs/pages/docs/expectations/05-delegates.md
@@ -20,7 +20,7 @@ A delegate can be any of the following:
 
 ## Not throw
 
-You can verify, that the delegate does not throw any exception:
+You can verify that the delegate does not throw any exception:
 
 ```csharp
 void Act() => {};
@@ -30,7 +30,7 @@ await Expect.That(Act).DoesNotThrow();
 
 ## Throw exception
 
-You can verify, that the delegate throws an exception:
+You can verify that the delegate throws an exception:
 
 ```csharp
 void Act() => throw new CustomException("my exception");
@@ -40,7 +40,7 @@ await Expect.That(Act).ThrowsException();
 
 ### Specific exception
 
-You can verify, that the delegate throws a specific exception:
+You can verify that the delegate throws a specific exception:
 
 ```csharp
 void Act() => throw new CustomException("my exception");
@@ -53,7 +53,7 @@ This will verify that the thrown exception is of type `CustomException` or any d
 
 ### Exact exception
 
-You can verify, that the delegate throws exactly a specific exception:
+You can verify that the delegate throws exactly a specific exception:
 
 ```csharp
 void Act() => throw new CustomException("my exception");
@@ -66,7 +66,7 @@ This will verify that the thrown exception is of type `CustomException` and not 
 
 ### Conditional throw
 
-You can verify, that the delegate throws an exception only if a predicate is satisfied (otherwise it verifies, that no
+You can verify that the delegate throws an exception only if a predicate is satisfied (otherwise it verifies, that no
 exception is thrown):
 
 ```csharp
@@ -130,7 +130,7 @@ await Expect.That(Act).ThrowsException()
 
 ## Execute within
 
-You can verify, that the delegate finishes execution in a specified amount of time
+You can verify that the delegate finishes execution in a specified amount of time
 
 ```csharp
 await Expect.That(Task.Delay(200)).ExecutesWithin(TimeSpan.FromMilliseconds(300))

--- a/Docs/pages/docs/expectations/06-collections.md
+++ b/Docs/pages/docs/expectations/06-collections.md
@@ -4,7 +4,7 @@ Describes the possible expectations for collections.
 
 ## Equality
 
-You can verify, that a collection matches another collection:
+You can verify that a collection matches another collection:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 3);
@@ -35,7 +35,7 @@ await Expect.That(values).HasCount().Between(8).And(12);
 
 ## All be
 
-You can verify, that all items in the collection are equal to the `expected` value
+You can verify that all items in the collection are equal to the `expected` value
 
 ```csharp
 await Expect.That([1, 1, 1]).All().AreEqualTo(1);
@@ -63,7 +63,7 @@ await Expect.That(["foo", "FOO", "Foo"]).All().AreEqualTo("foo").IgnoringCase();
 
 ## All be unique
 
-You can verify, that all items in a collection are unique.
+You can verify that all items in a collection are unique.
 
 ```csharp
 await Expect.That([1, 2, 3]).AreAllUnique();
@@ -90,7 +90,7 @@ You can add expectations that a certain number of elements must meet.
 
 ### Comply with
 
-You can verify, that items in a collection comply with an expectation on the individual elements:
+You can verify that items in a collection comply with an expectation on the individual elements:
 
 ```csharp
 await Expect.That([1, 2, 3]).All().ComplyWith(item => item.IsLessThan(4));
@@ -105,7 +105,7 @@ await Expect.That([1, 2, 3]).None().ComplyWith(item => item.IsNegative());
 
 ### Satisfy
 
-You can verify, that items in a collection satisfy a condition:
+You can verify that items in a collection satisfy a condition:
 
 ```csharp
 await Expect.That([1, 2, 3]).All().Satisfy(item => item < 4);
@@ -121,7 +121,7 @@ await Expect.That([1, 2, 3]).None().Satisfy(item => item < 0);
 
 ## Sort order
 
-You can verify, that the collection contains is sorted in ascending or descending order:
+You can verify that the collection contains is sorted in ascending or descending order:
 
 ```csharp
 await Expect.That([1, 2, 3]).IsInAscendingOrder();
@@ -146,7 +146,7 @@ await Expect.That(values).IsInAscendingOrder(x => x.Value);
 
 ## Contain
 
-You can verify, that the collection contains a specific item or not:
+You can verify that the collection contains a specific item or not:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -181,7 +181,7 @@ await Expect.That(values).Contains(expected).Using(new MyClassComparer());
 
 ### Predicate
 
-You can verify, that the collection contains an item that satisfies a condition:
+You can verify that the collection contains an item that satisfies a condition:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -205,7 +205,7 @@ await Expect.That(values).Contains(x => x == 1).Between(1).And(5.Times());
 
 ### Contain subset
 
-You can verify, that a collection contains another collection as a subset:
+You can verify that a collection contains another collection as a subset:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 3);
@@ -222,7 +222,7 @@ To check for a proper subset, append `.Properly()` (which would fail for equal c
 
 ### Be contained in
 
-You can verify, that a collection is contained in another collection (it is a superset):
+You can verify that a collection is contained in another collection (it is a superset):
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 3);
@@ -308,7 +308,7 @@ Specifications that count the elements in a collection.
 
 ### All
 
-You can verify, that all items in the collection, satisfy an expectation:
+You can verify that all items in the collection, satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -320,7 +320,7 @@ await Expect.That(values).All().Satisfy(i => i <= 20);
 
 ### At least
 
-You can verify, that at least `minimum` items in the collection, satisfy an expectation:
+You can verify that at least `minimum` items in the collection, satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -332,7 +332,7 @@ await Expect.That(values).AtLeast(9).Satisfy(i => i < 10);
 
 ### At most
 
-You can verify, that at most `maximum` items in the collection, satisfy an expectation:
+You can verify that at most `maximum` items in the collection, satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -344,7 +344,7 @@ await Expect.That(values).AtMost(1).Satisfy(i => i < 2);
 
 ### Between
 
-You can verify, that between `minimum` and `maximum` items in the collection, satisfy an expectation:
+You can verify that between `minimum` and `maximum` items in the collection, satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -356,7 +356,7 @@ await Expect.That(values).Between(1).And(2).Satisfy(i => i < 2);
 
 ### Exactly
 
-You can verify, that exactly `expected` items in the collection, satisfy an expectation:
+You can verify that exactly `expected` items in the collection, satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -368,7 +368,7 @@ await Expect.That(values).Exactly(9).Satisfy(i => i < 10);
 
 ### None
 
-You can verify, that not item in the collection, satisfies an expectation:
+You can verify that not item in the collection, satisfies an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -376,7 +376,7 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).None().Satisfy(i => i > 20);
 ```
 
-You can also verify, that the collection is empty.
+You can also verify that the collection is empty.
 
 ```csharp
 IEnumerable<int> values = Array.Empty<int>();
@@ -388,13 +388,27 @@ await Expect.That(values).IsEmpty();
 
 ## Have single
 
-You can verify, that the collection contains a single element that satisfies an expectation.
+You can verify that the collection contains a single element that satisfies an expectation.
 
 ```csharp
 IEnumerable<int> values = [42];
 
 await Expect.That(values).HasSingle();
 await Expect.That(values).HasSingle().Which.IsGreaterThan(41);
+```
+
+You can also apply filters for the items:
+
+```csharp
+IEnumerable<int> values = [1, 2, 3,];
+
+await Expect.That(values).HasSingle().Matching(it => it > 2);
+
+// Or with generic type:
+IEnumerable<Person> persons = //...
+
+await Expect.That(persons).HasSingle().Matching<Student>();
+await Expect.That(persons).HasSingle().Matching<Student>(student => student.Courses.Count == 0);
 ```
 
 The awaited result is the single element:
@@ -412,7 +426,7 @@ await Expect.That(result).IsGreaterThan(41);
 
 ### Contain key(s)
 
-You can verify, that a dictionary contains the `expected` key(s):
+You can verify that a dictionary contains the `expected` key(s):
 
 ```csharp
 Dictionary<int, string> values = new() { { 42, "foo" }, { 43, "bar" } };
@@ -434,7 +448,7 @@ await Expect.That(values).ContainsKeys(43, 44).WhoseValues.ComplyWith(v => v.Sta
 
 ### Contain value(s)
 
-You can verify, that a dictionary contains the `expected` value(s):
+You can verify that a dictionary contains the `expected` value(s):
 
 ```csharp
 Dictionary<int, string> values = new() { { 42, "foo" }, { 43, "bar" } };

--- a/Docs/pages/docs/expectations/07-object.md
+++ b/Docs/pages/docs/expectations/07-object.md
@@ -4,7 +4,7 @@ Describes the possible expectations for objects.
 
 ## Equality
 
-You can verify, that the `object` is equal to another one or not:
+You can verify that the `object` is equal to another one or not:
 
 ```csharp
 record MyClass(int Value);
@@ -18,7 +18,7 @@ await Expect.That(subject).IsNotEqualTo(new MyClass(2));
 
 ### Reference equality
 
-You can verify, that the `object` has the same reference as another one:
+You can verify that the `object` has the same reference as another one:
 
 ```csharp
 record MyClass(int Value);
@@ -32,7 +32,7 @@ await Expect.That(subject).IsNotSameAs(new MyClass(1));
 
 ### Custom comparer
 
-You can verify, that the `object` is equal to another one while using a custom `IEqualityComparer<object>`:
+You can verify that the `object` is equal to another one while using a custom `IEqualityComparer<object>`:
 
 ```csharp
 class MyClassComparer : IEqualityComparer<object>
@@ -49,7 +49,7 @@ await Expect.That(subject).IsEqualTo(new MyClass(2)).Using(new MyClassComparer()
 
 ## Equivalence
 
-You can verify, that the `object` is equivalent to another one or not:
+You can verify that the `object` is equivalent to another one or not:
 
 ```csharp
 class MyClass(int value)
@@ -66,7 +66,7 @@ await Expect.That(subject).IsNotEqualTo(new MyClass(2)).Equivalent();
 
 ## Type check
 
-You can verify, that the `object` is of a given type or not:
+You can verify that the `object` is of a given type or not:
 
 ```csharp
 object subject = new MyClass(1);
@@ -79,7 +79,7 @@ await Expect.That(subject).IsNot(typeof(OtherClass));
 
 This verifies, if the subject is of the given type or a derived type.
 
-You can also verify, that the `object` is only of the given type and not of a derived type:
+You can also verify that the `object` is only of the given type and not of a derived type:
 
 ```csharp
 object subject = new MyClass(1);
@@ -103,7 +103,7 @@ await Expect.That(new object()).IsNotNull();
 
 ## Satisfy
 
-You can verify, that any object satisfies a given predicate:
+You can verify that any object satisfies a given predicate:
 
 ```csharp
 object? subject = null;
@@ -111,7 +111,7 @@ object? subject = null;
 await Expect.That(subject).Satisfies(x => x == null);
 ```
 
-When the object changes in the background, you can also verify, that it satisfies a condition within a given time
+When the object changes in the background, you can also verify that it satisfies a condition within a given time
 period:
 
 ```csharp
@@ -126,7 +126,7 @@ await Expect.That(subject).Satisfies(x => x.IsTriggered == true).Within(2.Second
 
 ## Comply with
 
-You can verify, that any object complies with an expectation:
+You can verify that any object complies with an expectation:
 
 ```csharp
 List<int> values = new();
@@ -134,7 +134,7 @@ List<int> values = new();
 await Expect.That(values).CompliesWith(x => x.IsEmpty());
 ```
 
-When the object changes in the background, you can also verify, that it complies with an expectation within a given time
+When the object changes in the background, you can also verify that it complies with an expectation within a given time
 period:
 
 ```csharp

--- a/Docs/pages/docs/expectations/08-events.md
+++ b/Docs/pages/docs/expectations/08-events.md
@@ -28,7 +28,7 @@ IEventRecording<MyClass> recording = sut.Record().Events(nameof(MyClass.Threshol
 
 ## Triggering
 
-You can verify, that a recording recorded an event:
+You can verify that a recording recorded an event:
 
 ```csharp
 // Start the recording
@@ -87,7 +87,7 @@ await Expect.That(recording).Triggered(nameof(MyClass.ThresholdReached))
 
 ## Counting
 
-You can verify, that an event was recorded a specific number of times
+You can verify that an event was recorded a specific number of times
 
 ```csharp
 IEventRecording<MyClass> recording = sut.Record().Events();

--- a/Docs/pages/docs/expectations/10-timespan.md
+++ b/Docs/pages/docs/expectations/10-timespan.md
@@ -4,7 +4,7 @@ Describes the possible expectations for `TimeSpan`.
 
 ## Equality
 
-You can verify, that the `TimeSpan` is equal to another one or not:
+You can verify that the `TimeSpan` is equal to another one or not:
 
 ```csharp
 TimeSpan subject = TimeSpan.FromSeconds(42);
@@ -24,7 +24,7 @@ await Expect.That(subject).IsEqualTo(TimeSpan.FromSeconds(43)).Within(TimeSpan.F
 
 ## Greater than
 
-You can verify, that the `TimeSpan` is greater than (or equal to) another number:
+You can verify that the `TimeSpan` is greater than (or equal to) another number:
 
 ```csharp
 TimeSpan subject = TimeSpan.FromSeconds(42);
@@ -44,7 +44,7 @@ await Expect.That(subject).IsGreaterThan(42).Within(TimeSpan.FromSeconds(2))
 
 ## Less than
 
-You can verify, that the `TimeSpan` is less than (or equal to) another number:
+You can verify that the `TimeSpan` is less than (or equal to) another number:
 
 ```csharp
 TimeSpan subject = TimeSpan.FromSeconds(42);
@@ -64,7 +64,7 @@ await Expect.That(subject).IsLessThan(42).Within(TimeSpan.FromSeconds(2))
 
 ## Positive / negative
 
-You can verify, that the `TimeSpan` is positive or negative:
+You can verify that the `TimeSpan` is positive or negative:
 
 ```csharp
 await Expect.That(TimeSpan.FromSeconds(42)).IsPositive();

--- a/Docs/pages/docs/expectations/11-date-time-only.md
+++ b/Docs/pages/docs/expectations/11-date-time-only.md
@@ -4,7 +4,7 @@ Describes the possible expectations for `DateOnly` and `TimeOnly`.
 
 ## Equality
 
-You can verify, that the `DateOnly` or `TimeOnly` is equal to another one or not:
+You can verify that the `DateOnly` or `TimeOnly` is equal to another one or not:
 
 ```csharp
 DateOnly subjectA = new DateOnly(2024, 12, 24);
@@ -34,7 +34,7 @@ await Expect.That(subjectB).IsEqualTo(new TimeOnly(14, 15, 17)).Within(TimeSpan.
 
 ## After
 
-You can verify, that the `DateOnly` or `TimeOnly` is (on or) after another value
+You can verify that the `DateOnly` or `TimeOnly` is (on or) after another value
 
 ```csharp
 DateOnly subjectA = DateOnly.FromDateTime(DateTime.Now);
@@ -62,7 +62,7 @@ await Expect.That(subjectB).IsAfter(TimeOnly.FromDateTime(DateTime.Now)).Within(
 
 ## Before
 
-You can verify, that the `DateOnly` or `TimeOnly` is (on or) before another value
+You can verify that the `DateOnly` or `TimeOnly` is (on or) before another value
 
 ```csharp
 DateOnly subjectA = DateOnly.FromDateTime(DateTime.Now);

--- a/Docs/pages/docs/expectations/12-datetime-offset.md
+++ b/Docs/pages/docs/expectations/12-datetime-offset.md
@@ -4,7 +4,7 @@ Describes the possible expectations for `DateTime` and `DateTimeOffset`.
 
 ## Equality
 
-You can verify, that the `DateTime` or `DateTimeOffset` is equal to another one or not:
+You can verify that the `DateTime` or `DateTimeOffset` is equal to another one or not:
 
 ```csharp
 DateTime subject1 = new DateTime(2024, 12, 24);
@@ -32,7 +32,7 @@ await Expect.That(subject2).IsEqualTo(new DateTimeOffset(2024, 12, 24, 13, 5, 0,
 
 ## After
 
-You can verify, that the `DateTime` or `DateTimeOffset` is (on or) after another value:
+You can verify that the `DateTime` or `DateTimeOffset` is (on or) after another value:
 
 ```csharp
 DateTime subject1 = DateTime.Now;
@@ -57,7 +57,7 @@ await Expect.That(subject).IsAfter(DateTime.Now).Within(TimeSpan.FromSeconds(1))
 
 ## Before
 
-You can verify, that the `DateTime` or `DateTimeOffset` is (on or) before another value:
+You can verify that the `DateTime` or `DateTimeOffset` is (on or) before another value:
 
 ```csharp
 DateTime subject1 = DateTime.Now;

--- a/Docs/pages/docs/expectations/13-guid.md
+++ b/Docs/pages/docs/expectations/13-guid.md
@@ -4,7 +4,7 @@ Describes the possible expectations for `Guid` values.
 
 ## Equality
 
-You can verify, that the `Guid` is equal to another one or not:
+You can verify that the `Guid` is equal to another one or not:
 
 ```csharp
 Guid subject = Guid.Parse("5c01d9d2-66f7-4782-8c14-e54eae9aaacc");
@@ -17,7 +17,7 @@ await Expect.That(subject).IsNotEqualTo(Guid.Parse("cdd7a485-40a1-4bba-bb8b-d0e9
 
 ## Empty
 
-You can verify, that the `Guid` is empty or not:
+You can verify that the `Guid` is empty or not:
 
 ```csharp
 await Expect.That(Guid.Empty).IsEmpty();

--- a/Docs/pages/docs/expectations/advanced/03-callbacks.md
+++ b/Docs/pages/docs/expectations/advanced/03-callbacks.md
@@ -68,7 +68,7 @@ You can specify a number of times, that a callback must at least be signaled:
 await Expect.That(signaler).Signaled(3.Times());
 ```
 
-You can also verify, that the callback was not signaled at least the given number of times:
+You can also verify that the callback was not signaled at least the given number of times:
 
 ```csharp
 await Expect.That(signaler).DidNotSignal(3.Times());

--- a/Source/aweXpect/Options/PredicateOptions.cs
+++ b/Source/aweXpect/Options/PredicateOptions.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace aweXpect.Options;
+
+internal class PredicateOptions<TItem>
+{
+	private Func<TItem, bool>? _predicate;
+	private string? _predicateDescription;
+
+	public bool Matches(TItem item)
+		=> _predicate is null || _predicate(item);
+
+	internal void SetPredicate(Func<TItem, bool> predicate, string predicateDescription)
+	{
+		_predicate = predicate;
+		_predicateDescription = predicateDescription;
+	}
+
+	public string GetDescription()
+	{
+		if (_predicateDescription is null)
+		{
+			return "";
+		}
+
+		return _predicateDescription;
+	}
+}

--- a/Source/aweXpect/Results/SingleItemResult.cs
+++ b/Source/aweXpect/Results/SingleItemResult.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using aweXpect.Core;
+using aweXpect.Options;
 
 namespace aweXpect.Results;
 
@@ -15,11 +17,15 @@ public class SingleItemResult<TCollection, TItem>
 {
 	private readonly ExpectationBuilder _expectationBuilder;
 	private readonly Func<TCollection, TItem?> _memberAccessor;
+	private readonly PredicateOptions<TItem> _options;
 
-	internal SingleItemResult(ExpectationBuilder expectationBuilder, Func<TCollection, TItem?> memberAccessor)
+	internal SingleItemResult(ExpectationBuilder expectationBuilder,
+		PredicateOptions<TItem> options,
+		Func<TCollection, TItem?> memberAccessor)
 		: base(expectationBuilder)
 	{
 		_expectationBuilder = expectationBuilder;
+		_options = options;
 		_memberAccessor = memberAccessor;
 	}
 
@@ -30,17 +36,55 @@ public class SingleItemResult<TCollection, TItem>
 		=> new ThatSubject<TItem>(_expectationBuilder.ForWhich(_memberAccessor, " which "));
 
 	/// <summary>
+	///     …that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public SingleItemResult<TCollection, TItem> Matching(Func<TItem, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		_options.SetPredicate(predicate,
+			$" matching {doNotPopulateThisValue}");
+		return this;
+	}
+
+	/// <summary>
+	///     …of type <typeparamref name="T" />.
+	/// </summary>
+	public SingleItemResult<TCollection, TItem> Matching<T>()
+	{
+		_options.SetPredicate(item => item is T,
+			$" of type {Formatter.Format(typeof(T))}");
+		return this;
+	}
+
+	/// <summary>
+	///     …of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public SingleItemResult<TCollection, TItem> Matching<T>(Func<T, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		_options.SetPredicate(item => item is T typed && predicate(typed),
+			$" of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
+		return this;
+	}
+
+	/// <summary>
 	///     An <see cref="ExpectationResult" /> for a single item from an asynchronous collection.
 	/// </summary>
 	public class Async : ExpectationResult<TItem, Async>
 	{
 		private readonly Func<TCollection, Task<TItem?>> _asyncMemberAccessor;
 		private readonly ExpectationBuilder _expectationBuilder;
+		private readonly PredicateOptions<TItem> _options;
 
-		internal Async(ExpectationBuilder expectationBuilder, Func<TCollection, Task<TItem?>> asyncMemberAccessor)
+		internal Async(ExpectationBuilder expectationBuilder,
+			PredicateOptions<TItem> options,
+			Func<TCollection, Task<TItem?>> asyncMemberAccessor)
 			: base(expectationBuilder)
 		{
 			_expectationBuilder = expectationBuilder;
+			_options = options;
 			_asyncMemberAccessor = asyncMemberAccessor;
 		}
 
@@ -49,5 +93,39 @@ public class SingleItemResult<TCollection, TItem>
 		/// </summary>
 		public IThat<TItem> Which
 			=> new ThatSubject<TItem>(_expectationBuilder.ForWhich(_asyncMemberAccessor, " which "));
+
+		/// <summary>
+		///     …that satisfies the <paramref name="predicate" />.
+		/// </summary>
+		public Async Matching(Func<TItem, bool> predicate,
+			[CallerArgumentExpression("predicate")]
+			string doNotPopulateThisValue = "")
+		{
+			_options.SetPredicate(predicate,
+				$" matching {doNotPopulateThisValue}");
+			return this;
+		}
+
+		/// <summary>
+		///     …of type <typeparamref name="T" />.
+		/// </summary>
+		public Async Matching<T>()
+		{
+			_options.SetPredicate(item => item is T,
+				$" of type {Formatter.Format(typeof(T))}");
+			return this;
+		}
+
+		/// <summary>
+		///     …of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
+		/// </summary>
+		public Async Matching<T>(Func<T, bool> predicate,
+			[CallerArgumentExpression("predicate")]
+			string doNotPopulateThisValue = "")
+		{
+			_options.SetPredicate(item => item is T typed && predicate(typed),
+				$" of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
+			return this;
+		}
 	}
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -799,9 +799,15 @@ namespace aweXpect.Results
     public class SingleItemResult<TCollection, TItem> : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>>
     {
         public aweXpect.Core.IThat<TItem> Which { get; }
+        public aweXpect.Results.SingleItemResult<TCollection, TItem> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.SingleItemResult<TCollection, TItem> Matching<T>() { }
+        public aweXpect.Results.SingleItemResult<TCollection, TItem> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public class Async : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>.Async>
         {
             public aweXpect.Core.IThat<TItem> Which { get; }
+            public aweXpect.Results.SingleItemResult<TCollection, TItem>.Async Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+            public aweXpect.Results.SingleItemResult<TCollection, TItem>.Async Matching<T>() { }
+            public aweXpect.Results.SingleItemResult<TCollection, TItem>.Async Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }
     public class StringCollectionBeContainedInResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -857,9 +857,15 @@ namespace aweXpect.Results
     public class SingleItemResult<TCollection, TItem> : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>>
     {
         public aweXpect.Core.IThat<TItem> Which { get; }
+        public aweXpect.Results.SingleItemResult<TCollection, TItem> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.SingleItemResult<TCollection, TItem> Matching<T>() { }
+        public aweXpect.Results.SingleItemResult<TCollection, TItem> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public class Async : aweXpect.Results.ExpectationResult<TItem, aweXpect.Results.SingleItemResult<TCollection, TItem>.Async>
         {
             public aweXpect.Core.IThat<TItem> Which { get; }
+            public aweXpect.Results.SingleItemResult<TCollection, TItem>.Async Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+            public aweXpect.Results.SingleItemResult<TCollection, TItem>.Async Matching<T>() { }
+            public aweXpect.Results.SingleItemResult<TCollection, TItem>.Async Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
     }
     public class StringCollectionBeContainedInResult<TType, TThat> : aweXpect.Results.StringCollectionMatchResult<TType, TThat>

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
@@ -133,14 +133,8 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
-				IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers(x => new MyClass
-				{
-					Value = x,
-				}, 20);
-				MyClass expected = new()
-				{
-					Value = 1,
-				};
+				IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers(x => new MyClass(x), 20);
+				MyClass expected = new(1);
 
 				async Task Act()
 					=> await That(subject).Contains(expected).AtLeast(1).Equivalent();

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
@@ -65,38 +65,49 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not contain ThatAsyncEnumerable.MyClass {
+					             does not contain MyClass {
+					               StringValue = "",
 					               Value = 5
 					             } equivalent,
 					             but it contained it at least 1 times in [
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 2
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 3
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 5
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 8
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 13
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 21
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 34
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 55
 					               },
 					               …

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
@@ -57,10 +57,7 @@ public sealed partial class ThatAsyncEnumerable
 			public async Task ShouldSupportEquivalent()
 			{
 				IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers(x => new MyClass(x), 20);
-				MyClass unexpected = new()
-				{
-					Value = 5,
-				};
+				MyClass unexpected = new(5);
 
 				async Task Act()
 					=> await That(subject).DoesNotContain(unexpected).Equivalent();

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotEndWith.Tests.cs
@@ -58,24 +58,30 @@ public sealed partial class ThatAsyncEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not end with [ThatAsyncEnumerable.MyClass { Value = 3 }, ThatAsyncEnumerable.MyClass { Value = 5 }, ThatAsyncEnumerable.MyClass { Value = 8 }] equivalent,
+					             does not end with [MyClass { StringValue = "", Value = 3 }, MyClass { StringValue = "", Value = 5 }, MyClass { StringValue = "", Value = 8 }] equivalent,
 					             but it did end with [
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 2
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 3
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 5
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 8
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotStartWith.Tests.cs
@@ -67,13 +67,16 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             does not start with unexpected equivalent,
 					             but it did start with [
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatAsyncEnumerable.MyClass {
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 2
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
@@ -14,7 +14,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task ShouldReturnSingleItem()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([42,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(42);
 
 				int result = await That(subject).HasSingle();
 
@@ -24,7 +24,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenAsyncEnumerableContainsMoreThanOneElement_ShouldFail()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
 
 				async Task Act()
 					=> await That(subject).HasSingle();
@@ -40,7 +40,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenAsyncEnumerableContainsSingleElement_ShouldSucceed()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1);
 
 				int result = await That(subject).HasSingle();
 
@@ -80,12 +80,212 @@ public sealed partial class ThatAsyncEnumerable
 			}
 		}
 
+		public sealed class MatchingPredicateTests
+		{
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(x => x > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching x => x > 1,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldReturnSingleItem()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+				int result = await That(subject).HasSingle().Matching(x => x == 2);
+
+				await That(result).IsEqualTo(2);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(x => x > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching x => x > 1,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+				int result = await That(subject).HasSingle().Matching(x => x > 2);
+
+				await That(result).IsEqualTo(3);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(_ => true);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching _ => true,
+					             but it was empty
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(_ => false);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching _ => false,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class MatchingTypeTests
+		{
+			[Fact]
+			public async Task ShouldReturnSingleItem()
+			{
+				IAsyncEnumerable<MyBaseClass> subject =
+					ToAsyncEnumerable(new MyClass(1), new MyOtherClass(2), new MyBaseClass(3));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyOtherClass>();
+
+				await That(result.Value).IsEqualTo(2);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable<MyBaseClass>(
+					new MyClass(1), new MyOtherClass(2), new MyClass(3));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item of type MyClass,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable(
+					new MyClass(1), new MyOtherClass(2), new MyBaseClass(3));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyClass>();
+
+				await That(result.Value).IsEqualTo(1);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable<MyBaseClass>();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item of type MyClass,
+					             but it was empty
+					             """);
+			}
+		}
+
+		public sealed class MatchingTypePredicateTests
+		{
+			[Fact]
+			public async Task ShouldReturnSingleItem()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value == 2);
+
+				await That(result.Value).IsEqualTo(2);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(x => x.Value > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching x => x.Value > 1,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value > 2);
+
+				await That(result.Value).IsEqualTo(3);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([], x => new MyBaseClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(_ => true);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching _ => true,
+					             but it was empty
+					             """);
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]
 			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldSucceed()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(it => it.HasSingle());
@@ -96,7 +296,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsSingleElement_ShouldFail()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(it => it.HasSingle());
@@ -126,7 +326,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task ShouldReturnSingleItem()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([42,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(42);
 
 				int result = await That(subject).HasSingle().Which.IsGreaterThan(41).And
 					.IsLessThan(43);
@@ -137,7 +337,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenAsyncEnumerableContainsMoreThanOneElement_ShouldFail()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
 
 				async Task Act()
 					=> await That(subject).HasSingle().Which.IsGreaterThan(4);
@@ -169,7 +369,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenSingleItemDoesNotSatisfyExpectation_ShouldFail()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(3);
 
 				async Task Act()
 					=> await That(subject).HasSingle().Which.IsGreaterThan(4);
@@ -185,7 +385,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenSingleItemSatisfiesExpectation_ShouldSucceed()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(3);
 
 				async Task Act()
 					=> await That(subject).HasSingle().Which.IsGreaterThan(2);

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.cs
@@ -43,6 +43,15 @@ public partial class ThatAsyncEnumerable
 		}
 	}
 
+	public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(params T[] items)
+	{
+		foreach (T item in items)
+		{
+			await Task.Yield();
+			yield return item;
+		}
+	}
+
 	public static async IAsyncEnumerable<int> ToDelayedAsyncEnumerable(
 		int[] items,
 		[EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -101,11 +110,6 @@ public partial class ThatAsyncEnumerable
 		}
 
 		#endregion
-	}
-
-	public class MyClass(int value = 0)
-	{
-		public int Value { get; set; } = value;
 	}
 }
 #endif

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
@@ -169,14 +169,8 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
-				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass
-				{
-					Value = x,
-				});
-				MyClass expected = new()
-				{
-					Value = 1,
-				};
+				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x));
+				MyClass expected = new(1);
 
 				async Task Act()
 					=> await That(subject).Contains(expected).AtLeast(1).Equivalent();

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
@@ -55,14 +55,8 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task ShouldSupportEquivalent()
 			{
-				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass
-				{
-					Value = x,
-				});
-				MyClass unexpected = new()
-				{
-					Value = 5,
-				};
+				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x));
+				MyClass unexpected = new(5);
 
 				async Task Act()
 					=> await That(subject).DoesNotContain(unexpected).Equivalent();

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
@@ -64,49 +64,49 @@ public sealed partial class ThatEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not contain ThatEnumerable.MyClass {
-					               Inner = <null>,
+					             does not contain MyClass {
+					               StringValue = "",
 					               Value = 5
 					             },
 					             but it contained it at least 1 times in [
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 2
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 3
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 5
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 8
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 13
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 21
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 34
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 55
 					               },
 					               …

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotEndWith.Tests.cs
@@ -1,5 +1,4 @@
-﻿#if NET8_0_OR_GREATER
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Equivalency;
 
 // ReSharper disable PossibleMultipleEnumeration
@@ -57,18 +56,18 @@ public sealed partial class ThatEnumerable
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             does not end with [ThatEnumerable.MyClass { Inner = <null>, Value = 3 }, ThatEnumerable.MyClass { Inner = <null>, Value = 5 }, ThatEnumerable.MyClass { Inner = <null>, Value = 8 }] equivalent,
+					             does not end with [MyClass { StringValue = "", Value = 3 }, MyClass { StringValue = "", Value = 5 }, MyClass { StringValue = "", Value = 8 }] equivalent,
 					             but it did end with [
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 3
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 5
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 8
 					               }
 					             ]
@@ -187,4 +186,3 @@ public sealed partial class ThatEnumerable
 		}
 	}
 }
-#endif

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotStartWith.Tests.cs
@@ -66,16 +66,16 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             does not start with unexpected equivalent,
 					             but it did start with [
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 1
 					               },
-					               ThatEnumerable.MyClass {
-					                 Inner = <null>,
+					               MyClass {
+					                 StringValue = "",
 					                 Value = 2
 					               }
 					             ]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasSingle.Tests.cs
@@ -95,6 +95,206 @@ public sealed partial class ThatEnumerable
 			}
 		}
 
+		public sealed class MatchingPredicateTests
+		{
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(x => x > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching x => x > 1,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldReturnSingleItem()
+			{
+				IEnumerable<int> subject = ToEnumerable([1, 2, 3,]);
+
+				int result = await That(subject).HasSingle().Matching(x => x == 2);
+
+				await That(result).IsEqualTo(2);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+			{
+				IEnumerable<int> subject = ToEnumerable([1, 2, 3,]);
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(x => x > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching x => x > 1,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+			{
+				IEnumerable<int> subject = ToEnumerable([1, 2, 3,]);
+
+				int result = await That(subject).HasSingle().Matching(x => x > 2);
+
+				await That(result).IsEqualTo(3);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IEnumerable<int> subject = ToEnumerable(Array.Empty<int>());
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(_ => true);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching _ => true,
+					             but it was empty
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<string>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(_ => false);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching _ => false,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class MatchingTypeTests
+		{
+			[Fact]
+			public async Task ShouldReturnSingleItem()
+			{
+				IEnumerable<MyBaseClass> subject =
+					ToEnumerable(new MyClass(1), new MyOtherClass(2), new MyBaseClass(3));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyOtherClass>();
+
+				await That(result.Value).IsEqualTo(2);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>(
+					new MyClass(1), new MyOtherClass(2), new MyClass(3));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item of type MyClass,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable(
+					new MyClass(1), new MyOtherClass(2), new MyBaseClass(3));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyClass>();
+
+				await That(result.Value).IsEqualTo(1);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item of type MyClass,
+					             but it was empty
+					             """);
+			}
+		}
+
+		public sealed class MatchingTypePredicateTests
+		{
+			[Fact]
+			public async Task ShouldReturnSingleItem()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value == 2);
+
+				await That(result.Value).IsEqualTo(2);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(x => x.Value > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching x => x.Value > 1,
+					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value > 2);
+
+				await That(result.Value).IsEqualTo(3);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(_ => true);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item matching _ => true,
+					             but it was empty
+					             """);
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.cs
@@ -38,6 +38,14 @@ public partial class ThatEnumerable
 		}
 	}
 
+	public static IEnumerable<T> ToEnumerable<T>(params T[] items)
+	{
+		foreach (T item in items)
+		{
+			yield return item;
+		}
+	}
+
 	/// <summary>
 	///     Returns an <see cref="IEnumerable{T}" /> with incrementing numbers, starting with 0, which cancels the
 	///     <paramref name="cancellationTokenSource" /> after <paramref name="cancelAfter" /> iteration.
@@ -102,12 +110,6 @@ public partial class ThatEnumerable
 		}
 
 		#endregion
-	}
-
-	public class MyClass(int value = 0)
-	{
-		public InnerClass? Inner { get; set; }
-		public int Value { get; set; } = value;
 	}
 
 	public class InnerClass

--- a/Tests/aweXpect.Tests/TestHelpers/MyBaseClass.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/MyBaseClass.cs
@@ -1,0 +1,6 @@
+﻿namespace aweXpect.Tests;
+
+public class MyBaseClass(int value = 0)
+{
+	public int Value { get; } = value;
+}

--- a/Tests/aweXpect.Tests/TestHelpers/MyClass.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/MyClass.cs
@@ -1,0 +1,6 @@
+namespace aweXpect.Tests;
+
+public class MyClass(int value = 0, string stringValue = "") : MyBaseClass(value)
+{
+	public string StringValue { get; } = stringValue;
+}

--- a/Tests/aweXpect.Tests/TestHelpers/MyOtherClass.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/MyOtherClass.cs
@@ -1,0 +1,3 @@
+namespace aweXpect.Tests;
+
+public class MyOtherClass(int value = 0) : MyBaseClass(value);


### PR DESCRIPTION
You can now add filters for the items on `HasSingle`:

```csharp
IEnumerable<int> values = [1, 2, 3,];
await Expect.That(values).HasSingle().Matching(it => it > 2);

// Or with generic type:
IEnumerable<Person> persons = //...
await Expect.That(persons).HasSingle().Matching<Student>();
await Expect.That(persons).HasSingle().Matching<Student>(student => student.Courses.Count == 0);
```