### PR TITLE
feat: handle `null` in type tests

### DIFF
--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -25,11 +25,13 @@ public static partial class ThatObject
 		this IThat<T?> source,
 		Type? type)
 		where T : class
-		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsOfTypeConstraint(it, grammars,
-					// ReSharper disable once LocalizableElement
-					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null."))),
+	{
+		// ReSharper disable once LocalizableElement
+		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		return new AndOrResult<T?, IThat<T?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, type)),
 			source);
+	}
 
 	/// <summary>
 	///     Verifies that the subject is not of type <typeparamref name="TType" />.
@@ -47,11 +49,13 @@ public static partial class ThatObject
 		this IThat<T?> source,
 		Type? type)
 		where T : class
-		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsOfTypeConstraint(it, grammars,
-					// ReSharper disable once LocalizableElement
-					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.")).Invert()),
+	{
+		// ReSharper disable once LocalizableElement
+		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		return new AndOrResult<T?, IThat<T?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, type).Invert()),
 			source);
+	}
 
 	private sealed class IsOfTypeConstraint<TType>(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<object?>(grammars),

--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -23,10 +23,12 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<T?, IThat<T?>> Is<T>(
 		this IThat<T?> source,
-		Type type)
+		Type? type)
 		where T : class
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsOfTypeConstraint(it, grammars, type)),
+				=> new IsOfTypeConstraint(it, grammars,
+					// ReSharper disable once LocalizableElement
+					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null."))),
 			source);
 
 	/// <summary>
@@ -43,10 +45,12 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<T?, IThat<T?>> IsNot<T>(
 		this IThat<T?> source,
-		Type type)
+		Type? type)
 		where T : class
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsOfTypeConstraint(it, grammars, type).Invert()),
+				=> new IsOfTypeConstraint(it, grammars,
+					// ReSharper disable once LocalizableElement
+					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.")).Invert()),
 			source);
 
 	private sealed class IsOfTypeConstraint<TType>(string it, ExpectationGrammars grammars)

--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -22,9 +22,11 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<object?, IThat<object?>> IsExactly(
 		this IThat<object?> source,
-		Type type)
+		Type? type)
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsExactlyOfTypeConstraint(it, grammars, type)),
+				=> new IsExactlyOfTypeConstraint(it, grammars,
+					// ReSharper disable once LocalizableElement
+					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null."))),
 			source);
 
 	/// <summary>
@@ -41,9 +43,11 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<object?, IThat<object?>> IsNotExactly(
 		this IThat<object?> source,
-		Type type)
+		Type? type)
 		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsExactlyOfTypeConstraint(it, grammars, type).Invert()),
+				=> new IsExactlyOfTypeConstraint(it, grammars,
+					// ReSharper disable once LocalizableElement
+					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.")).Invert()),
 			source);
 
 	private sealed class IsExactlyOfTypeConstraint<TType>(string it, ExpectationGrammars grammars)

--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -23,11 +23,13 @@ public static partial class ThatObject
 	public static AndOrResult<object?, IThat<object?>> IsExactly(
 		this IThat<object?> source,
 		Type? type)
-		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsExactlyOfTypeConstraint(it, grammars,
-					// ReSharper disable once LocalizableElement
-					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null."))),
+	{
+		// ReSharper disable once LocalizableElement
+		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		return new AndOrResult<object?, IThat<object?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsExactlyOfTypeConstraint(it, grammars, type)),
 			source);
+	}
 
 	/// <summary>
 	///     Verifies that the subject is not exactly of type <typeparamref name="TType" />.
@@ -44,11 +46,13 @@ public static partial class ThatObject
 	public static AndOrResult<object?, IThat<object?>> IsNotExactly(
 		this IThat<object?> source,
 		Type? type)
-		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsExactlyOfTypeConstraint(it, grammars,
-					// ReSharper disable once LocalizableElement
-					type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.")).Invert()),
+	{
+		// ReSharper disable once LocalizableElement
+		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		return new AndOrResult<object?, IThat<object?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsExactlyOfTypeConstraint(it, grammars, type).Invert()),
 			source);
+	}
 
 	private sealed class IsExactlyOfTypeConstraint<TType>(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<object?>(grammars),

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -652,7 +652,7 @@ namespace aweXpect
     public static class ThatObject
     {
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsEqualTo(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsEqualTo<T>(this aweXpect.Core.IThat<T> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
@@ -660,10 +660,10 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotEqualTo(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsNotEqualTo<T>(this aweXpect.Core.IThat<T> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
@@ -671,7 +671,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsNotEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -744,7 +744,7 @@ namespace aweXpect
     public static class ThatObject
     {
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsEqualTo(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsEqualTo<T>(this aweXpect.Core.IThat<T> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
@@ -752,10 +752,10 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotEqualTo(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsNotEqualTo<T>(this aweXpect.Core.IThat<T> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
@@ -763,7 +763,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsNotEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
@@ -163,6 +163,19 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
+			public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+			{
+				object subject = new MyClass();
+
+				async Task Act()
+					=> await That(subject).Is(null);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("type").And
+					.WithMessage("The type cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenTypeIsSubtype_ShouldSucceed()
 			{
 				object subject = new MyClass();

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
@@ -172,6 +172,19 @@ public sealed partial class ThatObject
 					               """);
 			}
 
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+			{
+				object subject = new MyClass();
+
+				async Task Act()
+					=> await That(subject).IsExactly(null);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("type").And
+					.WithMessage("The type cannot be null.").AsPrefix();
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenTypeIsSubtype_ShouldSucceed(int value)

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
@@ -138,6 +138,19 @@ public sealed partial class ThatObject
 				await That(Act).DoesNotThrow();
 			}
 
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+			{
+				object subject = new MyClass();
+
+				async Task Act()
+					=> await That(subject).IsNot(null);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("type").And
+					.WithMessage("The type cannot be null.").AsPrefix();
+			}
+
 			[Theory]
 			[AutoData]
 			public async Task WhenTypeIsSubtype_ShouldFail(int value)

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotExactly.Tests.cs
@@ -127,6 +127,19 @@ public sealed partial class ThatObject
 			}
 
 			[Fact]
+			public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+			{
+				object subject = new MyClass();
+
+				async Task Act()
+					=> await That(subject).IsNotExactly(null);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("type").And
+					.WithMessage("The type cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenTypeIsSubtype_ShouldSucceed()
 			{
 				object subject = new MyClass();


### PR DESCRIPTION
Throw correct `ArgumentNullException` when providing `null` as expected type in is type tests.