### PR TITLE
feat: add difference to number equality

### DIFF
--- a/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
@@ -22,7 +22,7 @@ public static partial class ThatNumber
 		params TNumber?[] expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
@@ -38,7 +38,7 @@ public static partial class ThatNumber
 		params TNumber?[] expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
@@ -54,7 +54,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber> expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<TNumber>(it, grammars, expected, options)),
@@ -70,7 +70,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber> expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<TNumber>(it, grammars, expected, options)),
@@ -86,7 +86,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber?> expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
@@ -102,7 +102,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber?> expected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, expected, options)),
@@ -118,7 +118,7 @@ public static partial class ThatNumber
 		params TNumber?[] unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
@@ -134,7 +134,7 @@ public static partial class ThatNumber
 		params TNumber?[] unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
@@ -150,7 +150,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber> unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
@@ -166,7 +166,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber> unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<TNumber>(it, grammars, unexpected, options).Invert()),
@@ -182,7 +182,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber?> unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NumberToleranceResult<TNumber, IThat<TNumber>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
@@ -198,7 +198,7 @@ public static partial class ThatNumber
 		IEnumerable<TNumber?> unexpected)
 		where TNumber : struct, INumber<TNumber>
 	{
-		NumberTolerance<TNumber> options = new(IsWithinTolerance);
+		NumberTolerance<TNumber> options = new(CalculateDifference);
 		return new NullableNumberToleranceResult<TNumber, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<TNumber>(it, grammars, unexpected, options).Invert()),
@@ -374,7 +374,7 @@ public static partial class ThatNumber
 		params byte?[] expected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -390,7 +390,7 @@ public static partial class ThatNumber
 		IEnumerable<byte?> expected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -406,7 +406,7 @@ public static partial class ThatNumber
 		IEnumerable<byte> expected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<byte>(it, grammars, expected, options)),
@@ -422,7 +422,7 @@ public static partial class ThatNumber
 		params sbyte?[] expected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -438,7 +438,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte?> expected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -454,7 +454,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte> expected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<sbyte>(it, grammars, expected, options)),
@@ -470,7 +470,7 @@ public static partial class ThatNumber
 		params short?[] expected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -486,7 +486,7 @@ public static partial class ThatNumber
 		IEnumerable<short?> expected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -502,7 +502,7 @@ public static partial class ThatNumber
 		IEnumerable<short> expected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<short>(it, grammars, expected, options)),
@@ -518,7 +518,7 @@ public static partial class ThatNumber
 		params ushort?[] expected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -534,7 +534,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort?> expected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -550,7 +550,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort> expected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ushort>(it, grammars, expected, options)),
@@ -566,7 +566,7 @@ public static partial class ThatNumber
 		params int?[] expected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -582,7 +582,7 @@ public static partial class ThatNumber
 		IEnumerable<int?> expected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -598,7 +598,7 @@ public static partial class ThatNumber
 		IEnumerable<int> expected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<int>(it, grammars, expected, options)),
@@ -614,7 +614,7 @@ public static partial class ThatNumber
 		params uint?[] expected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -630,7 +630,7 @@ public static partial class ThatNumber
 		IEnumerable<uint?> expected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -646,7 +646,7 @@ public static partial class ThatNumber
 		IEnumerable<uint> expected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<uint>(it, grammars, expected, options)),
@@ -662,7 +662,7 @@ public static partial class ThatNumber
 		params long?[] expected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -678,7 +678,7 @@ public static partial class ThatNumber
 		IEnumerable<long?> expected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -694,7 +694,7 @@ public static partial class ThatNumber
 		IEnumerable<long> expected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<long>(it, grammars, expected, options)),
@@ -710,7 +710,7 @@ public static partial class ThatNumber
 		params ulong?[] expected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -726,7 +726,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong?> expected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -742,7 +742,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong> expected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ulong>(it, grammars, expected, options)),
@@ -758,7 +758,7 @@ public static partial class ThatNumber
 		params float?[] expected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -774,7 +774,7 @@ public static partial class ThatNumber
 		IEnumerable<float?> expected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -790,7 +790,7 @@ public static partial class ThatNumber
 		IEnumerable<float> expected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<float>(it, grammars, expected, options)),
@@ -806,7 +806,7 @@ public static partial class ThatNumber
 		params double?[] expected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -822,7 +822,7 @@ public static partial class ThatNumber
 		IEnumerable<double?> expected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -838,7 +838,7 @@ public static partial class ThatNumber
 		IEnumerable<double> expected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<double>(it, grammars, expected, options)),
@@ -854,7 +854,7 @@ public static partial class ThatNumber
 		params decimal?[] expected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -870,7 +870,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal?> expected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -886,7 +886,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal> expected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<decimal>(it, grammars, expected, options)),
@@ -902,7 +902,7 @@ public static partial class ThatNumber
 		params byte?[] expected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -918,7 +918,7 @@ public static partial class ThatNumber
 		IEnumerable<byte?> expected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -934,7 +934,7 @@ public static partial class ThatNumber
 		IEnumerable<byte> expected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<byte>(it, grammars, expected, options)),
@@ -950,7 +950,7 @@ public static partial class ThatNumber
 		params sbyte?[] expected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -966,7 +966,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte?> expected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -982,7 +982,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte> expected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<sbyte>(it, grammars, expected, options)),
@@ -998,7 +998,7 @@ public static partial class ThatNumber
 		params short?[] expected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -1014,7 +1014,7 @@ public static partial class ThatNumber
 		IEnumerable<short?> expected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -1030,7 +1030,7 @@ public static partial class ThatNumber
 		IEnumerable<short> expected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<short>(it, grammars, expected, options)),
