### PR TITLE
feat: add `ExecutesIn` for delegates

### DIFF
--- a/Docs/pages/docs/expectations/05-delegates.md
+++ b/Docs/pages/docs/expectations/05-delegates.md
@@ -128,9 +128,25 @@ await Expect.That(Act).ThrowsException()
 
 ```
 
-## Execute within
+## Execution time
 
-You can verify that the delegate finishes execution in a specified amount of time
+You can verify that the execution time of a delegate:
+
+```csharp
+await Expect.That(Task.Delay(200)).ExecutesIn().AtMost(300.Milliseconds())
+  .Because("the delegate should execute faster than 300ms");
+await Expect.That(Task.Delay(200)).ExecutesIn().AtLeast(100.Milliseconds())
+  .Because("the delegate should execute slower than 100ms");
+await Expect.That(Task.Delay(200)).ExecutesIn().Approximately(200.Milliseconds(), 50.Milliseconds())
+  .Because("the delegate should execute within 200ms ± 50ms");
+await Expect.That(Task.Delay(200)).ExecutesIn().Between(100.Milliseconds()).And(300.Milliseconds())
+  .Because("the delegate should execute slower than 100ms and faster than 300ms");
+```
+
+### Execute within
+
+There is also a shorthand expectation for a delegate that finishes the execution without throwing an exception
+in (at most) a given time:
 
 ```csharp
 await Expect.That(Task.Delay(200)).ExecutesWithin(TimeSpan.FromMilliseconds(300))

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrow.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrow.cs
@@ -16,7 +16,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw any exception.
 		/// </summary>
-		public AndOrResult<T, WithValue<T>> DoesNotThrow()
+		public AndResult<T, WithValue<T>> DoesNotThrow()
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowConstraint(it, grammars, typeof(Exception))),
 				this);
@@ -24,7 +24,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
 		/// </summary>
-		public AndOrResult<T, WithValue<T>> DoesNotThrow<TException>()
+		public AndResult<T, WithValue<T>> DoesNotThrow<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowConstraint(it, grammars, typeof(TException))),
@@ -33,7 +33,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
-		public AndOrResult<T, WithValue<T>> DoesNotThrow(Type exceptionType)
+		public AndResult<T, WithValue<T>> DoesNotThrow(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowConstraint(it, grammars, exceptionType)),
 				this);

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrowExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrowExactly.cs
@@ -16,7 +16,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
 		/// </summary>
-		public AndOrResult<T, WithValue<T>> DoesNotThrowExactly<TException>()
+		public AndResult<T, WithValue<T>> DoesNotThrowExactly<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowExactlyConstraint(it, grammars, typeof(TException))),
@@ -25,7 +25,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
-		public AndOrResult<T, WithValue<T>> DoesNotThrowExactly(Type exceptionType)
+		public AndResult<T, WithValue<T>> DoesNotThrowExactly(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowExactlyConstraint(it, grammars, exceptionType)),
 				this);

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.ExecutesIn.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.ExecutesIn.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.Helpers;
+using aweXpect.Core.Sources;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Delegates;
+
+public abstract partial class ThatDelegate
+{
+	public sealed partial class WithValue<T>
+	{
+		/// <summary>
+		///     Verifies that the delegate executes in…
+		/// </summary>
+		public ExecutesInResult<AndResult<WithValue<T>>> ExecutesIn()
+		{
+			TimeSpanEqualityOptions options = new();
+			return new ExecutesInResult<AndResult<WithValue<T>>>(
+				new AndResult<WithValue<T>>(ExpectationBuilder.AddConstraint((it, grammars)
+						=> new ExecutesInConstraint(it, grammars, options)),
+					this),
+				options);
+		}
+
+		private sealed class ExecutesInConstraint(
+			string it,
+			ExpectationGrammars grammars,
+			TimeSpanEqualityOptions options)
+			: ConstraintResult(grammars),
+				IValueConstraint<DelegateValue<T>>
+		{
+			private DelegateValue<T>? _actual;
+
+			/// <inheritdoc />
+			public ConstraintResult IsMetBy(DelegateValue<T> value)
+			{
+				_actual = value;
+				if (value.IsNull)
+				{
+					Outcome = Outcome.Failure;
+					return this;
+				}
+
+				Outcome = options.IsWithinLimit(value.Duration) ? Outcome.Success : Outcome.Failure;
+				return this;
+			}
+
+			public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
+				=> stringBuilder.Append("executes in ").Append(options);
+
+			public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+			{
+				if (_actual?.IsNull != false)
+				{
+					stringBuilder.ItWasNull(it);
+				}
+				else
+				{
+					stringBuilder.Append(it).Append(" took ");
+					options.AppendFailureResult(stringBuilder, _actual.Duration);
+				}
+			}
+
+			public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+			{
+				if (_actual is { Value: TValue typedValue, })
+				{
+					value = typedValue;
+					return true;
+				}
+
+				value = default;
+				return typeof(TValue).IsAssignableFrom(typeof(T));
+			}
+
+			public override ConstraintResult Negate()
+				=> throw new NotSupportedException($"Negation of {nameof(ExecutesIn)} is not supported.");
+		}
+	}
+}

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrow.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrow.cs
@@ -16,7 +16,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw any exception.
 		/// </summary>
