### PR TITLE
fix: handle `null` type in collections `Are(Type)`

### DIFF
--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
@@ -44,6 +44,8 @@ public static partial class ThatAsyncEnumerable
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
 			Are(Type type)
 		{
+			// ReSharper disable once LocalizableElement
+			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -43,6 +43,8 @@ public static partial class ThatEnumerable
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
 			Are(Type type)
 		{
+			// ReSharper disable once LocalizableElement
+			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Are.Tests.cs
@@ -76,6 +76,20 @@ public sealed partial class ThatAsyncEnumerable
 				}
 
 				[Fact]
+				public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(
+						Enumerable.Range(1, 10));
+
+					async Task Act()
+						=> await That(subject).All().Are(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("type").And
+						.WithMessage("The type cannot be null.").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenTypeMatchesBaseType_ShouldSucceed()
 				{
 					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable(

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
@@ -71,6 +71,19 @@ public sealed partial class ThatEnumerable
 				}
 
 				[Fact]
+				public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+				{
+					IEnumerable<int> subject = Enumerable.Range(1, 10);
+
+					async Task Act()
+						=> await That(subject).All().Are(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("type").And
+						.WithMessage("The type cannot be null.").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenTypeMatchesBaseType_ShouldSucceed()
 				{
 					IEnumerable<MyClass> subject = Enumerable.Range(1, 10).Select(_ => new MyClass());

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.TimesTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.TimesTests.cs
@@ -54,15 +54,16 @@ public sealed partial class ThatSignaler
 						signaler.Signal();
 						signaler.Signal();
 						signaler.Signal();
+						signaler.Signal();
 					});
 
 				async Task Act() =>
-					await That(signaler).DidNotSignal(2.Times());
+					await That(signaler).DidNotSignal(3.Times());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that signaler
-					             does not have recorded the callback at least twice,
+					             does not have recorded the callback at least 3 times,
 					             but it was recorded ? times
 					             """).AsWildcard();
 			}

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.WithTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.WithTests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatSignaler
 					.WithMessage("""
 					             Expected that signaler
 					             does not have recorded the callback at least twice with p => p > 1,
-					             but it was recorded ? times in [
+					             but it was recorded * in [
 					               1,
 					               2,
 					               *


### PR DESCRIPTION
Throw an exception when setting the type to `null` in collections elements `Are(Type)` expectation.

- make the signaler tests more resilient