### PR TITLE
fix: handle string `.Contains` with empty string

### DIFF
--- a/Source/aweXpect/That/Strings/ThatString.Contains.cs
+++ b/Source/aweXpect/That/Strings/ThatString.Contains.cs
@@ -17,6 +17,12 @@ public static partial class ThatString
 		this IThat<string?> source,
 		string expected)
 	{
+		if (expected == string.Empty)
+		{
+			// ReSharper disable once LocalizableElement
+			throw new ArgumentException("The 'expected' string cannot be empty.", nameof(expected));
+		}
+
 		Quantifier quantifier = new();
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeCountResult<string?, IThat<string?>>(
@@ -34,6 +40,12 @@ public static partial class ThatString
 		this IThat<string?> source,
 		string unexpected)
 	{
+		if (unexpected == string.Empty)
+		{
+			// ReSharper disable once LocalizableElement
+			throw new ArgumentException("The 'unexpected' string cannot be empty.", nameof(unexpected));
+		}
+
 		StringEqualityOptions options = new();
 		return new StringEqualityTypeResult<string?, IThat<string?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>

--- a/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
@@ -23,7 +23,7 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
-			public async Task WhenExpectedIsEmpty_ShouldFail()
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
 			{
 				string subject = "some text";
 				string expected = "";

--- a/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
@@ -12,14 +12,28 @@ public sealed partial class ThatString
 				string? subject = null;
 
 				async Task Act()
-					=> await That(subject).Contains("");
+					=> await That(subject).Contains("foo");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             contains "" at least once,
+					             contains "foo" at least once,
 					             but it was <null>
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldFail()
+			{
+				string subject = "some text";
+				string expected = "";
+
+				async Task Act()
+					=> await That(subject).Contains(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("The 'expected' string cannot be empty.").AsPrefix().And
+					.WithParamName("expected");
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotContain.Tests.cs
@@ -73,7 +73,7 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
-			public async Task WhenUnexpectedIsEmpty_ShouldFail()
+			public async Task WhenUnexpectedIsEmpty_ShouldThrowArgumentException()
 			{
 				string subject = "some text";
 				string unexpected = "";

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotContain.Tests.cs
@@ -71,6 +71,20 @@ public sealed partial class ThatString
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenUnexpectedIsEmpty_ShouldFail()
+			{
+				string subject = "some text";
+				string unexpected = "";
+
+				async Task Act()
+					=> await That(subject).DoesNotContain(unexpected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("The 'unexpected' string cannot be empty.").AsPrefix().And
+					.WithParamName("unexpected");
+			}
 		}
 	}
 }


### PR DESCRIPTION
When looking for an empty string in the `Contains` and `DoesNotContain` expectations, throw an `ArgumentException` instead of running in an endless loop.