### PR TITLE
feat: add `IsOneOf` expectations for objects

### DIFF
--- a/Docs/pages/docs/expectations/07-object.md
+++ b/Docs/pages/docs/expectations/07-object.md
@@ -64,6 +64,18 @@ await Expect.That(subject).IsNotEqualTo(new MyClass(2)).Equivalent();
 
 *Note: this compares recursively all properties on the two objects for equivalence.*
 
+## One of
+
+You can verify that the `object` is one of many alternatives:
+
+```csharp
+record MyClass(int Value);
+MyClass subject = new(1);
+
+await Expect.That(subject).IsOneOf([new MyClass(1), new MyClass(2)]);
+await Expect.That(subject).IsNotOneOf([new MyClass(2), new MyClass(3)]);
+```
+
 ## Type check
 
 You can verify that the `object` is of a given type or not:

--- a/Source/aweXpect/That/Objects/ThatObject.IsOneOf.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsOneOf.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatObject
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static ObjectEqualityResult<object?, IThat<object?>, object?> IsOneOf(
+		this IThat<object?> source,
+		params object?[] expected)
+	{
+		ObjectEqualityOptions<object?> options = new();
+		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOneOfConstraint<object?, object?>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static ObjectEqualityResult<object?, IThat<object?>, object?> IsOneOf(
+		this IThat<object?> source,
+		IEnumerable<object?> expected,
+		[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+	{
+		ObjectEqualityOptions<object?> options = new();
+		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOneOfConstraint<object?, object?>(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static ObjectEqualityResult<object?, IThat<object?>, object?> IsNotOneOf(
+		this IThat<object?> source,
+		params object?[] unexpected)
+	{
+		ObjectEqualityOptions<object?> options = new();
+		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOneOfConstraint<object?, object?>(it, grammars, unexpected, options)
+					.Invert()),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static ObjectEqualityResult<object?, IThat<object?>, object?> IsNotOneOf(
+		this IThat<object?> source,
+		IEnumerable<object?> unexpected,
+		[CallerArgumentExpression("unexpected")]
+		string doNotPopulateThisValue = "")
+	{
+		ObjectEqualityOptions<object?> options = new();
+		return new ObjectEqualityResult<object?, IThat<object?>, object?>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOneOfConstraint<object?, object?>(it, grammars, unexpected, options)
+					.Invert()),
+			source,
+			options);
+	}
+
+	private sealed class IsOneOfConstraint<TSubject, TExpected>(
+		string it,
+		ExpectationGrammars grammars,
+		IEnumerable<TExpected?> expected,
+		ObjectEqualityOptions<TSubject> options)
+		: ConstraintResult.WithNotNullValue<TSubject>(it, grammars),
+			IValueConstraint<TSubject>
+	{
+		public ConstraintResult IsMetBy(TSubject actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(value => options.AreConsideredEqual(actual, value)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExpectation("one of " + Formatter.Format(expected).TrimCommonWhiteSpace(),
+				Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExpectation("one of " + Formatter.Format(expected).TrimCommonWhiteSpace(),
+				Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual, expected));
+	}
+}

--- a/Source/aweXpect/That/Strings/ThatString.IsOneOf.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsOneOf.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
@@ -25,6 +26,21 @@ public static partial class ThatString
 	}
 
 	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static StringEqualityTypeResult<string?, IThat<string?>> IsOneOf(
+		this IThat<string?> source,
+		IEnumerable<string?> expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOneOfConstraint(it, grammars, expected, options)),
+			source,
+			options);
+	}
+
+	/// <summary>
 	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
 	/// </summary>
 	public static StringEqualityTypeResult<string?, IThat<string?>> IsNotOneOf(
@@ -39,10 +55,25 @@ public static partial class ThatString
 			options);
 	}
 
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static StringEqualityTypeResult<string?, IThat<string?>> IsNotOneOf(
+		this IThat<string?> source,
+		IEnumerable<string?> unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<string?, IThat<string?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOneOfConstraint(it, grammars, unexpected, options).Invert()),
+			source,
+			options);
+	}
+
 	private sealed class IsOneOfConstraint(
 		string it,
 		ExpectationGrammars grammars,
-		string?[] expectedValues,
+		IEnumerable<string?> expectedValues,
 		StringEqualityOptions options)
 		: ConstraintResult.WithNotNullValue<string?>(it, grammars),
 			IValueConstraint<string?>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -623,12 +623,16 @@ namespace aweXpect
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotOneOf(this aweXpect.Core.IThat<object?> source, params object?[] unexpected) { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotOneOf(this aweXpect.Core.IThat<object?> source, System.Collections.Generic.IEnumerable<object?> unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNotSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsOneOf(this aweXpect.Core.IThat<object?> source, params object?[] expected) { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsOneOf(this aweXpect.Core.IThat<object?> source, System.Collections.Generic.IEnumerable<object?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
     }
@@ -675,11 +679,13 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsNotOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsNotOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotUpperCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsUpperCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -671,12 +671,16 @@ namespace aweXpect
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotOneOf(this aweXpect.Core.IThat<object?> source, params object?[] unexpected) { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotOneOf(this aweXpect.Core.IThat<object?> source, System.Collections.Generic.IEnumerable<object?> unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNotSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  struct { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsOneOf(this aweXpect.Core.IThat<object?> source, params object?[] expected) { }
+        public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsOneOf(this aweXpect.Core.IThat<object?> source, System.Collections.Generic.IEnumerable<object?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsSameAs<T>(this aweXpect.Core.IThat<T?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  class { }
     }
@@ -723,11 +727,13 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsNotOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsNotOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotUpperCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
+        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsUpperCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotOneOf.Tests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using aweXpect.Equivalency;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatObject
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldFail()
+			{
+				object subject = new MyClass();
+				IEnumerable<object> unexpected = [new MyClass(), subject,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(unexpected)
+						.Because("we want to test the failure");
+				
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equal to one of [ThatObject.MyClass { Value = 0 }, ThatObject.MyClass { Value = 0 }], because we want to test the failure,
+					             but it was ThatObject.MyClass {
+					                 Value = 0
+					               }
+					             """);
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldSucceed()
+			{
+				object subject = new MyClass();
+				object[] unexpected = [new MyClass(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenComparingWithEquivalenceAndContainsEquivalentValue_ShouldFail()
+			{
+				object subject = new MyClass();
+				object[] unexpected = [new MyClass(),];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(unexpected).Equivalent();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equivalent to one of [ThatObject.MyClass { Value = 0 }],
+					             but it was considered equivalent to ThatObject.MyClass {
+					                 Value = 0
+					               }
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNullValues_ShouldSucceed()
+			{
+				MyClass subject = new();
+				IEnumerable<object?> unexpected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				MyClass? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(new MyClass());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not equal to one of [ThatObject.MyClass { Value = 0 }],
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsOneOf.Tests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using aweXpect.Equivalency;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatObject
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task SubjectToItself_ShouldSucceed()
+			{
+				object subject = new MyClass();
+				IEnumerable<object> expected = [new MyClass(), subject,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task SubjectToSomeOtherValue_ShouldFail()
+			{
+				object subject = new MyClass();
+				object[] expected = [new MyClass(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected)
+						.Because("we want to test the failure");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to one of [ThatObject.MyClass { Value = 0 }], because we want to test the failure,
+					             but it was ThatObject.MyClass {
+					                 Value = 0
+					               }
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenComparingWithEquivalence_ShouldSucceed()
+			{
+				object subject = new MyClass();
+				object[] expected = [new MyClass(),];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected).Equivalent();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedOnlyContainsNullValues_ShouldFail()
+			{
+				MyClass subject = new();
+				IEnumerable<object?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to one of [<null>],
+					             but it was ThatObject.MyClass {
+					                 Value = 0
+					               }
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				MyClass? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOneOf(new MyClass());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to one of [ThatObject.MyClass { Value = 0 }],
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsNotOneOf.Tests.cs
@@ -1,4 +1,7 @@
-﻿namespace aweXpect.Tests;
+﻿using System.Collections.Generic;
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
 
 public sealed partial class ThatString
 {
@@ -10,9 +13,10 @@ public sealed partial class ThatString
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				string? subject = null;
+				IEnumerable<string> unexpected = ["foo", "bar",];
 
 				async Task Act()
-					=> await That(subject).IsNotOneOf("foo", "bar");
+					=> await That(subject).IsNotOneOf(unexpected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsOneOf.Tests.cs
@@ -1,4 +1,8 @@
-﻿namespace aweXpect.Tests;
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
 
 public sealed partial class ThatString
 {
@@ -10,9 +14,10 @@ public sealed partial class ThatString
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				string? subject = null;
+				IEnumerable<string> expected = ["foo", "bar",];
 
 				async Task Act()
-					=> await That(subject).IsOneOf("foo", "bar");
+					=> await That(subject).IsOneOf(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""


### PR DESCRIPTION
## One of

You can verify that the `object` is one of many alternatives:

```csharp
record MyClass(int Value);
MyClass subject = new(1);

await Expect.That(subject).IsOneOf([new MyClass(1), new MyClass(2)]);
await Expect.That(subject).IsNotOneOf([new MyClass(2), new MyClass(3)]);
```

Also support `IsOneOf` for strings with `IEnumerable<string?>`

*Implements #537 for `object` and `string`*