@@ -1046,7 +1046,7 @@ public static partial class ThatNumber
 		params ushort?[] expected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -1062,7 +1062,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort?> expected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -1078,7 +1078,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort> expected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ushort>(it, grammars, expected, options)),
@@ -1094,7 +1094,7 @@ public static partial class ThatNumber
 		params int?[] expected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -1110,7 +1110,7 @@ public static partial class ThatNumber
 		IEnumerable<int?> expected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -1126,7 +1126,7 @@ public static partial class ThatNumber
 		IEnumerable<int> expected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<int>(it, grammars, expected, options)),
@@ -1142,7 +1142,7 @@ public static partial class ThatNumber
 		params uint?[] expected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -1158,7 +1158,7 @@ public static partial class ThatNumber
 		IEnumerable<uint?> expected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -1174,7 +1174,7 @@ public static partial class ThatNumber
 		IEnumerable<uint> expected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<uint>(it, grammars, expected, options)),
@@ -1190,7 +1190,7 @@ public static partial class ThatNumber
 		params long?[] expected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -1206,7 +1206,7 @@ public static partial class ThatNumber
 		IEnumerable<long?> expected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -1222,7 +1222,7 @@ public static partial class ThatNumber
 		IEnumerable<long> expected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<long>(it, grammars, expected, options)),
@@ -1238,7 +1238,7 @@ public static partial class ThatNumber
 		params ulong?[] expected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -1254,7 +1254,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong?> expected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -1270,7 +1270,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong> expected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ulong>(it, grammars, expected, options)),
@@ -1286,7 +1286,7 @@ public static partial class ThatNumber
 		params float?[] expected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -1302,7 +1302,7 @@ public static partial class ThatNumber
 		IEnumerable<float?> expected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -1318,7 +1318,7 @@ public static partial class ThatNumber
 		IEnumerable<float> expected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<float>(it, grammars, expected, options)),
@@ -1334,7 +1334,7 @@ public static partial class ThatNumber
 		params double?[] expected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -1350,7 +1350,7 @@ public static partial class ThatNumber
 		IEnumerable<double?> expected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -1366,7 +1366,7 @@ public static partial class ThatNumber
 		IEnumerable<double> expected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<double>(it, grammars, expected, options)),
@@ -1382,7 +1382,7 @@ public static partial class ThatNumber
 		params decimal?[] expected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -1398,7 +1398,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal?> expected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -1414,7 +1414,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal> expected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<decimal>(it, grammars, expected, options)),
@@ -1430,7 +1430,7 @@ public static partial class ThatNumber
 		params byte?[] unexpected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1446,7 +1446,7 @@ public static partial class ThatNumber
 		IEnumerable<byte?> unexpected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1462,7 +1462,7 @@ public static partial class ThatNumber
 		IEnumerable<byte> unexpected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<byte>(it, grammars, unexpected, options).Invert()),
@@ -1478,7 +1478,7 @@ public static partial class ThatNumber
 		params sbyte?[] unexpected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -1494,7 +1494,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte?> unexpected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -1510,7 +1510,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte> unexpected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -1526,7 +1526,7 @@ public static partial class ThatNumber
 		params short?[] unexpected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -1542,7 +1542,7 @@ public static partial class ThatNumber
 		IEnumerable<short?> unexpected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -1558,7 +1558,7 @@ public static partial class ThatNumber
 		IEnumerable<short> unexpected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<short>(it, grammars, unexpected, options).Invert()),
@@ -1574,7 +1574,7 @@ public static partial class ThatNumber
 		params ushort?[] unexpected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -1590,7 +1590,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort?> unexpected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -1606,7 +1606,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort> unexpected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ushort>(it, grammars, unexpected, options).Invert()),
@@ -1622,7 +1622,7 @@ public static partial class ThatNumber
 		params int?[] unexpected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -1638,7 +1638,7 @@ public static partial class ThatNumber
 		IEnumerable<int?> unexpected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -1654,7 +1654,7 @@ public static partial class ThatNumber
 		IEnumerable<int> unexpected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<int>(it, grammars, unexpected, options).Invert()),
@@ -1670,7 +1670,7 @@ public static partial class ThatNumber
 		params uint?[] unexpected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -1686,7 +1686,7 @@ public static partial class ThatNumber
 		IEnumerable<uint?> unexpected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -1702,7 +1702,7 @@ public static partial class ThatNumber
 		IEnumerable<uint> unexpected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<uint>(it, grammars, unexpected, options).Invert()),
@@ -1718,7 +1718,7 @@ public static partial class ThatNumber
 		params long?[] unexpected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -1734,7 +1734,7 @@ public static partial class ThatNumber
 		IEnumerable<long?> unexpected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -1750,7 +1750,7 @@ public static partial class ThatNumber
 		IEnumerable<long> unexpected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<long>(it, grammars, unexpected, options).Invert()),
@@ -1766,7 +1766,7 @@ public static partial class ThatNumber
 		params ulong?[] unexpected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -1782,7 +1782,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong?> unexpected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -1798,7 +1798,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong> unexpected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ulong>(it, grammars, unexpected, options).Invert()),
@@ -1814,7 +1814,7 @@ public static partial class ThatNumber
 		params float?[] unexpected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -1830,7 +1830,7 @@ public static partial class ThatNumber
 		IEnumerable<float?> unexpected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -1846,7 +1846,7 @@ public static partial class ThatNumber
 		IEnumerable<float> unexpected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<float>(it, grammars, unexpected, options).Invert()),
@@ -1862,7 +1862,7 @@ public static partial class ThatNumber
 		params double?[] unexpected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -1878,7 +1878,7 @@ public static partial class ThatNumber
 		IEnumerable<double?> unexpected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -1894,7 +1894,7 @@ public static partial class ThatNumber
 		IEnumerable<double> unexpected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<double>(it, grammars, unexpected, options).Invert()),
