### PR TITLE
fix: detect overflow in number equality expectations

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -101,7 +101,7 @@ internal class ExpectationNode : Node
 				result = _reason?.ApplyTo(result) ?? result;
 			}
 		}
-		catch (Exception e) when (e is not OverflowException && _constraint is not null)
+		catch (Exception e) when (_constraint is not null)
 		{
 			throw new InvalidOperationException(
 				$"Error evaluating {Formatter.Format(_constraint.GetType())} constraint with value {Formatter.Format(value)}: {e.Message}",

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -101,7 +101,7 @@ internal class ExpectationNode : Node
 				result = _reason?.ApplyTo(result) ?? result;
 			}
 		}
-		catch (Exception e) when (_constraint is not null)
+		catch (Exception e) when (e is not OverflowException && _constraint is not null)
 		{
 			throw new InvalidOperationException(
 				$"Error evaluating {Formatter.Format(_constraint.GetType())} constraint with value {Formatter.Format(value)}: {e.Message}",

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
@@ -459,6 +459,8 @@ public static partial class ValueFormatters
 		{
 			float.NegativeInfinity => "-\u221e",
 			float.PositiveInfinity => "+\u221e",
+			float.MinValue => "float.MinValue",
+			float.MaxValue => "float.MaxValue",
 			_ => value.ToString(CultureInfo.InvariantCulture)
 		};
 
@@ -519,6 +521,8 @@ public static partial class ValueFormatters
 		{
 			double.NegativeInfinity => "-\u221e",
 			double.PositiveInfinity => "+\u221e",
+			double.MinValue => "double.MinValue",
+			double.MaxValue => "double.MaxValue",
 			_ => value.ToString(CultureInfo.InvariantCulture)
 		};
 
@@ -650,7 +654,12 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		decimal value,
 		FormattingOptions? options = null)
-		=> value.ToString(CultureInfo.InvariantCulture);
+		=> value switch
+		{
+			decimal.MinValue => "decimal.MinValue",
+			decimal.MaxValue => "decimal.MaxValue",
+			_ => value.ToString(CultureInfo.InvariantCulture)
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -661,7 +670,7 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		decimal value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value.ToString(CultureInfo.InvariantCulture));
+		=> stringBuilder.Append(Formatter.Format(value, options));
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Options/NumberTolerance.cs
+++ b/Source/aweXpect.Core/Options/NumberTolerance.cs
@@ -52,11 +52,20 @@ public class NumberTolerance<TNumber>(
 	///     <paramref name="expected" /> number.
 	/// </summary>
 	public bool IsWithinTolerance(TNumber? actual, TNumber? expected)
-		=> (actual, expected) switch
+	{
+		try
 		{
-			(null, null) => true,
-			(_, null) => false,
-			(null, _) => false,
-			(_, _) => isWithinTolerance(actual.Value, expected.Value, Tolerance)
-		};
+			return (actual, expected) switch
+			{
+				(null, null) => true,
+				(_, null) => false,
+				(null, _) => false,
+				(_, _) => isWithinTolerance(actual.Value, expected.Value, Tolerance),
+			};
+		}
+		catch (OverflowException)
+		{
+			return false;
+		}
+	}
 }

