### PR TITLE
refactor: `Is`/`IsExactly` signature for `null` case

### DIFF
--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -23,7 +23,7 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<T?, IThat<T?>> Is<T>(
 		this IThat<T?> source,
-		Type? type)
+		Type type)
 		where T : class
 	{
 		// ReSharper disable once LocalizableElement
@@ -47,7 +47,7 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<T?, IThat<T?>> IsNot<T>(
 		this IThat<T?> source,
-		Type? type)
+		Type type)
 		where T : class
 	{
 		// ReSharper disable once LocalizableElement

--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -22,7 +22,7 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<object?, IThat<object?>> IsExactly(
 		this IThat<object?> source,
-		Type? type)
+		Type type)
 	{
 		// ReSharper disable once LocalizableElement
 		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
@@ -45,7 +45,7 @@ public static partial class ThatObject
 	/// </summary>
 	public static AndOrResult<object?, IThat<object?>> IsNotExactly(
 		this IThat<object?> source,
-		Type? type)
+		Type type)
 	{
 		// ReSharper disable once LocalizableElement
 		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -652,7 +652,7 @@ namespace aweXpect
     public static class ThatObject
     {
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsEqualTo(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsEqualTo<T>(this aweXpect.Core.IThat<T> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
@@ -660,10 +660,10 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotEqualTo(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsNotEqualTo<T>(this aweXpect.Core.IThat<T> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
@@ -671,7 +671,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsNotEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -744,7 +744,7 @@ namespace aweXpect
     public static class ThatObject
     {
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsEqualTo(this aweXpect.Core.IThat<object?> source, object? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsEqualTo<T>(this aweXpect.Core.IThat<T> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
@@ -752,10 +752,10 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type? type)
+        public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotEqualTo(this aweXpect.Core.IThat<object?> source, object? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<T, aweXpect.Core.IThat<T>, T> IsNotEqualTo<T>(this aweXpect.Core.IThat<T> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
@@ -763,7 +763,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<T?, aweXpect.Core.IThat<T?>, T?> IsNotEqualTo<T>(this aweXpect.Core.IThat<T?> source, T? unexpected, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type? type) { }
+        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
@@ -168,7 +168,7 @@ public sealed partial class ThatObject
 				object subject = new MyClass();
 
 				async Task Act()
-					=> await That(subject).Is(null);
+					=> await That(subject).Is(null!);
 
 				await That(Act).Throws<ArgumentNullException>()
 					.WithParamName("type").And

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
@@ -178,7 +178,7 @@ public sealed partial class ThatObject
 				object subject = new MyClass();
 
 				async Task Act()
-					=> await That(subject).IsExactly(null);
+					=> await That(subject).IsExactly(null!);
 
 				await That(Act).Throws<ArgumentNullException>()
 					.WithParamName("type").And

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNot.Tests.cs
@@ -144,7 +144,7 @@ public sealed partial class ThatObject
 				object subject = new MyClass();
 
 				async Task Act()
-					=> await That(subject).IsNot(null);
+					=> await That(subject).IsNot(null!);
 
 				await That(Act).Throws<ArgumentNullException>()
 					.WithParamName("type").And

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotExactly.Tests.cs
@@ -132,7 +132,7 @@ public sealed partial class ThatObject
 				object subject = new MyClass();
 
 				async Task Act()
-					=> await That(subject).IsNotExactly(null);
+					=> await That(subject).IsNotExactly(null!);
 
 				await That(Act).Throws<ArgumentNullException>()
 					.WithParamName("type").And


### PR DESCRIPTION
Avoid specifying nullable types when they throw a `ArgumentNullException`.

Related to #562 