@@ -1910,7 +1910,7 @@ public static partial class ThatNumber
 		params decimal?[] unexpected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -1926,7 +1926,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal?> unexpected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -1942,7 +1942,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal> unexpected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<decimal>(it, grammars, unexpected, options).Invert()),
@@ -1958,7 +1958,7 @@ public static partial class ThatNumber
 		params byte?[] unexpected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1974,7 +1974,7 @@ public static partial class ThatNumber
 		IEnumerable<byte?> unexpected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1990,7 +1990,7 @@ public static partial class ThatNumber
 		IEnumerable<byte> unexpected)
 	{
 		NumberTolerance<byte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<byte>(it, grammars, unexpected, options).Invert()),
@@ -2006,7 +2006,7 @@ public static partial class ThatNumber
 		params sbyte?[] unexpected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -2022,7 +2022,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte?> unexpected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -2038,7 +2038,7 @@ public static partial class ThatNumber
 		IEnumerable<sbyte> unexpected)
 	{
 		NumberTolerance<sbyte> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -2054,7 +2054,7 @@ public static partial class ThatNumber
 		params short?[] unexpected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -2070,7 +2070,7 @@ public static partial class ThatNumber
 		IEnumerable<short?> unexpected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -2086,7 +2086,7 @@ public static partial class ThatNumber
 		IEnumerable<short> unexpected)
 	{
 		NumberTolerance<short> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<short>(it, grammars, unexpected, options).Invert()),
@@ -2102,7 +2102,7 @@ public static partial class ThatNumber
 		params ushort?[] unexpected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -2118,7 +2118,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort?> unexpected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -2134,7 +2134,7 @@ public static partial class ThatNumber
 		IEnumerable<ushort> unexpected)
 	{
 		NumberTolerance<ushort> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ushort>(it, grammars, unexpected, options).Invert()),
@@ -2150,7 +2150,7 @@ public static partial class ThatNumber
 		params int?[] unexpected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -2166,7 +2166,7 @@ public static partial class ThatNumber
 		IEnumerable<int?> unexpected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -2182,7 +2182,7 @@ public static partial class ThatNumber
 		IEnumerable<int> unexpected)
 	{
 		NumberTolerance<int> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<int>(it, grammars, unexpected, options).Invert()),
@@ -2198,7 +2198,7 @@ public static partial class ThatNumber
 		params uint?[] unexpected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -2214,7 +2214,7 @@ public static partial class ThatNumber
 		IEnumerable<uint?> unexpected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -2230,7 +2230,7 @@ public static partial class ThatNumber
 		IEnumerable<uint> unexpected)
 	{
 		NumberTolerance<uint> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<uint>(it, grammars, unexpected, options).Invert()),
@@ -2246,7 +2246,7 @@ public static partial class ThatNumber
 		params long?[] unexpected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -2262,7 +2262,7 @@ public static partial class ThatNumber
 		IEnumerable<long?> unexpected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -2278,7 +2278,7 @@ public static partial class ThatNumber
 		IEnumerable<long> unexpected)
 	{
 		NumberTolerance<long> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<long>(it, grammars, unexpected, options).Invert()),
@@ -2294,7 +2294,7 @@ public static partial class ThatNumber
 		params ulong?[] unexpected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -2310,7 +2310,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong?> unexpected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -2326,7 +2326,7 @@ public static partial class ThatNumber
 		IEnumerable<ulong> unexpected)
 	{
 		NumberTolerance<ulong> options = new(
-			(a, e, t) => (a > e ? a - e : e - a) <= (t ?? 0));
+			(a, e) => (a > e ? a - e : e - a));
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ulong>(it, grammars, unexpected, options).Invert()),
@@ -2342,7 +2342,7 @@ public static partial class ThatNumber
 		params float?[] unexpected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -2358,7 +2358,7 @@ public static partial class ThatNumber
 		IEnumerable<float?> unexpected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -2374,7 +2374,7 @@ public static partial class ThatNumber
 		IEnumerable<float> unexpected)
 	{
 		NumberTolerance<float> options = new(
-			(a, e, t) => (float.IsNaN(a) && float.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<float>(it, grammars, unexpected, options).Invert()),
@@ -2390,7 +2390,7 @@ public static partial class ThatNumber
 		params double?[] unexpected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -2406,7 +2406,7 @@ public static partial class ThatNumber
 		IEnumerable<double?> unexpected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -2422,7 +2422,7 @@ public static partial class ThatNumber
 		IEnumerable<double> unexpected)
 	{
 		NumberTolerance<double> options = new(
-			(a, e, t) => (double.IsNaN(a) && double.IsNaN(e)) || Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<double>(it, grammars, unexpected, options).Invert()),
@@ -2438,7 +2438,7 @@ public static partial class ThatNumber
 		params decimal?[] unexpected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -2454,7 +2454,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal?> unexpected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -2470,7 +2470,7 @@ public static partial class ThatNumber
 		IEnumerable<decimal> unexpected)
 	{
 		NumberTolerance<decimal> options = new(
-			(a, e, t) => Math.Abs(a - e) <= (t ?? 0));
+			(a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<decimal>(it, grammars, unexpected, options).Invert()),

--- a/Source/aweXpect/That/Numbers/ThatNumber.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.cs
@@ -13,26 +13,26 @@ public static partial class ThatNumber
 	private static bool IsFinite<T>([NotNullWhen(true)] T? value) => value switch
 	{
 		null => false,
-		double d => !double.IsNaN(d),
-		float f => !float.IsNaN(f),
+		double d => !double.IsNaN(d) && !double.IsInfinity(d),
+		float f => !float.IsNaN(f) && !float.IsInfinity(f),
 #if NET8_0_OR_GREATER
-		Half h => !Half.IsNaN(h),
+		Half h => !Half.IsNaN(h) && !Half.IsInfinity(h),
 #endif
 		_ => true
 	};
 
 #if NET8_0_OR_GREATER
-	private static bool IsWithinTolerance<TNumber>(TNumber actual, TNumber expected, TNumber? tolerance)
+	private static TNumber? CalculateDifference<TNumber>(TNumber actual, TNumber expected)
 		where TNumber : struct, INumber<TNumber>
 	{
 		if (actual == expected)
 		{
-			return true;
+			return default(TNumber);
 		}
 
 		if (!IsFinite(actual))
 		{
-			return !IsFinite(expected);
+			return !IsFinite(expected) ? default(TNumber) : null;
 		}
 
 		try
@@ -40,13 +40,13 @@ public static partial class ThatNumber
 			checked
 			{
 				return actual < expected
-					? expected - actual <= (tolerance ?? default(TNumber))
-					: actual - expected <= (tolerance ?? default(TNumber));
+					? expected - actual
+					: actual - expected;
 			}
 		}
 		catch (OverflowException)
 		{
-			return false;
+			return null;
 		}
 	}
 #endif

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -766,8 +766,9 @@ namespace aweXpect.Options
     public class NumberTolerance<TNumber>
         where TNumber :  struct, System.Numerics.INumber<TNumber>
     {
-        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?, bool> isWithinTolerance) { }
+        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?> calculateDifference) { }
         public TNumber? Tolerance { get; }
