### PR TITLE
fix: correctly handle `null` in string `Contains`

### DIFF
--- a/Source/aweXpect/That/Strings/ThatString.Contains.cs
+++ b/Source/aweXpect/That/Strings/ThatString.Contains.cs
@@ -57,7 +57,7 @@ public static partial class ThatString
 	private sealed class ContainsConstraint(
 		string it,
 		ExpectationGrammars grammars,
-		string expected,
+		string? expected,
 		Quantifier quantifier,
 		StringEqualityOptions options)
 		: ConstraintResult(grammars),
@@ -65,11 +65,18 @@ public static partial class ThatString
 	{
 		private string? _actual;
 		private int _actualCount;
+		private bool _isNegated;
 
 		/// <inheritdoc />
 		public ConstraintResult IsMetBy(string? actual)
 		{
 			_actual = actual;
+			if (expected is null)
+			{
+				Outcome = _isNegated ? Outcome.Success : Outcome.Failure;
+				return this;
+			}
+
 			if (actual is null)
 			{
 				Outcome = Outcome.Failure;
@@ -146,6 +153,11 @@ public static partial class ThatString
 			{
 				stringBuilder.ItWasNull(it);
 			}
+			else if (expected is null)
+			{
+				Formatter.Format(stringBuilder, _actual);
+				stringBuilder.Append(" cannot be validated against <null>");
+			}
 			else
 			{
 				stringBuilder.Append(it).Append(" contained it ").Append(_actualCount).Append(" times in ");
@@ -155,6 +167,7 @@ public static partial class ThatString
 
 		public override ConstraintResult Negate()
 		{
+			_isNegated = !_isNegated;
 			quantifier.Negate();
 			Outcome = Outcome switch
 			{

--- a/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.Contains.Tests.cs
@@ -37,6 +37,23 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				string subject = "some text";
+				string? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains <null> at least once,
+					             but "some text" cannot be validated against <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenExpectedStringIsContained_ShouldSucceed()
 			{
 				string subject = "some text";

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotContain.Tests.cs
@@ -11,10 +11,10 @@ public sealed partial class ThatString
 			{
 				string subject =
 					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "INVESTIGATOR";
+				string unexpected = "INVESTIGATOR";
 
 				async Task Act()
-					=> await That(subject).DoesNotContain(expected).IgnoringCase();
+					=> await That(subject).DoesNotContain(unexpected).IgnoringCase();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -29,10 +29,10 @@ public sealed partial class ThatString
 			{
 				string subject =
 					"In this text in between the word an investigator should find the word 'IN' multiple times.";
-				string expected = "InvEstIgAtOr";
+				string unexpected = "InvEstIgAtOr";
 
 				async Task Act()
-					=> await That(subject).DoesNotContain(expected)
+					=> await That(subject).DoesNotContain(unexpected)
 						.Using(new IgnoreCaseForVocalsComparer());
 
 				await That(Act).Throws<XunitException>()
@@ -41,35 +41,6 @@ public sealed partial class ThatString
 					             does not contain "InvEstIgAtOr" using IgnoreCaseForVocalsComparer,
 					             but it contained it 1 times in "In this text in between the word an investigator should find the word 'IN' multiple times."
 					             """);
-			}
-
-			[Fact]
-			public async Task WhenExpectedStringIsContained_ShouldFail()
-			{
-				string subject = "some text";
-				string expected = "me";
-
-				async Task Act()
-					=> await That(subject).DoesNotContain(expected);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not contain "me",
-					             but it contained it 1 times in "some text"
-					             """);
-			}
-
-			[Fact]
-			public async Task WhenExpectedStringIsNotContained_ShouldSucceed()
-			{
-				string subject = "some text";
-				string expected = "not";
-
-				async Task Act()
-					=> await That(subject).DoesNotContain(expected);
-
-				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -84,6 +55,52 @@ public sealed partial class ThatString
 				await That(Act).Throws<ArgumentException>()
 					.WithMessage("The 'unexpected' string cannot be empty.").AsPrefix().And
 					.WithParamName("unexpected");
+			}
+
+			[Fact]
+			public async Task WhenUnexpectedIsNull_ShouldFail()
+			{
+				string subject = "some text";
+				string? unexpected = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotContain(unexpected!);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain <null>,
+					             but "some text" cannot be validated against <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenUnexpectedStringIsContained_ShouldFail()
+			{
+				string subject = "some text";
+				string unexpected = "me";
+
+				async Task Act()
+					=> await That(subject).DoesNotContain(unexpected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain "me",
+					             but it contained it 1 times in "some text"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenUnexpectedStringIsNotContained_ShouldSucceed()
+			{
+				string subject = "some text";
+				string unexpected = "not";
+
+				async Task Act()
+					=> await That(subject).DoesNotContain(unexpected);
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}


### PR DESCRIPTION
When the expected (or unexpected) string is `null` in string `Contains`/`DoesNotContain` expectation, provide a correct error message.