-		public AndOrResult<WithoutValue> DoesNotThrow()
+		public AndResult<WithoutValue> DoesNotThrow()
 			=> new(ExpectationBuilder.AddConstraint((it, grammars)
 					=> new DoesNotThrowConstraint(it, grammars, typeof(Exception))),
 				this);
@@ -24,7 +24,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
 		/// </summary>
-		public AndOrResult<WithoutValue> DoesNotThrow<TException>()
+		public AndResult<WithoutValue> DoesNotThrow<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowConstraint(it, grammars, typeof(TException))),
@@ -33,7 +33,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
-		public AndOrResult<WithoutValue> DoesNotThrow(Type exceptionType)
+		public AndResult<WithoutValue> DoesNotThrow(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowConstraint(it, grammars, exceptionType)),
 				this);

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrowExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrowExactly.cs
@@ -16,7 +16,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
 		/// </summary>
-		public AndOrResult<WithoutValue> DoesNotThrowExactly<TException>()
+		public AndResult<WithoutValue> DoesNotThrowExactly<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowExactlyConstraint(it, grammars, typeof(TException))),
@@ -25,7 +25,7 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
-		public AndOrResult<WithoutValue> DoesNotThrowExactly(Type exceptionType)
+		public AndResult<WithoutValue> DoesNotThrowExactly(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
 					new DoesNotThrowExactlyConstraint(it, grammars, exceptionType)),
 				this);

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.ExecutesIn.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.ExecutesIn.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.Helpers;
+using aweXpect.Core.Sources;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Delegates;
+
+public abstract partial class ThatDelegate
+{
+	public sealed partial class WithoutValue
+	{
+		/// <summary>
+		///     Verifies that the delegate executes in…
+		/// </summary>
+		public ExecutesInResult<AndResult<WithoutValue>> ExecutesIn()
+		{
+			TimeSpanEqualityOptions options = new();
+			return new ExecutesInResult<AndResult<WithoutValue>>(
+				new AndResult<WithoutValue>(ExpectationBuilder.AddConstraint((it, grammars)
+						=> new ExecutesInConstraint(it, grammars, options)),
+					this),
+				options);
+		}
+
+		private sealed class ExecutesInConstraint(
+			string it,
+			ExpectationGrammars grammars,
+			TimeSpanEqualityOptions options)
+			: ConstraintResult(grammars),
+				IValueConstraint<DelegateValue>
+		{
+			private DelegateValue? _actual;
+
+			/// <inheritdoc />
+			public ConstraintResult IsMetBy(DelegateValue value)
+			{
+				_actual = value;
+				if (value.IsNull)
+				{
+					Outcome = Outcome.Failure;
+					return this;
+				}
+
+				Outcome = options.IsWithinLimit(value.Duration) ? Outcome.Success : Outcome.Failure;
+				return this;
+			}
+
+			public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
+				=> stringBuilder.Append("executes in ").Append(options);
+
+			public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+			{
+				if (_actual?.IsNull != false)
+				{
+					stringBuilder.ItWasNull(it);
+				}
+				else
+				{
+					stringBuilder.Append(it).Append(" took ");
+					options.AppendFailureResult(stringBuilder, _actual.Duration);
+				}
+			}
+
+			public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+			{
+				value = default;
+				return false;
+			}
+
+			public override ConstraintResult Negate()
+				=> throw new NotSupportedException($"Negation of {nameof(ExecutesIn)} is not supported.");
+		}
+	}
+}

