### PR TITLE
fix: compare two `null` should succeed for `DateTime` and `TimeSpan`

### DIFF
--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsEqualTo.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsEqualTo.cs
@@ -58,7 +58,8 @@ public static partial class ThatNullableDateTime
 				tolerance.Tolerance ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
 			TimeSpan? difference = actual - expected;
 			_hasKindDifference = !AreKindCompatible(actual?.Kind, expected?.Kind);
-			Outcome = !_hasKindDifference && difference <= timeTolerance && difference >= timeTolerance.Negate()
+			Outcome = (actual is null && expected is null) ||
+			          (!_hasKindDifference && difference <= timeTolerance && difference >= timeTolerance.Negate())
 				? Outcome.Success
 				: Outcome.Failure;
 

--- a/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsEqualTo.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsEqualTo.cs
@@ -50,7 +50,10 @@ public static partial class ThatNullableTimeSpan
 		public ConstraintResult IsMetBy(TimeSpan? actual)
 		{
 			Actual = actual;
-			Outcome = IsWithinTolerance(tolerance.Tolerance, actual - expected) ? Outcome.Success : Outcome.Failure;
+			Outcome = (actual is null && expected is null) ||
+			          IsWithinTolerance(tolerance.Tolerance, actual - expected)
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsEqualTo.Tests.cs
@@ -8,6 +8,18 @@ public sealed partial class ThatBool
 		{
 			public sealed class Tests
 			{
+				[Fact]
+				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
+				{
+					bool? subject = null;
+					bool? expected = null;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
 				[Theory]
 				[InlineData(true, false)]
 				[InlineData(true, null)]

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotEqualTo.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatBool
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that subject
-						              is not {Formatter.Format(unexpected)},
+						              is not <null>,
 						              but it was <null>
 						              """);
 				}

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsEqualTo.Tests.cs
@@ -44,6 +44,18 @@ public sealed partial class ThatDateOnly
 				}
 
 				[Fact]
+				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
+				{
+					DateOnly? subject = null;
+					DateOnly? expected = null;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
 				public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
 				{
 					DateOnly? subject = null;

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotEqualTo.Tests.cs
@@ -34,7 +34,7 @@ public sealed partial class ThatDateOnly
 				}
 
 				[Fact]
-				public async Task WhenSubjectAndUnexpectedIsNull_ShouldFail()
+				public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
 				{
 					DateOnly? subject = null;
 					DateOnly? unexpected = null;

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsEqualTo.Tests.cs
@@ -9,6 +9,18 @@ public sealed partial class ThatDateTimeOffset
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
+				{
+					DateTimeOffset? subject = null;
+					DateTimeOffset? expected = null;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotEqualTo.Tests.cs
@@ -9,6 +9,23 @@ public sealed partial class ThatDateTimeOffset
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
+				{
+					DateTimeOffset? subject = null;
+					DateTimeOffset? unexpected = null;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not equal to <null>,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					DateTimeOffset? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsEqualTo.Tests.cs
@@ -77,6 +77,18 @@ public sealed partial class ThatDateTime
 				}
 
 				[Fact]
+				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
+				{
+					DateTime? subject = null;
+					DateTime? expected = null;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotEqualTo.Tests.cs
@@ -45,6 +45,23 @@ public sealed partial class ThatDateTime
 				}
 
 				[Fact]
+				public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
+				{
+					DateTime? subject = null;
+					DateTime? unexpected = null;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not equal to <null>,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					DateTime? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotEqualTo.Tests.cs
@@ -8,6 +8,23 @@ public sealed partial class ThatEnum
 		{
 			public sealed class Tests
 			{
+				[Fact]
+				public async Task ForLong_WhenSubjectAndUnexpectedAreNull_ShouldFail()
+				{
+					EnumLong? subject = null;
+					EnumLong? unexpected = null;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not <null>,
+						             but it was <null>
+						             """);
+				}
+
 				[Theory]
 				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
 				public async Task ForLong_WhenSubjectIsDifferent_ShouldSucceed(EnumLong? subject,
@@ -18,6 +35,7 @@ public sealed partial class ThatEnum
 
 					await That(Act).DoesNotThrow();
 				}
+
 
 				[Theory]
 				[InlineData(EnumLong.Int64Max)]

--- a/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsEqualTo.Tests.cs
@@ -12,9 +12,10 @@ public sealed partial class ThatGuid
 				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
 				{
 					Guid? subject = null;
+					Guid? expected = null;
 
 					async Task Act()
-						=> await That(subject).IsEqualTo(null);
+						=> await That(subject).IsEqualTo(expected);
 
 					await That(Act).DoesNotThrow();
 				}

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
@@ -417,6 +417,18 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 
+			[Fact]
+			public async Task ForNullableByte_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				byte? subject = null;
+				byte? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData((byte)1, (byte)2)]
 			[InlineData((byte)1, (byte)0)]
@@ -480,6 +492,18 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+			[Fact]
+			public async Task ForNullableDecimal_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				decimal? subject = null;
+				decimal? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
@@ -531,6 +555,18 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+			[Fact]
+			public async Task ForNullableDouble_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				double? subject = null;
+				double? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData(1.1, 2.1)]
 			[InlineData(1.1, 0.1)]