+        public TNumber? CalculateDifference(TNumber? actual, TNumber? expected) { }
         public bool IsWithinTolerance(TNumber? actual, TNumber? expected) { }
         public void SetTolerance(TNumber tolerance) { }
         public override string ToString() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -749,8 +749,9 @@ namespace aweXpect.Options
     public class NumberTolerance<TNumber>
         where TNumber :  struct, System.IComparable<TNumber>
     {
-        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?, bool> isWithinTolerance) { }
+        public NumberTolerance(System.Func<TNumber, TNumber, TNumber?> calculateDifference) { }
         public TNumber? Tolerance { get; }
+        public TNumber? CalculateDifference(TNumber? actual, TNumber? expected) { }
         public bool IsWithinTolerance(TNumber? actual, TNumber? expected) { }
         public void SetTolerance(TNumber tolerance) { }
         public override string ToString() { }

--- a/Tests/aweXpect.Core.Tests/Options/NumberToleranceTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/NumberToleranceTests.cs
@@ -7,7 +7,7 @@ public class NumberToleranceTests
 	[Fact]
 	public async Task IsWithinTolerance_WhenBothAreNull_ShouldReturnTrue()
 	{
-		NumberTolerance<int> sut = new((a, b, t) => Math.Abs(a - b) <= t);
+		NumberTolerance<int> sut = new((a, b) => Math.Abs(a - b));
 
 		bool result = sut.IsWithinTolerance(null, null);
 
@@ -19,7 +19,7 @@ public class NumberToleranceTests
 	[InlineData(-3, null)]
 	public async Task IsWithinTolerance_WhenOneIsNull_ShouldReturnFalse(int? actual, int? expected)
 	{
-		NumberTolerance<int> sut = new((a, b, t) => Math.Abs(a - b) <= t);
+		NumberTolerance<int> sut = new((a, b) => Math.Abs(a - b));
 
 		bool result = sut.IsWithinTolerance(actual, expected);
 
@@ -32,7 +32,7 @@ public class NumberToleranceTests
 	public async Task IsWithinTolerance_WhenValuesAreNotNull_ShouldApplyTolerance(
 		int actual, int expected, int tolerance, bool expectedResult)
 	{
-		NumberTolerance<int> sut = new((a, b, t) => Math.Abs(a - b) <= t);
+		NumberTolerance<int> sut = new((a, b) => Math.Abs(a - b));
 		sut.SetTolerance(tolerance);
 
 		bool result = sut.IsWithinTolerance(actual, expected);
@@ -43,7 +43,7 @@ public class NumberToleranceTests
 	[Fact]
 	public async Task WhenToleranceIsNegative_ShouldThrowArgumentOutOfRangeException()
 	{
-		NumberTolerance<int> sut = new((_, _, _) => false);
+		NumberTolerance<int> sut = new((_, _) => null);
 
 		void Act() => sut.SetTolerance(-1);
 
@@ -54,7 +54,7 @@ public class NumberToleranceTests
 	[Fact]
 	public async Task WhenToleranceIsZero_ShouldNotThrow()
 	{
-		NumberTolerance<int> sut = new((_, _, _) => false);
+		NumberTolerance<int> sut = new((_, _) => null);
 
 		void Act() => sut.SetTolerance(0);
 

--- a/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyExtensionsTests.cs
@@ -53,7 +53,7 @@ public class SynchronouslyExtensionsTests
 			.WithMessage("""
 			             Expected that value
 			             is equal to 2,
-			             but it was 3
+			             but it was 3 which differs by 1
 			             """).VerifySynchronously();
 	}
 

--- a/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyTests.cs
@@ -53,7 +53,7 @@ public class SynchronouslyTests
 			.WithMessage("""
 			             Expected that value
 			             is equal to 2,
-			             but it was 3
+			             but it was 3 which differs by 1
 			             """));
 	}
 

--- a/Tests/aweXpect.Internal.Tests/ThatTests/NumberTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/NumberTests.cs
@@ -15,8 +15,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -32,8 +32,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -49,8 +49,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -66,8 +66,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -83,8 +83,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -100,8 +100,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -117,8 +117,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -134,8 +134,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -151,8 +151,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -168,8 +168,8 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 
 	[Theory]
@@ -185,7 +185,7 @@ public sealed class NumberTests
 			.WithMessage($"""
 			              Expected that subject
 			              is equal to {Formatter.Format(expected)},
-			              but it was {Formatter.Format(subject)}
-			              """);
+			              but it was {Formatter.Format(subject)} which differs by
+			              """).AsPrefix();
 	}
 }

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WhoseTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WhoseTests.cs
@@ -44,7 +44,7 @@ public sealed partial class ThatDelegate
 					.WithMessage($"""
 					              Expected that Delegate
 					              throws an exception whose .HResult is equal to {expectedHResult} and with HResult {hResult},
-					              but .HResult was {hResult}
+					              but .HResult was {hResult} which differs by -1
 					              """);
 			}
 

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.Tests.cs
@@ -25,10 +25,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((byte)1, (byte)2)]
-			[InlineData((byte)1, (byte)0)]
+			[InlineData((byte)1, (byte)2, -1)]
+			[InlineData((byte)1, (byte)0, 1)]
 			public async Task ForByte_WhenValueIsDifferentFromExpected_ShouldFail(byte subject,
-				byte? expected)
+				byte? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -37,7 +37,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -70,10 +70,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(1.1, 2.1)]
-			[InlineData(1.1, 0.1)]
+			[InlineData(1.1, 2.1, "-1.0")]
+			[InlineData(1.1, 0.2, "0.9")]
 			public async Task ForDecimal_WhenValueIsDifferentFromExpected_ShouldFail(
-				double subjectValue, double expectedValue)
+				double subjectValue, double expectedValue, string expectedDifference)
 			{
 				decimal subject = new(subjectValue);
 				decimal expected = new(expectedValue);
@@ -85,7 +85,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -159,10 +159,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(1.1, 2.1)]
-			[InlineData(1.1, 0.1)]
+			[InlineData(1.1, 2.1, "-1.0")]
+			[InlineData(1.1, 0.3, "0.8")]
 			public async Task ForDouble_WhenValueIsDifferentFromExpected_ShouldFail(
-				double subject, double expected)
+				double subject, double expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -171,7 +171,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -231,10 +231,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((float)1.1, (float)2.1)]
-			[InlineData((float)1.1, (float)0.1)]
+			[InlineData((float)1.1, (float)2.2, "-1.1")]
+			[InlineData((float)1.1, (float)0.3, "0.8")]
 			public async Task ForFloat_WhenValueIsDifferentFromExpected_ShouldFail(
-				float subject, float expected)
+				float subject, float expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -243,7 +243,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -277,10 +277,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(1, 2)]
-			[InlineData(2, 1)]
-			public async Task ForInt_WhenValueIsDifferentFromExpected_ShouldFail(int subject,
-				int? expected)
+			[InlineData(1, 2, -1)]
+			[InlineData(3, 1, 2)]
+			public async Task ForInt_WhenValueIsDifferentFromExpected_ShouldFail(
+				int subject, int? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -289,7 +289,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -325,10 +325,10 @@ public sealed partial class ThatNumber
 
 #if NET8_0_OR_GREATER
 			[Theory]
-			[InlineData(1, 2)]
-			[InlineData(2, 1)]
+			[InlineData(1, 2, -1)]
+			[InlineData(2, 1, 1)]
 			public async Task ForInt128_WhenValueIsDifferentFromExpected_ShouldFail(
-				int subjectValue, int expectedValue)
+				int subjectValue, int expectedValue, int expectedDifference)
 			{
 				Int128 subject = subjectValue;
 				Int128? expected = expectedValue;
@@ -340,7 +340,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 #endif
@@ -390,10 +390,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((long)1, (long)2)]
-			[InlineData((long)1, (long)0)]
-			public async Task ForLong_WhenValueIsDifferentFromExpected_ShouldFail(long subject,
-				long? expected)
+			[InlineData((long)1, (long)2, -1)]
+			[InlineData((long)1, (long)0, 1)]
+			public async Task ForLong_WhenValueIsDifferentFromExpected_ShouldFail(
+				long subject, long? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -402,7 +402,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -430,10 +430,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((byte)1, (byte)2)]
-			[InlineData((byte)1, (byte)0)]
+			[InlineData((byte)1, (byte)2, -1)]
+			[InlineData((byte)1, (byte)0, 1)]
 			public async Task ForNullableByte_WhenValueIsDifferentFromExpected_ShouldFail(
-				byte? subject, byte? expected)
+				byte? subject, byte? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -442,7 +442,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -505,10 +505,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(1.1, 2.1)]
-			[InlineData(1.1, 0.1)]
+			[InlineData(1.1, 2.1, "-1.0")]
+			[InlineData(1.1, 0.3, "0.8")]
 			public async Task ForNullableDecimal_WhenValueIsDifferentFromExpected_ShouldFail(
-				double? subjectValue, double? expectedValue)
+				double? subjectValue, double? expectedValue, string expectedDifference)
 			{
 				decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
 				decimal? expected = expectedValue == null ? null : new decimal(expectedValue.Value);
@@ -520,7 +520,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -568,10 +568,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(1.1, 2.1)]
-			[InlineData(1.1, 0.1)]
+			[InlineData(1.1, 2.1, "-1.0")]
+			[InlineData(1.1, 0.3, "0.8")]
 			public async Task ForNullableDouble_WhenValueIsDifferentFromExpected_ShouldFail(
-				double? subject, double? expected)
+				double? subject, double? expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -580,7 +580,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -625,10 +625,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((float)1.1, (float)2.1)]
-			[InlineData((float)1.1, (float)0.1)]
+			[InlineData((float)1.1, (float)2.2, "-1.1")]
+			[InlineData((float)1.1, (float)0.2, "0.9")]
 			public async Task ForNullableFloat_WhenValueIsDifferentFromExpected_ShouldFail(
-				float? subject, float? expected)
+				float? subject, float? expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -637,7 +637,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -665,10 +665,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(1, 2)]
-			[InlineData(1, 0)]
+			[InlineData(1, 2, -1)]
+			[InlineData(1, 0, 1)]
 			public async Task ForNullableInt_WhenValueIsDifferentFromExpected_ShouldFail(
-				int? subject, int? expected)
+				int? subject, int? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -677,7 +677,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -746,10 +746,10 @@ public sealed partial class ThatNumber
 
 #if NET8_0_OR_GREATER
 			[Theory]
-			[InlineData(1, 2)]
-			[InlineData(2, 1)]
+			[InlineData(1, 2, -1)]
+			[InlineData(2, 1, 1)]
 			public async Task ForNullableInt128_WhenValueIsDifferentFromExpected_ShouldFail(
-				int subjectValue, int expectedValue)
+				int subjectValue, int expectedValue, int expectedDifference)
 			{
 				Int128 subject = subjectValue;
 				Int128? expected = expectedValue;
@@ -761,7 +761,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 #endif
@@ -795,10 +795,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((long)1, (long)2)]
-			[InlineData((long)1, (long)0)]
+			[InlineData((long)1, (long)2, -1)]
+			[InlineData((long)1, (long)0, 1)]
 			public async Task ForNullableLong_WhenValueIsDifferentFromExpected_ShouldFail(
-				long? subject, long? expected)
+				long? subject, long? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -807,7 +807,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -853,10 +853,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((sbyte)1, (sbyte)2)]
-			[InlineData((sbyte)1, (sbyte)0)]
+			[InlineData((sbyte)1, (sbyte)2, -1)]
+			[InlineData((sbyte)1, (sbyte)0, 1)]
 			public async Task ForNullableSbyte_WhenValueIsDifferentFromExpected_ShouldFail(
-				sbyte? subject, sbyte? expected)
+				sbyte? subject, sbyte? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -865,7 +865,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -911,10 +911,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((short)1, (short)2)]
-			[InlineData((short)1, (short)0)]
+			[InlineData((short)1, (short)2, -1)]
+			[InlineData((short)1, (short)0, 1)]
 			public async Task ForNullableShort_WhenValueIsDifferentFromExpected_ShouldFail(
-				short? subject, short? expected)
+				short? subject, short? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -923,7 +923,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -969,10 +969,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((uint)1, (uint)2)]
-			[InlineData((uint)1, (uint)0)]
+			[InlineData((uint)1, (uint)2, -1)]
+			[InlineData((uint)1, (uint)0, 1)]
 			public async Task ForNullableUint_WhenValueIsDifferentFromExpected_ShouldFail(
-				uint? subject, uint? expected)
+				uint? subject, uint? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -981,7 +981,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -1027,10 +1027,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((ulong)1, (ulong)2)]
-			[InlineData((ulong)1, (ulong)0)]
+			[InlineData((ulong)1, (ulong)2, -1)]
+			[InlineData((ulong)1, (ulong)0, 1)]
 			public async Task ForNullableUlong_WhenValueIsDifferentFromExpected_ShouldFail(
-				ulong? subject, ulong? expected)
+				ulong? subject, ulong? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1039,7 +1039,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -1085,10 +1085,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((ushort)1, (ushort)2)]
-			[InlineData((ushort)1, (ushort)0)]
+			[InlineData((ushort)1, (ushort)2, -1)]
+			[InlineData((ushort)1, (ushort)0, 1)]
 			public async Task ForNullableUshort_WhenValueIsDifferentFromExpected_ShouldFail(
-				ushort? subject, ushort? expected)
+				ushort? subject, ushort? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1097,7 +1097,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
@@ -1149,10 +1149,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((sbyte)1, (sbyte)2)]
-			[InlineData((sbyte)1, (sbyte)0)]
-			public async Task ForSbyte_WhenValueIsDifferentFromExpected_ShouldFail(sbyte subject,
-				sbyte? expected)
+			[InlineData((sbyte)1, (sbyte)2, -1)]
+			[InlineData((sbyte)1, (sbyte)0, 1)]
+			public async Task ForSbyte_WhenValueIsDifferentFromExpected_ShouldFail(
+				sbyte subject, sbyte? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1161,14 +1161,14 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
 			[Theory]
 			[InlineData((sbyte)1, (sbyte)1)]
-			public async Task ForSbyte_WhenValueIsEqualToExpected_ShouldSucceed(sbyte subject,
-				sbyte? expected)
+			public async Task ForSbyte_WhenValueIsEqualToExpected_ShouldSucceed(
+				sbyte subject, sbyte? expected)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1195,10 +1195,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((short)1, (short)2)]
-			[InlineData((short)1, (short)0)]
-			public async Task ForShort_WhenValueIsDifferentFromExpected_ShouldFail(short subject,
-				short? expected)
+			[InlineData((short)1, (short)2, -1)]
+			[InlineData((short)1, (short)0, 1)]
+			public async Task ForShort_WhenValueIsDifferentFromExpected_ShouldFail(
+				short subject, short? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1207,14 +1207,14 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
 			[Theory]
 			[InlineData((short)1, (short)1)]
-			public async Task ForShort_WhenValueIsEqualToExpected_ShouldSucceed(short subject,
-				short? expected)
+			public async Task ForShort_WhenValueIsEqualToExpected_ShouldSucceed(
+				short subject, short? expected)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1241,10 +1241,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((uint)1, (uint)2)]
-			[InlineData((uint)1, (uint)0)]
-			public async Task ForUint_WhenValueIsDifferentFromExpected_ShouldFail(uint subject,
-				uint? expected)
+			[InlineData((uint)1, (uint)2, -1)]
+			[InlineData((uint)1, (uint)0, 1)]
+			public async Task ForUint_WhenValueIsDifferentFromExpected_ShouldFail(
+				uint subject, uint? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1253,14 +1253,14 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
 			[Theory]
 			[InlineData((uint)1, (uint)1)]
-			public async Task ForUint_WhenValueIsEqualToExpected_ShouldSucceed(uint subject,
-				uint? expected)
+			public async Task ForUint_WhenValueIsEqualToExpected_ShouldSucceed(
+				uint subject, uint? expected)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1287,10 +1287,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((ulong)1, (ulong)2)]
-			[InlineData((ulong)1, (ulong)0)]
-			public async Task ForUlong_WhenValueIsDifferentFromExpected_ShouldFail(ulong subject,
-				ulong? expected)
+			[InlineData((ulong)1, (ulong)2, -1)]
+			[InlineData((ulong)1, (ulong)0, 1)]
+			public async Task ForUlong_WhenValueIsDifferentFromExpected_ShouldFail(
+				ulong subject, ulong? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1299,14 +1299,14 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
 			[Theory]
 			[InlineData((ulong)1, (ulong)1)]
-			public async Task ForUlong_WhenValueIsEqualToExpected_ShouldSucceed(ulong subject,
-				ulong? expected)
+			public async Task ForUlong_WhenValueIsEqualToExpected_ShouldSucceed(
+				ulong subject, ulong? expected)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1333,10 +1333,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((ushort)1, (ushort)2)]
-			[InlineData((ushort)1, (ushort)0)]
-			public async Task ForUshort_WhenValueIsDifferentFromExpected_ShouldFail(ushort subject,
-				ushort? expected)
+			[InlineData((ushort)1, (ushort)2, -1)]
+			[InlineData((ushort)1, (ushort)0, 1)]
+			public async Task ForUshort_WhenValueIsDifferentFromExpected_ShouldFail(
+				ushort subject, ushort? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);
@@ -1345,14 +1345,14 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)},
-					              but it was {Formatter.Format(subject)}
+					              but it was {Formatter.Format(subject)} which differs by {expectedDifference}
 					              """);
 			}
 
 			[Theory]
 			[InlineData((ushort)1, (ushort)1)]