--- a/Source/aweXpect.Core/Options/TimeSpanEqualityOptions.cs
+++ b/Source/aweXpect.Core/Options/TimeSpanEqualityOptions.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Text;
+
+namespace aweXpect.Options;
+
+/// <summary>
+///     Equality options for <see langword="TimeSpan" />s.
+/// </summary>
+public class TimeSpanEqualityOptions
+{
+	private Limit? _limit;
+
+	/// <summary>
+	///     Verifies if the <paramref name="actual" /> value is within the required limit.
+	/// </summary>
+	/// <param name="actual"></param>
+	/// <returns></returns>
+	public bool IsWithinLimit(TimeSpan? actual)
+	{
+		if (actual is null || _limit is null)
+		{
+			return false;
+		}
+
+		return _limit.IsWithinLimit(actual.Value);
+	}
+
+	/// <summary>
+	///     Appends the failure result text of the <paramref name="actual" /> value to the <paramref name="stringBuilder" />.
+	/// </summary>
+	public void AppendFailureResult(StringBuilder stringBuilder, TimeSpan actual)
+		=> _limit?.AppendFailureResult(stringBuilder, actual);
+
+	/// <inheritdoc />
+	public override string ToString() => _limit?.ToString() ?? "<no limit specified>";
+
+	/// <summary>
+	///     Verifies that the value is at most <paramref name="maximum" />.
+	/// </summary>
+	public void AtMost(TimeSpan maximum)
+		=> _limit = new MaximumLimit(maximum);
+
+	/// <summary>
+	///     Verifies that the value is at least <paramref name="minimum" />.
+	/// </summary>
+	public void AtLeast(TimeSpan minimum)
+		=> _limit = new MinimumLimit(minimum);
+
+	/// <summary>
+	///     Verifies that the value is approximately <paramref name="expected" />,
+	///     using the provided <paramref name="tolerance" />.
+	/// </summary>
+	public void Approximately(TimeSpan expected, TimeSpan tolerance)
+	{
+		if (tolerance < TimeSpan.Zero)
+		{
+			throw new ArgumentOutOfRangeException(nameof(tolerance), tolerance, "The tolerance must not be negative.");
+		}
+
+		_limit = new ApproximatelyLimit(expected, tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the value is between <paramref name="minimum" /> and <paramref name="maximum" />.
+	/// </summary>
+	public void Between(TimeSpan minimum, TimeSpan maximum)
+		=> _limit = new BetweenLimit(minimum, maximum);
+
+	private abstract record Limit
+	{
+		public abstract bool IsWithinLimit(TimeSpan actual);
+
+		public virtual void AppendFailureResult(StringBuilder stringBuilder, TimeSpan actual)
+			=> Formatter.Format(stringBuilder, actual);
+	}
+
+	private record ApproximatelyLimit(TimeSpan Expected, TimeSpan Tolerance) : Limit
+	{
+		public override bool IsWithinLimit(TimeSpan actual)
+			=> actual >= Expected - Tolerance && actual <= Expected + Tolerance;
+
+		public override string ToString()
+			=> $"approximately {Formatter.Format(Expected)} ± {Formatter.Format(Tolerance)}";
+
+		public override void AppendFailureResult(StringBuilder stringBuilder, TimeSpan actual)
+		{
+			if (actual < Expected)
+			{
+				stringBuilder.Append("only ");
+			}
+
+			Formatter.Format(stringBuilder, actual);
+		}
+	}
+
+	private record BetweenLimit(TimeSpan Minimum, TimeSpan Maximum) : Limit
+	{
+		public override bool IsWithinLimit(TimeSpan actual)
+			=> actual >= Minimum && actual <= Maximum;
+
+		public override string ToString() => $"between {Formatter.Format(Minimum)} and {Formatter.Format(Maximum)}";
+
+		public override void AppendFailureResult(StringBuilder stringBuilder, TimeSpan actual)
+		{
+			if (actual < Minimum)
+			{
+				stringBuilder.Append("only ");
+			}
+
+			Formatter.Format(stringBuilder, actual);
+		}
+	}
+
+	private record MinimumLimit(TimeSpan Minimum) : Limit
+	{
+		public override bool IsWithinLimit(TimeSpan actual)
+			=> actual >= Minimum;
+
+		public override string ToString() => $"at least {Formatter.Format(Minimum)}";
+
+		public override void AppendFailureResult(StringBuilder stringBuilder, TimeSpan actual)
+		{
+			stringBuilder.Append("only ");
+			Formatter.Format(stringBuilder, actual);
+		}
+	}
+
+	private record MaximumLimit(TimeSpan Maximum) : Limit
+	{
+		public override bool IsWithinLimit(TimeSpan actual)
+			=> actual <= Maximum;
+
+		public override string ToString() => $"at most {Formatter.Format(Maximum)}";
+	}
+}

--- a/Source/aweXpect.Core/Results/AndResult.cs
+++ b/Source/aweXpect.Core/Results/AndResult.cs
@@ -1,0 +1,66 @@
+﻿using aweXpect.Core;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an expectation with no underlying value.
+///     <para />
+///     Allows combining multiple expectations with <see cref="And" />.
+/// </summary>
+public class AndResult<TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue)
+	: ExpectationResult(expectationBuilder)
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     … AND …
+	/// </summary>
+	public TThat And
+	{
+		get
+		{
+			_expectationBuilder.And();
+			return returnValue;
+		}
+	}
+}
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     Allows combining multiple expectations with <see cref="AndResult{TResult,TValue,TSelf}.And" />.
+/// </summary>
+public class AndResult<TType, TThat>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue)
+	: AndResult<TType, TThat, AndResult<TType, TThat>>(
+		expectationBuilder,
+		returnValue);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />.
+///     <para />
+///     Allows combining multiple expectations with <see cref="And" />.
+/// </summary>
+public class AndResult<TType, TThat, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue)
+	: ExpectationResult<TType, TSelf>(expectationBuilder)
+	where TSelf : AndResult<TType, TThat, TSelf>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     … AND …
+	/// </summary>
+	public TThat And
+	{
+		get
+		{
+			_expectationBuilder.And();
+			return returnValue;
+		}
+	}
+}

