### PR TITLE
fix: support open-generic types and interfaces in `ThatObject.IsExactly`

### DIFF
--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -94,7 +94,11 @@ public static partial class ThatObject
 		public ConstraintResult IsMetBy(object? actual)
 		{
 			Actual = actual;
-			Outcome = actual?.GetType() == type ? Outcome.Success : Outcome.Failure;
+			Outcome = actual?.GetType() == type ||
+			          type.IsGenericTypeDefinition && actual?.GetType().IsGenericType == true &&
+			          actual.GetType().GetGenericTypeDefinition() == type
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
@@ -241,6 +241,22 @@ public sealed partial class ThatObject
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WithNotMatchingOpenGenericInterfaceType_ShouldFail()
+			{
+				List<string> subject = new();
+
+				async Task Act()
+					=> await That(subject).Is(typeof(IDictionary<,>));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is type IDictionary<, >,
+					             but it was []
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Tests;
+﻿using System.Collections.Generic;
+
+namespace aweXpect.Tests;
 
 public sealed partial class ThatObject
 {
@@ -240,6 +242,49 @@ public sealed partial class ThatObject
 					=> await That(subject).IsExactly(typeof(MyClass));
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithMatchingOpenGenericInterfaceType_ShouldFail()
+			{
+				List<string> subject = new();
+
+				async Task Act()
+					=> await That(subject).IsExactly(typeof(IList<>));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is exactly type IList<>,
+					             but it was []
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMatchingOpenGenericType_ShouldSucceed()
+			{
+				List<string> subject = new();
+
+				async Task Act()
+					=> await That(subject).IsExactly(typeof(List<>));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithNotMatchingOpenGenericInterfaceType_ShouldFail()
+			{
+				List<string> subject = new();
+
+				async Task Act()
+					=> await That(subject).IsExactly(typeof(IDictionary<,>));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is exactly type IDictionary<, >,
+					             but it was []
+					             """);
 			}
 		}
 	}


### PR DESCRIPTION
Support the following case:
```csharp
List<string> subject = new();

await That(subject).IsExactly(typeof(List<>));
```

*Related to #561*