### PR TITLE
feat: add `IsOneOf` expectations for `DateOnly` and `TimeOnly`

### DIFF
--- a/Docs/pages/docs/expectations/11-date-time-only.md
+++ b/Docs/pages/docs/expectations/11-date-time-only.md
@@ -32,6 +32,36 @@ await Expect.That(subjectB).IsEqualTo(new TimeOnly(14, 15, 17)).Within(TimeSpan.
   .Because("we accept values between 14:15:16 and 14:15:18");
 ```
 
+## One of
+
+You can verify that the `DateOnly` or `TimeOnly` is one of many alternatives:
+
+```csharp
+DateOnly subjectA = new DateOnly(2024, 12, 24);
+
+await Expect.That(subjectA).IsOneOf([new DateOnly(2024, 12, 23), new DateOnly(2024, 12, 24)]);
+await Expect.That(subjectA).IsNotOneOf([new DateOnly(2024, 12, 23), new DateOnly(2024, 12, 25)]);
+
+TimeOnly subjectB = new TimeOnly(14, 15, 16);
+
+await Expect.That(subjectB).IsOneOf([new TimeOnly(14, 15, 15), new TimeOnly(14, 15, 16)]);
+await Expect.That(subjectB).IsNotOneOf([new TimeOnly(13, 15, 16), new TimeOnly(13, 14, 15)]);
+```
+
+You can also specify a tolerance:
+
+```csharp
+DateOnly subjectA = new DateOnly(2024, 12, 24);
+
+await Expect.That(subjectA).IsOneOf([new DateOnly(2024, 12, 23)]).Within(TimeSpan.FromDays(1))
+  .Because("we accept values between 2024-12-22 and 2024-12-24");
+
+TimeOnly subjectB = new TimeOnly(14, 15, 16);
+
+await Expect.That(subjectB).IsOneOf([new TimeOnly(14, 15, 17)]).Within(TimeSpan.FromSeconds(1))
+  .Because("we accept values between 14:15:16 and 14:15:18");
+```
+
 ## After
 
 You can verify that the `DateOnly` or `TimeOnly` is (on or) after another value

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsOneOf.cs
@@ -1,0 +1,151 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatDateOnly
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> IsOneOf(
+		this IThat<DateOnly> source,
+		params DateOnly?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> IsOneOf(
+		this IThat<DateOnly> source,
+		IEnumerable<DateOnly> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected.Cast<DateOnly?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> IsOneOf(
+		this IThat<DateOnly> source,
+		IEnumerable<DateOnly?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> IsNotOneOf(
+		this IThat<DateOnly> source,
+		params DateOnly?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> IsNotOneOf(
+		this IThat<DateOnly> source,
+		IEnumerable<DateOnly> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<DateOnly?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly, IThat<DateOnly>> IsNotOneOf(
+		this IThat<DateOnly> source,
+		IEnumerable<DateOnly?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<DateOnly?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<DateOnly>(grammars),
+			IValueConstraint<DateOnly>
+	{
+		public ConstraintResult IsMetBy(DateOnly actual)
+		{
+			Actual = actual;
+			TimeSpan timeTolerance = tolerance.Tolerance ??
+			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+			Outcome = expected.Any(value =>
+				value != null && Math.Abs(actual.DayNumber - value.Value.DayNumber) <= (int)timeTolerance.TotalDays)
+				? Outcome.Success
+				: Outcome.Failure;
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsOneOf.cs
@@ -1,0 +1,159 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableDateOnly
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> IsOneOf(
+		this IThat<DateOnly?> source,
+		params DateOnly?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> IsOneOf(
+		this IThat<DateOnly?> source,
+		IEnumerable<DateOnly> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected.Cast<DateOnly?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> IsOneOf(
+		this IThat<DateOnly?> source,
+		IEnumerable<DateOnly?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> IsNotOneOf(
+		this IThat<DateOnly?> source,
+		params DateOnly?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> IsNotOneOf(
+		this IThat<DateOnly?> source,
+		IEnumerable<DateOnly> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<DateOnly?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateOnly?, IThat<DateOnly?>> IsNotOneOf(
+		this IThat<DateOnly?> source,
+		IEnumerable<DateOnly?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<DateOnly?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<DateOnly?>(grammars),
+			IValueConstraint<DateOnly?>
+	{
+		public ConstraintResult IsMetBy(DateOnly? actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance ??
+				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				Outcome = expected.Any(value =>
+					value != null &&
+					Math.Abs(actual.Value.DayNumber - value.Value.DayNumber) <= (int)timeTolerance.TotalDays)
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
@@ -50,7 +51,7 @@ public static partial class ThatNumber
 	/// </summary>
 	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsOneOf<TNumber>(
 		this IThat<TNumber> source,
-		params TNumber[] expected)
+		IEnumerable<TNumber> expected)
 		where TNumber : struct, INumber<TNumber>
 	{
 		NumberTolerance<TNumber> options = new(IsWithinTolerance);
@@ -66,13 +67,45 @@ public static partial class ThatNumber
 	/// </summary>
 	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsOneOf<TNumber>(
 		this IThat<TNumber?> source,
-		params TNumber[] expected)
+		IEnumerable<TNumber> expected)
 		where TNumber : struct, INumber<TNumber>
 	{
 		NumberTolerance<TNumber> options = new(IsWithinTolerance);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsOneOf<TNumber>(
+		this IThat<TNumber> source,
+		IEnumerable<TNumber?> expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsOneOf<TNumber>(
+		this IThat<TNumber?> source,
+		IEnumerable<TNumber?> expected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
 			source,
 			options);
 	}
@@ -114,7 +147,7 @@ public static partial class ThatNumber
 	/// </summary>
 	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsNotOneOf<TNumber>(
 		this IThat<TNumber> source,
-		params TNumber[] unexpected)
+		IEnumerable<TNumber> unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
 		NumberTolerance<TNumber> options = new(IsWithinTolerance);
@@ -130,7 +163,7 @@ public static partial class ThatNumber
 	/// </summary>
 	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsNotOneOf<TNumber>(
 		this IThat<TNumber?> source,
-		params TNumber[] unexpected)
+		IEnumerable<TNumber> unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
 		NumberTolerance<TNumber> options = new(IsWithinTolerance);
@@ -141,10 +174,42 @@ public static partial class ThatNumber
 			options);
 	}
 
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static NumberToleranceResult<TNumber, IThat<TNumber>> IsNotOneOf<TNumber>(
+		this IThat<TNumber> source,
+		IEnumerable<TNumber?> unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static NullableNumberToleranceResult<TNumber, IThat<TNumber?>> IsNotOneOf<TNumber>(
+		this IThat<TNumber?> source,
+		IEnumerable<TNumber?> unexpected)
+		where TNumber : struct, INumber<TNumber>
+	{
+		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
 	private sealed class IsOneOfConstraint<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		TNumber[] expected,
+		IEnumerable<TNumber> expected,
 		NumberTolerance<TNumber> options)
 		: ConstraintResult.WithValue<TNumber>(grammars),
 			IValueConstraint<TNumber>
@@ -184,7 +249,7 @@ public static partial class ThatNumber
 	private sealed class NullableIsOneOfConstraint<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		TNumber[] expected,
+		IEnumerable<TNumber> expected,
 		NumberTolerance<TNumber> options)
 		: ConstraintResult.WithValue<TNumber?>(grammars),
 			IValueConstraint<TNumber?>
@@ -224,7 +289,7 @@ public static partial class ThatNumber
 	private sealed class IsOneOfConstraintWithNullable<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		TNumber?[] expected,
+		IEnumerable<TNumber?> expected,
 		NumberTolerance<TNumber> options)
 		: ConstraintResult.WithValue<TNumber>(grammars),
 			IValueConstraint<TNumber>
@@ -264,7 +329,7 @@ public static partial class ThatNumber
 	private sealed class NullableIsOneOfConstraintWithNullable<TNumber>(
 		string it,
 		ExpectationGrammars grammars,
-		TNumber?[] expected,
+		IEnumerable<TNumber?> expected,
 		NumberTolerance<TNumber> options)
 		: ConstraintResult.WithValue<TNumber?>(grammars),
 			IValueConstraint<TNumber?>

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsOneOf.cs
@@ -1,0 +1,159 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableTimeOnly
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> IsOneOf(
+		this IThat<TimeOnly?> source,
+		params TimeOnly?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+	
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> IsOneOf(
+		this IThat<TimeOnly?> source,
+		IEnumerable<TimeOnly> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected.Cast<TimeOnly?>(), tolerance)),
+			source,
+			tolerance);
+	}
+	
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> IsOneOf(
+		this IThat<TimeOnly?> source,
+		IEnumerable<TimeOnly?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> IsNotOneOf(
+		this IThat<TimeOnly?> source,
+		params TimeOnly?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> IsNotOneOf(
+		this IThat<TimeOnly?> source,
+		IEnumerable<TimeOnly> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<TimeOnly?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>> IsNotOneOf(
+		this IThat<TimeOnly?> source,
+		IEnumerable<TimeOnly?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<TimeOnly?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<TimeOnly?>(grammars),
+			IValueConstraint<TimeOnly?>
+	{
+		public ConstraintResult IsMetBy(TimeOnly? actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance ??
+				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				Outcome = expected.Any(value =>
+					value != null &&
+					Math.Abs(actual.Value.Ticks - value.Value.Ticks) <= timeTolerance.Ticks)
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsOneOf.cs
@@ -1,0 +1,152 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatTimeOnly
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> IsOneOf(
+		this IThat<TimeOnly> source,
+		params TimeOnly?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+	
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> IsOneOf(
+		this IThat<TimeOnly> source,
+		IEnumerable<TimeOnly> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected.Cast<TimeOnly?>(), tolerance)),
+			source,
+			tolerance);
+	}
+	
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> IsOneOf(
+		this IThat<TimeOnly> source,
+		IEnumerable<TimeOnly?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> IsNotOneOf(
+		this IThat<TimeOnly> source,
+		params TimeOnly?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> IsNotOneOf(
+		this IThat<TimeOnly> source,
+		IEnumerable<TimeOnly> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<TimeOnly?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeOnly, IThat<TimeOnly>> IsNotOneOf(
+		this IThat<TimeOnly> source,
+		IEnumerable<TimeOnly?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<TimeOnly?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<TimeOnly?>(grammars),
+			IValueConstraint<TimeOnly>
+	{
+		public ConstraintResult IsMetBy(TimeOnly actual)
+		{
+			Actual = actual;
+			TimeSpan timeTolerance = tolerance.Tolerance ??
+			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+			Outcome = expected.Any(value =>
+				value != null &&
+				Math.Abs(actual.Ticks - value.Value.Ticks) <= timeTolerance.Ticks)
+				? Outcome.Success
+				: Outcome.Failure;
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -115,8 +115,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOneOf(this aweXpect.Core.IThat<System.DateOnly> source, System.Collections.Generic.IEnumerable<System.DateOnly> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOneOf(this aweXpect.Core.IThat<System.DateOnly> source, System.Collections.Generic.IEnumerable<System.DateOnly?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOneOf(this aweXpect.Core.IThat<System.DateOnly> source, params System.DateOnly?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsOneOf(this aweXpect.Core.IThat<System.DateOnly> source, System.Collections.Generic.IEnumerable<System.DateOnly> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsOneOf(this aweXpect.Core.IThat<System.DateOnly> source, System.Collections.Generic.IEnumerable<System.DateOnly?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsOneOf(this aweXpect.Core.IThat<System.DateOnly> source, params System.DateOnly?[] expected) { }
     }
     public static class ThatDateTime
     {
@@ -359,8 +365,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateOnly?> source, System.Collections.Generic.IEnumerable<System.DateOnly> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateOnly?> source, System.Collections.Generic.IEnumerable<System.DateOnly?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateOnly?> source, params System.DateOnly?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsOneOf(this aweXpect.Core.IThat<System.DateOnly?> source, System.Collections.Generic.IEnumerable<System.DateOnly> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsOneOf(this aweXpect.Core.IThat<System.DateOnly?> source, System.Collections.Generic.IEnumerable<System.DateOnly?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsOneOf(this aweXpect.Core.IThat<System.DateOnly?> source, params System.DateOnly?[] expected) { }
     }
     public static class ThatNullableDateTime
     {
@@ -444,8 +456,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeOnly?> source, System.Collections.Generic.IEnumerable<System.TimeOnly> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeOnly?> source, System.Collections.Generic.IEnumerable<System.TimeOnly?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeOnly?> source, params System.TimeOnly?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsOnOrBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsOneOf(this aweXpect.Core.IThat<System.TimeOnly?> source, System.Collections.Generic.IEnumerable<System.TimeOnly> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsOneOf(this aweXpect.Core.IThat<System.TimeOnly?> source, System.Collections.Generic.IEnumerable<System.TimeOnly?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsOneOf(this aweXpect.Core.IThat<System.TimeOnly?> source, params System.TimeOnly?[] expected) { }
     }
     public static class ThatNullableTimeSpan
     {
@@ -518,19 +536,27 @@ namespace aweXpect
             where TNumber :  struct, System.Numerics.IFloatingPoint<TNumber> { }
         public static aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>> IsNotNaN<TNumber>(this aweXpect.Core.IThat<TNumber?> source)
             where TNumber :  struct, System.Numerics.IFloatingPoint<TNumber> { }
-        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, params TNumber[] unexpected)
+        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, System.Collections.Generic.IEnumerable<TNumber> unexpected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, System.Collections.Generic.IEnumerable<TNumber?> unexpected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, params TNumber?[] unexpected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
-        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, params TNumber[] unexpected)
+        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, System.Collections.Generic.IEnumerable<TNumber> unexpected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, System.Collections.Generic.IEnumerable<TNumber?> unexpected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsNotOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, params TNumber?[] unexpected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
-        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, params TNumber[] expected)
+        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, System.Collections.Generic.IEnumerable<TNumber> expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, System.Collections.Generic.IEnumerable<TNumber?> expected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber> source, params TNumber?[] expected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
-        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, params TNumber[] expected)
+        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, System.Collections.Generic.IEnumerable<TNumber> expected)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, System.Collections.Generic.IEnumerable<TNumber?> expected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsOneOf<TNumber>(this aweXpect.Core.IThat<TNumber?> source, params TNumber?[] expected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
@@ -642,8 +668,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeOnly> source, System.Collections.Generic.IEnumerable<System.TimeOnly> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeOnly> source, System.Collections.Generic.IEnumerable<System.TimeOnly?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeOnly> source, params System.TimeOnly?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsOnOrBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsOneOf(this aweXpect.Core.IThat<System.TimeOnly> source, System.Collections.Generic.IEnumerable<System.TimeOnly> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsOneOf(this aweXpect.Core.IThat<System.TimeOnly> source, System.Collections.Generic.IEnumerable<System.TimeOnly?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsOneOf(this aweXpect.Core.IThat<System.TimeOnly> source, params System.TimeOnly?[] expected) { }
     }
     public static class ThatTimeSpan
     {

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotOneOf.Tests.cs
@@ -1,0 +1,82 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				IEnumerable<DateOnly?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				IEnumerable<DateOnly> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 2, false)]
+			[InlineData(5, 3, false)]
+			[InlineData(2, 2, true)]
+			[InlineData(0, 2, true)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				DateOnly subject = EarlierTime(actualDifference);
+				DateOnly[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected)
+						.Within(tolerance.Days())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsOneOf.Tests.cs
@@ -1,0 +1,87 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				IEnumerable<DateOnly?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				IEnumerable<DateOnly> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(3, 2, true)]
+			[InlineData(5, 3, true)]
+			[InlineData(2, 2, false)]
+			[InlineData(0, 2, false)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				DateOnly subject = EarlierTime(actualDifference);
+				DateOnly[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected)
+						.Within(tolerance.Days())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotOneOf.Tests.cs
@@ -1,0 +1,85 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					IEnumerable<DateOnly?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					IEnumerable<DateOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(3, 2, false)]
+				[InlineData(5, 3, false)]
+				[InlineData(2, 2, true)]
+				[InlineData(0, 2, true)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					DateOnly? subject = EarlierTime(actualDifference);
+					DateOnly?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected)
+							.Within(tolerance.Days())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsOneOf.Tests.cs
@@ -1,0 +1,90 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					IEnumerable<DateOnly?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					IEnumerable<DateOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(3, 2, true)]
+				[InlineData(5, 3, true)]
+				[InlineData(2, 2, false)]
+				[InlineData(0, 2, false)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					DateOnly? subject = EarlierTime(actualDifference);
+					DateOnly?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected)
+							.Within(tolerance.Days())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)} ± {tolerance} days, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
@@ -1,4 +1,9 @@
 ﻿using System.Linq;
+#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+#endif
 
 namespace aweXpect.Tests;
 
@@ -1014,6 +1019,25 @@ public sealed partial class ThatNumber
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task ShouldSupportEnumerable()
+			{
+				int subject = 2;
+				IEnumerable<int> unexpected = [1, 2, 3,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not one of [1, 2, 3],
+					             but it was 2
+					             """);
+			}
+#endif
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
@@ -1,4 +1,9 @@
 ﻿using System.Linq;
+#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+#endif
 
 namespace aweXpect.Tests;
 
@@ -866,6 +871,25 @@ public sealed partial class ThatNumber
 
 				await That(Act).DoesNotThrow();
 			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task ShouldSupportEnumerable()
+			{
+				int subject = 1;
+				IEnumerable<int> expected = [2, 3,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is one of [2, 3],
+					             but it was 1
+					             """);
+			}
+#endif
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotOneOf.Tests.cs
@@ -1,0 +1,82 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				IEnumerable<TimeOnly?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				IEnumerable<TimeOnly> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 2, false)]
+			[InlineData(5, 3, false)]
+			[InlineData(2, 2, true)]
+			[InlineData(0, 2, true)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				TimeOnly subject = EarlierTime(actualDifference);
+				TimeOnly[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsOneOf.Tests.cs
@@ -1,0 +1,87 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				IEnumerable<TimeOnly?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				IEnumerable<TimeOnly> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(3, 2, true)]
+			[InlineData(5, 3, true)]
+			[InlineData(2, 2, false)]
+			[InlineData(0, 2, false)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				TimeOnly subject = EarlierTime(actualDifference);
+				TimeOnly[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotOneOf.Tests.cs
@@ -1,0 +1,85 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					IEnumerable<TimeOnly?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					IEnumerable<TimeOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(3, 2, false)]
+				[InlineData(5, 3, false)]
+				[InlineData(2, 2, true)]
+				[InlineData(0, 2, true)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					TimeOnly? subject = EarlierTime(actualDifference);
+					TimeOnly?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsOneOf.Tests.cs
@@ -1,0 +1,90 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					IEnumerable<TimeOnly?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					IEnumerable<TimeOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(3, 2, true)]
+				[InlineData(5, 3, true)]
+				[InlineData(2, 2, false)]
+				[InlineData(0, 2, false)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					TimeOnly? subject = EarlierTime(actualDifference);
+					TimeOnly?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
## One of

You can verify that the `DateOnly` or `TimeOnly` is one of many alternatives:

```csharp
DateOnly subjectA = new DateOnly(2024, 12, 24);

await Expect.That(subjectA).IsOneOf([new DateOnly(2024, 12, 23), new DateOnly(2024, 12, 24)]);
await Expect.That(subjectA).IsNotOneOf([new DateOnly(2024, 12, 23), new DateOnly(2024, 12, 25)]);

TimeOnly subjectB = new TimeOnly(14, 15, 16);

await Expect.That(subjectB).IsOneOf([new TimeOnly(14, 15, 15), new TimeOnly(14, 15, 16)]);
await Expect.That(subjectB).IsNotOneOf([new TimeOnly(13, 15, 16), new TimeOnly(13, 14, 15)]);
```

You can also specify a tolerance:

```csharp
DateOnly subjectA = new DateOnly(2024, 12, 24);

await Expect.That(subjectA).IsOneOf([new DateOnly(2024, 12, 23)]).Within(TimeSpan.FromDays(1))
  .Because("we accept values between 2024-12-22 and 2024-12-24");

TimeOnly subjectB = new TimeOnly(14, 15, 16);

await Expect.That(subjectB).IsOneOf([new TimeOnly(14, 15, 17)]).Within(TimeSpan.FromSeconds(1))
  .Because("we accept values between 14:15:16 and 14:15:18");
```

*Implements #537 for `DateOnly` and `TimeOnly`*