-			public async Task ForUshort_WhenValueIsEqualToExpected_ShouldSucceed(ushort subject,
-				ushort? expected)
+			public async Task ForUshort_WhenValueIsEqualToExpected_ShouldSucceed(
+				ushort subject, ushort? expected)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected);

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsEqualTo.WithinTests.cs
@@ -19,10 +19,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((byte)5, (byte)7)]
-			[InlineData((byte)5, (byte)3)]
+			[InlineData((byte)5, (byte)7, -2)]
+			[InlineData((byte)5, (byte)3, 2)]
 			public async Task ForByte_WhenOutsideTolerance_ShouldFail(
-				byte subject, byte expected)
+				byte subject, byte expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -31,7 +31,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -51,10 +51,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(12.5, 12.7)]
-			[InlineData(12.5, 12.3)]
+			[InlineData(12.5, 12.7, "-0.2")]
+			[InlineData(12.5, 12.3, "0.2")]
 			public async Task ForDecimal_WhenOutsideTolerance_ShouldFail(
-				double subjectValue, double expectedValue)
+				double subjectValue, double expectedValue, string expectedDifference)
 			{
 				decimal subject = new(subjectValue);
 				decimal expected = new(expectedValue);
@@ -66,7 +66,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 0.1,
-					              but it was 12.5
+					              but it was 12.5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -97,10 +97,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(12.5, 12.7)]
-			[InlineData(12.5, 12.3)]
+			[InlineData(12.5, 12.9, "-0.4")]
+			[InlineData(12.5, 12.1, "0.4")]
 			public async Task ForDouble_WhenOutsideTolerance_ShouldFail(
-				double subject, double expected)
+				double subject, double expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(0.1);
@@ -109,7 +109,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 0.1,
-					              but it was 12.5
+					              but it was 12.5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -140,10 +140,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(12.5F, 12.7F)]
-			[InlineData(12.5F, 12.3F)]
+			[InlineData(12.5F, 13.0F, "-0.5")]
+			[InlineData(12.5F, 12.0F, "0.5")]
 			public async Task ForFloat_WhenOutsideTolerance_ShouldFail(
-				float subject, float expected)
+				float subject, float expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(0.1F);
@@ -152,7 +152,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 0.1,
-					              but it was 12.5
+					              but it was 12.5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -183,10 +183,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForInt_WhenOutsideTolerance_ShouldFail(
-				int subject, int expected)
+				int subject, int expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -195,7 +195,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -226,10 +226,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5L, 7L)]
-			[InlineData(5L, 3L)]
+			[InlineData(5L, 7L, -2)]
+			[InlineData(5L, 3L, 2)]
 			public async Task ForLong_WhenOutsideTolerance_ShouldFail(
-				long subject, long expected)
+				long subject, long expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -238,7 +238,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -269,10 +269,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((byte)5, (byte)7)]
-			[InlineData((byte)5, (byte)3)]
+			[InlineData((byte)5, (byte)7, -2)]
+			[InlineData((byte)5, (byte)3, 2)]
 			public async Task ForNullableByte_WhenOutsideTolerance_ShouldFail(
-				byte? subject, byte? expected)
+				byte? subject, byte? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -281,7 +281,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -301,10 +301,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(12.5, 12.7)]
-			[InlineData(12.5, 12.3)]
+			[InlineData(12.5, 12.7, "-0.2")]
+			[InlineData(12.5, 12.3, "0.2")]
 			public async Task ForNullableDecimal_WhenOutsideTolerance_ShouldFail(
-				double subjectValue, double expectedValue)
+				double subjectValue, double expectedValue, string expectedDifference)
 			{
 				decimal? subject = new(subjectValue);
 				decimal expected = new(expectedValue);
@@ -316,7 +316,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 0.1,
-					              but it was 12.5
+					              but it was 12.5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -347,10 +347,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(12.5, 12.7)]
-			[InlineData(12.5, 12.3)]
+			[InlineData(12.5, 12.9, "-0.4")]
+			[InlineData(12.5, 12.1, "0.4")]
 			public async Task ForNullableDouble_WhenOutsideTolerance_ShouldFail(
-				double? subject, double? expected)
+				double? subject, double? expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(0.1);
@@ -359,7 +359,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 0.1,
-					              but it was 12.5
+					              but it was 12.5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -390,10 +390,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(12.5F, 12.7F)]
-			[InlineData(12.5F, 12.3F)]
+			[InlineData(12.5F, 13.0F, "-0.5")]
+			[InlineData(12.5F, 12.0F, "0.5")]
 			public async Task ForNullableFloat_WhenOutsideTolerance_ShouldFail(
-				float? subject, float? expected)
+				float? subject, float? expected, string expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(0.1F);
@@ -402,7 +402,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 0.1,
-					              but it was 12.5
+					              but it was 12.5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -433,10 +433,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForNullableInt_WhenOutsideTolerance_ShouldFail(
-				int? subject, int? expected)
+				int? subject, int? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -445,7 +445,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -476,10 +476,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((long)5, (long)7)]
-			[InlineData((long)5, (long)3)]
+			[InlineData((long)5, (long)7, -2)]
+			[InlineData((long)5, (long)3, 2)]
 			public async Task ForNullableLong_WhenOutsideTolerance_ShouldFail(
-				long? subject, long? expected)
+				long? subject, long? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -488,7 +488,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -519,10 +519,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((sbyte)5, (sbyte)7)]
-			[InlineData((sbyte)5, (sbyte)3)]
+			[InlineData((sbyte)5, (sbyte)7, -2)]
+			[InlineData((sbyte)5, (sbyte)3, 2)]
 			public async Task ForNullableSbyte_WhenOutsideTolerance_ShouldFail(
-				sbyte? subject, sbyte? expected)
+				sbyte? subject, sbyte? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -531,7 +531,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -562,10 +562,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((short)5, (short)7)]
-			[InlineData((short)5, (short)3)]
+			[InlineData((short)5, (short)7, -2)]
+			[InlineData((short)5, (short)3, 2)]
 			public async Task ForNullableShort_WhenOutsideTolerance_ShouldFail(
-				short? subject, short? expected)
+				short? subject, short? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -574,7 +574,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -605,10 +605,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((uint)5, (uint)7)]
-			[InlineData((uint)5, (uint)3)]
+			[InlineData((uint)5, (uint)7, -2)]
+			[InlineData((uint)5, (uint)3, 2)]
 			public async Task ForNullableUint_WhenOutsideTolerance_ShouldFail(
-				uint? subject, uint? expected)
+				uint? subject, uint? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -617,7 +617,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -634,10 +634,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((ulong)5, (ulong)7)]
-			[InlineData((ulong)5, (ulong)3)]
+			[InlineData((ulong)5, (ulong)7, -2)]
+			[InlineData((ulong)5, (ulong)3, 2)]
 			public async Task ForNullableUlong_WhenOutsideTolerance_ShouldFail(
-				ulong? subject, ulong? expected)
+				ulong? subject, ulong? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -646,7 +646,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -663,10 +663,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData((ushort)5, (ushort)7)]
-			[InlineData((ushort)5, (ushort)3)]
+			[InlineData((ushort)5, (ushort)7, -2)]
+			[InlineData((ushort)5, (ushort)3, 2)]
 			public async Task ForNullableUshort_WhenOutsideTolerance_ShouldFail(
-				ushort? subject, ushort? expected)
+				ushort? subject, ushort? expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -675,7 +675,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -692,10 +692,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForSbyte_WhenOutsideTolerance_ShouldFail(
-				sbyte subject, sbyte expected)
+				sbyte subject, sbyte expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -704,7 +704,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -735,10 +735,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForShort_WhenOutsideTolerance_ShouldFail(
-				short subject, short expected)
+				short subject, short expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -747,7 +747,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -778,10 +778,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForUint_WhenOutsideTolerance_ShouldFail(
-				uint subject, uint expected)
+				uint subject, uint expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -790,7 +790,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -807,10 +807,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForUlong_WhenOutsideTolerance_ShouldFail(
-				ulong subject, ulong expected)
+				ulong subject, ulong expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -819,7 +819,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 
@@ -836,10 +836,10 @@ public sealed partial class ThatNumber
 			}
 
 			[Theory]
