### PR TITLE
feat: add option to include type information in formatters

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Formatting/FormattingOptions.cs
+++ b/Source/aweXpect.Core/Formatting/FormattingOptions.cs
@@ -5,31 +5,45 @@
 /// </summary>
 public record FormattingOptions
 {
-	private FormattingOptions(bool useLineBreaks, string indentation = "")
-	{
-		UseLineBreaks = useLineBreaks;
-		Indentation = indentation;
-	}
-
 	/// <summary>
 	///     Format the objects on multiple lines.
 	/// </summary>
-	public static FormattingOptions MultipleLines { get; } = new(true);
+	public static FormattingOptions MultipleLines { get; } = new()
+	{
+		UseLineBreaks = true,
+	};
 
 	/// <summary>
 	///     Format the objects on a single line.
 	/// </summary>
-	public static FormattingOptions SingleLine { get; } = new(false);
+	public static FormattingOptions SingleLine { get; } = new()
+	{
+		UseLineBreaks = false,
+	};
+
+	/// <summary>
+	///     Format the objects on a single line with prefixed type information.
+	/// </summary>
+	public static FormattingOptions WithType { get; } = new()
+	{
+		UseLineBreaks = false,
+		IncludeType = true,
+	};
 
 	/// <summary>
 	///     Flag indicating, if line-breaks should be used during formatting.
 	/// </summary>
-	public bool UseLineBreaks { get; }
+	public bool UseLineBreaks { get; init; }
+
+	/// <summary>
+	///     Flag indicating, if the type should be included during formatting.
+	/// </summary>
+	public bool IncludeType { get; init; }
 
 	/// <summary>
 	///     The indentation prefix for subsequent lines when <see cref="UseLineBreaks" /> is <see langword="true" />
 	/// </summary>
-	public string Indentation { get; }
+	public string Indentation { get; init; } = "";
 
 	/// <summary>
 	///     Format the objects on multiple lines with the given <paramref name="indentation" />.
@@ -37,5 +51,11 @@ public record FormattingOptions
 	/// <remarks>
 	///     Use an indentation of 2 blanks, if the <paramref name="indentation" /> is <see langword="null" />.
 	/// </remarks>
-	public static FormattingOptions Indented(string? indentation = null) => new(true, indentation ?? "  ");
+	public static FormattingOptions Indented(string? indentation = null, bool includeType = false)
+		=> new()
+		{
+			UseLineBreaks = true,
+			Indentation = indentation ?? "  ",
+			IncludeType = includeType,
+		};
 }

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Bool.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Bool.cs
@@ -11,7 +11,13 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		bool value,
 		FormattingOptions? options = null)
-		=> value ? "True" : "False";
+		=> (value, options?.IncludeType) switch
+		{
+			(true, true) => "bool True",
+			(false, true) => "bool False",
+			(true, _) => "True",
+			(false, _) => "False",
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -22,7 +28,7 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		bool value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value ? "True" : "False");
+		=> stringBuilder.Append(Format(formatter, value, options));
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Char.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Char.cs
@@ -11,7 +11,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		char value,
 		FormattingOptions? options = null)
-		=> $"'{value}'";
+		=> options?.IncludeType switch
+		{
+			true => $"char '{value}'",
+			_ => $"'{value}'",
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -23,6 +27,11 @@ public static partial class ValueFormatters
 		char value,
 		FormattingOptions? options = null)
 	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("char ");
+		}
+
 		stringBuilder.Append('\'');
 		stringBuilder.Append(value);
 		stringBuilder.Append('\'');
@@ -32,7 +41,7 @@ public static partial class ValueFormatters
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
 	/// </summary>
 	public static string Format(
-		this ValueFormatter _,
+		this ValueFormatter formatter,
 		char? value,
 		FormattingOptions? options = null)
 	{
@@ -41,7 +50,7 @@ public static partial class ValueFormatters
 			return ValueFormatter.NullString;
 		}
 
-		return $"'{value}'";
+		return Format(formatter, value.Value, options);
 	}
 
 	/// <summary>
@@ -60,8 +69,6 @@ public static partial class ValueFormatters
 			return;
 		}
 
-		stringBuilder.Append('\'');
-		stringBuilder.Append(value);
-		stringBuilder.Append('\'');
+		Format(formatter, stringBuilder, value.Value, options);
 	}
 }

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -41,6 +41,12 @@ public static partial class ValueFormatters
 		}
 
 		options ??= FormattingOptions.SingleLine;
+		if (options.IncludeType)
+		{
+			Format(Formatter, stringBuilder, value.GetType());
+			stringBuilder.Append(' ');
+		}
+
 		int maxCount = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
 		int count = maxCount;
 		stringBuilder.Append('[');
@@ -73,7 +79,10 @@ public static partial class ValueFormatters
 				break;
 			}
 
-			stringBuilder.Append(Format(formatter, v, options).Indent("  ", false));
+			stringBuilder.Append(Format(formatter, v, options with
+			{
+				IncludeType = false,
+			}).Indent("  ", false));
 		}
 
 		if (hasMoreValues)

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateOnly.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateOnly.cs
@@ -13,7 +13,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		DateOnly value,
 		FormattingOptions? options = null)
-		=> value.ToString("o");
+		=> options?.IncludeType switch
+		{
+			true => $"DateOnly {value.ToString("o")}",
+			_ => value.ToString("o"),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -24,7 +28,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		DateOnly value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value.ToString("o"));
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("DateOnly ");
+		}
+
+		stringBuilder.Append(value.ToString("o"));
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateTime.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateTime.cs
@@ -12,7 +12,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		DateTime value,
 		FormattingOptions? options = null)
