### PR TITLE
fix: throw exception with message when `Equals` throws during equivalency check

### DIFF
--- a/Source/aweXpect.Core/Core/Polyfills/ReferenceEqualityComparer.cs
+++ b/Source/aweXpect.Core/Core/Polyfills/ReferenceEqualityComparer.cs
@@ -1,0 +1,61 @@
+﻿#if !NET8_0_OR_GREATER
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+// ReSharper disable once CheckNamespace
+namespace System.Collections.Generic
+{
+	/// <summary>
+	///     An <see cref="IEqualityComparer{Object}" /> that uses reference equality (
+	///     <see cref="object.ReferenceEquals(object?, object?)" />)
+	///     instead of value equality (<see cref="object.Equals(object?)" />) when comparing two object instances.
+	/// </summary>
+	/// <remarks>
+	///     The <see cref="ReferenceEqualityComparer" /> type cannot be instantiated. Instead, use the <see cref="Instance" />
+	///     property
+	///     to access the singleton instance of this type.
+	/// </remarks>
+	internal sealed class ReferenceEqualityComparer : IEqualityComparer<object?>, IEqualityComparer
+	{
+		private ReferenceEqualityComparer() { }
+
+		/// <summary>
+		///     Gets the singleton <see cref="ReferenceEqualityComparer" /> instance.
+		/// </summary>
+		public static ReferenceEqualityComparer Instance { get; } = new();
+
+		/// <summary>
+		///     Determines whether two object references refer to the same object instance.
+		/// </summary>
+		/// <param name="x">The first object to compare.</param>
+		/// <param name="y">The second object to compare.</param>
+		/// <returns>
+		///     <see langword="true" /> if both <paramref name="x" /> and <paramref name="y" /> refer to the same object instance
+		///     or if both are <see langword="null" />; otherwise, <see langword="false" />.
+		/// </returns>
+		/// <remarks>
+		///     This API is a wrapper around <see cref="object.ReferenceEquals(object?, object?)" />.
+		///     It is not necessarily equivalent to calling <see cref="object.Equals(object?, object?)" />.
+		/// </remarks>
+		public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+		/// <summary>
+		///     Returns a hash code for the specified object. The returned hash code is based on the object
+		///     identity, not on the contents of the object.
+		/// </summary>
+		/// <param name="obj">The object for which to retrieve the hash code.</param>
+		/// <returns>A hash code for the identity of <paramref name="obj" />.</returns>
+		/// <remarks>
+		///     This API is a wrapper around <see cref="RuntimeHelpers.GetHashCode(object)" />.
+		///     It is not necessarily equivalent to calling <see cref="object.GetHashCode()" />.
+		/// </remarks>
+		public int GetHashCode(object? obj) =>
+			// Depending on target framework, RuntimeHelpers.GetHashCode might not be annotated
+			// with the proper nullability attribute. We'll suppress any warning that might
+			// result.
+			RuntimeHelpers.GetHashCode(obj!);
+	}
+}
+#endif

--- a/Source/aweXpect.Core/Equivalency/EquivalencyComparison.Compare.cs
+++ b/Source/aweXpect.Core/Equivalency/EquivalencyComparison.Compare.cs
@@ -32,9 +32,18 @@ public static partial class EquivalencyComparison
 			return CompareByValue(actual, expected, failureBuilder, memberPath, memberType);
 		}
 
-		if (!context.ComparedObjects.Add(actual) || actual.Equals(expected))
+		try
 		{
-			return true;
+			if (!context.ComparedObjects.Add(actual) || actual.Equals(expected))
+			{
+				return true;
+			}
+		}
+		catch (Exception exception)
+		{
+			throw new InvalidOperationException(
+				$"The equals method of {Formatter.Format(actual.GetType())} threw an {Formatter.Format(exception.GetType())}: {exception.Message}",
+				exception);
 		}
 
 		if (actual is IDictionary actualDictionary && expected is IDictionary expectedDictionary)

--- a/Source/aweXpect.Core/Equivalency/EquivalencyComparison.cs
+++ b/Source/aweXpect.Core/Equivalency/EquivalencyComparison.cs
@@ -35,6 +35,6 @@ public static partial class EquivalencyComparison
 		/// <summary>
 		///     Tracks already compared objects to catch recursions.
 		/// </summary>
-		public HashSet<object> ComparedObjects { get; } = new();
+		public HashSet<object> ComparedObjects { get; } = new(ReferenceEqualityComparer.Instance);
 	}
 }


### PR DESCRIPTION
When an object overrides `Equals` and throws an exception, when using `IsEquivalentTo`, it should include this information in the thrown `InvalidOperationException`.