### PR TITLE
fix: also apply analyzer "aweXpect0001" when mixing with `Synchronously.Verify`

### DIFF
--- a/Source/aweXpect.Analyzers/AwaitExpectationAnalyzer.cs
+++ b/Source/aweXpect.Analyzers/AwaitExpectationAnalyzer.cs
@@ -53,24 +53,24 @@ public class AwaitExpectationAnalyzer : DiagnosticAnalyzer
 
 	private static bool IsAwaitedOrVerifyCalled(IInvocationOperation invocationOperation)
 	{
-		IOperation? parent = invocationOperation.Parent;
+		IOperation? operation = invocationOperation.Parent;
 
-		while (parent != null)
+		while (operation != null)
 		{
-			if (parent is IBlockOperation or IDelegateCreationOperation &&
-			    parent.SemanticModel != null)
+			if (operation.Parent is IBlockOperation or IDelegateCreationOperation &&
+			    operation.SemanticModel != null)
 			{
-				ExpressionSyntaxWalker walker = new(parent.SemanticModel);
-				walker.Visit(parent.Syntax);
+				ExpressionSyntaxWalker walker = new(operation.SemanticModel);
+				walker.Visit(operation.Syntax);
 				return walker.IsVerifyCalled;
 			}
 
-			if (parent is IAwaitOperation)
+			if (operation is IAwaitOperation)
 			{
 				return true;
 			}
 
-			parent = parent.Parent;
+			operation = operation.Parent;
 		}
 
 		return false;

--- a/Tests/aweXpect.Analyzers.Tests/AwaitExpectationAnalyzerTests.cs
+++ b/Tests/aweXpect.Analyzers.Tests/AwaitExpectationAnalyzerTests.cs
@@ -80,6 +80,26 @@ public class AwaitExpectationAnalyzerTests
 		);
 
 	[Fact]
+	public async Task WhenNotAwaited_WithoutReturnValue_WithVerifyInMethod_ShouldStillBeFlagged() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using System.Threading.Tasks;
+			using aweXpect;
+
+			public class MyClass
+			{
+			    public async Task MyTest()
+			    {
+			        aweXpect.Synchronous.Synchronously.Verify(Expect.That(true).IsTrue());
+			        {|#0:Expect.That(() => {})|}.DoesNotThrow();
+			    }
+			}
+			""",
+			Verifier.Diagnostic(Rules.AwaitExpectationRule)
+				.WithLocation(0)
+		);
+
+	[Fact]
 	public async Task WhenVerified_ShouldNotBeFlagged() => await Verifier
 		.VerifyAnalyzerAsync(
 			"""


### PR DESCRIPTION
When having a `Synchronously.Verify` call anywhere in the method, the await analyzer is currently no longer applied. It should only check if the `Synchronously.Verify` is applied to the current operation.