### PR TITLE
fix: format key and value of dictionaries correctly

### DIFF
--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Bool.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Bool.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -14,7 +14,7 @@ public static partial class ValueFormatters
 		=> value ? "True" : "False";
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -25,7 +25,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value ? "True" : "False");
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -41,7 +41,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Char.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Char.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -14,7 +14,7 @@ public static partial class ValueFormatters
 		=> $"'{value}'";
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -29,7 +29,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -45,7 +45,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -12,7 +12,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format<T>(
 		this ValueFormatter formatter,
@@ -25,7 +25,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -91,7 +91,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format<T>(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateOnly.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateOnly.cs
@@ -7,7 +7,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -16,7 +16,7 @@ public static partial class ValueFormatters
 		=> value.ToString("o");
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -27,7 +27,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value.ToString("o"));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -43,7 +43,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateTime.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateTime.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -15,7 +15,7 @@ public static partial class ValueFormatters
 		=> value.ToString("o");
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -26,7 +26,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value.ToString("o"));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -42,7 +42,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateTimeOffset.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateTimeOffset.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -15,7 +15,7 @@ public static partial class ValueFormatters
 		=> value.ToString("o");
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -26,7 +26,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value.ToString("o"));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -42,7 +42,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Enum.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Enum.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -22,7 +22,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Guid.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Guid.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -15,7 +15,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -26,7 +26,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -42,7 +42,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.HttpStatusCode.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.HttpStatusCode.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -22,7 +22,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
@@ -9,7 +9,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -18,7 +18,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -29,7 +29,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -45,7 +45,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -64,7 +64,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -73,7 +73,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -84,7 +84,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -100,7 +100,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -119,7 +119,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -128,7 +128,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -139,7 +139,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -155,7 +155,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -174,7 +174,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -183,7 +183,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -194,7 +194,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -210,7 +210,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -229,7 +229,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -238,7 +238,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -249,7 +249,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -265,7 +265,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -284,7 +284,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -293,7 +293,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -304,7 +304,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -320,7 +320,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -339,7 +339,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -348,7 +348,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -359,7 +359,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -375,7 +375,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -394,7 +394,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -403,7 +403,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -414,7 +414,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -430,7 +430,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -449,7 +449,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -463,7 +463,7 @@ public static partial class ValueFormatters
 		};
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -474,7 +474,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(Format(formatter, value, options));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -490,7 +490,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -509,7 +509,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -523,7 +523,7 @@ public static partial class ValueFormatters
 		};
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -534,7 +534,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(Format(formatter, value, options));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -550,7 +550,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -570,7 +570,7 @@ public static partial class ValueFormatters
 
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -593,7 +593,7 @@ public static partial class ValueFormatters
 
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -606,7 +606,7 @@ public static partial class ValueFormatters
 
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -624,7 +624,7 @@ public static partial class ValueFormatters
 
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -644,7 +644,7 @@ public static partial class ValueFormatters
 #endif
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -653,7 +653,7 @@ public static partial class ValueFormatters
 		=> value.ToString(CultureInfo.InvariantCulture);
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -664,7 +664,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value.ToString(CultureInfo.InvariantCulture));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -680,7 +680,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -699,7 +699,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -708,7 +708,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -719,7 +719,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -735,7 +735,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -754,7 +754,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -763,7 +763,7 @@ public static partial class ValueFormatters
 		=> value.ToString();
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -774,7 +774,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -790,7 +790,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.String.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.String.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -28,7 +28,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.TimeOnly.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.TimeOnly.cs
@@ -7,7 +7,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter _,
@@ -16,7 +16,7 @@ public static partial class ValueFormatters
 		=> value.ToString("o");
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -27,7 +27,7 @@ public static partial class ValueFormatters
 		=> stringBuilder.Append(value.ToString("o"));
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -43,7 +43,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.TimeSpan.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.TimeSpan.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Formatting;
 public static partial class ValueFormatters
 {
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -19,7 +19,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(
@@ -30,7 +30,7 @@ public static partial class ValueFormatters
 		=> Format(formatter, stringBuilder, (TimeSpan?)value, options);
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -46,7 +46,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
@@ -67,7 +67,7 @@ public static partial class ValueFormatters
 	};
 
 	/// <summary>
-	///     Returns the according to the <paramref name="options" /> formatted <paramref name="value" />.
+	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
 		this ValueFormatter formatter,
@@ -85,7 +85,7 @@ public static partial class ValueFormatters
 	}
 
 	/// <summary>
-	///     Appends the according to the <paramref name="options" /> formatted <paramref name="value" />
+	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
 	/// </summary>
 	public static void Format(

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -135,6 +136,19 @@ public static partial class ValueFormatters
 			case nuint nuintValue:
 				formatter.Format(stringBuilder, nuintValue, options);
 				return;
+		}
+
+		Type? valueType = value.GetType();
+		if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+		{
+			object? key = valueType.GetProperty("Key")?.GetValue(value);
+			object? item = valueType.GetProperty("Value")?.GetValue(value);
+			stringBuilder.Append('[');
+			Formatter.Format(stringBuilder, key, options);
+			stringBuilder.Append(", ");
+			Formatter.Format(stringBuilder, item, options);
+			stringBuilder.Append(']');
+			return;
 		}
 
 		FormatObject(stringBuilder, value,

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DictionaryTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DictionaryTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Core.Tests.Formatting;
+
+public partial class ValueFormatters
+{
+	public sealed class DictionaryFormatterTests
+	{
+		[Fact]
+		public async Task ShouldFormatItems()
+		{
+			string expectedResult = "[[\"1\", 1], [\"2\", 2], [\"3\", 3], [\"4\", 4]]";
+			Dictionary<string, int> value = Enumerable.Range(1, 4).ToDictionary(i => i.ToString(), i => i);
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task WhenNull_ShouldUseDefaultNullString()
+		{
+			Dictionary<int, object>? value = null;
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value!);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value!);
+
+			await That(result).IsEqualTo(ValueFormatter.NullString);
+			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
+			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
@@ -522,7 +522,7 @@ public sealed partial class ThatObject
 					             """);
 			}
 
-			[Fact]
+			[Fact(Skip="TODO: Re-enable after next core update")]
 			public async Task WhenSameEntriesInDifferentOrder_ShouldFail()
 			{
 				Dictionary<string, string> subject = new(StringComparer.OrdinalIgnoreCase)
@@ -553,8 +553,8 @@ public sealed partial class ThatObject
 					             Expected that subject
 					             is not equivalent to unexpected,
 					             but it was considered equivalent to [
-					               [A, A],
-					               [B, B]
+					               ["A", "A"],
+					               ["B", "B"]
 					             ]
 					             
 					             Equivalency options:


### PR DESCRIPTION
When formatting a dictionary, the key and value are not formatted themselves.

*Fixes #518*