@@ -576,6 +612,18 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+			[Fact]
+			public async Task ForNullableFloat_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				float? subject = null;
+				float? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData((float)1.1, (float)2.1)]
 			[InlineData((float)1.1, (float)0.1)]
@@ -598,6 +646,18 @@ public sealed partial class ThatNumber
 			public async Task ForNullableFloat_WhenValueIsEqualToExpected_ShouldSucceed(
 				float? subject, float? expected)
 			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				int? subject = null;
+				int? expected = null;
+
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
 
@@ -671,6 +731,20 @@ public sealed partial class ThatNumber
 #endif
 
 #if NET8_0_OR_GREATER
+			[Fact]
+			public async Task ForNullableInt128_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				Int128? subject = null;
+				Int128? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
 			[Theory]
 			[InlineData(1, 2)]
 			[InlineData(2, 1)]
@@ -707,6 +781,18 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 #endif
+
+			[Fact]
+			public async Task ForNullableLong_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				long? subject = null;
+				long? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
 
 			[Theory]
 			[InlineData((long)1, (long)2)]
@@ -752,6 +838,18 @@ public sealed partial class ThatNumber
 					              is equal to {Formatter.Format(expected)},
 					              but it was <null>
 					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableSbyte_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				sbyte? subject = null;
+				sbyte? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Theory]
@@ -800,6 +898,18 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+			[Fact]
+			public async Task ForNullableShort_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				short? subject = null;
+				short? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData((short)1, (short)2)]
 			[InlineData((short)1, (short)0)]
@@ -844,6 +954,18 @@ public sealed partial class ThatNumber
 					              is equal to {Formatter.Format(expected)},
 					              but it was <null>
 					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableUint_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				uint? subject = null;