--- a/Source/aweXpect.Core/Options/NumberTolerance.cs
+++ b/Source/aweXpect.Core/Options/NumberTolerance.cs
@@ -55,13 +55,16 @@ public class NumberTolerance<TNumber>(
 	{
 		try
 		{
-			return (actual, expected) switch
+			checked
 			{
-				(null, null) => true,
-				(_, null) => false,
-				(null, _) => false,
-				(_, _) => isWithinTolerance(actual.Value, expected.Value, Tolerance),
-			};
+				return (actual, expected) switch
+				{
+					(null, null) => true,
+					(_, null) => false,
+					(null, _) => false,
+					(_, _) => isWithinTolerance(actual.Value, expected.Value, Tolerance),
+				};
+			}
 		}
 		catch (OverflowException)
 		{

--- a/Source/aweXpect/That/Numbers/ThatNumber.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.cs
@@ -35,9 +35,19 @@ public static partial class ThatNumber
 			return !IsFinite(expected);
 		}
 
-		return actual < expected
-			? expected - actual <= (tolerance ?? default(TNumber))
-			: actual - expected <= (tolerance ?? default(TNumber));
+		try
+		{
+			checked
+			{
+				return actual < expected
+					? expected - actual <= (tolerance ?? default(TNumber))
+					: actual - expected <= (tolerance ?? default(TNumber));
+			}
+		}
+		catch (OverflowException)
+		{
+			return false;
+		}
 	}
 #endif
 }

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
@@ -1360,5 +1360,250 @@ public sealed partial class ThatNumber
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+		public sealed class OverflowTests
+		{
+			[Fact]
+			public async Task DecimalDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(decimal.MinValue).IsEqualTo(decimal.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that decimal.MinValue
+					             is equal to 79228162514264337593543950335,
+					             but it was -79228162514264337593543950335
+					             """);
+			}
+
+			[Fact]
+			public async Task DoubleDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(double.MinValue).IsEqualTo(double.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+#if NET8_0_OR_GREATER
+					.WithMessage("""
+					             Expected that double.MinValue
+					             is equal to 1.7976931348623157E+308,
+					             but it was -1.7976931348623157E+308
+					             """);
+#else
+					.WithMessage("""
+					             Expected that double.MinValue
+					             is equal to 1.79769313486232E+308,
+					             but it was -1.79769313486232E+308
+					             """);
+#endif
+			}
+
+			[Fact]
+			public async Task FloatDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(float.MinValue).IsEqualTo(float.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+#if NET8_0_OR_GREATER
+					.WithMessage("""
+					             Expected that float.MinValue
+					             is equal to 3.4028235E+38,
+					             but it was -3.4028235E+38
+					             """);
+#else
+					.WithMessage("""
+					             Expected that float.MinValue
+					             is equal to 3.402823E+38,
+					             but it was -3.402823E+38
+					             """);
+#endif
+			}
+
+			[Fact]
+			public async Task IntDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(int.MinValue).IsEqualTo(int.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that int.MinValue
+					             is equal to 2147483647,
+					             but it was -2147483648
+					             """);
+			}
+
+			[Fact]
+			public async Task LongDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(long.MinValue).IsEqualTo(long.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that long.MinValue
+					             is equal to 9223372036854775807,
+					             but it was -9223372036854775808
+					             """);
+			}
+
+			[Fact]
+			public async Task NullableDecimalDifferenceOverflow_ShouldFail()
+			{
+				decimal? minValue = decimal.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(decimal.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 79228162514264337593543950335,
+					             but it was -79228162514264337593543950335
+					             """);
+			}
+
+			[Fact]
+			public async Task NullableDoubleDifferenceOverflow_ShouldFail()
+			{
+				double? minValue = double.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(double.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+#if NET8_0_OR_GREATER
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 1.7976931348623157E+308,
+					             but it was -1.7976931348623157E+308
+					             """);
+#else
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 1.79769313486232E+308,
+					             but it was -1.79769313486232E+308
+					             """);
+#endif
+			}
+
+			[Fact]
+			public async Task NullableFloatDifferenceOverflow_ShouldFail()
+			{
+				float? minValue = float.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(float.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+#if NET8_0_OR_GREATER
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 3.4028235E+38,
+					             but it was -3.4028235E+38
+					             """);
+#else
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 3.402823E+38,
+					             but it was -3.402823E+38
+					             """);
+#endif
+			}
+
+			[Fact]
+			public async Task NullableIntDifferenceOverflow_ShouldFail()
+			{
+				int? minValue = int.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(int.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 2147483647,
+					             but it was -2147483648
+					             """);
+			}
+
+			[Fact]
+			public async Task NullableLongDifferenceOverflow_ShouldFail()
+			{
+				long? minValue = long.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(long.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 9223372036854775807,
+					             but it was -9223372036854775808
+					             """);
+			}
+
+			[Fact]
+			public async Task NullableSbyteDifferenceOverflow_ShouldFail()
+			{
+				sbyte? minValue = sbyte.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(sbyte.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 127,
+					             but it was -128
+					             """);
+			}
+
+			[Fact]
+			public async Task NullableShortDifferenceOverflow_ShouldFail()
+			{
+				short? minValue = short.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsEqualTo(short.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that minValue
+					             is equal to 32767,
+					             but it was -32768
+					             """);
+			}
+
+			[Fact]
+			public async Task SbyteDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(sbyte.MinValue).IsEqualTo(sbyte.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that sbyte.MinValue
+					             is equal to 127,
+					             but it was -128
+					             """);
+			}
+
+			[Fact]
+			public async Task ShortDifferenceOverflow_ShouldFail()
+			{
+				async Task Action()
+					=> await That(short.MinValue).IsEqualTo(short.MaxValue);
+
+				await That(Action).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that short.MinValue
+					             is equal to 32767,
+					             but it was -32768
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
@@ -1372,8 +1372,8 @@ public sealed partial class ThatNumber
 				await That(Action).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that decimal.MinValue
-					             is equal to 79228162514264337593543950335,
-					             but it was -79228162514264337593543950335
+					             is equal to decimal.MaxValue,
+					             but it was decimal.MinValue
 					             """);
 			}
 
@@ -1384,19 +1384,11 @@ public sealed partial class ThatNumber
 					=> await That(double.MinValue).IsEqualTo(double.MaxValue);
 
 				await That(Action).Throws<XunitException>()
-#if NET8_0_OR_GREATER
 					.WithMessage("""
 					             Expected that double.MinValue
-					             is equal to 1.7976931348623157E+308,
-					             but it was -1.7976931348623157E+308
+					             is equal to double.MaxValue,
+					             but it was double.MinValue
 					             """);
