### PR TITLE
refactor: adjust namespaces

### DIFF
--- a/Source/aweXpect.Core/Core/Times.cs
+++ b/Source/aweXpect.Core/Core/Times.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect;
+﻿namespace aweXpect.Core;
 
 /// <summary>
 ///     Count the number of times something occurred.

--- a/Source/aweXpect.Core/Core/TimesExtensions.cs
+++ b/Source/aweXpect.Core/Core/TimesExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect;
+﻿namespace aweXpect.Core;
 
 /// <summary>
 ///     Extension methods for <see cref="Times" />.

--- a/Source/aweXpect.Core/Results/BetweenResult.cs
+++ b/Source/aweXpect.Core/Results/BetweenResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using aweXpect.Core;
 
 namespace aweXpect.Results;
 

--- a/Source/aweXpect.Core/Signaling/Signaler.cs
+++ b/Source/aweXpect.Core/Signaling/Signaler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using aweXpect.Core;
 using aweXpect.Core.Helpers;
 using aweXpect.Customization;
 

--- a/Source/aweXpect/That/Collections/CollectionCountResult.cs
+++ b/Source/aweXpect/That/Collections/CollectionCountResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
+using aweXpect.Results;
 
-namespace aweXpect.Results;
+namespace aweXpect;
 
 /// <summary>
 ///     The result for counting items in a collection.

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -3,6 +3,14 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect
 {
+    public class CollectionCountResult<TReturn>
+    {
+        public CollectionCountResult(System.Func<aweXpect.EnumerableQuantifier, TReturn> factory) { }
+        public TReturn AtLeast(int minimum) { }
+        public TReturn AtMost(int maximum) { }
+        public aweXpect.Results.BetweenResult<TReturn> Between(int minimum) { }
+        public TReturn EqualTo(int expected) { }
+    }
     public abstract class EnumerableQuantifier
     {
         protected EnumerableQuantifier() { }
@@ -54,7 +62,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> EndsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.ThatAsyncEnumerable.Elements Exactly(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject, int expected) { }
         public static aweXpect.ThatAsyncEnumerable.Elements<TItem> Exactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject, int expected) { }
-        public static aweXpect.Results.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
+        public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>, TItem>.Async HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringCollectionBeContainedInResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> IsContainedIn(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
@@ -294,7 +302,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> EndsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.ThatEnumerable.Elements Exactly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject, int expected) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> Exactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
-        public static aweXpect.Results.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
+        public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringCollectionBeContainedInResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> IsContainedIn(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
@@ -693,13 +701,13 @@ namespace aweXpect
     public static class ThatSignaler
     {
         public static aweXpect.Results.SignalCountResult DidNotSignal(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source) { }
-        public static aweXpect.Results.SignalCountResult DidNotSignal(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountResult DidNotSignal(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Core.Times times) { }
         public static aweXpect.Results.SignalCountResult<TParameter> DidNotSignal<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source) { }
-        public static aweXpect.Results.SignalCountResult<TParameter> DidNotSignal<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountResult<TParameter> DidNotSignal<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Core.Times times) { }
         public static aweXpect.Results.SignalCountResult Signaled(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source) { }
-        public static aweXpect.Results.SignalCountResult Signaled(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountResult Signaled(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Core.Times times) { }
         public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source) { }
-        public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Core.Times times) { }
     }
     public static class ThatStream
     {
@@ -834,14 +842,6 @@ namespace aweXpect.Options
 }
 namespace aweXpect.Results
 {
-    public class CollectionCountResult<TReturn>
-    {
-        public CollectionCountResult(System.Func<aweXpect.EnumerableQuantifier, TReturn> factory) { }
-        public TReturn AtLeast(int minimum) { }
-        public TReturn AtMost(int maximum) { }
-        public aweXpect.Results.BetweenResult<TReturn> Between(int minimum) { }
-        public TReturn EqualTo(int expected) { }
-    }
     public class ContainsValueResult<TCollection, TThat, TKey, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
     {
         public aweXpect.Core.IThat<TValue> WhoseValue { get; }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -3,6 +3,14 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect
 {
+    public class CollectionCountResult<TReturn>
+    {
+        public CollectionCountResult(System.Func<aweXpect.EnumerableQuantifier, TReturn> factory) { }
+        public TReturn AtLeast(int minimum) { }
+        public TReturn AtMost(int maximum) { }
+        public aweXpect.Results.BetweenResult<TReturn> Between(int minimum) { }
+        public TReturn EqualTo(int expected) { }
+    }
     public abstract class EnumerableQuantifier
     {
         protected EnumerableQuantifier() { }
@@ -195,7 +203,7 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> EndsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.ThatEnumerable.Elements Exactly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject, int expected) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> Exactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
-        public static aweXpect.Results.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
+        public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringCollectionBeContainedInResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> IsContainedIn(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
@@ -785,13 +793,13 @@ namespace aweXpect
     public static class ThatSignaler
     {
         public static aweXpect.Results.SignalCountResult DidNotSignal(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source) { }
-        public static aweXpect.Results.SignalCountResult DidNotSignal(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountResult DidNotSignal(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Core.Times times) { }
         public static aweXpect.Results.SignalCountResult<TParameter> DidNotSignal<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source) { }
-        public static aweXpect.Results.SignalCountResult<TParameter> DidNotSignal<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountResult<TParameter> DidNotSignal<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Core.Times times) { }
         public static aweXpect.Results.SignalCountResult Signaled(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source) { }
-        public static aweXpect.Results.SignalCountResult Signaled(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountResult Signaled(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler> source, aweXpect.Core.Times times) { }
         public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source) { }
-        public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Times times) { }
+        public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Core.Times times) { }
     }
     public static class ThatStream
     {
@@ -903,14 +911,6 @@ namespace aweXpect.Options
 }
 namespace aweXpect.Results
 {
-    public class CollectionCountResult<TReturn>
-    {
-        public CollectionCountResult(System.Func<aweXpect.EnumerableQuantifier, TReturn> factory) { }
-        public TReturn AtLeast(int minimum) { }
-        public TReturn AtMost(int maximum) { }
-        public aweXpect.Results.BetweenResult<TReturn> Between(int minimum) { }
-        public TReturn EqualTo(int expected) { }
-    }
     public class ContainsValueResult<TCollection, TThat, TKey, TValue> : aweXpect.Results.AndOrResult<TCollection, TThat>
     {
         public aweXpect.Core.IThat<TValue> WhoseValue { get; }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -299,6 +299,16 @@ namespace aweXpect.Core
         public ThatSubject(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
     }
+    public readonly struct Times
+    {
+        public Times(int value) { }
+        public int Value { get; }
+        public static aweXpect.Core.Times op_Implicit(int value) { }
+    }
+    public static class TimesExtensions
+    {
+        public static aweXpect.Core.Times Times(this int value) { }
+    }
 }
 namespace aweXpect.Core.Helpers
 {
@@ -587,16 +597,6 @@ namespace aweXpect
     public class SkipException : System.Exception
     {
         public SkipException(string message) { }
-    }
-    public readonly struct Times
-    {
-        public Times(int value) { }
-        public int Value { get; }
-        public static aweXpect.Times op_Implicit(int value) { }
-    }
-    public static class TimesExtensions
-    {
-        public static aweXpect.Times Times(this int value) { }
     }
 }
 namespace aweXpect.Formatting
@@ -947,7 +947,7 @@ namespace aweXpect.Results
     public class BetweenResult<TTarget>
     {
         public BetweenResult(System.Func<int, TTarget> callback) { }
-        public TTarget And(aweXpect.Times maximum) { }
+        public TTarget And(aweXpect.Core.Times maximum) { }
     }
     public class CollectionOrderResult<TMember, TType, TThat> : aweXpect.Results.AndOrResult<TType, TThat>
     {
@@ -962,12 +962,12 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.CountResult<TType, TThat, TSelf>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }
-        public TSelf AtLeast(aweXpect.Times minimum) { }
-        public TSelf AtMost(aweXpect.Times maximum) { }
+        public TSelf AtLeast(aweXpect.Core.Times minimum) { }
+        public TSelf AtMost(aweXpect.Core.Times maximum) { }
         public aweXpect.Results.BetweenResult<TSelf> Between(int minimum) { }
-        public TSelf Exactly(aweXpect.Times expected) { }
-        public TSelf LessThan(aweXpect.Times maximum) { }
-        public TSelf MoreThan(aweXpect.Times minimum) { }
+        public TSelf Exactly(aweXpect.Core.Times expected) { }
+        public TSelf LessThan(aweXpect.Core.Times maximum) { }
+        public TSelf MoreThan(aweXpect.Core.Times minimum) { }
         public TSelf Never() { }
         public TSelf Once() { }
     }
@@ -1174,10 +1174,10 @@ namespace aweXpect.Signaling
     public class Signaler
     {
         public Signaler() { }
-        public bool IsSignaled(aweXpect.Times? amount = default) { }
+        public bool IsSignaled(aweXpect.Core.Times? amount = default) { }
         public void Signal() { }
         public aweXpect.Signaling.SignalerResult Wait(System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
-        public aweXpect.Signaling.SignalerResult Wait(aweXpect.Times amount, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public aweXpect.Signaling.SignalerResult Wait(aweXpect.Core.Times amount, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class SignalerResult
     {
@@ -1193,10 +1193,10 @@ namespace aweXpect.Signaling
     public class Signaler<TParameter>
     {
         public Signaler() { }
-        public bool IsSignaled(aweXpect.Times? amount = default) { }
+        public bool IsSignaled(aweXpect.Core.Times? amount = default) { }
         public void Signal(TParameter parameter) { }
         public aweXpect.Signaling.SignalerResult<TParameter> Wait(System.Func<TParameter, bool>? predicate = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
-        public aweXpect.Signaling.SignalerResult<TParameter> Wait(aweXpect.Times amount, System.Func<TParameter, bool>? predicate = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public aweXpect.Signaling.SignalerResult<TParameter> Wait(aweXpect.Core.Times amount, System.Func<TParameter, bool>? predicate = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
 namespace aweXpect.Synchronous

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -299,6 +299,16 @@ namespace aweXpect.Core
         public ThatSubject(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
     }
+    public readonly struct Times
+    {
+        public Times(int value) { }
+        public int Value { get; }
+        public static aweXpect.Core.Times op_Implicit(int value) { }
+    }
+    public static class TimesExtensions
+    {
+        public static aweXpect.Core.Times Times(this int value) { }
+    }
 }
 namespace aweXpect.Core.Helpers
 {
@@ -582,16 +592,6 @@ namespace aweXpect
     public class SkipException : System.Exception
     {
         public SkipException(string message) { }
-    }
-    public readonly struct Times
-    {
-        public Times(int value) { }
-        public int Value { get; }
-        public static aweXpect.Times op_Implicit(int value) { }
-    }
-    public static class TimesExtensions
-    {
-        public static aweXpect.Times Times(this int value) { }
     }
 }
 namespace aweXpect.Formatting
@@ -930,7 +930,7 @@ namespace aweXpect.Results
     public class BetweenResult<TTarget>
     {
         public BetweenResult(System.Func<int, TTarget> callback) { }
-        public TTarget And(aweXpect.Times maximum) { }
+        public TTarget And(aweXpect.Core.Times maximum) { }
     }
     public class CollectionOrderResult<TMember, TType, TThat> : aweXpect.Results.AndOrResult<TType, TThat>
     {
@@ -945,12 +945,12 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.CountResult<TType, TThat, TSelf>
     {
         public CountResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.Quantifier quantifier) { }
-        public TSelf AtLeast(aweXpect.Times minimum) { }
-        public TSelf AtMost(aweXpect.Times maximum) { }
+        public TSelf AtLeast(aweXpect.Core.Times minimum) { }
+        public TSelf AtMost(aweXpect.Core.Times maximum) { }
         public aweXpect.Results.BetweenResult<TSelf> Between(int minimum) { }
-        public TSelf Exactly(aweXpect.Times expected) { }
-        public TSelf LessThan(aweXpect.Times maximum) { }
-        public TSelf MoreThan(aweXpect.Times minimum) { }
+        public TSelf Exactly(aweXpect.Core.Times expected) { }
+        public TSelf LessThan(aweXpect.Core.Times maximum) { }
+        public TSelf MoreThan(aweXpect.Core.Times minimum) { }
         public TSelf Never() { }
         public TSelf Once() { }
     }
@@ -1157,10 +1157,10 @@ namespace aweXpect.Signaling
     public class Signaler
     {
         public Signaler() { }
-        public bool IsSignaled(aweXpect.Times? amount = default) { }
+        public bool IsSignaled(aweXpect.Core.Times? amount = default) { }
         public void Signal() { }
         public aweXpect.Signaling.SignalerResult Wait(System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
-        public aweXpect.Signaling.SignalerResult Wait(aweXpect.Times amount, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public aweXpect.Signaling.SignalerResult Wait(aweXpect.Core.Times amount, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class SignalerResult
     {
@@ -1176,10 +1176,10 @@ namespace aweXpect.Signaling
     public class Signaler<TParameter>
     {
         public Signaler() { }
-        public bool IsSignaled(aweXpect.Times? amount = default) { }
+        public bool IsSignaled(aweXpect.Core.Times? amount = default) { }
         public void Signal(TParameter parameter) { }
         public aweXpect.Signaling.SignalerResult<TParameter> Wait(System.Func<TParameter, bool>? predicate = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
-        public aweXpect.Signaling.SignalerResult<TParameter> Wait(aweXpect.Times amount, System.Func<TParameter, bool>? predicate = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public aweXpect.Signaling.SignalerResult<TParameter> Wait(aweXpect.Core.Times amount, System.Func<TParameter, bool>? predicate = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
 namespace aweXpect.Synchronous

--- a/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Recording;
+﻿using aweXpect.Core;
+using aweXpect.Recording;
 using aweXpect.Results;
 
 namespace aweXpect.Internal.Tests.Results;

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
@@ -1,6 +1,7 @@
 ﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
+using aweXpect.Core;
 
 // ReSharper disable PossibleMultipleEnumeration
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using aweXpect.Core;
 
 // ReSharper disable PossibleMultipleEnumeration
 

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.CountTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.CountTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Recording;
+﻿using aweXpect.Core;
+using aweXpect.Recording;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.Tests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Recording;
+﻿using aweXpect.Core;
+using aweXpect.Recording;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithParameterTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.Triggered.WithParameterTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Recording;
+﻿using aweXpect.Core;
+using aweXpect.Recording;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using aweXpect.Core;
 using aweXpect.Recording;
 
 namespace aweXpect.Tests;

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChanged.WithinTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Recording;
+﻿using aweXpect.Core;
+using aweXpect.Recording;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Recording/ThatEventRecording.TriggeredPropertyChangedFor.WithinTests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Recording;
+﻿using aweXpect.Core;
+using aweXpect.Recording;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.TimesTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.TimesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using aweXpect.Core;
 using aweXpect.Signaling;
 
 namespace aweXpect.Tests;

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.WithTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.WithTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using aweXpect.Core;
 using aweXpect.Signaling;
 
 namespace aweXpect.Tests;

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.TimesTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.TimesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using aweXpect.Core;
 using aweXpect.Signaling;
 
 namespace aweXpect.Tests;

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.WhoseParametersTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.WhoseParametersTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using aweXpect.Core;
 using aweXpect.Signaling;
 
 namespace aweXpect.Tests;

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.WithTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.WithTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using aweXpect.Core;
 using aweXpect.Signaling;
 
 namespace aweXpect.Tests;


### PR DESCRIPTION
- Move `Times` to `aweXpect.Core` to reduce the number of collisions (e.g. with Moq)
- Move `CollectionCountResult` to `aweXpect`