+				uint? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Theory]
@@ -892,6 +1014,18 @@ public sealed partial class ThatNumber
 					              """);
 			}
 
+			[Fact]
+			public async Task ForNullableUlong_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				ulong? subject = null;
+				ulong? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData((ulong)1, (ulong)2)]
 			[InlineData((ulong)1, (ulong)0)]
@@ -936,6 +1070,18 @@ public sealed partial class ThatNumber
 					              is equal to {Formatter.Format(expected)},
 					              but it was <null>
 					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableUshort_WhenValueAndExpectedAreNull_ShouldSucceed()
+			{
+				ushort? subject = null;
+				ushort? expected = null;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Theory]

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEqualTo.Tests.cs
@@ -38,7 +38,7 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
-			public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+			public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
 			{
 				MyClass? subject = null;
 				MyClass? expected = null;

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEqualTo.Tests.cs
@@ -55,6 +55,23 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
+			public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
+			{
+				MyClass? subject = null;
+				MyClass? unexpected = null;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equal to unexpected,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldSucceed()
 			{
 				MyClass? subject = null;

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsNotEqualTo.Tests.cs
@@ -7,13 +7,13 @@ public sealed partial class ThatString
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenActualAndExpectedAreNull_ShouldSucceed()
+			public async Task WhenActualAndUnunexpectedAreNull_ShouldSucceed()
 			{
 				string? subject = null;
-				string? expected = null;
+				string? ununexpected = null;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -27,22 +27,22 @@ public sealed partial class ThatString
 			public async Task WhenActualIsNull_ShouldSucceed()
 			{
 				string? subject = null;
-				string expected = "some text";
+				string ununexpected = "some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenExpectedIsNull_ShouldSucceed()
+			public async Task WhenUnunexpectedIsNull_ShouldSucceed()
 			{
 				string subject = "some text";
-				string? expected = null;
+				string? ununexpected = null;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -51,10 +51,10 @@ public sealed partial class ThatString
 			public async Task WhenStringHasMissingLeadingWhitespace_ShouldSucceed()
 			{
 				string subject = "some text";
-				string expected = " \t some text";
+				string ununexpected = " \t some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -63,34 +63,34 @@ public sealed partial class ThatString
 			public async Task WhenStringHasMissingTrailingWhitespace_ShouldSucceed()
 			{
 				string subject = "some text";
-				string expected = "some text \t ";
+				string ununexpected = "some text \t ";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenStringHasUnexpectedLeadingWhitespace_ShouldSucceed()
+			public async Task WhenStringHasUnunexpectedLeadingWhitespace_ShouldSucceed()
 			{
 				string subject = " \t some text";
-				string expected = "some text";
+				string ununexpected = "some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenStringHasUnexpectedTrailingWhitespace_ShouldSucceed()
+			public async Task WhenStringHasUnunexpectedTrailingWhitespace_ShouldSucceed()
 			{
 				string subject = "some text \t ";
-				string expected = "some text";
+				string ununexpected = "some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(ununexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -99,10 +99,10 @@ public sealed partial class ThatString
 			public async Task WhenStringIsLonger_ShouldSucceed()
 			{
 				string subject = "some text without out";
-				string expected = "some text with";
+				string unexpected = "some text with";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -111,10 +111,10 @@ public sealed partial class ThatString
 			public async Task WhenStringIsShorter_ShouldSucceed()
 			{
 				string subject = "some text with";
-				string expected = "some text without out";
+				string unexpected = "some text without out";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -123,10 +123,10 @@ public sealed partial class ThatString
 			public async Task WhenStringsAreTheSame_ShouldFail()
 			{
 				string subject = "foo";
-				string expected = subject;
+				string unexpected = subject;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -143,10 +143,10 @@ public sealed partial class ThatString
 			public async Task WhenStringsDiffer_ShouldSucceed()
 			{
 				string subject = "actual text";
-				string expected = "expected other text";
+				string unexpected = "unexpected other text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -161,15 +161,15 @@ public sealed partial class ThatString
 			[InlineAutoData("\r\nfoo", "foo")]
 			[InlineAutoData("foo", "\tfoo")]
 			public async Task WhenStringsDifferOnlyInLeadingWhiteSpace_ShouldSucceed(
-				string subject, string expected)
+				string subject, string unexpected)
 			{
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected).IgnoringLeadingWhiteSpace();
+					=> await That(subject).IsNotEqualTo(unexpected).IgnoringLeadingWhiteSpace();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not equal to "{expected.DisplayWhitespace()}" ignoring leading white-space,
+					              is not equal to "{unexpected.DisplayWhitespace()}" ignoring leading white-space,
 					              but it was "{subject.DisplayWhitespace()}"
 
 					              Actual:
@@ -188,15 +188,15 @@ public sealed partial class ThatString
 			[InlineAutoData("foo\r\nbar", "foo\nbar")]
 			[InlineAutoData("foo\r\nbar", "foo\rbar")]
 			public async Task WhenStringsDifferOnlyInNewlineStyle_ShouldSucceed(
-				string subject, string expected)
+				string subject, string unexpected)
 			{
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected).IgnoringNewlineStyle();
+					=> await That(subject).IsNotEqualTo(unexpected).IgnoringNewlineStyle();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not equal to "{expected.DisplayWhitespace()}" ignoring newline style,
+					              is not equal to "{unexpected.DisplayWhitespace()}" ignoring newline style,
 					              but it was "{subject.DisplayWhitespace()}"
 
 					              Actual:
@@ -214,15 +214,15 @@ public sealed partial class ThatString
 			[InlineAutoData("foo\r\n", "foo")]
 			[InlineAutoData("foo", "foo\t")]
 			public async Task WhenStringsDifferOnlyInTrailingWhiteSpace_ShouldFail(
-				string subject, string expected)
+				string subject, string unexpected)
 			{
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(expected).IgnoringTrailingWhiteSpace();
+					=> await That(subject).IsNotEqualTo(unexpected).IgnoringTrailingWhiteSpace();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is not equal to "{expected.DisplayWhitespace()}" ignoring trailing white-space,
+					              is not equal to "{unexpected.DisplayWhitespace()}" ignoring trailing white-space,
 					              but it was "{subject.DisplayWhitespace()}"
 
 					              Actual:

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsEqualTo.Tests.cs
@@ -44,7 +44,7 @@ public sealed partial class ThatTimeOnly
 				}
 
 				[Fact]
-				public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
+				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
 				{
 					TimeOnly? subject = null;
 					TimeOnly? expected = null;

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotEqualTo.Tests.cs
@@ -34,6 +34,23 @@ public sealed partial class ThatTimeOnly
 				}
 
 				[Fact]
+				public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
+				{
+					TimeOnly? subject = null;
+					TimeOnly? unexpected = null;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not equal to <null>,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
 				public async Task WhenSubjectAndUnexpectedIsNull_ShouldFail()
 				{
 					TimeOnly? subject = null;

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsEqualTo.Tests.cs
@@ -33,6 +33,18 @@ public sealed partial class ThatTimeSpan
 				}
 
 				[Fact]
+				public async Task WhenSubjectAndExpectedAreNull_ShouldSucceed()
+				{
+					TimeSpan? subject = null;
+					TimeSpan? expected = null;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					TimeSpan? subject = CurrentTime();

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotEqualTo.Tests.cs
@@ -45,6 +45,23 @@ public sealed partial class ThatTimeSpan
 				}
 
 				[Fact]
+				public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
+				{
+					TimeSpan? subject = null;
+					TimeSpan? unexpected = null;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not equal to <null>,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					TimeSpan? subject = CurrentTime();


### PR DESCRIPTION
When comparing two `null` values for equality they should succeed also for `DateTime?` and `TimeSpan?`.

Also add tests for more scenarios.