-		=> value.ToString("o");
+		=> options?.IncludeType switch
+		{
+			true => $"DateTime {value:o}",
+			_ => value.ToString("o"),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -23,7 +27,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		DateTime value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value.ToString("o"));
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("DateTime ");
+		}
+
+		stringBuilder.Append(value.ToString("o"));
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.DateTimeOffset.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.DateTimeOffset.cs
@@ -12,7 +12,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		DateTimeOffset value,
 		FormattingOptions? options = null)
-		=> value.ToString("o");
+		=> options?.IncludeType switch
+		{
+			true => $"DateTimeOffset {value:o}",
+			_ => value.ToString("o"),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -23,7 +27,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		DateTimeOffset value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value.ToString("o"));
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("DateTimeOffset ");
+		}
+
+		stringBuilder.Append(value.ToString("o"));
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Enum.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Enum.cs
@@ -18,6 +18,11 @@ public static partial class ValueFormatters
 			return ValueFormatter.NullString;
 		}
 
+		if (options?.IncludeType == true)
+		{
+			return $"{Format(formatter, value.GetType())} {value}";
+		}
+
 		return value.ToString();
 	}
 
@@ -37,6 +42,12 @@ public static partial class ValueFormatters
 		}
 		else
 		{
+			if (options?.IncludeType == true)
+			{
+				Format(formatter, stringBuilder, value.GetType());
+				stringBuilder.Append(' ');
+			}
+
 			stringBuilder.Append(value);
 		}
 	}

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Guid.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Guid.cs
@@ -12,7 +12,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		Guid value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"Guid {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -23,7 +27,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		Guid value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("Guid ");
+		}
+
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.HttpStatusCode.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.HttpStatusCode.cs
@@ -18,7 +18,11 @@ public static partial class ValueFormatters
 			return ValueFormatter.NullString;
 		}
 
-		return $"{(int)value} {value}";
+		return options?.IncludeType switch
+		{
+			true => $"HttpStatusCode {(int)value} {value}",
+			_ => $"{(int)value} {value}",
+		};
 	}
 
 	/// <summary>
@@ -35,6 +39,11 @@ public static partial class ValueFormatters
 		{
 			stringBuilder.Append(ValueFormatter.NullString);
 			return;
+		}
+
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("HttpStatusCode ");
 		}
 
 		stringBuilder.Append((int)value).Append(' ').Append(value);

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
@@ -15,7 +15,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		byte value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"byte {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -26,7 +30,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		byte value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("byte ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -70,7 +81,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		sbyte value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"sbyte {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -81,7 +96,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		sbyte value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("sbyte ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -125,7 +147,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		short value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"short {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -136,7 +162,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		short value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("short ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -180,7 +213,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		ushort value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"ushort {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -191,7 +228,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		ushort value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("ushort ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -235,7 +279,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		int value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"int {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -246,7 +294,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		int value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("int ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -290,7 +345,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		uint value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"uint {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -301,7 +360,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		uint value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("uint ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -345,7 +411,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		long value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"long {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -356,7 +426,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		long value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("long ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -400,7 +477,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		ulong value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"ulong {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -411,7 +492,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		ulong value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("ulong ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -455,13 +543,18 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		float value,
 		FormattingOptions? options = null)
-		=> value switch
+		=> (options?.IncludeType, value) switch
 		{
-			float.NegativeInfinity => "-\u221e",
-			float.PositiveInfinity => "+\u221e",
-			float.MinValue => "float.MinValue",
-			float.MaxValue => "float.MaxValue",
-			_ => value.ToString(CultureInfo.InvariantCulture)
+			(true, float.NegativeInfinity) => "float -\u221e",
+			(true, float.PositiveInfinity) => "float +\u221e",
+			(true, float.MinValue) => "float.MinValue",
+			(true, float.MaxValue) => "float.MaxValue",
+			(true, _) => $"float {value.ToString(CultureInfo.InvariantCulture)}",
+			(_, float.NegativeInfinity) => "-\u221e",
+			(_, float.PositiveInfinity) => "+\u221e",
+			(_, float.MinValue) => "float.MinValue",
+			(_, float.MaxValue) => "float.MaxValue",
+			(_, _) => value.ToString(CultureInfo.InvariantCulture),
 		};
 
 	/// <summary>
@@ -517,13 +610,18 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		double value,
 		FormattingOptions? options = null)
-		=> value switch
+		=> (options?.IncludeType, value) switch
 		{
-			double.NegativeInfinity => "-\u221e",
-			double.PositiveInfinity => "+\u221e",
-			double.MinValue => "double.MinValue",
-			double.MaxValue => "double.MaxValue",
-			_ => value.ToString(CultureInfo.InvariantCulture)
+			(true, double.NegativeInfinity) => "double -\u221e",
+			(true, double.PositiveInfinity) => "double +\u221e",
+			(true, double.MinValue) => "double.MinValue",
+			(true, double.MaxValue) => "double.MaxValue",
+			(true, _) => $"double {value.ToString(CultureInfo.InvariantCulture)}",
+			(_, double.NegativeInfinity) => "-\u221e",
+			(_, double.PositiveInfinity) => "+\u221e",
+			(_, double.MinValue) => "double.MinValue",
+			(_, double.MaxValue) => "double.MaxValue",
+			(_, _) => value.ToString(CultureInfo.InvariantCulture),
 		};
 
 	/// <summary>
@@ -583,12 +681,17 @@ public static partial class ValueFormatters
 	{
 		if (Half.IsNegativeInfinity(value))
 		{
-			return "-\u221e";
+			return options?.IncludeType == true ? "Half -\u221e" : "-\u221e";
 		}
 
 		if (Half.IsPositiveInfinity(value))
 		{
-			return "+\u221e";
+			return options?.IncludeType == true ? "Half +\u221e" : "+\u221e";
+		}
+
+		if (options?.IncludeType == true)
+		{
+			return $"Half {value.ToString(CultureInfo.InvariantCulture)}";
 		}
 
 		return value.ToString(CultureInfo.InvariantCulture);
@@ -654,11 +757,14 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		decimal value,
 		FormattingOptions? options = null)
