### PR TITLE
feat: add `IsOneOf` expectations for `TimeSpan`

### DIFF
--- a/Docs/pages/docs/expectations/10-timespan.md
+++ b/Docs/pages/docs/expectations/10-timespan.md
@@ -22,6 +22,26 @@ await Expect.That(subject).IsEqualTo(TimeSpan.FromSeconds(43)).Within(TimeSpan.F
   .Because("we accept values between 0:41 and 0:43");
 ```
 
+## One of
+
+You can verify that the `TimeSpan` is one of many alternatives:
+
+```csharp
+TimeSpan subject = TimeSpan.FromSeconds(42);
+
+await Expect.That(subject).IsOneOf([TimeSpan.FromSeconds(40), TimeSpan.FromSeconds(42)]);
+await Expect.That(subject).IsNotOneOf([TimeSpan.FromSeconds(41), TimeSpan.FromSeconds(43)]);
+```
+
+You can also specify a tolerance:
+
+```csharp
+TimeSpan subject = TimeSpan.FromSeconds(42);
+
+await Expect.That(subject).IsOneOf([TimeSpan.FromSeconds(43), TimeSpan.FromSeconds(45)]).Within(TimeSpan.FromSeconds(1))
+  .Because("we accept values between 0:41 and 0:43 or between 00:44 and 00:46");
+```
+
 ## Greater than
 
 You can verify that the `TimeSpan` is greater than (or equal to) another number:

--- a/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsOneOf.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableTimeSpan
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>> IsOneOf(
+		this IThat<TimeSpan?> source,
+		params TimeSpan?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>> IsOneOf(
+		this IThat<TimeSpan?> source,
+		IEnumerable<TimeSpan> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected.Cast<TimeSpan?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>> IsOneOf(
+		this IThat<TimeSpan?> source,
+		IEnumerable<TimeSpan?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>> IsNotOneOf(
+		this IThat<TimeSpan?> source,
+		params TimeSpan?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>> IsNotOneOf(
+		this IThat<TimeSpan?> source,
+		IEnumerable<TimeSpan> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<TimeSpan?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>> IsNotOneOf(
+		this IThat<TimeSpan?> source,
+		IEnumerable<TimeSpan?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<TimeSpan?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<TimeSpan?>(grammars),
+			IValueConstraint<TimeSpan?>
+	{
+		public ConstraintResult IsMetBy(TimeSpan? actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+			}
+			else
+			{
+				Outcome = expected.Any(value =>
+					value != null &&
+					IsWithinTolerance(tolerance.Tolerance, actual.Value - value.Value))
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsOneOf.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatTimeSpan
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan, IThat<TimeSpan>> IsOneOf(
+		this IThat<TimeSpan> source,
+		params TimeSpan?[] expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan, IThat<TimeSpan>> IsOneOf(
+		this IThat<TimeSpan> source,
+		IEnumerable<TimeSpan> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected.Cast<TimeSpan?>(), tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan, IThat<TimeSpan>> IsOneOf(
+		this IThat<TimeSpan> source,
+		IEnumerable<TimeSpan?> expected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, expected, tolerance)),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan, IThat<TimeSpan>> IsNotOneOf(
+		this IThat<TimeSpan> source,
+		params TimeSpan?[] unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan, IThat<TimeSpan>> IsNotOneOf(
+		this IThat<TimeSpan> source,
+		IEnumerable<TimeSpan> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected.Cast<TimeSpan?>(), tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static TimeToleranceResult<TimeSpan, IThat<TimeSpan>> IsNotOneOf(
+		this IThat<TimeSpan> source,
+		IEnumerable<TimeSpan?> unexpected)
+	{
+		TimeTolerance tolerance = new();
+		return new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint(it, grammars, unexpected, tolerance).Invert()),
+			source,
+			tolerance);
+	}
+
+	private sealed class IsOneOfConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<TimeSpan?> expected,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithValue<TimeSpan?>(grammars),
+			IValueConstraint<TimeSpan>
+	{
+		public ConstraintResult IsMetBy(TimeSpan actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(value =>
+				value != null &&
+				IsWithinTolerance(tolerance.Tolerance, actual - value.Value))
+				? Outcome.Success
+				: Outcome.Failure;
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -479,7 +479,13 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotLessThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotNegative(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, params System.TimeSpan?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotPositive(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, params System.TimeSpan?[] expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsPositive(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
     }
     public static class ThatNumber
@@ -691,7 +697,13 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotLessThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotNegative(this aweXpect.Core.IThat<System.TimeSpan> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, params System.TimeSpan?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotPositive(this aweXpect.Core.IThat<System.TimeSpan> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, params System.TimeSpan?[] expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsPositive(this aweXpect.Core.IThat<System.TimeSpan> source) { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -335,7 +335,13 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotLessThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotNegative(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, params System.TimeSpan?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotPositive(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan?> source, params System.TimeSpan?[] expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsPositive(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
     }
     public static class ThatNumber
@@ -716,7 +722,13 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotLessThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotNegative(this aweXpect.Core.IThat<System.TimeSpan> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> unexpected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, params System.TimeSpan?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotPositive(this aweXpect.Core.IThat<System.TimeSpan> source) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, System.Collections.Generic.IEnumerable<System.TimeSpan?> expected) { }
+        public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, params System.TimeSpan?[] expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsPositive(this aweXpect.Core.IThat<System.TimeSpan> source) { }
     }
 }

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotOneOf.Tests.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				IEnumerable<TimeSpan?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				IEnumerable<TimeSpan> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 2, false)]
+			[InlineData(5, 3, false)]
+			[InlineData(2, 2, true)]
+			[InlineData(0, 2, true)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				TimeSpan subject = EarlierTime(actualDifference);
+				TimeSpan[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsOneOf.Tests.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				IEnumerable<TimeSpan?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsContained_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				IEnumerable<TimeSpan> expected = [LaterTime(), subject, EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsDifferent_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan[] expected = [LaterTime(), EarlierTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(3, 2, true)]
+			[InlineData(5, 3, true)]
+			[InlineData(2, 2, false)]
+			[InlineData(0, 2, false)]
+			public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+				int actualDifference, int tolerance, bool expectToThrow)
+			{
+				TimeSpan subject = EarlierTime(actualDifference);
+				TimeSpan[] expected = [CurrentTime(), LaterTime(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected)
+						.Within(tolerance.Seconds())
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.OnlyIf(expectToThrow)
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotOneOf.Tests.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					IEnumerable<TimeSpan?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					IEnumerable<TimeSpan?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(3, 2, false)]
+				[InlineData(5, 3, false)]
+				[InlineData(2, 2, true)]
+				[InlineData(0, 2, true)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					TimeSpan? subject = EarlierTime(actualDifference);
+					TimeSpan?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsOneOf.Tests.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsOneOf
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					IEnumerable<TimeSpan?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsContained_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					IEnumerable<TimeSpan?> expected = [LaterTime(), subject, EarlierTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsDifferent_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(3, 2, true)]
+				[InlineData(5, 3, true)]
+				[InlineData(2, 2, false)]
+				[InlineData(0, 2, false)]
+				public async Task Within_WhenValuesAreOutsideTheTolerance_ShouldFail(
+					int actualDifference, int tolerance, bool expectToThrow)
+				{
+					TimeSpan? subject = EarlierTime(actualDifference);
+					TimeSpan?[] expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected)
+							.Within(tolerance.Seconds())
+							.Because("we want to test the failure");
+
+					await That(Act).Throws<XunitException>()
+						.OnlyIf(expectToThrow)
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)} ± 0:0{tolerance}, because we want to test the failure,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## One of

You can verify that the `TimeSpan` is one of many alternatives:

```csharp
TimeSpan subject = TimeSpan.FromSeconds(42);

await Expect.That(subject).IsOneOf([TimeSpan.FromSeconds(40), TimeSpan.FromSeconds(42)]);
await Expect.That(subject).IsNotOneOf([TimeSpan.FromSeconds(41), TimeSpan.FromSeconds(43)]);
```

You can also specify a tolerance:

```csharp
TimeSpan subject = TimeSpan.FromSeconds(42);

await Expect.That(subject).IsOneOf([TimeSpan.FromSeconds(43), TimeSpan.FromSeconds(45)]).Within(TimeSpan.FromSeconds(1))
  .Because("we accept values between 0:41 and 0:43 or between 00:44 and 00:46");
```

*Implements #537 for `TimeSpan`*