-#else
-					.WithMessage("""
-					             Expected that double.MinValue
-					             is equal to 1.79769313486232E+308,
-					             but it was -1.79769313486232E+308
-					             """);
-#endif
 			}
 
 			[Fact]
@@ -1406,19 +1398,11 @@ public sealed partial class ThatNumber
 					=> await That(float.MinValue).IsEqualTo(float.MaxValue);
 
 				await That(Action).Throws<XunitException>()
-#if NET8_0_OR_GREATER
 					.WithMessage("""
 					             Expected that float.MinValue
-					             is equal to 3.4028235E+38,
-					             but it was -3.4028235E+38
+					             is equal to float.MaxValue,
+					             but it was float.MinValue
 					             """);
-#else
-					.WithMessage("""
-					             Expected that float.MinValue
-					             is equal to 3.402823E+38,
-					             but it was -3.402823E+38
-					             """);
-#endif
 			}
 
 			[Fact]
@@ -1460,8 +1444,8 @@ public sealed partial class ThatNumber
 				await That(Action).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that minValue
-					             is equal to 79228162514264337593543950335,
-					             but it was -79228162514264337593543950335
+					             is equal to decimal.MaxValue,
+					             but it was decimal.MinValue
 					             """);
 			}
 
@@ -1474,19 +1458,11 @@ public sealed partial class ThatNumber
 					=> await That(minValue).IsEqualTo(double.MaxValue);
 
 				await That(Action).Throws<XunitException>()
-#if NET8_0_OR_GREATER
 					.WithMessage("""
 					             Expected that minValue
-					             is equal to 1.7976931348623157E+308,
-					             but it was -1.7976931348623157E+308
+					             is equal to double.MaxValue,
+					             but it was double.MinValue
 					             """);
-#else
-					.WithMessage("""
-					             Expected that minValue
-					             is equal to 1.79769313486232E+308,
-					             but it was -1.79769313486232E+308
-					             """);
-#endif
 			}
 
 			[Fact]
@@ -1498,19 +1474,11 @@ public sealed partial class ThatNumber
 					=> await That(minValue).IsEqualTo(float.MaxValue);
 
 				await That(Action).Throws<XunitException>()
-#if NET8_0_OR_GREATER
 					.WithMessage("""
 					             Expected that minValue
-					             is equal to 3.4028235E+38,
-					             but it was -3.4028235E+38
+					             is equal to float.MaxValue,
+					             but it was float.MinValue
 					             """);
-#else
-					.WithMessage("""
-					             Expected that minValue
-					             is equal to 3.402823E+38,
-					             but it was -3.402823E+38
-					             """);
-#endif
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotEqualTo.Tests.cs
@@ -428,11 +428,11 @@ public sealed partial class ThatNumber
 				byte? unexpected)
 			{
 				byte? subject = null;
-				byte? result = await That(subject).IsNotEqualTo(unexpected);
 
 				async Task Act()
-					=>
-						await That(Act).DoesNotThrow();
+					=> await That(subject).IsNotEqualTo(unexpected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Theory]
@@ -1106,6 +1106,149 @@ public sealed partial class ThatNumber
 					              is not equal to {Formatter.Format(unexpected)},
 					              but it was {Formatter.Format(subject)}
 					              """);
+			}
+		}
+
+		public sealed class OverflowTests
+		{
+			[Fact]
+			public async Task DecimalDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(decimal.MinValue).IsNotEqualTo(decimal.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoubleDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(double.MinValue).IsNotEqualTo(double.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task FloatDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(float.MinValue).IsNotEqualTo(float.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IntDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(int.MinValue).IsNotEqualTo(int.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task LongDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(long.MinValue).IsNotEqualTo(long.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableDecimalDifferenceOverflow_ShouldSucceed()
+			{
+				decimal? minValue = decimal.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(decimal.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableDoubleDifferenceOverflow_ShouldSucceed()
+			{
+				double? minValue = double.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(double.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableFloatDifferenceOverflow_ShouldSucceed()
+			{
+				float? minValue = float.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(float.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableIntDifferenceOverflow_ShouldSucceed()
+			{
+				int? minValue = int.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(int.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableLongDifferenceOverflow_ShouldSucceed()
+			{
+				long? minValue = long.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(long.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableSbyteDifferenceOverflow_ShouldSucceed()
+			{
+				sbyte? minValue = sbyte.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(sbyte.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NullableShortDifferenceOverflow_ShouldSucceed()
+			{
+				short? minValue = short.MinValue;
+
+				async Task Action()
+					=> await That(minValue).IsNotEqualTo(short.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task SbyteDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(sbyte.MinValue).IsNotEqualTo(sbyte.MaxValue);
+
+				await That(Action).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShortDifferenceOverflow_ShouldSucceed()
+			{
+				async Task Action()
+					=> await That(short.MinValue).IsNotEqualTo(short.MaxValue);
+
+				await That(Action).DoesNotThrow();
 			}
 		}
 	}


### PR DESCRIPTION
Also improve the formatting of `MinValue` and `MaxValue` for `double`, `float` and `decimal`.