--- a/Source/aweXpect.Core/Results/ExecutesInResult.cs
+++ b/Source/aweXpect.Core/Results/ExecutesInResult.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an execution time expectation with no underlying value.
+/// </summary>
+public class ExecutesInResult<TResult>(
+	TResult returnValue,
+	TimeSpanEqualityOptions options)
+{
+	/// <summary>
+	///     …at most <paramref name="maximum" /> time.
+	/// </summary>
+	public TResult AtMost(TimeSpan maximum)
+	{
+		options.AtMost(maximum);
+		return returnValue;
+	}
+
+	/// <summary>
+	///     …at least <paramref name="minimum" /> time.
+	/// </summary>
+	public TResult AtLeast(TimeSpan minimum)
+	{
+		options.AtLeast(minimum);
+		return returnValue;
+	}
+
+	/// <summary>
+	///     …approximately the <paramref name="expected" /> time using the provided <paramref name="tolerance" />.
+	/// </summary>
+	public TResult Approximately(TimeSpan expected, TimeSpan tolerance)
+	{
+		options.Approximately(expected, tolerance);
+		return returnValue;
+	}
+
+	/// <summary>
+	///     …between <paramref name="minimum" />…
+	/// </summary>
+	public BetweenResult Between(TimeSpan minimum) => new(maximum =>
+	{
+		options.Between(minimum, maximum);
+		return returnValue;
+	});
+
+	/// <summary>
+	///     An intermediate type to collect the maximum of the time range.
+	/// </summary>
+	public class BetweenResult(
+		Func<TimeSpan, TResult> callback)
+	{
+		/// <summary>
+		///     …and <paramref name="maximum" /> time.
+		/// </summary>
+		public TResult And(TimeSpan maximum)
+			=> callback(maximum);
+	}
+}