-		=> value switch
+		=> (options?.IncludeType, value) switch
 		{
-			decimal.MinValue => "decimal.MinValue",
-			decimal.MaxValue => "decimal.MaxValue",
-			_ => value.ToString(CultureInfo.InvariantCulture)
+			(true, decimal.MinValue) => "decimal.MinValue",
+			(true, decimal.MaxValue) => "decimal.MaxValue",
+			(true, _) => $"decimal {value.ToString(CultureInfo.InvariantCulture)}",
+			(_, decimal.MinValue) => "decimal.MinValue",
+			(_, decimal.MaxValue) => "decimal.MaxValue",
+			(_, _) => value.ToString(CultureInfo.InvariantCulture),
 		};
 
 	/// <summary>
@@ -714,7 +820,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		nint value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"nint {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -725,7 +835,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		nint value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("nint ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.
@@ -769,7 +886,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		nuint value,
 		FormattingOptions? options = null)
-		=> value.ToString();
+		=> options?.IncludeType switch
+		{
+			true => $"nuint {value}",
+			_ => value.ToString(),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -780,7 +901,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		nuint value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value);
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("nuint ");
+		}
+		
+		stringBuilder.Append(value);
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Object.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Object.cs
@@ -18,7 +18,10 @@ public static partial class ValueFormatters
 		else if (HasDefaultToStringImplementation(value))
 		{
 			context ??= new FormattingContext();
-			WriteTypeAndMemberValues(value, stringBuilder, options, context);
+			WriteTypeAndMemberValues(value, stringBuilder, options with
+			{
+				IncludeType = false,
+			}, context);
 		}
 		else if (options.UseLineBreaks)
 		{

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.String.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.String.cs
@@ -19,12 +19,13 @@ public static partial class ValueFormatters
 		}
 
 		options ??= FormattingOptions.SingleLine;
-		if (!options.UseLineBreaks)
+		return (options.UseLineBreaks, options.IncludeType) switch
 		{
-			return $"\"{value.DisplayWhitespace().TruncateWithEllipsis(100)}\"";
-		}
-
-		return $"\"{value}\"";
+			(true, true) => $"string \"{value}\"",
+			(false, true) => $"string \"{value.DisplayWhitespace().TruncateWithEllipsis(100)}\"",
+			(true, false) => $"\"{value}\"",
+			(false, false) => $"\"{value.DisplayWhitespace().TruncateWithEllipsis(100)}\"",
+		};
 	}
 
 	/// <summary>
@@ -44,6 +45,11 @@ public static partial class ValueFormatters
 		}
 
 		options ??= FormattingOptions.SingleLine;
+		if (options.IncludeType)
+		{
+			stringBuilder.Append("string ");
+		}
+
 		stringBuilder.Append('\"');
 		if (!options.UseLineBreaks)
 		{

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.TimeOnly.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.TimeOnly.cs
@@ -13,7 +13,11 @@ public static partial class ValueFormatters
 		this ValueFormatter _,
 		TimeOnly value,
 		FormattingOptions? options = null)
-		=> value.ToString("o");
+		=> options?.IncludeType switch
+		{
+			true => $"TimeOnly {value.ToString("o")}",
+			_ => value.ToString("o"),
+		};
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
@@ -24,7 +28,14 @@ public static partial class ValueFormatters
 		StringBuilder stringBuilder,
 		TimeOnly value,
 		FormattingOptions? options = null)
-		=> stringBuilder.Append(value.ToString("o"));
+	{
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("TimeOnly ");
+		}
+
+		stringBuilder.Append(value.ToString("o"));
+	}
 
 	/// <summary>
 	///     Returns the formatted <paramref name="value" /> according to the <paramref name="options" />.

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.TimeSpan.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.TimeSpan.cs
@@ -73,6 +73,11 @@ public static partial class ValueFormatters
 			return;
 		}
 
