### PR TITLE
fix: null-handling for enum `DoesNotHaveValue`

### DIFF
--- a/Source/aweXpect/That/Enums/ThatNullableEnum.HasValue.cs
+++ b/Source/aweXpect/That/Enums/ThatNullableEnum.HasValue.cs
@@ -32,7 +32,7 @@ public static partial class ThatNullableEnum
 			source);
 
 	private sealed class HasValueConstraint<TEnum>(string it, ExpectationGrammars grammars, long? expectedValue)
-		: ConstraintResult.WithNotNullValue<TEnum?>(it, grammars),
+		: ConstraintResult.WithValue<TEnum?>(grammars),
 			IValueConstraint<TEnum?>
 		where TEnum : struct, Enum
 	{
@@ -53,7 +53,7 @@ public static partial class ThatNullableEnum
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(It).Append(" was ");
+			stringBuilder.Append(it).Append(" was ");
 			Formatter.Format(stringBuilder, Actual);
 		}
 

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.DoesNotHaveFlag.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.DoesNotHaveFlag.Tests.cs
@@ -9,6 +9,17 @@ public sealed partial class ThatEnum
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					MyColors? subject = null;
+
+					async Task Act()
+						=> await That(subject).DoesNotHaveFlag(MyColors.Blue);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
 				public async Task WhenSubjectAndUnexpectedIsNull_ShouldFail()
 				{
 					MyColors? subject = null;

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.DoesNotHaveValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.DoesNotHaveValue.Tests.cs
@@ -40,19 +40,14 @@ public sealed partial class ThatEnum
 				}
 
 				[Fact]
-				public async Task WhenSubjectIsNull_ShouldFail()
+				public async Task WhenSubjectIsNull_ShouldSucceed()
 				{
-					MyNumbers? subject = null;
+					MyColors? subject = null;
 
 					async Task Act()
-						=> await That(subject).DoesNotHaveValue(1L);
+						=> await That(subject).DoesNotHaveValue(2);
 
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that subject
-						             does not have value 1,
-						             but it was <null>
-						             """);
+					await That(Act).DoesNotThrow();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasFlag.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasFlag.Tests.cs
@@ -9,6 +9,22 @@ public sealed partial class ThatEnum
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					MyColors? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasFlag(MyColors.Blue);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has flag Blue,
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
 				public async Task WhenExpectedIsNull_ShouldFail()
 				{
 					MyColors? subject = MyColors.Yellow;

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasFlag.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasFlag.Tests.cs
@@ -9,22 +9,6 @@ public sealed partial class ThatEnum
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task WhenSubjectIsNull_ShouldSucceed()
-				{
-					MyColors? subject = null;
-
-					async Task Act()
-						=> await That(subject).HasFlag(MyColors.Blue);
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              has flag Blue,
-						              but it was <null>
-						              """);
-				}
-
-				[Fact]
 				public async Task WhenExpectedIsNull_ShouldFail()
 				{
 					MyColors? subject = MyColors.Yellow;
@@ -79,6 +63,22 @@ public sealed partial class ThatEnum
 						=> await That(subject).HasFlag(expected);
 
 					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					MyColors? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasFlag(MyColors.Blue);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has flag Blue,
+						             but it was <null>
+						             """);
 				}
 
 				[Theory]

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasValue.Tests.cs
@@ -9,6 +9,22 @@ public sealed partial class ThatEnum
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenSubjectIsNull_ShouldSucceed()
+				{
+					MyColors? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasValue(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has value 2,
+						              but it was <null>
+						              """);
+				}
+
+				[Fact]
 				public async Task WhenExpectedIsNull_ShouldFail()
 				{
 					MyColors? subject = MyColors.Yellow;

--- a/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Enums/ThatEnum.Nullable.HasValue.Tests.cs
@@ -9,22 +9,6 @@ public sealed partial class ThatEnum
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task WhenSubjectIsNull_ShouldSucceed()
-				{
-					MyColors? subject = null;
-
-					async Task Act()
-						=> await That(subject).HasValue(2);
-
-					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              has value 2,
-						              but it was <null>
-						              """);
-				}
-
-				[Fact]
 				public async Task WhenExpectedIsNull_ShouldFail()
 				{
 					MyColors? subject = MyColors.Yellow;


### PR DESCRIPTION
The null-handling should be analogous to `DoesNotHaveFlag`.