--- a/Source/aweXpect/That/Delegates/ThatDelegate.ExecutesWithin.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegate.ExecutesWithin.cs
@@ -11,7 +11,8 @@ namespace aweXpect;
 public static partial class ThatDelegate
 {
 	/// <summary>
-	///     Verifies that the delegate finishes execution within the given <paramref name="duration" />.
+	///     Verifies that the delegate finishes execution within the given <paramref name="duration" />
+	///     without throwing an exception.
 	/// </summary>
 	public static ExpectationResult<TValue> ExecutesWithin<TValue>(
 		this IThat<Delegates.ThatDelegate.WithValue<TValue>> source,
@@ -20,7 +21,8 @@ public static partial class ThatDelegate
 			.AddConstraint((it, grammars) => new ExecutesWithinConstraint<TValue>(it, grammars, duration)));
 
 	/// <summary>
-	///     Verifies that the delegate finishes execution within the given <paramref name="duration" />.
+	///     Verifies that the delegate finishes execution within the given <paramref name="duration" />
+	///     without throwing an exception.
 	/// </summary>
 	public static ExpectationResult ExecutesWithin(
 		this IThat<Delegates.ThatDelegate.WithoutValue> source,
@@ -29,7 +31,8 @@ public static partial class ThatDelegate
 			.AddConstraint((it, grammars) => new ExecutesWithinConstraint(it, grammars, duration)));
 
 	/// <summary>
-	///     Verifies that the delegate does not finish execution within the given <paramref name="duration" />.
+	///     Verifies that the delegate does not finish execution within the given <paramref name="duration" />
+	///     or throws an exception.
 	/// </summary>
 	public static ExpectationResult<TValue> DoesNotExecuteWithin<TValue>(
 		this IThat<Delegates.ThatDelegate.WithValue<TValue>> source,
@@ -38,7 +41,8 @@ public static partial class ThatDelegate
 			.AddConstraint((it, grammars) => new ExecutesWithinConstraint<TValue>(it, grammars, duration).Invert()));
 
 	/// <summary>
-	///     Verifies that the delegate does not finish execution within the given <paramref name="duration" />.
+	///     Verifies that the delegate does not finish execution within the given <paramref name="duration" />
+	///     or throws an exception.
 	/// </summary>
 	public static ExpectationResult DoesNotExecuteWithin(
 		this IThat<Delegates.ThatDelegate.WithoutValue> source,

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -442,24 +442,26 @@ namespace aweXpect.Delegates
         public sealed class WithValue<T> : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>
         {
             public WithValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow() { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow<TException>()
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow() { }
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow<TException>()
                 where TException : System.Exception { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly<TException>()
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly<TException>()
                 where TException : System.Exception { }
+            public aweXpect.Results.ExecutesInResult<aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithValue<T>>> ExecutesIn() { }
         }
         public sealed class WithoutValue : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithoutValue>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithoutValue>
         {
             public WithoutValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow() { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow<TException>()
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow() { }
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow<TException>()
                 where TException : System.Exception { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly<TException>()
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly<TException>()
                 where TException : System.Exception { }
+            public aweXpect.Results.ExecutesInResult<aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue>> ExecutesIn() { }
         }
     }
     public class ThatDelegateThrows<TException> : aweXpect.Results.ExpectationResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>>, aweXpect.Core.IExpectThat<TException>, aweXpect.Core.IThatDelegateThrows<TException>, aweXpect.Core.IThat<TException>
@@ -814,6 +816,17 @@ namespace aweXpect.Options
         public override string ToString() { }
         public aweXpect.Options.StringEqualityOptions UsingComparer(System.Collections.Generic.IEqualityComparer<string>? comparer) { }
     }
+    public class TimeSpanEqualityOptions
+    {
+        public TimeSpanEqualityOptions() { }
+        public void AppendFailureResult(System.Text.StringBuilder stringBuilder, System.TimeSpan actual) { }
+        public void Approximately(System.TimeSpan expected, System.TimeSpan tolerance) { }
+        public void AtLeast(System.TimeSpan minimum) { }
+        public void AtMost(System.TimeSpan maximum) { }
+        public void Between(System.TimeSpan minimum, System.TimeSpan maximum) { }
+        public bool IsWithinLimit(System.TimeSpan? actual) { }
+        public override string ToString() { }
+    }
     public class TimeTolerance
     {
         public TimeTolerance() { }
@@ -902,6 +915,21 @@ namespace aweXpect.Results
             public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult AndWhose<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
         }
     }
+    public class AndResult<TThat> : aweXpect.Results.ExpectationResult
+    {
+        public AndResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+        public TThat And { get; }
+    }
+    public class AndResult<TType, TThat> : aweXpect.Results.AndResult<TType, TThat, aweXpect.Results.AndResult<TType, TThat>>
+    {
+        public AndResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+    }
+    public class AndResult<TType, TThat, TSelf> : aweXpect.Results.ExpectationResult<TType, TSelf>
+        where TSelf : aweXpect.Results.AndResult<TType, TThat, TSelf>
+    {
+        public AndResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+        public TThat And { get; }
+    }
     public class BetweenResult<TTarget>
     {
         public BetweenResult(System.Func<int, TTarget> callback) { }
@@ -926,6 +954,19 @@ namespace aweXpect.Results
         public TSelf Exactly(aweXpect.Times expected) { }
         public TSelf Never() { }
         public TSelf Once() { }
+    }
+    public class ExecutesInResult<TResult>
+    {
+        public ExecutesInResult(TResult returnValue, aweXpect.Options.TimeSpanEqualityOptions options) { }
+        public TResult Approximately(System.TimeSpan expected, System.TimeSpan tolerance) { }
+        public TResult AtLeast(System.TimeSpan minimum) { }
+        public TResult AtMost(System.TimeSpan maximum) { }
+        public aweXpect.Results.ExecutesInResult<TResult>.BetweenResult Between(System.TimeSpan minimum) { }
+        public class BetweenResult
+        {
+            public BetweenResult(System.Func<System.TimeSpan, TResult> callback) { }
+            public TResult And(System.TimeSpan maximum) { }
+        }
     }
     [System.Diagnostics.StackTraceHidden]
     public abstract class Expectation

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -442,24 +442,26 @@ namespace aweXpect.Delegates
         public sealed class WithValue<T> : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>
         {
             public WithValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow() { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow<TException>()
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow() { }
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrow<TException>()
                 where TException : System.Exception { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly<TException>()
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>> DoesNotThrowExactly<TException>()
                 where TException : System.Exception { }
+            public aweXpect.Results.ExecutesInResult<aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithValue<T>>> ExecutesIn() { }
         }
         public sealed class WithoutValue : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithoutValue>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithoutValue>
         {
             public WithoutValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow() { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow<TException>()
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow() { }
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow<TException>()
                 where TException : System.Exception { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly(System.Type exceptionType) { }
-            public aweXpect.Results.AndOrResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly<TException>()
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly(System.Type exceptionType) { }
+            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly<TException>()
                 where TException : System.Exception { }
+            public aweXpect.Results.ExecutesInResult<aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue>> ExecutesIn() { }
         }
     }
     public class ThatDelegateThrows<TException> : aweXpect.Results.ExpectationResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>>, aweXpect.Core.IExpectThat<TException>, aweXpect.Core.IThatDelegateThrows<TException>, aweXpect.Core.IThat<TException>
@@ -797,6 +799,17 @@ namespace aweXpect.Options
         public override string ToString() { }
         public aweXpect.Options.StringEqualityOptions UsingComparer(System.Collections.Generic.IEqualityComparer<string>? comparer) { }
     }
+    public class TimeSpanEqualityOptions
+    {
+        public TimeSpanEqualityOptions() { }
+        public void AppendFailureResult(System.Text.StringBuilder stringBuilder, System.TimeSpan actual) { }
+        public void Approximately(System.TimeSpan expected, System.TimeSpan tolerance) { }
+        public void AtLeast(System.TimeSpan minimum) { }
+        public void AtMost(System.TimeSpan maximum) { }
+        public void Between(System.TimeSpan minimum, System.TimeSpan maximum) { }
+        public bool IsWithinLimit(System.TimeSpan? actual) { }
+        public override string ToString() { }
+    }
     public class TimeTolerance
     {
         public TimeTolerance() { }
@@ -885,6 +898,21 @@ namespace aweXpect.Results
             public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult AndWhose<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
         }
     }
+    public class AndResult<TThat> : aweXpect.Results.ExpectationResult
+    {
+        public AndResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+        public TThat And { get; }
+    }
+    public class AndResult<TType, TThat> : aweXpect.Results.AndResult<TType, TThat, aweXpect.Results.AndResult<TType, TThat>>
+    {
+        public AndResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+    }
+    public class AndResult<TType, TThat, TSelf> : aweXpect.Results.ExpectationResult<TType, TSelf>
+        where TSelf : aweXpect.Results.AndResult<TType, TThat, TSelf>
+    {
+        public AndResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
+        public TThat And { get; }
+    }
     public class BetweenResult<TTarget>
     {
         public BetweenResult(System.Func<int, TTarget> callback) { }
@@ -909,6 +937,19 @@ namespace aweXpect.Results
         public TSelf Exactly(aweXpect.Times expected) { }
         public TSelf Never() { }
         public TSelf Once() { }
+    }
+    public class ExecutesInResult<TResult>
+    {
+        public ExecutesInResult(TResult returnValue, aweXpect.Options.TimeSpanEqualityOptions options) { }
+        public TResult Approximately(System.TimeSpan expected, System.TimeSpan tolerance) { }
+        public TResult AtLeast(System.TimeSpan minimum) { }
+        public TResult AtMost(System.TimeSpan maximum) { }
+        public aweXpect.Results.ExecutesInResult<TResult>.BetweenResult Between(System.TimeSpan minimum) { }
+        public class BetweenResult
+        {
+            public BetweenResult(System.Func<System.TimeSpan, TResult> callback) { }
+            public TResult And(System.TimeSpan maximum) { }
+        }
     }
     [System.Diagnostics.StackTraceHidden]
     public abstract class Expectation

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.ApproximatelyTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.ApproximatelyTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ExecutesIn
+	{
+		public sealed class ApproximatelyTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsTooFast_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(5); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().Approximately(5000.Milliseconds(), 1123.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in approximately 0:05 ± 0:01.123,
+					             but it took only 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLongEnough_ShouldSucceed()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().Approximately(50.Milliseconds(), 500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesTooLong_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().Approximately(10.Milliseconds(), 5.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in approximately 0:00.010 ± 0:00.005,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.AtLeastTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ExecutesIn
+	{
+		public sealed class AtLeastTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsTooFast_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(5); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtLeast(5123.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in at least 0:05.123,
+					             but it took only 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLongEnough_ShouldSucceed()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtLeast(10.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.AtMostTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ExecutesIn
+	{
+		public sealed class AtMostTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				Action @delegate = () => { };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.BetweenTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ExecutesIn
+	{
+		public sealed class BetweenTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsTooFast_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(5); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().Between(5123.Milliseconds()).And(6000.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in between 0:05.123 and 0:06,
+					             but it took only 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLongEnough_ShouldSucceed()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().Between(10.Milliseconds()).And(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesTooLong_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().Between(5.Milliseconds()).And(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in between 0:00.005 and 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ExecutesIn.Tests.cs
@@ -1,0 +1,615 @@
+﻿using System.Diagnostics;
+using System.Threading;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ExecutesIn
+	{
+		public sealed class ActionTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				Action @delegate = () => { };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Action @delegate = () => { Thread.Sleep(50); };
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				Action @delegate = () => throw new MyException();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Action? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class FuncTaskTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsCanceled_ShouldSucceed()
+			{
+				CancellationToken canceledToken = new(true);
+				Func<Task> @delegate = () => Task.FromCanceled(canceledToken);
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				Func<Task> @delegate = () => Task.CompletedTask;
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Func<Task> @delegate = () => Task.Delay(50.Milliseconds());
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				Func<Task> @delegate = () => Task.FromException(new MyException());
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<Task>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class FuncTaskValueTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsCanceled_ShouldSucceed()
+			{
+				CancellationToken canceledToken = new(true);
+				Func<Task<int>> @delegate = () => Task.FromCanceled<int>(canceledToken);
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				Func<Task<int>> @delegate = () => Task.FromResult(1);
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Func<Task<int>> @delegate = () => Task.Delay(50.Milliseconds()).ContinueWith(_ => 1);
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				Func<Task<int>> @delegate = () => Task.FromException<int>(new MyException());
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<Task<int>>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class FuncValueTaskTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				ValueTask Delegate() => new(Task.CompletedTask);
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask Delegate() => new(Task.Delay(50.Milliseconds()));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				ValueTask Delegate() => new(Task.FromException(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<ValueTask>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
+		public sealed class FuncCancellationTokenValueTaskTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsCanceled_ShouldSucceed()
+			{
+				CancellationToken canceledToken = new(true);
+
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.FromCanceled(canceledToken));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.CompletedTask);
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask Delegate(CancellationToken token) => new(Task.Delay(50.Milliseconds(), token));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				ValueTask Delegate(CancellationToken _)
+					=> new(Task.FromException(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<CancellationToken, ValueTask>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
+		public sealed class FuncValueTaskValueTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				ValueTask<int> Delegate() => new(Task.FromResult(1));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask<int> Delegate() => new(Task.Delay(50.Milliseconds()).ContinueWith(_ => 1));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				ValueTask<int> Delegate() => new(Task.FromException<int>(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<ValueTask<int>>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+#if NET8_0_OR_GREATER
+		public sealed class FuncCancellationTokenValueTaskValueTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsCanceled_ShouldSucceed()
+			{
+				CancellationToken canceledToken = new(true);
+
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromCanceled<int>(canceledToken));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromResult(1));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				ValueTask<int> Delegate(CancellationToken token)
+					=> new(Task.Delay(50.Milliseconds(), token).ContinueWith(_ => 1, token));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				ValueTask<int> Delegate(CancellationToken _)
+					=> new(Task.FromException<int>(new MyException()));
+
+				async Task Act()
+					=> await That(Delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<CancellationToken, ValueTask<int>>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+#endif
+
+		public sealed class FuncValueTests
+		{
+			[Fact]
+			public async Task WhenDelegateIsFastEnough_ShouldSucceed()
+			{
+				Func<int> @delegate = () => 0;
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(5000.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDelegateTakesLonger_ShouldFail()
+			{
+				Func<int> @delegate = () =>
+				{
+					Thread.Sleep(50);
+					return 0;
+				};
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that @delegate
+					             executes in at most 0:00.010,
+					             but it took 0:*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenDelegateThrowsAnException_ShouldSucceed()
+			{
+				Func<int> @delegate = () => throw new MyException();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				Func<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).ExecutesIn().AtMost(500.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             executes in at most 0:00.500,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class WithTimeoutTests
+		{
+			[Fact]
+			public async Task WithoutReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task> @delegate = token => Task.Delay(6.Seconds(), token);
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(50.Milliseconds()).WithTimeout(50.Milliseconds());
+
+				sw.Start();
+				await That(Act).Throws<XunitException>();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(5.Seconds());
+			}
+
+			[Fact]
+			public async Task WithReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task<int>> @delegate = async token =>
+				{
+					await Task.Delay(6.Seconds(), token);
+					return 1;
+				};
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(50.Milliseconds()).WithTimeout(50.Milliseconds());
+
+				sw.Start();
+				await That(Act).Throws<XunitException>();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(5.Seconds());
+			}
+		}
+
+		public sealed class WithCancellationTests
+		{
+			[Fact]
+			public async Task WithoutReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task> @delegate = token => Task.Delay(6.Seconds(), token);
+				CancellationToken cancelledToken = new(true);
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(50.Milliseconds()).WithCancellation(cancelledToken);
+
+				sw.Start();
+				await That(Act).DoesNotThrow();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(5.Seconds());
+			}
+
+			[Fact]
+			public async Task WithReturnValue_WhenTimeoutIsApplied_ShouldCancelTheCancellationToken()
+			{
+				Func<CancellationToken, Task<int>> @delegate = async token =>
+				{
+					await Task.Delay(6.Seconds(), token);
+					return 1;
+				};
+				CancellationToken cancelledToken = new(true);
+				Stopwatch sw = new();
+
+				async Task Act()
+					=> await That(@delegate).ExecutesIn().AtMost(50.Milliseconds()).WithCancellation(cancelledToken);
+
+				sw.Start();
+				await That(Act).DoesNotThrow();
+				sw.Stop();
+
+				await That(sw.Elapsed).IsLessThan(5.Seconds());
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds verification for the execution time of a delegate:

```csharp
await Expect.That(Task.Delay(200)).ExecutesIn().AtMost(300.Milliseconds())
  .Because("the delegate should execute faster than 300ms");
await Expect.That(Task.Delay(200)).ExecutesIn().AtLeast(100.Milliseconds())
  .Because("the delegate should execute slower than 100ms");
await Expect.That(Task.Delay(200)).ExecutesIn().Approximately(200.Milliseconds(), 50.Milliseconds())
  .Because("the delegate should execute within 200ms ± 50ms");
await Expect.That(Task.Delay(200)).ExecutesIn().Between(100.Milliseconds()).And(300.Milliseconds())
  .Because("the delegate should execute slower than 100ms and faster than 300ms");
```