+		if (options?.IncludeType == true)
+		{
+			stringBuilder.Append("TimeSpan ");
+		}
+
 		TimeSpan absoluteValue = value.Value.Duration();
 		bool hasDays = absoluteValue.Days > 0;
 		bool hasHours = absoluteValue.Hours > 0;

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -52,95 +52,103 @@ public static partial class ValueFormatters
 		switch (value)
 		{
 			case bool boolValue:
-				formatter.Format(stringBuilder, boolValue, options);
+				Format(formatter, stringBuilder, boolValue, options);
 				return;
 			case string stringValue:
-				formatter.Format(stringBuilder, stringValue, options);
+				Format(formatter, stringBuilder, stringValue, options);
 				return;
 			case char charValue:
-				formatter.Format(stringBuilder, charValue, options);
+				Format(formatter, stringBuilder, charValue, options);
 				return;
 			case Type typeValue:
-				formatter.Format(stringBuilder, typeValue, options);
+				Format(formatter, stringBuilder, typeValue, options);
 				return;
 			case IEnumerable enumerableValue:
-				formatter.Format(stringBuilder, enumerableValue, options);
+				Format(formatter, stringBuilder, enumerableValue, options);
 				return;
 			case HttpStatusCode httpStatusCodeValue:
-				formatter.Format(stringBuilder, httpStatusCodeValue, options);
+				Format(formatter, stringBuilder, httpStatusCodeValue, options);
 				return;
 			case DateTime dateTimeValue:
-				formatter.Format(stringBuilder, dateTimeValue, options);
+				Format(formatter, stringBuilder, dateTimeValue, options);
 				return;
 			case DateTimeOffset dateTimeOffsetValue:
-				formatter.Format(stringBuilder, dateTimeOffsetValue, options);
+				Format(formatter, stringBuilder, dateTimeOffsetValue, options);
 				return;
 			case TimeSpan timeSpanValue:
-				formatter.Format(stringBuilder, timeSpanValue, options);
+				Format(formatter, stringBuilder, timeSpanValue, options);
 				return;
 #if NET8_0_OR_GREATER
 			case DateOnly dateOnlyValue:
-				formatter.Format(stringBuilder, dateOnlyValue, options);
+				Format(formatter, stringBuilder, dateOnlyValue, options);
 				return;
 			case TimeOnly timeOnlyValue:
-				formatter.Format(stringBuilder, timeOnlyValue, options);
+				Format(formatter, stringBuilder, timeOnlyValue, options);
 				return;
 #endif
 			case Guid guidValue:
-				formatter.Format(stringBuilder, guidValue, options);
+				Format(formatter, stringBuilder, guidValue, options);
 				return;
 			case Enum enumValue:
-				formatter.Format(stringBuilder, enumValue, options);
+				Format(formatter, stringBuilder, enumValue, options);
 				return;
 			case double doubleValue:
-				formatter.Format(stringBuilder, doubleValue, options);
+				Format(formatter, stringBuilder, doubleValue, options);
 				return;
 			case float floatValue:
-				formatter.Format(stringBuilder, floatValue, options);
+				Format(formatter, stringBuilder, floatValue, options);
 				return;
 #if NET8_0_OR_GREATER
 			case Half halfValue:
-				formatter.Format(stringBuilder, halfValue, options);
+				Format(formatter, stringBuilder, halfValue, options);
 				return;
 #endif
 			case decimal decimalValue:
-				formatter.Format(stringBuilder, decimalValue, options);
+				Format(formatter, stringBuilder, decimalValue, options);
 				return;
 			case int intValue:
-				formatter.Format(stringBuilder, intValue, options);
+				Format(formatter, stringBuilder, intValue, options);
 				return;
 			case uint uintValue:
-				formatter.Format(stringBuilder, uintValue, options);
+				Format(formatter, stringBuilder, uintValue, options);
 				return;
 			case long longValue:
-				formatter.Format(stringBuilder, longValue, options);
+				Format(formatter, stringBuilder, longValue, options);
 				return;
 			case ulong ulongValue:
-				formatter.Format(stringBuilder, ulongValue, options);
+				Format(formatter, stringBuilder, ulongValue, options);
 				return;
 			case byte byteValue:
-				formatter.Format(stringBuilder, byteValue, options);
+				Format(formatter, stringBuilder, byteValue, options);
 				return;
 			case sbyte sbyteValue:
-				formatter.Format(stringBuilder, sbyteValue, options);
+				Format(formatter, stringBuilder, sbyteValue, options);
 				return;
 			case short shortValue:
-				formatter.Format(stringBuilder, shortValue, options);
+				Format(formatter, stringBuilder, shortValue, options);
 				return;
 			case ushort ushortValue:
-				formatter.Format(stringBuilder, ushortValue, options);
+				Format(formatter, stringBuilder, ushortValue, options);
 				return;
 			case nint nintValue:
-				formatter.Format(stringBuilder, nintValue, options);
+				Format(formatter, stringBuilder, nintValue, options);
 				return;
 			case nuint nuintValue:
-				formatter.Format(stringBuilder, nuintValue, options);
+				Format(formatter, stringBuilder, nuintValue, options);
 				return;
 		}
 
 		Type? valueType = value.GetType();
 		if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
 		{
+			if (options is not null)
+			{
+				options = options with
+				{
+					IncludeType = false,
+				};
+			}
+
 			object? key = valueType.GetProperty("Key")?.GetValue(value);
 			object? item = valueType.GetProperty("Value")?.GetValue(value);
 			stringBuilder.Append('[');

--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -77,7 +77,7 @@ public static partial class ThatObject
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" was ");
-			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation));
+			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation, true));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
@@ -141,7 +141,7 @@ public static partial class ThatObject
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" was ");
-			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation));
+			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation, true));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)

