### PR TITLE
feat: add `Within` for event recording

### DIFF
--- a/Docs/pages/docs/expectations/08-events.md
+++ b/Docs/pages/docs/expectations/08-events.md
@@ -55,6 +55,27 @@ await Expect.That(recording).Triggered(nameof(MyClass.ThresholdReached))
   .WithParameter<ThresholdReachedEventArgs>(e => e.Threshold > 10);
 ```
 
+## Timeout
+
+You can specify a timeout within the expected events should be triggered:
+
+```csharp
+IEventRecording<MyClass> recording = sut.Record().Events();
+
+_ = Task.Delay(2.Seconds()).ContinueWith(_ => {
+    // Trigger the events in the background
+    sut.OnThresholdReached(new ThresholdReachedEventArgs(5));
+    sut.OnThresholdReached(new ThresholdReachedEventArgs(15));
+});
+
+await Expect.That(recording).Triggered(nameof(MyClass.ThresholdReached))
+  .WithParameter<ThresholdReachedEventArgs>(e => e.Threshold > 10)
+  .Within(3.Seconds());
+```
+
+The `.Within(TimeSpan)` method will wait up to 3 seconds for the expected events and
+finish successfully as soon as the events are triggered.
+
 ### Sender
 
 When you follow

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Recording/EventRecorder.cs
+++ b/Source/aweXpect.Core/Recording/EventRecorder.cs
@@ -3,6 +3,11 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading.Channels;
+#else
+using System.Threading;
+#endif
 
 namespace aweXpect.Recording;
 
@@ -10,8 +15,21 @@ internal sealed class EventRecorder(string eventName) : IDisposable
 {
 	private readonly ConcurrentQueue<RecordedEvent> _eventQueue = new();
 	private Action? _onDispose;
+#if NET8_0_OR_GREATER
+	private ChannelWriter<bool>? _channelWriter;
+#else
+	private ManualResetEventSlim? _ms;
+#endif
 
-	public void Dispose() => _onDispose?.Invoke();
+	public void Dispose()
+	{
+#if NET8_0_OR_GREATER
+		_channelWriter = null;
+#else
+		_ms = null;
+#endif
+		_onDispose?.Invoke();
+	}
 
 	public void Attach(WeakReference subject, EventInfo eventInfo)
 	{
@@ -52,19 +70,46 @@ internal sealed class EventRecorder(string eventName) : IDisposable
 	}
 
 	public void RecordEvent()
-		=> _eventQueue.Enqueue(new RecordedEvent(eventName));
+	{
+		_eventQueue.Enqueue(new RecordedEvent(eventName));
+		NotifyRecordedEvent();
+	}
 
 	public void RecordEvent<T1>(T1 parameter1)
-		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1));
+	{
+		_eventQueue.Enqueue(new RecordedEvent(eventName, parameter1));
+		NotifyRecordedEvent();
+	}
 
 	public void RecordEvent<T1, T2>(T1 parameter1, T2 parameter2)
-		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2));
+	{
+		_eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2));
+		NotifyRecordedEvent();
+	}
 
 	public void RecordEvent<T1, T2, T3>(T1 parameter1, T2 parameter2, T3 parameter3)
-		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2, parameter3));
+	{
+		_eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2, parameter3));
+		NotifyRecordedEvent();
+	}
 
 	public void RecordEvent<T1, T2, T3, T4>(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
-		=> _eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2, parameter3, parameter4));
+	{
+		_eventQueue.Enqueue(new RecordedEvent(eventName, parameter1, parameter2, parameter3, parameter4));
+		NotifyRecordedEvent();
+	}
+
+#if NET8_0_OR_GREATER
+	public void Register(ChannelWriter<bool> channel)
+		=> _channelWriter = channel;
+
+	private void NotifyRecordedEvent() => _channelWriter?.TryWrite(true);
+#else
+	public void Register(ManualResetEventSlim ms)
+		=> _ms = ms;
+
+	private void NotifyRecordedEvent() => _ms?.Set();
+#endif
 
 	/// <summary>
 	///     Returns a formatted string for all recorded events.

--- a/Source/aweXpect.Core/Recording/IEventRecording.cs
+++ b/Source/aweXpect.Core/Recording/IEventRecording.cs
@@ -1,4 +1,7 @@
-﻿namespace aweXpect.Recording;
+﻿using System;
+using System.Threading.Tasks;
+
+namespace aweXpect.Recording;
 
 /// <summary>
 ///     A recording of events on a subject of type <typeparamref name="TSubject" />.
@@ -7,8 +10,9 @@
 public interface IEventRecording<TSubject>
 {
 	/// <summary>
-	///     Stops the recording of events.
+	///     Stops the recording of events when checked events <see paramref="areFound" />
+	///     or the <paramref name="timeout" /> elapsed.
 	/// </summary>
-	IEventRecordingResult Stop();
+	Task<IEventRecordingResult> StopWhen(Func<IEventRecordingResult, bool> areFound, TimeSpan timeout);
 }
 #pragma warning restore S2326

--- a/Source/aweXpect/Results/EventTriggerResult.cs
+++ b/Source/aweXpect/Results/EventTriggerResult.cs
@@ -15,7 +15,8 @@ public class EventTriggerResult<TSubject>(
 	ExpectationBuilder expectationBuilder,
 	IThat<IEventRecording<TSubject>> returnValue,
 	TriggerEventFilter filter,
-	Quantifier quantifier)
+	Quantifier quantifier,
+	RepeatedCheckOptions options)
 	: CountResult<IEventRecording<TSubject>, IThat<IEventRecording<TSubject>>>(
 			expectationBuilder, returnValue, quantifier),
 		EventTriggerResult<TSubject>.IExtensions
@@ -103,6 +104,15 @@ public class EventTriggerResult<TSubject>(
 		return this;
 	}
 
+	/// <summary>
+	///     Allows a <paramref name="timeout" /> until the condition must be met.
+	/// </summary>
+	public EventTriggerResult<TSubject> Within(TimeSpan timeout)
+	{
+		options.Within(timeout);
+		return this;
+	}
+	
 	/// <summary>
 	///     Gives access to additional methods for extensions.
 	/// </summary>

--- a/Source/aweXpect/That/Recording/ThatEventRecording.Triggered.cs
+++ b/Source/aweXpect/That/Recording/ThatEventRecording.Triggered.cs
@@ -21,11 +21,13 @@ public static partial class ThatEventRecording
 	{
 		Quantifier quantifier = new();
 		TriggerEventFilter filter = new();
+		RepeatedCheckOptions options = new();
 		return new EventTriggerResult<TSubject>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HaveTriggeredConstraint<TSubject>(it, grammars, eventName, filter, quantifier)),
+				=> new HaveTriggeredConstraint<TSubject>(it, grammars, eventName, filter, quantifier, options)),
 			source,
 			filter,
-			quantifier);
+			quantifier,
+			options);
 	}
 }

--- a/Source/aweXpect/That/Recording/ThatEventRecording.TriggeredPropertyChanged.cs
+++ b/Source/aweXpect/That/Recording/ThatEventRecording.TriggeredPropertyChanged.cs
@@ -18,14 +18,17 @@ public static partial class ThatEventRecording
 	{
 		Quantifier quantifier = new();
 		TriggerEventFilter filter = new();
+		RepeatedCheckOptions options = new();
 		return new EventTriggerResult<TSubject>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveTriggeredConstraint<TSubject>(it, grammars, nameof(INotifyPropertyChanged.PropertyChanged),
 					filter,
-					quantifier)),
+					quantifier,
+					options)),
 			source,
 			filter,
-			quantifier);
+			quantifier,
+			options);
 	}
 
 	/// <summary>
@@ -38,13 +41,16 @@ public static partial class ThatEventRecording
 		Quantifier quantifier = new();
 		quantifier.Exactly(0);
 		TriggerEventFilter filter = new();
+		RepeatedCheckOptions options = new();
 		return new EventTriggerResult<TSubject>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveTriggeredConstraint<TSubject>(it, grammars, nameof(INotifyPropertyChanged.PropertyChanged),
 					filter,
-					quantifier)),
+					quantifier,
+					options)),
 			source,
 			filter,
-			quantifier);
+			quantifier,
+			options);
 	}
 }

--- a/Source/aweXpect/That/Recording/ThatEventRecording.TriggeredPropertyChangedFor.cs
+++ b/Source/aweXpect/That/Recording/ThatEventRecording.TriggeredPropertyChangedFor.cs
@@ -39,6 +39,7 @@ public static partial class ThatEventRecording
 	{
 		Quantifier quantifier = new();
 		TriggerEventFilter filter = new();
+		RepeatedCheckOptions options = new();
 		filter.AddPredicate(
 			o => o.Length > 1 && o[1] is PropertyChangedEventArgs m && m.PropertyName == propertyName,
 			$" for property {propertyName}");
@@ -46,10 +47,12 @@ public static partial class ThatEventRecording
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveTriggeredConstraint<TSubject>(it, grammars, nameof(INotifyPropertyChanged.PropertyChanged),
 					filter,
-					quantifier)),
+					quantifier,
+					options)),
 			source,
 			filter,
-			quantifier);
+			quantifier,
+			options);
 	}
 
 	/// <summary>
@@ -80,6 +83,7 @@ public static partial class ThatEventRecording
 		Quantifier quantifier = new();
 		quantifier.Exactly(0);
 		TriggerEventFilter filter = new();
+		RepeatedCheckOptions options = new();
 		filter.AddPredicate(
 			o => o.Length > 1 && o[1] is PropertyChangedEventArgs m && m.PropertyName == propertyName,
 			$" for property {propertyName}");
@@ -87,9 +91,11 @@ public static partial class ThatEventRecording
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveTriggeredConstraint<TSubject>(it, grammars, nameof(INotifyPropertyChanged.PropertyChanged),
 					filter,
-					quantifier)),
+					quantifier,
+					options)),
 			source,
 			filter,
-			quantifier);
+			quantifier,
+			options);
 	}
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -725,12 +725,13 @@ namespace aweXpect.Results
     public class EventTriggerResult<TSubject> : aweXpect.Results.CountResult<aweXpect.Recording.IEventRecording<TSubject>, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>>>, aweXpect.Results.EventTriggerResult<TSubject>.IExtensions
         where TSubject :  notnull
     {
-        public EventTriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>> returnValue, aweXpect.Options.TriggerEventFilter filter, aweXpect.Options.Quantifier quantifier) { }
+        public EventTriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>> returnValue, aweXpect.Options.TriggerEventFilter filter, aweXpect.Options.Quantifier quantifier, aweXpect.Options.RepeatedCheckOptions options) { }
         public aweXpect.Results.EventTriggerResult<TSubject> With<TEventArgs>(System.Func<TEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TEventArgs : System.EventArgs { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithSender(System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.EventTriggerResult<TSubject> Within(System.TimeSpan timeout) { }
         public interface IExtensions
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -782,12 +782,13 @@ namespace aweXpect.Results
     public class EventTriggerResult<TSubject> : aweXpect.Results.CountResult<aweXpect.Recording.IEventRecording<TSubject>, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>>>, aweXpect.Results.EventTriggerResult<TSubject>.IExtensions
         where TSubject :  notnull
     {
-        public EventTriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>> returnValue, aweXpect.Options.TriggerEventFilter filter, aweXpect.Options.Quantifier quantifier) { }
+        public EventTriggerResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Recording.IEventRecording<TSubject>> returnValue, aweXpect.Options.TriggerEventFilter filter, aweXpect.Options.Quantifier quantifier, aweXpect.Options.RepeatedCheckOptions options) { }
         public aweXpect.Results.EventTriggerResult<TSubject> With<TEventArgs>(System.Func<TEventArgs, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TEventArgs : System.EventArgs { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(int position, System.Func<TParameter, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.EventTriggerResult<TSubject> WithSender(System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.EventTriggerResult<TSubject> Within(System.TimeSpan timeout) { }
         public interface IExtensions
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -852,7 +852,7 @@ namespace aweXpect.Recording
     }
     public interface IEventRecording<TSubject>
     {
-        aweXpect.Recording.IEventRecordingResult Stop();
+        System.Threading.Tasks.Task<aweXpect.Recording.IEventRecordingResult> StopWhen(System.Func<aweXpect.Recording.IEventRecordingResult, bool> areFound, System.TimeSpan timeout);
     }
     public static class RecordExtensions
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -835,7 +835,7 @@ namespace aweXpect.Recording
     }
     public interface IEventRecording<TSubject>
     {
-        aweXpect.Recording.IEventRecordingResult Stop();
+        System.Threading.Tasks.Task<aweXpect.Recording.IEventRecordingResult> StopWhen(System.Func<aweXpect.Recording.IEventRecordingResult, bool> areFound, System.TimeSpan timeout);
     }
     public static class RecordExtensions
     {

--- a/Tests/aweXpect.Core.Tests/Recording/EventRecordingTests.cs
+++ b/Tests/aweXpect.Core.Tests/Recording/EventRecordingTests.cs
@@ -24,7 +24,7 @@ public sealed class EventRecordingTests
 		IEventRecording<CustomEventClass> recording = subject.Record().Events();
 		subject.NotifyCustomEvent(1);
 		subject.NotifyCustomEvent(2);
-		IEventRecordingResult result = recording.Stop();
+		IEventRecordingResult result = await recording.StopWhen(_ => false, TimeSpan.Zero);
 		subject.NotifyCustomEvent(3);
 
 		await That(result.GetEventCount(nameof(CustomEventClass.CustomEvent))).IsEqualTo(2);
@@ -39,7 +39,7 @@ public sealed class EventRecordingTests
 		subject.NotifyCustomEvent(1);
 		subject.NotifyCustomEvent(2);
 
-		IEventRecordingResult result = recording.Stop();
+		IEventRecordingResult result = await recording.StopWhen(_ => false, TimeSpan.Zero);
 
 		subject.NotifyCustomEvent(3);
 
@@ -52,9 +52,9 @@ public sealed class EventRecordingTests
 		CustomEventClass subject = new();
 
 		IEventRecording<CustomEventClass> recording = subject.Record().Events();
-		recording.Stop();
+		await recording.StopWhen(_ => false, TimeSpan.Zero);
 
-		await That(() => recording.Stop()).DoesNotThrow();
+		await That(() => recording.StopWhen(_ => false, TimeSpan.Zero)).DoesNotThrow();
 	}
 
 	private sealed class CustomEventClass

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -753,7 +753,7 @@ public sealed partial class ThatObject
 
 				await That(Act).Throws<InvalidOperationException>()
 					.WithMessage(
-						"*The equals method of ThatObject.IsEquivalentTo.PropertyTests.MyClassThrowingOnEqualsCheck threw an ArgumentNullException: Value cannot be null.*")
+						"*The equals method of ThatObject.IsEquivalentTo.PropertyTests.MyClassThrowingOnEqualsCheck threw an ArgumentNullException:*")
 					.AsWildcard();
 			}
 

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithinTests.cs
@@ -1,0 +1,234 @@
+﻿using aweXpect.Recording;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEventRecording
+{
+	public sealed partial class Triggered
+	{
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenEventWith1ParameterIsNotTriggeredWithinTimeout_ShouldFail()
+			{
+				CustomEventWithParametersClass<string> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo"));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+						.Within(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the CustomEvent event on sut at least once within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventWith1ParameterIsTriggeredWithinTimeout_ShouldSucceed()
+			{
+				CustomEventWithParametersClass<string> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo"));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+						.Within(5.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventWith2ParametersIsNotTriggeredWithinTimeout_ShouldFail()
+			{
+				CustomEventWithParametersClass<string, int> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string, int>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo", 1));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, int>.CustomEvent))
+						.Within(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the CustomEvent event on sut at least once within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventWith2ParametersIsTriggeredWithinTimeout_ShouldSucceed()
+			{
+				CustomEventWithParametersClass<string, int> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string, int>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo", 1));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, int>.CustomEvent))
+						.Within(5.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventWith3ParametersIsNotTriggeredWithinTimeout_ShouldFail()
+			{
+				CustomEventWithParametersClass<string, int, bool> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string, int, bool>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo", 1, true));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, int, bool>.CustomEvent))
+						.Within(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the CustomEvent event on sut at least once within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventWith3ParametersIsTriggeredWithinTimeout_ShouldSucceed()
+			{
+				CustomEventWithParametersClass<string, int, bool> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string, int, bool>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo", 1, true));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, int, bool>.CustomEvent))
+						.Within(5.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventWith4ParametersIsNotTriggeredWithinTimeout_ShouldFail()
+			{
+				CustomEventWithParametersClass<string, int, bool, DateTime> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string, int, bool, DateTime>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo", 1, true, DateTime.Now));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, int, bool, DateTime>.CustomEvent))
+						.Within(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the CustomEvent event on sut at least once within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventWith4ParametersIsTriggeredWithinTimeout_ShouldSucceed()
+			{
+				CustomEventWithParametersClass<string, int, bool, DateTime> sut = new();
+				IEventRecording<CustomEventWithParametersClass<string, int, bool, DateTime>> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent("foo", 1, true, DateTime.Now));
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithParametersClass<string, int, bool, DateTime>.CustomEvent))
+						.Within(5.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventWithoutParametersIsNotTriggeredWithinTimeout_ShouldFail()
+			{
+				CustomEventWithoutParametersClass sut = new();
+				IEventRecording<CustomEventWithoutParametersClass> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent());
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithoutParametersClass.CustomEvent))
+						.Within(10.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the CustomEvent event on sut at least once within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventWithoutParametersIsTriggeredWithinTimeout_ShouldSucceed()
+			{
+				CustomEventWithoutParametersClass sut = new();
+				IEventRecording<CustomEventWithoutParametersClass> recording =
+					sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ => sut.NotifyCustomEvent());
+
+				async Task Act() =>
+					await That(recording)
+						.Triggered(nameof(CustomEventWithoutParametersClass.CustomEvent))
+						.Within(5.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEventRecording<CustomEventWithoutParametersClass>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).Triggered(nameof(CustomEventWithoutParametersClass.CustomEvent))
+						.Within(4.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has recorded the CustomEvent event at least once within 0:04,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed class TriggeredPropertyChanged
+	public sealed partial class TriggeredPropertyChanged
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.WithinTests.cs
@@ -1,0 +1,79 @@
+﻿using aweXpect.Recording;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEventRecording
+{
+	public sealed partial class TriggeredPropertyChanged
+	{
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task TriggersPropertyChangedFor_WhenEventIsNotTriggeredOftenEnoughWithinTimeout_ShouldFail()
+			{
+				PropertyChangedClass sut = new();
+
+				IEventRecording<PropertyChangedClass> recording = sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ =>
+					{
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+					});
+
+				async Task Act() =>
+					await That(recording).TriggeredPropertyChanged()
+						.Within(10.Milliseconds())
+						.AtLeast(3.Times());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the PropertyChanged event on sut at least 3 times within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task TriggersPropertyChangedFor_WhenEventIsTriggeredOftenEnoughWithinTimeout_ShouldSucceed()
+			{
+				PropertyChangedClass sut = new();
+
+				IEventRecording<PropertyChangedClass> recording = sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ =>
+					{
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+					});
+
+				async Task Act() =>
+					await That(recording).TriggeredPropertyChanged()
+						.Within(5.Seconds())
+						.AtLeast(3.Times());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEventRecording<PropertyChangedClass>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).TriggeredPropertyChanged().Within(5671.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has recorded the PropertyChanged event at least once within 0:05.671,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatEventRecording
 {
-	public sealed class TriggeredPropertyChangedFor
+	public sealed partial class TriggeredPropertyChangedFor
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.WithinTests.cs
@@ -1,0 +1,79 @@
+﻿using aweXpect.Recording;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEventRecording
+{
+	public sealed partial class TriggeredPropertyChangedFor
+	{
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task TriggersPropertyChangedFor_WhenEventIsNotTriggeredOftenEnoughWithinTimeout_ShouldFail()
+			{
+				PropertyChangedClass sut = new();
+
+				IEventRecording<PropertyChangedClass> recording = sut.Record().Events();
+
+				_ = Task.Delay(2000.Milliseconds())
+					.ContinueWith(_ =>
+					{
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+					});
+
+				async Task Act() =>
+					await That(recording).TriggeredPropertyChangedFor(x => x.MyValue)
+						.Within(10.Milliseconds())
+						.AtLeast(3.Times());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that recording
+					             has recorded the PropertyChanged event on sut for property MyValue at least 3 times within 0:00.010,
+					             but it was never recorded in []
+					             """);
+			}
+
+			[Fact]
+			public async Task TriggersPropertyChangedFor_WhenEventIsTriggeredOftenEnoughWithinTimeout_ShouldSucceed()
+			{
+				PropertyChangedClass sut = new();
+
+				IEventRecording<PropertyChangedClass> recording = sut.Record().Events();
+
+				_ = Task.Delay(20.Milliseconds())
+					.ContinueWith(_ =>
+					{
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+						sut.NotifyPropertyChanged(nameof(PropertyChangedClass.MyValue));
+					});
+
+				async Task Act() =>
+					await That(recording).TriggeredPropertyChangedFor(x => x.MyValue)
+						.Within(5.Seconds())
+						.AtLeast(3.Times());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEventRecording<PropertyChangedClass>? subject = null;
+
+				async Task Act()
+					=> await That(subject!).TriggeredPropertyChangedFor(x => x.MyValue).Within(5678.Milliseconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has recorded the PropertyChanged event for property MyValue at least once within 0:05.678,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Timeout

You can specify a timeout within the expected events should be triggered:

```csharp
IEventRecording<MyClass> recording = sut.Record().Events();

_ = Task.Delay(2.Seconds()).ContinueWith(_ => {
    // Trigger the events in the background
    sut.OnThresholdReached(new ThresholdReachedEventArgs(5));
    sut.OnThresholdReached(new ThresholdReachedEventArgs(15));
});

await Expect.That(recording).Triggered(nameof(MyClass.ThresholdReached))
  .WithParameter<ThresholdReachedEventArgs>(e => e.Threshold > 10)
  .Within(3.Seconds());
```

The `.Within(TimeSpan)` method will wait up to 3 seconds for the expected events and finish successfully as soon as the events are triggered.

*Fixes #539*