-			[InlineData(5, 7)]
-			[InlineData(5, 3)]
+			[InlineData(5, 7, -2)]
+			[InlineData(5, 3, 2)]
 			public async Task ForUshort_WhenOutsideTolerance_ShouldFail(
-				ushort subject, ushort expected)
+				ushort subject, ushort expected, int expectedDifference)
 			{
 				async Task Act()
 					=> await That(subject).IsEqualTo(expected).Within(1);
@@ -848,7 +848,7 @@ public sealed partial class ThatNumber
 					.WithMessage($"""
 					              Expected that subject
 					              is equal to {Formatter.Format(expected)} ± 1,
-					              but it was 5
+					              but it was 5 which differs by {expectedDifference}
 					              """);
 			}
 		}

--- a/Tests/aweXpect.Tests/ThatGeneric.For.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.For.Tests.cs
@@ -76,7 +76,7 @@ public sealed partial class ThatGeneric
 					.WithMessage($"""
 					              Expected that subject
 					              for .Value is equal to {Formatter.Format(expectedValue)},
-					              but .Value was {Formatter.Format(value)}
+					              but .Value was {Formatter.Format(value)} which differs by -1
 					              """);
 			}
 


### PR DESCRIPTION
When comparing two numbers for equality, and they differ, include the difference in the error message.

- *Fixes #572*