--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -74,7 +74,7 @@ public static partial class ThatObject
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" was ");
-			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation));
+			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation, true));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
@@ -111,7 +111,7 @@ public static partial class ThatObject
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" was ");
-			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation));
+			Formatter.Format(stringBuilder, Actual, FormattingOptions.Indented(indentation, true));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -612,11 +612,14 @@ namespace aweXpect.Formatting
     }
     public class FormattingOptions : System.IEquatable<aweXpect.Formatting.FormattingOptions>
     {
-        public string Indentation { get; }
-        public bool UseLineBreaks { get; }
+        public FormattingOptions() { }
+        public bool IncludeType { get; init; }
+        public string Indentation { get; init; }
+        public bool UseLineBreaks { get; init; }
         public static aweXpect.Formatting.FormattingOptions MultipleLines { get; }
         public static aweXpect.Formatting.FormattingOptions SingleLine { get; }
-        public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null) { }
+        public static aweXpect.Formatting.FormattingOptions WithType { get; }
+        public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null, bool includeType = false) { }
     }
     public interface IValueFormatter
     {
@@ -641,7 +644,6 @@ namespace aweXpect.Formatting
         public static string Format(this aweXpect.Formatting.ValueFormatter _, bool value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, byte value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, char value, aweXpect.Formatting.FormattingOptions? options = null) { }
-        public static string Format(this aweXpect.Formatting.ValueFormatter _, char? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, decimal value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, double value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, float value, aweXpect.Formatting.FormattingOptions? options = null) { }
@@ -667,6 +669,7 @@ namespace aweXpect.Formatting
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.UIntPtr? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, bool? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, byte? value, aweXpect.Formatting.FormattingOptions? options = null) { }
+        public static string Format(this aweXpect.Formatting.ValueFormatter formatter, char? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, decimal? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, double? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, float? value, aweXpect.Formatting.FormattingOptions? options = null) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -607,11 +607,14 @@ namespace aweXpect.Formatting
     }
     public class FormattingOptions : System.IEquatable<aweXpect.Formatting.FormattingOptions>
     {
-        public string Indentation { get; }
-        public bool UseLineBreaks { get; }
+        public FormattingOptions() { }
+        public bool IncludeType { get; init; }
+        public string Indentation { get; init; }
+        public bool UseLineBreaks { get; init; }
         public static aweXpect.Formatting.FormattingOptions MultipleLines { get; }
         public static aweXpect.Formatting.FormattingOptions SingleLine { get; }
-        public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null) { }
+        public static aweXpect.Formatting.FormattingOptions WithType { get; }
+        public static aweXpect.Formatting.FormattingOptions Indented(string? indentation = null, bool includeType = false) { }
     }
     public interface IValueFormatter
     {
@@ -633,7 +636,6 @@ namespace aweXpect.Formatting
         public static string Format(this aweXpect.Formatting.ValueFormatter _, bool value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, byte value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, char value, aweXpect.Formatting.FormattingOptions? options = null) { }
-        public static string Format(this aweXpect.Formatting.ValueFormatter _, char? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, decimal value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, double value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter _, float value, aweXpect.Formatting.FormattingOptions? options = null) { }
@@ -656,6 +658,7 @@ namespace aweXpect.Formatting
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, System.UIntPtr? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, bool? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, byte? value, aweXpect.Formatting.FormattingOptions? options = null) { }
+        public static string Format(this aweXpect.Formatting.ValueFormatter formatter, char? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, decimal? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, double? value, aweXpect.Formatting.FormattingOptions? options = null) { }
         public static string Format(this aweXpect.Formatting.ValueFormatter formatter, float? value, aweXpect.Formatting.FormattingOptions? options = null) { }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.BoolTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.BoolTests.cs
@@ -23,6 +23,22 @@ public partial class ValueFormatters
 		}
 
 		[Theory]
