### PR TITLE
feat: add `IsOneOf` expectations for `DateTime` and `DateTimeOffset`

### DIFF
--- a/Docs/pages/docs/expectations/12-datetime-offset.md
+++ b/Docs/pages/docs/expectations/12-datetime-offset.md
@@ -30,6 +30,36 @@ await Expect.That(subject2).IsEqualTo(new DateTimeOffset(2024, 12, 24, 13, 5, 0,
   .Because("we accept values between 2024-12-24T12:55:00+2:00 and 2024-12-24T13:15:00+2:00");
 ```
 
+## One of
+
+You can verify that the `DateTime` or `DateTimeOffset` is one of many alternatives:
+
+```csharp
+DateTime subjectA = new DateTime(2024, 12, 24);
+
+await Expect.That(subjectA).IsOneOf([new DateTime(2024, 12, 23), new DateTime(2024, 12, 24)]);
+await Expect.That(subjectA).IsNotOneOf([new DateTime(2022, 12, 24), new DateTime(2023, 12, 24)]);
+
+DateTimeOffset subject2 = new DateTimeOffset(2024, 12, 24, 13, 15, 0, TimeSpan.FromHours(2));
+
+await Expect.That(subjectB).IsOneOf([new DateTimeOffset(2024, 12, 24, 13, 5, 0, TimeSpan.FromHours(2)), new DateTimeOffset(2024, 12, 24, 13, 15, 0, TimeSpan.FromHours(2))]);
+await Expect.That(subjectB).IsNotOneOf([new DateTimeOffset(2024, 12, 24, 13, 5, 0, TimeSpan.FromHours(2)), new DateTimeOffset(2025, 12, 24, 13, 15, 0, TimeSpan.FromHours(3))]);
+```
+
+You can also specify a tolerance:
+
+```csharp
+DateTime subjectA = new DateTime(2024, 12, 24);
+
+await Expect.That(subjectA).IsOneOf([new DateTime(2024, 12, 23)]).Within(TimeSpan.FromDays(1))
+  .Because("we accept values between 2024-12-22 and 2024-12-24");
+
+DateTimeOffset subjectB = new DateTimeOffset(2024, 12, 24, 13, 15, 0, TimeSpan.FromHours(2));
+
+await Expect.That(subjectB).IsOneOf([new DateTimeOffset(2024, 12, 24, 13, 5, 0, TimeSpan.FromHours(2))]).Within(TimeSpan.FromMinutes(10))
+  .Because("we accept values between 2024-12-24T12:55:00+2:00 and 2024-12-24T13:15:00+2:00");
+```
+
 ## After
 
 You can verify that the `DateTime` or `DateTimeOffset` is (on or) after another value:

--- a/Source/aweXpect/That/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatDateTimeOffset
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> IsOneOf(
+		this IThat<DateTimeOffset> source,
+		params DateTimeOffset?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> IsOneOf(
+		this IThat<DateTimeOffset> source,
+		IEnumerable<DateTimeOffset> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected.Cast<DateTimeOffset?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> IsOneOf(
+		this IThat<DateTimeOffset> source,
+		IEnumerable<DateTimeOffset?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> IsNotOneOf(
+		this IThat<DateTimeOffset> source,
+		params DateTimeOffset?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> IsNotOneOf(
+		this IThat<DateTimeOffset> source,
+		IEnumerable<DateTimeOffset> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<DateTimeOffset?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>> IsNotOneOf(
+		this IThat<DateTimeOffset> source,
+		IEnumerable<DateTimeOffset?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset, IThat<DateTimeOffset>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<DateTimeOffset?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<DateTimeOffset>(grammars),
+			IValueConstraint<DateTimeOffset>
+	{
+		public ConstraintResult IsMetBy(DateTimeOffset actual)
+		{
+			Actual = actual;
+			TimeSpan timeTolerance = tolerance.Tolerance ??
+			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+			Outcome = expected.Any(value =>
+				value != null &&
+				actual - value.Value <= timeTolerance &&
+				actual - value.Value >= timeTolerance.Negate())
+				? Outcome.Success
+				: Outcome.Failure;
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsOneOf.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableDateTimeOffset
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> IsOneOf(
+		this IThat<DateTimeOffset?> source,
+		params DateTimeOffset?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> IsOneOf(
+		this IThat<DateTimeOffset?> source,
+		IEnumerable<DateTimeOffset> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected.Cast<DateTimeOffset?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> IsOneOf(
+		this IThat<DateTimeOffset?> source,
+		IEnumerable<DateTimeOffset?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> IsNotOneOf(
+		this IThat<DateTimeOffset?> source,
+		params DateTimeOffset?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> IsNotOneOf(
+		this IThat<DateTimeOffset?> source,
+		IEnumerable<DateTimeOffset> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<DateTimeOffset?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>> IsNotOneOf(
+		this IThat<DateTimeOffset?> source,
+		IEnumerable<DateTimeOffset?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTimeOffset?, IThat<DateTimeOffset?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<DateTimeOffset?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<DateTimeOffset?>(grammars),
+			IValueConstraint<DateTimeOffset?>
+	{
+		public ConstraintResult IsMetBy(DateTimeOffset? actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance ??
+				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				Outcome = expected.Any(value =>
+					value != null &&
+					actual.Value - value.Value <= timeTolerance &&
+					actual.Value - value.Value >= timeTolerance.Negate())
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect/That/DateTimes/ThatDateTime.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimes/ThatDateTime.IsOneOf.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatDateTime
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime, IThat<DateTime>> IsOneOf(
+		this IThat<DateTime> source,
+		params DateTime?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime, IThat<DateTime>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime, IThat<DateTime>> IsOneOf(
+		this IThat<DateTime> source,
+		IEnumerable<DateTime> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime, IThat<DateTime>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected.Cast<DateTime?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime, IThat<DateTime>> IsOneOf(
+		this IThat<DateTime> source,
+		IEnumerable<DateTime?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime, IThat<DateTime>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime, IThat<DateTime>> IsNotOneOf(
+		this IThat<DateTime> source,
+		params DateTime?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime, IThat<DateTime>> IsNotOneOf(
+		this IThat<DateTime> source,
+		IEnumerable<DateTime> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<DateTime?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime, IThat<DateTime>> IsNotOneOf(
+		this IThat<DateTime> source,
+		IEnumerable<DateTime?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime, IThat<DateTime>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<DateTime?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<DateTime>(grammars),
+			IValueConstraint<DateTime>
+	{
+		public ConstraintResult IsMetBy(DateTime actual)
+		{
+			Actual = actual;
+			TimeSpan timeTolerance = tolerance.Tolerance ??
+			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+			Outcome = expected.Any(value =>
+				value != null &&
+				actual - value.Value <= timeTolerance &&
+				actual - value.Value >= timeTolerance.Negate())
+				? Outcome.Success
+				: Outcome.Failure;
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsOneOf.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableDateTime
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> IsOneOf(
+		this IThat<DateTime?> source,
+		params DateTime?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> IsOneOf(
+		this IThat<DateTime?> source,
+		IEnumerable<DateTime> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected.Cast<DateTime?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> IsOneOf(
+		this IThat<DateTime?> source,
+		IEnumerable<DateTime?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> IsNotOneOf(
+		this IThat<DateTime?> source,
+		params DateTime?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> IsNotOneOf(
+		this IThat<DateTime?> source,
+		IEnumerable<DateTime> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<DateTime?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<DateTime?, IThat<DateTime?>> IsNotOneOf(
+		this IThat<DateTime?> source,
+		IEnumerable<DateTime?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<DateTime?, IThat<DateTime?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<DateTime?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<DateTime?>(grammars),
+			IValueConstraint<DateTime?>
+	{
+		public ConstraintResult IsMetBy(DateTime? actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance ??
+				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				Outcome = expected.Any(value =>
+					value != null &&
+					actual.Value - value.Value <= timeTolerance &&
+					actual.Value - value.Value >= timeTolerance.Negate())
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -142,8 +142,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime> source, params System.DateTime?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOneOf(this aweXpect.Core.IThat<System.DateTime> source, params System.DateTime?[] expected) { }
     }
     public static class ThatDateTimeOffset
     {
@@ -163,8 +169,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, params System.DateTimeOffset?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, params System.DateTimeOffset?[] expected) { }
     }
     public static class ThatDelegate
     {
@@ -392,8 +404,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime?> source, params System.DateTime?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOneOf(this aweXpect.Core.IThat<System.DateTime?> source, params System.DateTime?[] expected) { }
     }
     public static class ThatNullableDateTimeOffset
     {
@@ -413,8 +431,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, params System.DateTimeOffset?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, params System.DateTimeOffset?[] expected) { }
     }
     public static class ThatNullableEnum
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -43,8 +43,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime> source, params System.DateTime?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTime> source, System.DateTime? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOneOf(this aweXpect.Core.IThat<System.DateTime> source, System.Collections.Generic.IEnumerable<System.DateTime?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime, aweXpect.Core.IThat<System.DateTime>> IsOneOf(this aweXpect.Core.IThat<System.DateTime> source, params System.DateTime?[] expected) { }
     }
     public static class ThatDateTimeOffset
     {
@@ -64,8 +70,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, params System.DateTimeOffset?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.DateTimeOffset? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset, aweXpect.Core.IThat<System.DateTimeOffset>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset> source, params System.DateTimeOffset?[] expected) { }
     }
     public static class ThatDelegate
     {
@@ -271,8 +283,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTime?> source, params System.DateTime?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTime?> source, System.DateTime? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOneOf(this aweXpect.Core.IThat<System.DateTime?> source, System.Collections.Generic.IEnumerable<System.DateTime?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTime?, aweXpect.Core.IThat<System.DateTime?>> IsOneOf(this aweXpect.Core.IThat<System.DateTime?> source, params System.DateTime?[] expected) { }
     }
     public static class ThatNullableDateTimeOffset
     {
@@ -292,8 +310,14 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsNotOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, params System.DateTimeOffset?[] unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOnOrAfter(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOnOrBefore(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.DateTimeOffset? expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, System.Collections.Generic.IEnumerable<System.DateTimeOffset?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.DateTimeOffset?, aweXpect.Core.IThat<System.DateTimeOffset?>> IsOneOf(this aweXpect.Core.IThat<System.DateTimeOffset?> source, params System.DateTimeOffset?[] expected) { }
     }
     public static class ThatNullableEnum
     {

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsNotOneOf.Tests.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTimeOffset
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+			{
+				DateTimeOffset subject = CurrentTime();
+				IEnumerable<DateTimeOffset?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldFail()
+			{
+				DateTimeOffset subject = CurrentTime();
+				IEnumerable<DateTimeOffset> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed()
+			{
+				DateTimeOffset subject = CurrentTime();
+				DateTimeOffset[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 2, false)]
+			[InlineData(5, 3, false)]
+			[InlineData(2, 2, true)]
+			[InlineData(0, 2, true)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				DateTimeOffset subject = EarlierTime(actualDifference);
+				DateTimeOffset[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.Tests.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTimeOffset
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+			{
+				DateTimeOffset subject = CurrentTime();
+				IEnumerable<DateTimeOffset?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldSucceed()
+			{
+				DateTimeOffset subject = CurrentTime();
+				IEnumerable<DateTimeOffset> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldFail()
+			{
+				DateTimeOffset subject = CurrentTime();
+				DateTimeOffset[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(3, 2, true)]
+			[InlineData(5, 3, true)]
+			[InlineData(2, 2, false)]
+			[InlineData(0, 2, false)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				DateTimeOffset subject = EarlierTime(actualDifference);
+				DateTimeOffset[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotOneOf.Tests.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTimeOffset
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					IEnumerable<DateTimeOffset?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldFail()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					IEnumerable<DateTimeOffset?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					DateTimeOffset[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(3, 2, false)]
+				[InlineData(5, 3, false)]
+				[InlineData(2, 2, true)]
+				[InlineData(0, 2, true)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					DateTimeOffset? subject = EarlierTime(actualDifference);
+					DateTimeOffset?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsOneOf.Tests.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTimeOffset
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					IEnumerable<DateTimeOffset?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldSucceed()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					IEnumerable<DateTimeOffset?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldFail()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					DateTimeOffset[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(3, 2, true)]
+				[InlineData(5, 3, true)]
+				[InlineData(2, 2, false)]
+				[InlineData(0, 2, false)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					DateTimeOffset? subject = EarlierTime(actualDifference);
+					DateTimeOffset?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsNotOneOf.Tests.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+			{
+				DateTime subject = CurrentTime();
+				IEnumerable<DateTime?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldFail()
+			{
+				DateTime subject = CurrentTime();
+				IEnumerable<DateTime> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed()
+			{
+				DateTime subject = CurrentTime();
+				DateTime[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 2, false)]
+			[InlineData(5, 3, false)]
+			[InlineData(2, 2, true)]
+			[InlineData(0, 2, true)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				DateTime subject = EarlierTime(actualDifference);
+				DateTime[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsOneOf.Tests.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTime
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+			{
+				DateTime subject = CurrentTime();
+				IEnumerable<DateTime?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldSucceed()
+			{
+				DateTime subject = CurrentTime();
+				IEnumerable<DateTime> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldFail()
+			{
+				DateTime subject = CurrentTime();
+				DateTime[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(3, 2, true)]
+			[InlineData(5, 3, true)]
+			[InlineData(2, 2, false)]
+			[InlineData(0, 2, false)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				DateTime subject = EarlierTime(actualDifference);
+				DateTime[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsAfter.Tests.cs
@@ -127,7 +127,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime expected = EarlierTime(-3);
+					DateTime expected = EarlierTime(-3)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsAfter(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsBefore.Tests.cs
@@ -126,7 +126,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime expected = LaterTime(-3);
+					DateTime expected = LaterTime(-3)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsBefore(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsEqualTo.Tests.cs
@@ -28,7 +28,7 @@ public sealed partial class ThatDateTime
 				public async Task WhenNullableSubjectIsTheExpectedValue_ShouldSucceed()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime expected = CurrentTime();
+					DateTime expected = CurrentTime()!.Value;
 
 					async Task Act()
 						=> await That(subject).IsEqualTo(expected);

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotAfter.Tests.cs
@@ -112,7 +112,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime unexpected = EarlierTime(4);
+					DateTime unexpected = EarlierTime(4)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsNotAfter(unexpected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotBefore.Tests.cs
@@ -112,7 +112,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime unexpected = LaterTime(4);
+					DateTime unexpected = LaterTime(4)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsNotBefore(unexpected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOnOrAfter.Tests.cs
@@ -127,7 +127,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime unexpected = EarlierTime(4);
+					DateTime unexpected = EarlierTime(4)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsNotOnOrAfter(unexpected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOnOrBefore.Tests.cs
@@ -127,7 +127,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenUnexpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime unexpected = LaterTime(4);
+					DateTime unexpected = LaterTime(4)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsNotOnOrBefore(unexpected)
@@ -163,8 +163,8 @@ public sealed partial class ThatDateTime
 				[Fact]
 				public async Task Within_WhenValuesAreWithinTheTolerance_ShouldSucceed()
 				{
-					DateTime subject = EarlierTime(2);
-					DateTime unexpected = CurrentTime();
+					DateTime? subject = EarlierTime(2);
+					DateTime unexpected = CurrentTime()!.Value;
 
 					async Task Act()
 						=> await That(subject).IsNotOnOrBefore(unexpected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOneOf.Tests.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTime
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+				{
+					DateTime? subject = CurrentTime();
+					IEnumerable<DateTime?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldFail()
+				{
+					DateTime? subject = CurrentTime();
+					IEnumerable<DateTime?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed()
+				{
+					DateTime? subject = CurrentTime();
+					DateTime[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(3, 2, false)]
+				[InlineData(5, 3, false)]
+				[InlineData(2, 2, true)]
+				[InlineData(0, 2, true)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					DateTime? subject = EarlierTime(actualDifference);
+					DateTime?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOnOrAfter.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOnOrAfter.Tests.cs
@@ -111,7 +111,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime expected = EarlierTime(-4);
+					DateTime expected = EarlierTime(-4)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsOnOrAfter(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOnOrBefore.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOnOrBefore.Tests.cs
@@ -111,7 +111,7 @@ public sealed partial class ThatDateTime
 				public async Task Within_WhenExpectedValueIsOutsideTheTolerance_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime expected = LaterTime(-4);
+					DateTime expected = LaterTime(-4)!.Value;
 
 					async Task Act()
 						=> await That(subject).IsOnOrBefore(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOneOf.Tests.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateTime
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+				{
+					DateTime? subject = CurrentTime();
+					IEnumerable<DateTime?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldSucceed()
+				{
+					DateTime? subject = CurrentTime();
+					IEnumerable<DateTime?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldFail()
+				{
+					DateTime? subject = CurrentTime();
+					DateTime[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(3, 2, true)]
+				[InlineData(5, 3, true)]
+				[InlineData(2, 2, false)]
+				[InlineData(0, 2, false)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					DateTime? subject = EarlierTime(actualDifference);
+					DateTime?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.cs
@@ -11,13 +11,13 @@ public sealed partial class ThatDateTime
 		private static readonly Lazy<DateTime> CurrentTimeLazy = new(
 			() => DateTime.MinValue.AddSeconds(new Random().Next(100, 100000)));
 
-		private static DateTime CurrentTime()
+		private static DateTime? CurrentTime()
 			=> CurrentTimeLazy.Value;
 
-		private static DateTime EarlierTime(int seconds = 1)
-			=> CurrentTime().AddSeconds(-1 * seconds);
+		private static DateTime? EarlierTime(int seconds = 1)
+			=> CurrentTime()?.AddSeconds(-1 * seconds);
 
-		private static DateTime LaterTime(int seconds = 1)
-			=> CurrentTime().AddSeconds(seconds);
+		private static DateTime? LaterTime(int seconds = 1)
+			=> CurrentTime()?.AddSeconds(seconds);
 	}
 }


### PR DESCRIPTION
## One of

You can verify that the `DateTime` or `DateTimeOffset` is one of many alternatives:

```csharp
DateTime subjectA = new DateTime(2024, 12, 24);

await Expect.That(subjectA).IsOneOf([new DateTime(2024, 12, 23), new DateTime(2024, 12, 24)]);
await Expect.That(subjectA).IsNotOneOf([new DateTime(2022, 12, 24), new DateTime(2023, 12, 24)]);

DateTimeOffset subject2 = new DateTimeOffset(2024, 12, 24, 13, 15, 0, TimeSpan.FromHours(2));

await Expect.That(subjectB).IsOneOf([new DateTimeOffset(2024, 12, 24, 13, 5, 0, TimeSpan.FromHours(2)), new DateTimeOffset(2024, 12, 24, 13, 15, 0, TimeSpan.FromHours(2))]);
await Expect.That(subjectB).IsNotOneOf([new DateTimeOffset(2024, 12, 24, 13, 5, 0, TimeSpan.FromHours(2)), new DateTimeOffset(2025, 12, 24, 13, 15, 0, TimeSpan.FromHours(3))]);
```

You can also specify a tolerance:

```csharp
DateTime subjectA = new DateTime(2024, 12, 24);

await Expect.That(subjectA).IsOneOf([new DateTime(2024, 12, 23)]).Within(TimeSpan.FromDays(1))
  .Because("we accept values between 2024-12-22 and 2024-12-24");

DateTimeOffset subjectB = new DateTimeOffset(2024, 12, 24, 13, 15, 0, TimeSpan.FromHours(2));

await Expect.That(subjectB).IsOneOf([new DateTimeOffset(2024, 12, 24, 13, 5, 0, TimeSpan.FromHours(2))]).Within(TimeSpan.FromMinutes(10))
  .Because("we accept values between 2024-12-24T12:55:00+2:00 and 2024-12-24T13:15:00+2:00");
```