### PR TITLE
feat: add `IsOneOf` expectations for enums

### DIFF
--- a/Docs/pages/docs/expectations/04-enum.md
+++ b/Docs/pages/docs/expectations/04-enum.md
@@ -7,7 +7,7 @@ Describes the possible expectations for `enum` values.
 You can verify that the `enum` is equal to another one or not:
 
 ```csharp
-enum Colors { Red = 1, Green = 2, Blue = 3}
+enum Colors { Red = 1, Green = 2, Blue = 3, Yellow = 4 }
 
 await Expect.That(Colors.Red).IsEqualTo(Colors.Red)
   .Because("it is 'Red'");
@@ -15,12 +15,23 @@ await Expect.That(Colors.Red).IsNotEqualTo(Colors.Blue)
   .Because("it is 'Red'");
 ```
 
+## One of
+
+You can verify that the `enum` is one of many alternatives:
+
+```csharp
+enum Colors { Red = 1, Green = 2, Blue = 3, Yellow = 4 }
+
+await Expect.That(Colors.Red).IsOneOf(Colors.Red, Colors.Green, Colors.Blue);
+await Expect.That(Colors.Yellow).IsNotOneOf(Colors.Red, Colors.Green, Colors.Blue);
+```
+
 ## Value
 
 You can verify that the `enum` has a given value or not:
 
 ```csharp
-enum Colors { Red = 1, Green = 2, Blue = 3}
+enum Colors { Red = 1, Green = 2, Blue = 3, Yellow = 4 }
 
 await Expect.That(Colors.Red).HasValue(1)
   .Because("'Red' is 1");
@@ -33,7 +44,7 @@ await Expect.That(Colors.Red).DoesNotHaveValue(2)
 You can verify that the `enum` has a defined value or not:
 
 ```csharp
-enum Colors { Red = 1, Green = 2, Blue = 3}
+enum Colors { Red = 1, Green = 2, Blue = 3, Yellow = 4 }
 
 await Expect.That((Colors)3).IsDefined()
   .Because("3 corresponds to 'Blue'");

