### PR TITLE
fix: handle `null` type in collections `AreExactly(Type)`

### DIFF
--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreExactly.cs
@@ -44,6 +44,8 @@ public static partial class ThatAsyncEnumerable
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
 			AreExactly(Type type)
 		{
+			// ReSharper disable once LocalizableElement
+			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreExactly.cs
@@ -43,6 +43,8 @@ public static partial class ThatEnumerable
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
 			AreExactly(Type type)
 		{
+			// ReSharper disable once LocalizableElement
+			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreExactly.Tests.cs
@@ -81,6 +81,20 @@ public sealed partial class ThatAsyncEnumerable
 				}
 
 				[Fact]
+				public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(
+						Enumerable.Range(1, 10));
+
+					async Task Act()
+						=> await That(subject).All().AreExactly(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("type").And
+						.WithMessage("The type cannot be null.").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenTypeMatchesBaseType_ShouldFail()
 				{
 					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable(

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.Tests.cs
@@ -76,6 +76,19 @@ public sealed partial class ThatEnumerable
 				}
 
 				[Fact]
+				public async Task WhenTypeIsNull_ShouldThrowArgumentNullException()
+				{
+					IEnumerable<int> subject = Enumerable.Range(1, 10);
+
+					async Task Act()
+						=> await That(subject).All().AreExactly(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("type").And
+						.WithMessage("The type cannot be null.").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenTypeMatchesBaseType_ShouldFail()
 				{
 					IEnumerable<MyClass> subject = Enumerable.Range(1, 10).Select(_ => new MyClass());


### PR DESCRIPTION
Throw an exception when setting the type to `null` in collections elements `AreExactly(Type)` expectation.

- *Remaining case from #587*