### PR TITLE
fix: nullability handling in `IsOneOf`

### DIFF
--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsOneOf.cs
@@ -116,7 +116,7 @@ public static partial class ThatNullableDateOnly
 			Actual = actual;
 			if (actual is null)
 			{
-				Outcome = Outcome.Failure;
+				Outcome = expected.Any(x => x is null) ? Outcome.Success : Outcome.Failure;
 			}
 			else
 			{

--- a/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsOneOf.cs
@@ -115,7 +115,7 @@ public static partial class ThatNullableDateTimeOffset
 			Actual = actual;
 			if (actual is null)
 			{
-				Outcome = Outcome.Failure;
+				Outcome = expected.Any(x => x is null) ? Outcome.Success : Outcome.Failure;
 			}
 			else
 			{

--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsOneOf.cs
@@ -115,7 +115,7 @@ public static partial class ThatNullableDateTime
 			Actual = actual;
 			if (actual is null)
 			{
-				Outcome = Outcome.Failure;
+				Outcome = expected.Any(x => x is null) ? Outcome.Success : Outcome.Failure;
 			}
 			else
 			{

--- a/Source/aweXpect/That/Objects/ThatObject.IsOneOf.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsOneOf.cs
@@ -81,28 +81,32 @@ public static partial class ThatObject
 		ExpectationGrammars grammars,
 		IEnumerable<TExpected?> expected,
 		ObjectEqualityOptions<TSubject> options)
-		: ConstraintResult.WithNotNullValue<TSubject>(it, grammars),
+		: ConstraintResult.WithValue<TSubject>(grammars),
 			IValueConstraint<TSubject>
 	{
 		public ConstraintResult IsMetBy(TSubject actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(value => options.AreConsideredEqual(actual, value)) ? Outcome.Success : Outcome.Failure;
+			Outcome = expected.Any(value => options.AreConsideredEqual(actual, value))
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(options.GetExpectation("one of " + Formatter.Format(expected).TrimCommonWhiteSpace(),
+			=> stringBuilder.Append(options.GetExpectation(
+				"one of " + Formatter.Format(expected).TrimCommonWhiteSpace(),
 				Grammars));
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual, expected));
+			=> stringBuilder.Append(options.GetExtendedFailure(it, Grammars, Actual, expected));
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(options.GetExpectation("one of " + Formatter.Format(expected).TrimCommonWhiteSpace(),
+			=> stringBuilder.Append(options.GetExpectation(
+				"one of " + Formatter.Format(expected).TrimCommonWhiteSpace(),
 				Grammars));
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual, expected));
+			=> AppendNormalResult(stringBuilder, indentation);
 	}
 }

--- a/Source/aweXpect/That/Strings/ThatString.IsOneOf.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsOneOf.cs
@@ -75,7 +75,7 @@ public static partial class ThatString
 		ExpectationGrammars grammars,
 		IEnumerable<string?> expectedValues,
 		StringEqualityOptions options)
-		: ConstraintResult.WithNotNullValue<string?>(it, grammars),
+		: ConstraintResult.WithValue<string?>(grammars),
 			IValueConstraint<string?>
 	{
 		public ConstraintResult IsMetBy(string? actual)
@@ -98,7 +98,7 @@ public static partial class ThatString
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(It).Append(" was ");
+			stringBuilder.Append(it).Append(" was ");
 			Formatter.Format(stringBuilder, Actual);
 		}
 

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsOneOf.cs
@@ -116,7 +116,7 @@ public static partial class ThatNullableTimeOnly
 			Actual = actual;
 			if (actual is null)
 			{
-				Outcome = Outcome.Failure;
+				Outcome = expected.Any(x => x is null) ? Outcome.Success : Outcome.Failure;
 			}
 			else
 			{

--- a/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsOneOf.cs
@@ -114,7 +114,7 @@ public static partial class ThatNullableTimeSpan
 			Actual = actual;
 			if (actual is null)
 			{
-				Outcome = Outcome.Failure;
+				Outcome = expected.Any(x => x is null) ? Outcome.Success : Outcome.Failure;
 			}
 			else
 			{

--- a/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsNotOneOf.Tests.cs
@@ -56,6 +56,23 @@ public sealed partial class ThatChar
 
 					await That(Act).DoesNotThrow();
 				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					char? subject = null;
+					IEnumerable<char?> expected = ['a', null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsOneOf.Tests.cs
@@ -61,6 +61,18 @@ public sealed partial class ThatChar
 						              but it was {Formatter.Format(subject)}
 						              """);
 				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					char? subject = null;
+					IEnumerable<char?> expected = ['a', null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotOneOf.Tests.cs
@@ -54,6 +54,34 @@ public sealed partial class ThatDateOnly
 					await That(Act).DoesNotThrow();
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					DateOnly? subject = null;
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(CurrentTime(), LaterTime());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					DateOnly? subject = null;
+					IEnumerable<DateOnly?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
 				[Theory]
 				[InlineData(3, 2, false)]
 				[InlineData(5, 3, false)]

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsOneOf.Tests.cs
@@ -59,6 +59,35 @@ public sealed partial class ThatDateOnly
 						              """);
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					DateOnly? subject = null;
+					IEnumerable<DateOnly?> expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					DateOnly? subject = null;
+					IEnumerable<DateOnly?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
 				[Theory]
 				[InlineData(3, 2, true)]
 				[InlineData(5, 3, true)]

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotOneOf.Tests.cs
@@ -53,6 +53,34 @@ public sealed partial class ThatDateTimeOffset
 					await That(Act).DoesNotThrow();
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					DateTimeOffset? subject = null;
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(CurrentTime(), LaterTime());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					DateTimeOffset? subject = null;
+					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
 				[Theory]
 				[InlineData(3, 2, false)]
 				[InlineData(5, 3, false)]

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsOneOf.Tests.cs
@@ -58,6 +58,35 @@ public sealed partial class ThatDateTimeOffset
 						              """);
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					DateTimeOffset? subject = null;
+					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					DateTimeOffset? subject = null;
+					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
 				[Theory]
 				[InlineData(3, 2, true)]
 				[InlineData(5, 3, true)]

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOneOf.Tests.cs
@@ -53,6 +53,34 @@ public sealed partial class ThatDateTime
 					await That(Act).DoesNotThrow();
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					DateTime? subject = null;
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(CurrentTime(), LaterTime());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					DateTime? subject = null;
+					IEnumerable<DateTime?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
 				[Theory]
 				[InlineData(3, 2, false)]
 				[InlineData(5, 3, false)]

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOneOf.Tests.cs
@@ -58,6 +58,35 @@ public sealed partial class ThatDateTime
 						              """);
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					DateTime? subject = null;
+					IEnumerable<DateTime?> expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					DateTime? subject = null;
+					IEnumerable<DateTime?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
 				[Theory]
 				[InlineData(3, 2, true)]
 				[InlineData(5, 3, true)]

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsNotOneOf.Tests.cs
@@ -54,6 +54,34 @@ public sealed partial class ThatEnum
 
 					await That(Act).DoesNotThrow();
 				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					MyColors? subject = null;
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(MyColors.Green, MyColors.Blue);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					MyColors? subject = null;
+					IEnumerable<MyColors?> expected = [MyColors.Green, null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
 			}
 
 			public sealed class LongTests

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.IsOneOf.Tests.cs
@@ -59,6 +59,35 @@ public sealed partial class ThatEnum
 						              but it was {Formatter.Format(subject)}
 						              """);
 				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					MyColors? subject = null;
+					IEnumerable<MyColors?> expected = [MyColors.Green, MyColors.Blue,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					MyColors? subject = null;
+					IEnumerable<MyColors?> expected = [MyColors.Green, null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
 			}
 
 			public sealed class LongTests

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
@@ -1391,6 +1391,23 @@ public sealed partial class ThatNumber
 					              but it was {Formatter.Format(subject)}
 					              """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+			{
+				int? subject = null;
+				IEnumerable<int?> expected = [1, null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
@@ -1243,6 +1243,18 @@ public sealed partial class ThatNumber
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+			{
+				int? subject = null;
+				IEnumerable<int?> expected = [1, null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotOneOf.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatObject
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected)
 						.Because("we want to test the failure");
-				
+
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
@@ -75,19 +75,31 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
+			public async Task WhenSubjectIsNull_ShouldSucceed()
 			{
 				MyClass? subject = null;
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(new MyClass());
 
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+			{
+				object? subject = null;
+				IEnumerable<object?> expected = [new MyClass(), null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is not equal to one of [ThatObject.MyClass { Value = 0 }],
-					             but it was <null>
-					             """);
+					.WithMessage($"""
+					              Expected that subject
+					              is not equal to one of {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsOneOf.Tests.cs
@@ -89,6 +89,18 @@ public sealed partial class ThatObject
 					             but it was <null>
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+			{
+				object? subject = null;
+				IEnumerable<object?> expected = [new MyClass(), null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsNotOneOf.Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+
 // ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Tests;
@@ -10,7 +11,7 @@ public sealed partial class ThatString
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
+			public async Task WhenSubjectIsNull_ShouldSucceed()
 			{
 				string? subject = null;
 				IEnumerable<string> unexpected = ["foo", "bar",];
@@ -18,12 +19,24 @@ public sealed partial class ThatString
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
 
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+			{
+				string? subject = null;
+				IEnumerable<string?> expected = ["foo", null,];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             is not one of ["foo", "bar"],
-					             but it was <null>
-					             """);
+					.WithMessage($"""
+					              Expected that subject
+					              is not one of {Formatter.Format(expected)},
+					              but it was <null>
+					              """);
 			}
 
 			[Theory]

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsOneOf.Tests.cs
@@ -27,6 +27,18 @@ public sealed partial class ThatString
 					             """);
 			}
 
+			[Fact]
+			public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+			{
+				string? subject = null;
+				IEnumerable<string?> expected = ["foo", null,];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Theory]
 			[InlineData("foo", "bar", "baz")]
 			public async Task WhenValueIsDifferentToAllExpected_ShouldFail(

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotOneOf.Tests.cs
@@ -54,6 +54,34 @@ public sealed partial class ThatTimeOnly
 					await That(Act).DoesNotThrow();
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					TimeOnly? subject = null;
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(CurrentTime(), LaterTime());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					TimeOnly? subject = null;
+					IEnumerable<TimeOnly?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
 				[Theory]
 				[InlineData(3, 2, false)]
 				[InlineData(5, 3, false)]

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsOneOf.Tests.cs
@@ -59,6 +59,35 @@ public sealed partial class ThatTimeOnly
 						              """);
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					TimeOnly? subject = null;
+					IEnumerable<TimeOnly?> expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					TimeOnly? subject = null;
+					IEnumerable<TimeOnly?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
 				[Theory]
 				[InlineData(3, 2, true)]
 				[InlineData(5, 3, true)]

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotOneOf.Tests.cs
@@ -53,6 +53,34 @@ public sealed partial class ThatTimeSpan
 					await That(Act).DoesNotThrow();
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					TimeSpan? subject = null;
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(CurrentTime(), LaterTime());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
+				{
+					TimeSpan? subject = null;
+					IEnumerable<TimeSpan?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
 				[Theory]
 				[InlineData(3, 2, false)]
 				[InlineData(5, 3, false)]

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsOneOf.Tests.cs
@@ -58,6 +58,35 @@ public sealed partial class ThatTimeSpan
 						              """);
 				}
 
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					TimeSpan? subject = null;
+					IEnumerable<TimeSpan?> expected = [CurrentTime(), LaterTime(),];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is one of {Formatter.Format(expected)},
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
+				{
+					TimeSpan? subject = null;
+					IEnumerable<TimeSpan?> expected = [CurrentTime(), null,];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).DoesNotThrow();
+				}
+
 				[Theory]
 				[InlineData(3, 2, true)]
 				[InlineData(5, 3, true)]


### PR DESCRIPTION
When subject is `null` and `null` is listed in the expected values, it should succeed.