--- a/Source/aweXpect/That/Enums/ThatEnum.IsOneOf.cs
+++ b/Source/aweXpect/That/Enums/ThatEnum.IsOneOf.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatEnum
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum, IThat<TEnum>> IsOneOf<TEnum>(this IThat<TEnum> source,
+		params TEnum?[] expected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum, IThat<TEnum>> IsOneOf<TEnum>(this IThat<TEnum> source,
+		IEnumerable<TEnum?> expected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, expected)),
+			source);
+	
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum, IThat<TEnum>> IsOneOf<TEnum>(this IThat<TEnum> source,
+		IEnumerable<TEnum> expected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, expected.Cast<TEnum?>())),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum, IThat<TEnum>> IsNotOneOf<TEnum>(this IThat<TEnum> source,
+		params TEnum?[] unexpected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, unexpected).Invert()),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum, IThat<TEnum>> IsNotOneOf<TEnum>(this IThat<TEnum> source,
+		IEnumerable<TEnum?> unexpected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, unexpected).Invert()),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum, IThat<TEnum>> IsNotOneOf<TEnum>(this IThat<TEnum> source,
+		IEnumerable<TEnum> unexpected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, unexpected.Cast<TEnum?>()).Invert()),
+			source);
+
+	private sealed class IsOneOfConstraint<TEnum>(string it, ExpectationGrammars grammars, IEnumerable<TEnum?> expected)
+		: ConstraintResult.WithNotNullValue<TEnum>(it, grammars),
+			IValueConstraint<TEnum>
+		where TEnum : struct, Enum
+	{
+		public ConstraintResult IsMetBy(TEnum actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(value => actual.Equals(value)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect/That/Enums/ThatNullableEnum.IsOneOf.cs
+++ b/Source/aweXpect/That/Enums/ThatNullableEnum.IsOneOf.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableEnum
+{
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum?, IThat<TEnum?>> IsOneOf<TEnum>(this IThat<TEnum?> source,
+		params TEnum?[] expected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum?, IThat<TEnum?>> IsOneOf<TEnum>(this IThat<TEnum?> source,
+		IEnumerable<TEnum?> expected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, expected)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is one of the <paramref name="expected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum?, IThat<TEnum?>> IsOneOf<TEnum>(this IThat<TEnum?> source,
+		IEnumerable<TEnum> expected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, expected.Cast<TEnum?>())),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum?, IThat<TEnum?>> IsNotOneOf<TEnum>(this IThat<TEnum?> source,
+		params TEnum?[] unexpected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, unexpected).Invert()),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum?, IThat<TEnum?>> IsNotOneOf<TEnum>(this IThat<TEnum?> source,
+		IEnumerable<TEnum?> unexpected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, unexpected).Invert()),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not one of the <paramref name="unexpected" /> values.
+	/// </summary>
+	public static AndOrResult<TEnum?, IThat<TEnum?>> IsNotOneOf<TEnum>(this IThat<TEnum?> source,
+		IEnumerable<TEnum> unexpected)
+		where TEnum : struct, Enum
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsOneOfConstraint<TEnum>(it, grammars, unexpected.Cast<TEnum?>()).Invert()),
+			source);
+
+	private sealed class IsOneOfConstraint<TEnum>(string it, ExpectationGrammars grammars, IEnumerable<TEnum?> expected)
+		: ConstraintResult.WithValue<TEnum?>(grammars),
+			IValueConstraint<TEnum?>
+		where TEnum : struct, Enum
+	{
+		public ConstraintResult IsMetBy(TEnum? actual)
+		{
+			Actual = actual;
+			Outcome = expected.Any(value => actual.Equals(value)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is one of ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not one of ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -229,6 +229,18 @@ namespace aweXpect
             where TEnum :  struct, System.Enum { }
         public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotEqualTo<TEnum>(this aweXpect.Core.IThat<TEnum> source, TEnum? unexpected)
             where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum?> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, params TEnum?[] unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum?> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, params TEnum?[] expected)
+            where TEnum :  struct, System.Enum { }
     }
     public static class ThatEnumerable
     {
@@ -457,6 +469,18 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotDefined<TEnum>(this aweXpect.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
         public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotEqualTo<TEnum>(this aweXpect.Core.IThat<TEnum?> source, TEnum? unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum?> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, params TEnum?[] unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum?> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, params TEnum?[] expected)
             where TEnum :  struct, System.Enum { }
     }
     public static class ThatNullableGuid

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -130,6 +130,18 @@ namespace aweXpect
             where TEnum :  struct, System.Enum { }
         public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotEqualTo<TEnum>(this aweXpect.Core.IThat<TEnum> source, TEnum? unexpected)
             where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum?> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, params TEnum?[] unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, System.Collections.Generic.IEnumerable<TEnum?> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum, aweXpect.Core.IThat<TEnum>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum> source, params TEnum?[] expected)
+            where TEnum :  struct, System.Enum { }
     }
     public static class ThatEnumerable
     {
@@ -336,6 +348,18 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotDefined<TEnum>(this aweXpect.Core.IThat<TEnum?> source)
             where TEnum :  struct, System.Enum { }
         public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotEqualTo<TEnum>(this aweXpect.Core.IThat<TEnum?> source, TEnum? unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum?> unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsNotOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, params TEnum?[] unexpected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, System.Collections.Generic.IEnumerable<TEnum?> expected)
+            where TEnum :  struct, System.Enum { }
+        public static aweXpect.Results.AndOrResult<TEnum?, aweXpect.Core.IThat<TEnum?>> IsOneOf<TEnum>(this aweXpect.Core.IThat<TEnum?> source, params TEnum?[] expected)
             where TEnum :  struct, System.Enum { }
     }
     public static class ThatNullableGuid

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.IsEqualTo.Tests.cs
@@ -6,66 +6,6 @@ public sealed partial class ThatEnum
 	{
 		public sealed class Tests
 		{
-			[Theory]
-			[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
-			public async Task ForLong_WhenSubjectIsDifferent_ShouldFail(EnumLong subject,
-				EnumLong expected)
-			{
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
-					              """);
-			}
-
-			[Theory]
-			[InlineData(EnumLong.Int64Max)]
-			[InlineData(EnumLong.Int64LessOne)]
-			public async Task ForLong_WhenSubjectTheSame_ShouldSucceed(EnumLong subject)
-			{
-				EnumLong expected = subject;
-
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
-			[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
-			public async Task ForULong_WhenSubjectIsDifferent_ShouldFail(EnumULong subject,
-				EnumULong expected)
-			{
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
-					              """);
-			}
-
-			[Theory]
-			[InlineData(EnumULong.Int64Max)]
-			[InlineData(EnumULong.UInt64LessOne)]
-			[InlineData(EnumULong.UInt64Max)]
-			public async Task ForULong_WhenSubjectTheSame_ShouldSucceed(EnumULong subject)
-			{
-				EnumULong expected = subject;
-
-				async Task Act()
-					=> await That(subject).IsEqualTo(expected);
-
-				await That(Act).DoesNotThrow();
-			}
-
 			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
@@ -104,6 +44,72 @@ public sealed partial class ThatEnum
 			public async Task WhenSubjectIsTheSame_ShouldSucceed(MyColors subject)
 			{
 				MyColors expected = subject;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class LongTests
+		{
+			[Theory]
+			[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+			public async Task WhenSubjectIsDifferent_ShouldFail(EnumLong subject,
+				EnumLong expected)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(EnumLong.Int64Max)]
+			[InlineData(EnumLong.Int64LessOne)]
+			public async Task WhenSubjectTheSame_ShouldSucceed(EnumLong subject)
+			{
+				EnumLong expected = subject;
+
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class UlongTests
+		{
+			[Theory]
+			[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+			[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+			public async Task WhenSubjectIsDifferent_ShouldFail(EnumULong subject,
+				EnumULong expected)
+			{
+				async Task Act()
+					=> await That(subject).IsEqualTo(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(EnumULong.Int64Max)]
+			[InlineData(EnumULong.UInt64LessOne)]
+			[InlineData(EnumULong.UInt64Max)]
+			public async Task WhenSubjectTheSame_ShouldSucceed(EnumULong subject)
+			{
+				EnumULong expected = subject;
 
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.IsNotEqualTo.Tests.cs
@@ -7,66 +7,6 @@ public sealed partial class ThatEnum
 		public sealed class Tests
 		{
 			[Theory]
-			[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
-			public async Task ForLong_WhenSubjectIsDifferent_ShouldSucceed(EnumLong subject,
-				EnumLong unexpected)
-			{
-				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineData(EnumLong.Int64Max)]
-			[InlineData(EnumLong.Int64LessOne)]
-			public async Task ForLong_WhenSubjectTheSame_ShouldFail(EnumLong subject)
-			{
-				EnumLong unexpected = subject;
-
-				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
-					              but it was {Formatter.Format(subject)}
-					              """);
-			}
-
-			[Theory]
-			[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
-			[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
-			public async Task ForULong_WhenSubjectIsDifferent_ShouldSucceed(EnumULong subject,
-				EnumULong unexpected)
-			{
-				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Theory]
-			[InlineData(EnumULong.Int64Max)]
-			[InlineData(EnumULong.UInt64LessOne)]
-			[InlineData(EnumULong.UInt64Max)]
-			public async Task ForULong_WhenSubjectTheSame_ShouldFail(EnumULong subject)
-			{
-				EnumULong unexpected = subject;
-
-				async Task Act()
-					=> await That(subject).IsNotEqualTo(unexpected);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is not {Formatter.Format(unexpected)},
-					              but it was {Formatter.Format(subject)}
-					              """);
-			}
-
-			[Theory]
 			[InlineData(MyColors.Blue, MyColors.Green)]
 			[InlineData(MyColors.Green, MyColors.Blue)]
 			public async Task WhenSubjectIsDifferent_ShouldSucceed(MyColors subject,
@@ -105,6 +45,72 @@ public sealed partial class ThatEnum
 					=> await That(subject).IsNotEqualTo(null);
 
 				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class LongTests
+		{
+			[Theory]
+			[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumLong subject,
+				EnumLong unexpected)
+			{
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(EnumLong.Int64Max)]
+			[InlineData(EnumLong.Int64LessOne)]
+			public async Task WhenSubjectTheSame_ShouldFail(EnumLong subject)
+			{
+				EnumLong unexpected = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not {Formatter.Format(unexpected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class UlongTests
+		{
+			[Theory]
+			[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+			[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumULong subject,
+				EnumULong unexpected)
+			{
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(EnumULong.Int64Max)]
+			[InlineData(EnumULong.UInt64LessOne)]
+			[InlineData(EnumULong.UInt64Max)]
+			public async Task WhenSubjectTheSame_ShouldFail(EnumULong subject)
+			{
+				EnumULong unexpected = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not {Formatter.Format(unexpected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.IsNotOneOf.Tests.cs
@@ -1,0 +1,149 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnum
+{
+	public sealed class IsNotOneOf
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData(MyColors.Blue)]
+			[InlineData(MyColors.Green)]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(MyColors subject)
+			{
+				IEnumerable<MyColors?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(MyColors.Blue)]
+			[InlineData(MyColors.Green, MyColors.Blue, MyColors.Yellow)]
+			public async Task WhenSubjectIsContained_ShouldFail(MyColors subject,
+				params MyColors[] otherValues)
+			{
+				IEnumerable<MyColors> expected = [..otherValues, subject,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(MyColors.Blue, MyColors.Green, MyColors.Red)]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed(MyColors subject,
+				params MyColors[] expected)
+			{
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class LongTests
+		{
+			[Theory]
+			[InlineData(EnumLong.Int64Max)]
+			[InlineData(EnumLong.Int64LessOne)]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(EnumLong subject)
+			{
+				IEnumerable<EnumLong?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(EnumLong.Int64Max)]
+			[InlineData(EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+			public async Task WhenSubjectIsContained_ShouldFail(EnumLong subject,
+				params EnumLong[] otherValues)
+			{
+				IEnumerable<EnumLong> expected = [..otherValues, subject,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumLong subject,
+				params EnumLong[] expected)
+			{
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class UlongTests
+		{
+			[Theory]
+			[InlineData(EnumULong.Int64Max)]
+			[InlineData(EnumULong.UInt64LessOne)]
+			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(EnumULong subject)
+			{
+				IEnumerable<EnumULong?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(EnumULong.Int64Max)]
+			[InlineData(EnumULong.UInt64LessOne, EnumULong.UInt64Max, EnumULong.Int64Max)]
+			public async Task WhenSubjectIsContained_ShouldFail(EnumULong subject,
+				params EnumULong[] otherValues)
+			{
+				IEnumerable<EnumULong> expected = [..otherValues, subject,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne, EnumULong.Int64Max)]
+			public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumULong subject,
+				params EnumULong[] expected)
+			{
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.IsOneOf.Tests.cs
@@ -1,0 +1,164 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnum
+{
+	public sealed class IsOneOf
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData(MyColors.Blue)]
+			[InlineData(MyColors.Green)]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail(MyColors subject)
+			{
+				IEnumerable<MyColors?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(MyColors.Blue)]
+			[InlineData(MyColors.Green, MyColors.Blue, MyColors.Yellow)]
+			public async Task WhenSubjectIsContained_ShouldSucceed(MyColors subject,
+				params MyColors[] otherValues)
+			{
+				IEnumerable<MyColors> expected = [..otherValues, subject,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(MyColors.Blue, MyColors.Green, MyColors.Red)]
+			public async Task WhenSubjectIsDifferent_ShouldFail(MyColors subject,
+				params MyColors[] expected)
+			{
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class LongTests
+		{
+			[Theory]
+			[InlineData(EnumLong.Int64Max)]
+			[InlineData(EnumLong.Int64LessOne)]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail(EnumLong subject)
+			{
+				IEnumerable<EnumLong?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(EnumLong.Int64Max)]
+			[InlineData(EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+			public async Task WhenSubjectIsContained_ShouldSucceed(EnumLong subject,
+				params EnumLong[] otherValues)
+			{
+				IEnumerable<EnumLong> expected = [..otherValues, subject,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+			public async Task WhenSubjectIsDifferent_ShouldFail(EnumLong subject,
+				params EnumLong[] expected)
+			{
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class UlongTests
+		{
+			[Theory]
+			[InlineData(EnumULong.Int64Max)]
+			[InlineData(EnumULong.UInt64LessOne)]
+			public async Task WhenExpectedOnlyContainsNull_ShouldFail(EnumULong subject)
+			{
+				IEnumerable<EnumULong?> expected = [null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of [<null>],
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(EnumULong.Int64Max)]
+			[InlineData(EnumULong.UInt64LessOne, EnumULong.UInt64Max, EnumULong.Int64Max)]
+			public async Task WhenSubjectIsContained_ShouldSucceed(EnumULong subject,
+				params EnumULong[] otherValues)
+			{
+				IEnumerable<EnumULong> expected = [..otherValues, subject,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne, EnumULong.Int64Max)]
+			public async Task WhenSubjectIsDifferent_ShouldFail(EnumULong subject,
+				params EnumULong[] expected)
+			{
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is one of {Formatter.Format(expected)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsEqualTo.Tests.cs
@@ -8,66 +8,6 @@ public sealed partial class ThatEnum
 		{
 			public sealed class Tests
 			{
-				[Theory]
-				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
-				public async Task ForLong_WhenSubjectIsDifferent_ShouldFail(EnumLong? subject,
-					EnumLong? expected)
-				{
-					async Task Act()
-						=> await That(subject).IsEqualTo(expected);
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              is {Formatter.Format(expected)},
-						              but it was {Formatter.Format(subject)}
-						              """);
-				}
-
-				[Theory]
-				[InlineData(EnumLong.Int64Max)]
-				[InlineData(EnumLong.Int64LessOne)]
-				public async Task ForLong_WhenSubjectTheSame_ShouldSucceed(EnumLong? subject)
-				{
-					EnumLong? expected = subject;
-
-					async Task Act()
-						=> await That(subject).IsEqualTo(expected);
-
-					await That(Act).DoesNotThrow();
-				}
-
-				[Theory]
-				[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
-				[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
-				public async Task ForULong_WhenSubjectIsDifferent_ShouldFail(EnumULong? subject,
-					EnumULong? expected)
-				{
-					async Task Act()
-						=> await That(subject).IsEqualTo(expected);
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              is {Formatter.Format(expected)},
-						              but it was {Formatter.Format(subject)}
-						              """);
-				}
-
-				[Theory]
-				[InlineData(EnumULong.Int64Max)]
-				[InlineData(EnumULong.UInt64LessOne)]
-				[InlineData(EnumULong.UInt64Max)]
-				public async Task ForULong_WhenSubjectTheSame_ShouldSucceed(EnumULong? subject)
-				{
-					EnumULong? expected = subject;
-
-					async Task Act()
-						=> await That(subject).IsEqualTo(expected);
-
-					await That(Act).DoesNotThrow();
-				}
-
 				[Fact]
 				public async Task WhenExpectedIsNull_ShouldFail()
 				{
@@ -137,6 +77,72 @@ public sealed partial class ThatEnum
 				public async Task WhenSubjectIsTheSame_ShouldSucceed(MyColors? subject)
 				{
 					MyColors? expected = subject;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class LongTests
+			{
+				[Theory]
+				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+				public async Task WhenSubjectIsDifferent_ShouldFail(EnumLong? subject,
+					EnumLong? expected)
+				{
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(EnumLong.Int64Max)]
+				[InlineData(EnumLong.Int64LessOne)]
+				public async Task WhenSubjectTheSame_ShouldSucceed(EnumLong? subject)
+				{
+					EnumLong? expected = subject;
+
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class UlongTests
+			{
+				[Theory]
+				[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+				[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+				public async Task WhenSubjectIsDifferent_ShouldFail(EnumULong? subject,
+					EnumULong? expected)
+				{
+					async Task Act()
+						=> await That(subject).IsEqualTo(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(EnumULong.Int64Max)]
+				[InlineData(EnumULong.UInt64LessOne)]
+				[InlineData(EnumULong.UInt64Max)]
+				public async Task WhenSubjectTheSame_ShouldSucceed(EnumULong? subject)
+				{
+					EnumULong? expected = subject;
 
 					async Task Act()
 						=> await That(subject).IsEqualTo(expected);

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotEqualTo.Tests.cs
@@ -9,13 +9,12 @@ public sealed partial class ThatEnum
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task ForLong_WhenSubjectAndUnexpectedAreNull_ShouldFail()
+				public async Task WhenSubjectAndExpectedAreNull_ShouldFail()
 				{
-					EnumLong? subject = null;
-					EnumLong? unexpected = null;
+					MyColors? subject = null;
 
 					async Task Act()
-						=> await That(subject).IsNotEqualTo(unexpected);
+						=> await That(subject).IsNotEqualTo(null);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -25,74 +24,14 @@ public sealed partial class ThatEnum
 						             """);
 				}
 
-				[Theory]
-				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
-				public async Task ForLong_WhenSubjectIsDifferent_ShouldSucceed(EnumLong? subject,
-					EnumLong? unexpected)
-				{
-					async Task Act()
-						=> await That(subject).IsNotEqualTo(unexpected);
-
-					await That(Act).DoesNotThrow();
-				}
-
-
-				[Theory]
-				[InlineData(EnumLong.Int64Max)]
-				[InlineData(EnumLong.Int64LessOne)]
-				public async Task ForLong_WhenSubjectTheSame_ShouldFail(EnumLong? subject)
-				{
-					EnumLong? unexpected = subject;
-
-					async Task Act()
-						=> await That(subject).IsNotEqualTo(unexpected);
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              is not {Formatter.Format(unexpected)},
-						              but it was {Formatter.Format(subject)}
-						              """);
-				}
-
-				[Theory]
-				[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
-				[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
-				public async Task ForULong_WhenSubjectIsDifferent_ShouldSucceed(EnumULong? subject,
-					EnumULong? unexpected)
-				{
-					async Task Act()
-						=> await That(subject).IsNotEqualTo(unexpected);
-
-					await That(Act).DoesNotThrow();
-				}
-
-				[Theory]
-				[InlineData(EnumULong.Int64Max)]
-				[InlineData(EnumULong.UInt64LessOne)]
-				[InlineData(EnumULong.UInt64Max)]
-				public async Task ForULong_WhenSubjectTheSame_ShouldFail(EnumULong? subject)
-				{
-					EnumULong? unexpected = subject;
-
-					async Task Act()
-						=> await That(subject).IsNotEqualTo(unexpected);
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              is not {Formatter.Format(unexpected)},
-						              but it was {Formatter.Format(subject)}
-						              """);
-				}
-
 				[Fact]
-				public async Task WhenSubjectAndExpectedAreNull_ShouldFail()
+				public async Task WhenSubjectAndUnexpectedAreNull_ShouldFail()
 				{
 					MyColors? subject = null;
+					MyColors? unexpected = null;
 
 					async Task Act()
-						=> await That(subject).IsNotEqualTo(null);
+						=> await That(subject).IsNotEqualTo(unexpected);
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
@@ -146,6 +85,72 @@ public sealed partial class ThatEnum
 						=> await That(subject).IsNotEqualTo(null);
 
 					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class LongTests
+			{
+				[Theory]
+				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne)]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumLong? subject,
+					EnumLong? unexpected)
+				{
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(EnumLong.Int64Max)]
+				[InlineData(EnumLong.Int64LessOne)]
+				public async Task WhenSubjectTheSame_ShouldFail(EnumLong? subject)
+				{
+					EnumLong? unexpected = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not {Formatter.Format(unexpected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+
+			public sealed class UlongTests
+			{
+				[Theory]
+				[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne)]
+				[InlineData(EnumULong.UInt64Max, EnumULong.Int64Max)]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumULong? subject,
+					EnumULong? unexpected)
+				{
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(EnumULong.Int64Max)]
+				[InlineData(EnumULong.UInt64LessOne)]
+				[InlineData(EnumULong.UInt64Max)]
+				public async Task WhenSubjectTheSame_ShouldFail(EnumULong? subject)
+				{
+					EnumULong? unexpected = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotEqualTo(unexpected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not {Formatter.Format(unexpected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
 				}
 			}
 		}

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotOneOf.Tests.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnum
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotOneOf
+		{
+			public sealed class Tests
+			{
+				[Theory]
+				[InlineData(MyColors.Blue)]
+				[InlineData(MyColors.Green)]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(MyColors subject)
+				{
+					IEnumerable<MyColors?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(MyColors.Blue)]
+				[InlineData(MyColors.Green, MyColors.Blue, MyColors.Yellow)]
+				public async Task WhenSubjectIsContained_ShouldFail(MyColors subject,
+					params MyColors[] otherValues)
+				{
+					IEnumerable<MyColors> expected = [..otherValues, subject,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(MyColors.Blue, MyColors.Green, MyColors.Red)]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed(MyColors subject,
+					params MyColors[] expected)
+				{
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class LongTests
+			{
+				[Theory]
+				[InlineData(EnumLong.Int64Max)]
+				[InlineData(EnumLong.Int64LessOne)]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(EnumLong subject)
+				{
+					IEnumerable<EnumLong?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(EnumLong.Int64Max)]
+				[InlineData(EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+				public async Task WhenSubjectIsContained_ShouldFail(EnumLong subject,
+					params EnumLong[] otherValues)
+				{
+					IEnumerable<EnumLong> expected = [..otherValues, subject,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumLong subject,
+					params EnumLong[] expected)
+				{
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class UlongTests
+			{
+				[Theory]
+				[InlineData(EnumULong.Int64Max)]
+				[InlineData(EnumULong.UInt64LessOne)]
+				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(EnumULong subject)
+				{
+					IEnumerable<EnumULong?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(EnumULong.Int64Max)]
+				[InlineData(EnumULong.UInt64LessOne, EnumULong.UInt64Max, EnumULong.Int64Max)]
+				public async Task WhenSubjectIsContained_ShouldFail(EnumULong subject,
+					params EnumULong[] otherValues)
+				{
+					IEnumerable<EnumULong> expected = [..otherValues, subject,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne, EnumULong.Int64Max)]
+				public async Task WhenSubjectIsDifferent_ShouldSucceed(EnumULong subject,
+					params EnumULong[] expected)
+				{
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsOneOf.Tests.cs
@@ -1,0 +1,167 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnum
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsOneOf
+		{
+			public sealed class Tests
+			{
+				[Theory]
+				[InlineData(MyColors.Blue)]
+				[InlineData(MyColors.Green)]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail(MyColors? subject)
+				{
+					IEnumerable<MyColors?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(MyColors.Blue)]
+				[InlineData(MyColors.Green, MyColors.Blue, MyColors.Yellow)]
+				public async Task WhenSubjectIsContained_ShouldSucceed(MyColors? subject,
+					params MyColors[] otherValues)
+				{
+					MyColors?[] expected = [..otherValues, subject,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(MyColors.Blue, MyColors.Green, MyColors.Red)]
+				public async Task WhenSubjectIsDifferent_ShouldFail(MyColors? subject,
+					params MyColors[] expected)
+				{
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+
+			public sealed class LongTests
+			{
+				[Theory]
+				[InlineData(EnumLong.Int64Max)]
+				[InlineData(EnumLong.Int64LessOne)]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail(EnumLong? subject)
+				{
+					IEnumerable<EnumLong?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(EnumLong.Int64Max)]
+				[InlineData(EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+				public async Task WhenSubjectIsContained_ShouldSucceed(EnumLong? subject,
+					params EnumLong[] otherValues)
+				{
+					EnumLong?[] expected = [..otherValues, subject,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(EnumLong.Int64Max, EnumLong.Int64LessOne, EnumLong.Int64LessTwo)]
+				public async Task WhenSubjectIsDifferent_ShouldFail(EnumLong? subject,
+					params EnumLong[] expected)
+				{
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+
+			public sealed class UlongTests
+			{
+				[Theory]
+				[InlineData(EnumULong.Int64Max)]
+				[InlineData(EnumULong.UInt64LessOne)]
+				public async Task WhenExpectedOnlyContainsNull_ShouldFail(EnumULong? subject)
+				{
+					IEnumerable<EnumULong?> expected = [null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of [<null>],
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Theory]
+				[InlineData(EnumULong.Int64Max)]
+				[InlineData(EnumULong.UInt64LessOne, EnumULong.UInt64Max, EnumULong.Int64Max)]
+				public async Task WhenSubjectIsContained_ShouldSucceed(EnumULong? subject,
+					params EnumULong[] otherValues)
+				{
+					EnumULong?[] expected = [..otherValues, subject,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Theory]
+				[InlineData(EnumULong.UInt64Max, EnumULong.UInt64LessOne, EnumULong.Int64Max)]
+				public async Task WhenSubjectIsDifferent_ShouldFail(EnumULong? subject,
+					params EnumULong[] expected)
+				{
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.cs
@@ -3,35 +3,5 @@
 public sealed partial class ThatEnum
 {
 	// ReSharper disable once ClassNeverInstantiated.Global
-	public sealed partial class Nullable
-	{
-		public enum EnumLong : long
-		{
-			Int64Max = long.MaxValue,
-			Int64LessOne = long.MaxValue - 1,
-		}
-
-		public enum EnumULong : ulong
-		{
-			Int64Max = long.MaxValue,
-			UInt64LessOne = ulong.MaxValue - 1,
-			UInt64Max = ulong.MaxValue,
-		}
-
-		[Flags]
-		public enum MyColors
-		{
-			Blue = 1 << 0,
-			Green = 1 << 1,
-			Yellow = 1 << 2,
-			Red = 1 << 3,
-		}
-
-		public enum MyNumbers
-		{
-			One = 1,
-			Two = 2,
-			Three = 3,
-		}
-	}
+	public sealed partial class Nullable;
 }

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.cs
@@ -7,6 +7,7 @@ public sealed partial class ThatEnum
 	{
 		Int64Max = long.MaxValue,
 		Int64LessOne = long.MaxValue - 1,
+		Int64LessTwo = long.MaxValue - 2,
 	}
 
 	public enum EnumULong : ulong


### PR DESCRIPTION
## One of

You can verify that the `enum` is one of many alternatives:

```csharp
enum Colors { Red = 1, Green = 2, Blue = 3, Yellow = 4 }

await Expect.That(Colors.Red).IsOneOf(Colors.Red, Colors.Green, Colors.Blue);
await Expect.That(Colors.Yellow).IsNotOneOf(Colors.Red, Colors.Green, Colors.Blue);
```

*Implements #537 for enums*