+		[InlineData(true, "bool True")]
+		[InlineData(false, "bool False")]
+		public async Task Booleans_WithType_ShouldHaveCapitalizedFirstLetter(bool value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
 		[InlineData(true, "True")]
 		[InlineData(false, "False")]
 		[InlineData(null, "<null>")]
@@ -33,6 +49,23 @@ public partial class ValueFormatters
 			string result = Formatter.Format(value);
 			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
+		[InlineData(true, "bool True")]
+		[InlineData(false, "bool False")]
+		[InlineData(null, "<null>")]
+		public async Task NullableBooleans_WithType_ShouldHaveCapitalizedFirstLetter(bool? value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
 
 			await That(result).IsEqualTo(expectedResult);
 			await That(objectResult).IsEqualTo(expectedResult);

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.CharTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.CharTests.cs
@@ -23,6 +23,22 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task NullableValue_WithType_ShouldAddSingleQuotes()
+		{
+			char? value = 'X';
+			string expectedResult = "char 'X'";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
 		public async Task Value_ShouldAddSingleQuotes()
 		{
 			char value = 'a';
@@ -32,6 +48,22 @@ public partial class ValueFormatters
 			string result = Formatter.Format(value);
 			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Value_WithType_ShouldAddSingleQuotes()
+		{
+			char value = 'a';
+			string expectedResult = "char 'a'";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
 
 			await That(result).IsEqualTo(expectedResult);
 			await That(objectResult).IsEqualTo(expectedResult);

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.CollectionTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.CollectionTests.cs
@@ -8,7 +8,7 @@ namespace aweXpect.Core.Tests.Formatting;
 
 public partial class ValueFormatters
 {
-	public sealed class CollectionFormatterTests
+	public sealed class CollectionTests
 	{
 		[Fact]
 		public async Task ShouldFormatItems()
@@ -55,6 +55,38 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_Array_ShouldIncludeTypeInformation()
+		{
+			string expectedResult = "int[] [1, 2, 3, 4]";
+			int[] value = [..Enumerable.Range(1, 4),];
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task WithType_EnumerableShouldIncludeTypeInformation()
+		{
+			string expectedResult = "List<int> [1, 2, 3, 4, 5]";
+			IEnumerable<int> value = Enumerable.Range(1, 5).ToList();
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateOnlyTests.cs
@@ -24,6 +24,22 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task Nullable_WithType_ShouldUseRoundtripFormat()
+		{
+			DateOnly? value = new(2024, 11, 2);
+			string expectedResult = "DateOnly 2024-11-02";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
 		public async Task ShouldUseRoundtripFormat()
 		{
 			DateOnly value = new(2024, 11, 2);
@@ -52,6 +68,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldUseRoundtripFormat()
+		{
+			DateOnly value = new(2024, 11, 2);
+			string expectedResult = "DateOnly 2024-11-02";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeOffsetTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeOffsetTests.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Core.Tests.Formatting;
 
 public partial class ValueFormatters
 {
-	public sealed class DateTimeOffsetFormatterTests
+	public sealed class DateTimeOffsetTests
 	{
 		[Fact]
 		public async Task Nullable_ShouldUseRoundtripFormat()
@@ -17,6 +17,22 @@ public partial class ValueFormatters
 			string result = Formatter.Format(value);
 			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Nullable_WithType_ShouldUseRoundtripFormat()
+		{
+			DateTimeOffset? value = 2.November(2024).At(15, 42, 08, 123).WithOffset(3.Hours());
+			string expectedResult = "DateTimeOffset 2024-11-02T15:42:08.1230000+03:00";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
 
 			await That(result).IsEqualTo(expectedResult);
 			await That(objectResult).IsEqualTo(expectedResult);
@@ -52,6 +68,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldUseRoundtripFormat()
+		{
+			DateTimeOffset value = 2.November(2024).At(15, 42, 08, 123).WithOffset(3.Hours());
+			string expectedResult = "DateTimeOffset 2024-11-02T15:42:08.1230000+03:00";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DateTimeTests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Core.Tests.Formatting;
 
 public partial class ValueFormatters
 {
-	public sealed class DateTimeFormatterTests
+	public sealed class DateTimeTests
 	{
 		[Fact]
 		public async Task Nullable_ShouldUseRoundtripFormat()
@@ -16,6 +16,22 @@ public partial class ValueFormatters
 			string result = Formatter.Format(value);
 			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Nullable_WithType_ShouldUseRoundtripFormat()
+		{
+			DateTime? value = new(2024, 11, 2, 15, 42, 08, 123);
+			string expectedResult = "DateTime 2024-11-02T15:42:08.1230000";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
 
 			await That(result).IsEqualTo(expectedResult);
 			await That(objectResult).IsEqualTo(expectedResult);
@@ -51,6 +67,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldUseRoundtripFormat()
+		{
+			DateTime value = new(2024, 11, 2, 15, 42, 08, 123);
+			string expectedResult = "DateTime 2024-11-02T15:42:08.1230000";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DictionaryTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DictionaryTests.cs
@@ -8,7 +8,7 @@ namespace aweXpect.Core.Tests.Formatting;
 
 public partial class ValueFormatters
 {
-	public sealed class DictionaryFormatterTests
+	public sealed class DictionaryTests
 	{
 		[Fact]
 		public async Task ShouldFormatItems()
@@ -39,6 +39,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldIncludeTypeInformation()
+		{
+			string expectedResult = "Dictionary<string, int> [[\"1\", 1], [\"2\", 2], [\"3\", 3]]";
+			Dictionary<string, int> value = Enumerable.Range(1, 3).ToDictionary(i => i.ToString(), i => i);
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.EnumTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.EnumTests.cs
@@ -10,13 +10,30 @@ public partial class ValueFormatters
 		[InlineData(Dummy.Foo, "Foo")]
 		[InlineData(Dummy.Bar, "Bar")]
 		[InlineData(null, "<null>")]
-		public async Task NullableShouldUseStringRepresentation(Dummy? value, string expectedResult)
+		public async Task Nullable_ShouldUseStringRepresentation(Dummy? value, string expectedResult)
 		{
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value);
 			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
+		[InlineData(Dummy.Foo, "ValueFormatters.EnumTests.Dummy Foo")]
+		[InlineData(Dummy.Bar, "ValueFormatters.EnumTests.Dummy Bar")]
+		[InlineData(null, "<null>")]
+		public async Task Nullable_WithType_ShouldUseStringRepresentation(Dummy? value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
 
 			await That(result).IsEqualTo(expectedResult);
 			await That(objectResult).IsEqualTo(expectedResult);
@@ -52,6 +69,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Theory]
+		[InlineData(Dummy.Foo, "ValueFormatters.EnumTests.Dummy Foo")]
+		[InlineData(Dummy.Bar, "ValueFormatters.EnumTests.Dummy Bar")]
+		public async Task WithType_ShouldUseStringRepresentation(Dummy value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 
 		public enum Dummy

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.GuidTests.cs
@@ -23,7 +23,7 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
-		public async Task NullableEmpty_ShouldUseDefaultFormat()
+		public async Task Nullable_Empty_ShouldUseDefaultFormat()
 		{
 			Guid? value = Guid.Empty;
 			string expectedResult = "00000000-0000-0000-0000-000000000000";
@@ -39,7 +39,7 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
-		public async Task NullableShouldUseRoundtripFormat()
+		public async Task Nullable_ShouldUseRoundtripFormat()
 		{
 			Guid? value = Guid.NewGuid();
 			string? expectedResult = value.ToString();
@@ -48,6 +48,22 @@ public partial class ValueFormatters
 			string result = Formatter.Format(value);
 			string objectResult = Formatter.Format((object?)value);
 			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Nullable_WithType_ShouldUseRoundtripFormat()
+		{
+			Guid? value = Guid.NewGuid();
+			string expectedResult = $"Guid {value.ToString()}";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
 
 			await That(result).IsEqualTo(expectedResult);
 			await That(objectResult).IsEqualTo(expectedResult);
@@ -83,6 +99,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldUseRoundtripFormat()
+		{
+			Guid value = Guid.NewGuid();
+			string expectedResult = $"Guid {value.ToString()}";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.HttpStatusCodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.HttpStatusCodeTests.cs
@@ -26,6 +26,24 @@ public partial class ValueFormatters
 		}
 
 		[Theory]
+		[InlineData(HttpStatusCode.OK, "HttpStatusCode 200 OK")]
+		[InlineData(HttpStatusCode.BadRequest, "HttpStatusCode 400 BadRequest")]
+		[InlineData(null, "<null>")]
+		public async Task Nullable_WithType_ShouldIncludeNumberAndDescription(HttpStatusCode? value,
+			string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
 		[InlineData(HttpStatusCode.OK, "200 OK")]
 		[InlineData(HttpStatusCode.BadRequest, "400 BadRequest")]
 		public async Task ShouldIncludeNumberAndDescription(HttpStatusCode value, string expectedResult)
@@ -54,6 +72,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.OK, "HttpStatusCode 200 OK")]
+		[InlineData(HttpStatusCode.BadRequest, "HttpStatusCode 400 BadRequest")]
+		public async Task WithType_ShouldIncludeNumberAndDescription(HttpStatusCode value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
@@ -670,5 +670,457 @@ public partial class ValueFormatters
 			await That(objectResult).IsEqualTo(expectedResult);
 			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
+		
+		[Fact]
+		public async Task Numbers_WithType_Byte_ShouldReturnExpectedValue()
+		{
+			byte value = 3;
+			string expectedResult = "byte 3";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Decimal_ShouldReturnExpectedValue()
+		{
+			decimal value = new(11.3);
+			string expectedResult = "decimal 11.3";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Double_ShouldReturnExpectedValue()
+		{
+			double value = 10.2;
+			string expectedResult = "double 10.2";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+#if NET8_0_OR_GREATER
+		[Fact]
+		public async Task Numbers_WithType_Half_ShouldReturnExpectedValue()
+		{
+			Half value = (Half)11.3;
+			string expectedResult = "Half 11.3";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+#endif
+
+		[Fact]
+		public async Task Numbers_WithType_Int16_ShouldReturnExpectedValue()
+		{
+			short value = -5;
+			string expectedResult = "short -5";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Int32_ShouldReturnExpectedValue()
+		{
+			int value = -1;
+			string expectedResult = "int -1";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Int64_ShouldReturnExpectedValue()
+		{
+			long value = -7;
+			string expectedResult = "long -7";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Nint_ShouldReturnExpectedValue()
+		{
+			nint value = -123;
+			string expectedResult = "nint -123";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Nuint_ShouldReturnExpectedValue()
+		{
+			nuint value = 123;
+			string expectedResult = "nuint 123";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableByte_ShouldReturnExpectedValue()
+		{
+			byte? value = 30;
+			string expectedResult = "byte 30";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableDecimal_ShouldReturnExpectedValue()
+		{
+			decimal? value = new(11.03);
+			string expectedResult = "decimal 11.03";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableDouble_ShouldReturnExpectedValue()
+		{
+			double? value = 10.02;
+			string expectedResult = "double 10.02";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+#if NET8_0_OR_GREATER
+		[Fact]
+		public async Task Numbers_WithType_NullableHalf_ShouldReturnExpectedValue()
+		{
+			Half? value = (Half)11.03;
+			string expectedResult = "Half 11.03";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+#endif
+
+		[Fact]
+		public async Task Numbers_WithType_NullableInt16_ShouldReturnExpectedValue()
+		{
+			short? value = -50;
+			string expectedResult = "short -50";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableInt32_ShouldReturnExpectedValue()
+		{
+			int? value = -10;
+			string expectedResult = "int -10";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableInt64_ShouldReturnExpectedValue()
+		{
+			long? value = -70;
+			string expectedResult = "long -70";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableNint_ShouldReturnExpectedValue()
+		{
+			nint? value = -123;
+			string expectedResult = "nint -123";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableNuint_ShouldReturnExpectedValue()
+		{
+			nuint? value = 123;
+			string expectedResult = "nuint 123";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableSByte_ShouldReturnExpectedValue()
+		{
+			sbyte? value = -40;
+			string expectedResult = "sbyte -40";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableSingle_ShouldReturnExpectedValue()
+		{
+			float? value = 9.01F;
+			string expectedResult = "float 9.01";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableUInt16_ShouldReturnExpectedValue()
+		{
+			ushort? value = 60;
+			string expectedResult = "ushort 60";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableUInt32_ShouldReturnExpectedValue()
+		{
+			uint? value = 20;
+			string expectedResult = "uint 20";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_NullableUInt64_ShouldReturnExpectedValue()
+		{
+			ulong? value = 80;
+			string expectedResult = "ulong 80";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_SByte_ShouldReturnExpectedValue()
+		{
+			sbyte value = -4;
+			string expectedResult = "sbyte -4";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_Single_ShouldReturnExpectedValue()
+		{
+			float value = 9.1F;
+			string expectedResult = "float 9.1";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_UInt16_ShouldReturnExpectedValue()
+		{
+			ushort value = 6;
+			string expectedResult = "ushort 6";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_UInt32_ShouldReturnExpectedValue()
+		{
+			uint value = 2;
+			string expectedResult = "uint 2";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Numbers_WithType_UInt64_ShouldReturnExpectedValue()
+		{
+			ulong value = 8;
+			string expectedResult = "ulong 8";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.ObjectTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.ObjectTests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Core.Tests.Formatting;
 
 public partial class ValueFormatters
 {
-	public sealed class FormatObjectTests
+	public sealed class ObjectTests
 	{
 		[Fact]
 		public async Task ShouldDisplayNestedObjects()
@@ -18,7 +18,7 @@ public partial class ValueFormatters
 				Value = 2,
 			};
 			string expectedResult = """
-			                        ValueFormatters.FormatObjectTests.Dummy { Inner = ValueFormatters.FormatObjectTests.InnerDummy { InnerValue = "foo" }, Value = 2 }
+			                        ValueFormatters.ObjectTests.Dummy { Inner = ValueFormatters.ObjectTests.InnerDummy { InnerValue = "foo" }, Value = 2 }
 			                        """;
 			StringBuilder sb = new();
 
@@ -38,7 +38,7 @@ public partial class ValueFormatters
 			};
 			value.Inner = value;
 			string expectedResult = """
-			                        ValueFormatters.FormatObjectTests.RecursiveDummy { Inner = ValueFormatters.FormatObjectTests.RecursiveDummy { *recursive* }, Value = 1 }
+			                        ValueFormatters.ObjectTests.RecursiveDummy { Inner = ValueFormatters.ObjectTests.RecursiveDummy { *recursive* }, Value = 1 }
 			                        """;
 			StringBuilder sb = new();
 
@@ -61,8 +61,8 @@ public partial class ValueFormatters
 				Value = 2,
 			};
 			string expectedResult = """
-			                        ValueFormatters.FormatObjectTests.Dummy {
-			                            Inner = ValueFormatters.FormatObjectTests.InnerDummy {
+			                        ValueFormatters.ObjectTests.Dummy {
+			                            Inner = ValueFormatters.ObjectTests.InnerDummy {
 			                              InnerValue = "foo"
 			                            },
 			                            Value = 2
@@ -89,8 +89,8 @@ public partial class ValueFormatters
 				Value = 2,
 			};
 			string expectedResult = """
-			                        ValueFormatters.FormatObjectTests.Dummy {
-			                          Inner = ValueFormatters.FormatObjectTests.InnerDummy {
+			                        ValueFormatters.ObjectTests.Dummy {
+			                          Inner = ValueFormatters.ObjectTests.InnerDummy {
 			                            InnerValue = "foo"
 			                          },
 			                          Value = 2
@@ -143,7 +143,7 @@ public partial class ValueFormatters
 			{
 				Value = 42,
 			};
-			string expectedResult = "ValueFormatters.FormatObjectTests.ClassWithField { Value = 42 }";
+			string expectedResult = "ValueFormatters.ObjectTests.ClassWithField { Value = 42 }";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value, FormattingOptions.SingleLine);
@@ -157,7 +157,7 @@ public partial class ValueFormatters
 		public async Task WhenClassIsEmpty_ShouldDisplayClassName()
 		{
 			object value = new EmptyClass();
-			string expectedResult = "ValueFormatters.FormatObjectTests.EmptyClass { }";
+			string expectedResult = "ValueFormatters.ObjectTests.EmptyClass { }";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value, FormattingOptions.SingleLine);
@@ -172,7 +172,8 @@ public partial class ValueFormatters
 		{
 			Exception exception = new("foo");
 			object value = new ClassWithExceptionProperty(exception);
-			string expectedResult = "ValueFormatters.FormatObjectTests.ClassWithExceptionProperty { Value = [Member 'Value' threw an exception: 'foo'] }";
+			string expectedResult =
+				"ValueFormatters.ObjectTests.ClassWithExceptionProperty { Value = [Member 'Value' threw an exception: 'foo'] }";
 			StringBuilder sb = new();
 
 			string result = Formatter.Format(value, FormattingOptions.SingleLine);
@@ -209,6 +210,20 @@ public partial class ValueFormatters
 
 			await That(result).IsEqualTo(expectedResult).AsWildcard();
 			await That(sb.ToString()).IsEqualTo(expectedResult).AsWildcard();
+		}
+
+		[Fact]
+		public async Task WithType_ShouldDisplayClassNameOnlyOnce()
+		{
+			object value = new EmptyClass();
+			string expectedResult = "ValueFormatters.ObjectTests.EmptyClass { }";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 
 		private sealed class ClassWithExceptionProperty(Exception exception)

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.StringTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.StringTests.cs
@@ -52,10 +52,27 @@ public partial class ValueFormatters
 			                        """;
 			StringBuilder sb = new();
 
-			string result = Formatter.Format(value, FormattingOptions.MultipleLines);
+			string result =
+				Formatter.Format(value, FormattingOptions.MultipleLines);
 			Formatter.Format(sb, value, FormattingOptions.MultipleLines);
 
 			await That(result).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
+		public async Task Strings_WithType_ShouldIncludeTypeInformation()
+		{
+			string value = "foo";
+			string expectedResult = "string \"foo\"";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
 			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeOnlyTests.cs
@@ -24,6 +24,22 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task Nullable_WithType_ShouldUseRoundtripFormat()
+		{
+			TimeOnly? value = new(15, 42, 15, 234);
+			string expectedResult = "TimeOnly 15:42:15.2340000";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
 		public async Task ShouldUseRoundtripFormat()
 		{
 			TimeOnly value = new(15, 42, 15, 234);
@@ -52,6 +68,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldUseRoundtripFormat()
+		{
+			TimeOnly value = new(15, 42, 15, 234);
+			string expectedResult = "TimeOnly 15:42:15.2340000";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeSpanTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TimeSpanTests.cs
@@ -120,6 +120,22 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task Nullable_WithType_ShouldIncludeTypeInformation()
+		{
+			TimeSpan? value = 12.Seconds();
+			string expectedResult = "TimeSpan 0:12";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
 		public async Task ShouldIncludeSingleDigitMinuteEvenWhenOnlySecondsAreSpecified()
 		{
 			TimeSpan value = 12.Seconds();
@@ -260,6 +276,22 @@ public partial class ValueFormatters
 			await That(result).IsEqualTo(ValueFormatter.NullString);
 			await That(objectResult).IsEqualTo(ValueFormatter.NullString);
 			await That(sb.ToString()).IsEqualTo(ValueFormatter.NullString);
+		}
+
+		[Fact]
+		public async Task WithType_ShouldIncludeTypeInformation()
+		{
+			TimeSpan value = 3.Minutes(20.Seconds());
+			string expectedResult = "TimeSpan 3:20";
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value, FormattingOptions.WithType);
+			string objectResult = Formatter.Format((object?)value, FormattingOptions.WithType);
+			Formatter.Format(sb, value, FormattingOptions.WithType);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.Is.Tests.cs
@@ -254,7 +254,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is type IDictionary<, >,
-					             but it was []
+					             but it was List<string> []
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsExactly.Tests.cs
@@ -256,7 +256,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is exactly type IList<>,
-					             but it was []
+					             but it was List<string> []
 					             """);
 			}
 
@@ -283,7 +283,7 @@ public sealed partial class ThatObject
 					.WithMessage("""
 					             Expected that subject
 					             is exactly type IDictionary<, >,
-					             but it was []
+					             but it was List<string> []
 					             """);
 			}
 		}


### PR DESCRIPTION
When using `FormattingOptions.WithType` include the type information in the formatted string