### PR TITLE
feat: include at least one digit for floating-point numbers

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Numbers.cs
@@ -554,7 +554,7 @@ public static partial class ValueFormatters
 			(_, float.PositiveInfinity) => "+\u221e",
 			(_, float.MinValue) => "float.MinValue",
 			(_, float.MaxValue) => "float.MaxValue",
-			(_, _) => value.ToString(CultureInfo.InvariantCulture),
+			(_, _) => value.ToString("0.0###########################", CultureInfo.InvariantCulture),
 		};
 
 	/// <summary>
@@ -621,7 +621,7 @@ public static partial class ValueFormatters
 			(_, double.PositiveInfinity) => "+\u221e",
 			(_, double.MinValue) => "double.MinValue",
 			(_, double.MaxValue) => "double.MaxValue",
-			(_, _) => value.ToString(CultureInfo.InvariantCulture),
+			(_, _) => value.ToString("0.0###########################", CultureInfo.InvariantCulture),
 		};
 
 	/// <summary>
@@ -764,7 +764,7 @@ public static partial class ValueFormatters
 			(true, _) => $"decimal {value.ToString(CultureInfo.InvariantCulture)}",
 			(_, decimal.MinValue) => "decimal.MinValue",
 			(_, decimal.MaxValue) => "decimal.MaxValue",
-			(_, _) => value.ToString(CultureInfo.InvariantCulture),
+			(_, _) => value.ToString("0.0###########################", CultureInfo.InvariantCulture),
 		};
 
 	/// <summary>

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.NumberTests.cs
@@ -38,6 +38,64 @@ public partial class ValueFormatters
 			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
 
+		[Theory]
+		[InlineData(2, "2.0")]
+		[InlineData(1.1, "1.1")]
+		[InlineData(1.12, "1.12")]
+		[InlineData(1.123, "1.123")]
+		[InlineData(1.12345678910111, "1.12345678910111")]
+		public async Task Numbers_Decimal_ShouldHaveAtLeastOneDecimalDigit(double doubleValue, string expectedResult)
+		{
+			decimal value = new(doubleValue);
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
+		[InlineData(2, "2.0")]
+		[InlineData(1.1, "1.1")]
+		[InlineData(1.12, "1.12")]
+		[InlineData(1.123, "1.123")]
+		[InlineData(1.12345678910111, "1.12345678910111")]
+		public async Task Numbers_Double_ShouldHaveAtLeastOneDecimalDigit(double value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
+		[InlineData(2F, "2.0")]
+		[InlineData(1.1F, "1.1")]
+		[InlineData(1.12F, "1.12")]
+		[InlineData(1.123F, "1.123")]
+		[InlineData(1.123456, "1.123456")]
+		public async Task Numbers_Float_ShouldHaveAtLeastOneDecimalDigit(float value, string expectedResult)
+		{
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
 		[Fact]
 		public async Task Numbers_Double_ShouldReturnExpectedValue()
 		{
@@ -670,7 +728,7 @@ public partial class ValueFormatters
 			await That(objectResult).IsEqualTo(expectedResult);
 			await That(sb.ToString()).IsEqualTo(expectedResult);
 		}
-		
+
 		[Fact]
 		public async Task Numbers_WithType_Byte_ShouldReturnExpectedValue()
 		{

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
@@ -81,8 +81,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not one of [1, 2, 3],
-					             but it was 2
+					             is not one of [1.0, 2.0, 3.0],
+					             but it was 2.0
 					             """);
 			}
 
@@ -148,8 +148,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not one of [1, 2, 3],
-					             but it was 2
+					             is not one of [1.0, 2.0, 3.0],
+					             but it was 2.0
 					             """);
 			}
 
@@ -248,8 +248,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not one of [1, 2, 3],
-					             but it was 2
+					             is not one of [1.0, 2.0, 3.0],
+					             but it was 2.0
 					             """);
 			}
 
@@ -522,8 +522,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not one of [1, 2, 3],
-					             but it was 2
+					             is not one of [1.0, 2.0, 3.0],
+					             but it was 2.0
 					             """);
 			}
 
@@ -593,8 +593,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not one of [1, 2, 3],
-					             but it was 2
+					             is not one of [1.0, 2.0, 3.0],
+					             but it was 2.0
 					             """);
 			}
 
@@ -650,8 +650,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not one of [1, 2, 3],
-					             but it was 2
+					             is not one of [1.0, 2.0, 3.0],
+					             but it was 2.0
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
@@ -68,8 +68,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is one of [2, 3],
-					             but it was 1
+					             is one of [2.0, 3.0],
+					             but it was 1.0
 					             """);
 			}
 
@@ -441,8 +441,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is one of [2, 3],
-					             but it was 1
+					             is one of [2.0, 3.0],
+					             but it was 1.0
 					             """);
 			}
 
@@ -500,8 +500,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is one of [2, 3],
-					             but it was 1
+					             is one of [2.0, 3.0],
+					             but it was 1.0
 					             """);
 			}
 
@@ -545,8 +545,8 @@ public sealed partial class ThatNumber
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is one of [2, 3],
-					             but it was 1
+					             is one of [2.0, 3.0],
+					             but it was 1.0
 					             """);
 			}
 


### PR DESCRIPTION
When formatting a floating-point number include at least one digit, so
- `1` is formatted to `"1.0"`
- `1.2` is formatted to `"1.2"`
- `1.23` is formatted to `"1.23"`
- `1.234` is formatted to `"1.234"`
- ...