### PR TITLE
fix: handle `null` predicates

### DIFF
--- a/Source/aweXpect.Core/Options/TriggerEventFilter.cs
+++ b/Source/aweXpect.Core/Options/TriggerEventFilter.cs
@@ -19,6 +19,8 @@ public class TriggerEventFilter
 	/// </summary>
 	public void AddPredicate(Func<object?[], bool> predicate, string predicateExpression)
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		if (_predicates.Count != 0)
 		{
 			_toString.Append(" and");

--- a/Source/aweXpect/Helpers/ExceptionHelpers.cs
+++ b/Source/aweXpect/Helpers/ExceptionHelpers.cs
@@ -1,10 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace aweXpect.Helpers;
 
 internal static class ExceptionHelpers
 {
+	public static void ThrowIfNull(this object? parameter, [CallerArgumentExpression(nameof(parameter))] string? paramName = null)
+	{
+		if (parameter is null)
+		{
+			// ReSharper disable once LocalizableElement
+			throw new ArgumentNullException(paramName, $"The {paramName} cannot be null.");
+		}
+	}
+	
 	public static string FormatForMessage(this Exception exception)
 	{
 		string message = Formatter.Format(exception.GetType()).PrependAOrAn();

--- a/Source/aweXpect/Results/EventTriggerResult.cs
+++ b/Source/aweXpect/Results/EventTriggerResult.cs
@@ -28,6 +28,8 @@ public class EventTriggerResult<TSubject>(
 		int? position,
 		Func<TParameter, bool> predicate)
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		filter.AddPredicate(
 			o => position == null
 				? o.Any(x => x is TParameter p && predicate(p))
@@ -47,6 +49,8 @@ public class EventTriggerResult<TSubject>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		filter.AddPredicate(
 			o => o.Length > 0 && predicate(o[0]),
 			$" with sender {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
@@ -65,6 +69,8 @@ public class EventTriggerResult<TSubject>(
 		string doNotPopulateThisValue = "")
 		where TEventArgs : EventArgs
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		filter.AddPredicate(
 			o => o.Length > 1 && o[1] is TEventArgs m && predicate(m),
 			$" with {Formatter.Format(typeof(TEventArgs))} {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
@@ -81,6 +87,8 @@ public class EventTriggerResult<TSubject>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		filter.AddPredicate(
 			o => o.Any(x => x is TParameter m && predicate(m)),
 			$" with {Formatter.Format(typeof(TParameter))} parameter {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
@@ -98,6 +106,8 @@ public class EventTriggerResult<TSubject>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		filter.AddPredicate(
 			o => o.Length > position && o[position] is TParameter m && predicate(m),
 			$" with {Formatter.Format(typeof(TParameter))} parameter [{position}] {doNotPopulateThisValue.TrimCommonWhiteSpace()}");

--- a/Source/aweXpect/Results/EventTriggerResult.cs
+++ b/Source/aweXpect/Results/EventTriggerResult.cs
@@ -28,8 +28,7 @@ public class EventTriggerResult<TSubject>(
 		int? position,
 		Func<TParameter, bool> predicate)
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		filter.AddPredicate(
 			o => position == null
 				? o.Any(x => x is TParameter p && predicate(p))
@@ -49,8 +48,7 @@ public class EventTriggerResult<TSubject>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		filter.AddPredicate(
 			o => o.Length > 0 && predicate(o[0]),
 			$" with sender {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
@@ -69,8 +67,7 @@ public class EventTriggerResult<TSubject>(
 		string doNotPopulateThisValue = "")
 		where TEventArgs : EventArgs
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		filter.AddPredicate(
 			o => o.Length > 1 && o[1] is TEventArgs m && predicate(m),
 			$" with {Formatter.Format(typeof(TEventArgs))} {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
@@ -87,8 +84,7 @@ public class EventTriggerResult<TSubject>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		filter.AddPredicate(
 			o => o.Any(x => x is TParameter m && predicate(m)),
 			$" with {Formatter.Format(typeof(TParameter))} parameter {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
@@ -106,8 +102,7 @@ public class EventTriggerResult<TSubject>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		filter.AddPredicate(
 			o => o.Length > position && o[position] is TParameter m && predicate(m),
 			$" with {Formatter.Format(typeof(TParameter))} parameter [{position}] {doNotPopulateThisValue.TrimCommonWhiteSpace()}");

--- a/Source/aweXpect/Results/SignalCountResult.cs
+++ b/Source/aweXpect/Results/SignalCountResult.cs
@@ -62,8 +62,7 @@ public class SignalCountResult<TParameter, TSelf>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		options.WithPredicate(predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return (TSelf)this;
 	}

--- a/Source/aweXpect/Results/SignalCountResult.cs
+++ b/Source/aweXpect/Results/SignalCountResult.cs
@@ -62,6 +62,8 @@ public class SignalCountResult<TParameter, TSelf>(
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		options.WithPredicate(predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return (TSelf)this;
 	}

--- a/Source/aweXpect/Results/SingleItemResult.cs
+++ b/Source/aweXpect/Results/SingleItemResult.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using aweXpect.Core;
+using aweXpect.Helpers;
 using aweXpect.Options;
 
 namespace aweXpect.Results;
@@ -42,8 +43,7 @@ public class SingleItemResult<TCollection, TItem>
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		_options.SetPredicate(predicate,
 			$" matching {doNotPopulateThisValue}");
 		return this;
@@ -66,8 +66,7 @@ public class SingleItemResult<TCollection, TItem>
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		_options.SetPredicate(item => item is T typed && predicate(typed),
 			$" of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
 		return this;
@@ -105,8 +104,7 @@ public class SingleItemResult<TCollection, TItem>
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 		{
-			// ReSharper disable once LocalizableElement
-			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			predicate.ThrowIfNull();
 			_options.SetPredicate(predicate,
 				$" matching {doNotPopulateThisValue}");
 			return this;
@@ -129,8 +127,7 @@ public class SingleItemResult<TCollection, TItem>
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 		{
-			// ReSharper disable once LocalizableElement
-			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			predicate.ThrowIfNull();
 			_options.SetPredicate(item => item is T typed && predicate(typed),
 				$" of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
 			return this;

--- a/Source/aweXpect/Results/SingleItemResult.cs
+++ b/Source/aweXpect/Results/SingleItemResult.cs
@@ -42,6 +42,8 @@ public class SingleItemResult<TCollection, TItem>
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		_options.SetPredicate(predicate,
 			$" matching {doNotPopulateThisValue}");
 		return this;
@@ -64,6 +66,8 @@ public class SingleItemResult<TCollection, TItem>
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		_options.SetPredicate(item => item is T typed && predicate(typed),
 			$" of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
 		return this;
@@ -101,6 +105,8 @@ public class SingleItemResult<TCollection, TItem>
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 		{
+			// ReSharper disable once LocalizableElement
+			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 			_options.SetPredicate(predicate,
 				$" matching {doNotPopulateThisValue}");
 			return this;
@@ -123,6 +129,8 @@ public class SingleItemResult<TCollection, TItem>
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 		{
+			// ReSharper disable once LocalizableElement
+			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 			_options.SetPredicate(item => item is T typed && predicate(typed),
 				$" of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
 			return this;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
@@ -77,6 +77,8 @@ public static partial class ThatAsyncEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		Quantifier quantifier = new();
 		return new CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
@@ -187,6 +189,8 @@ public static partial class ThatAsyncEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		Quantifier quantifier = new();
 		return new CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
@@ -77,8 +77,7 @@ public static partial class ThatAsyncEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
 		return new CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
@@ -189,8 +188,7 @@ public static partial class ThatAsyncEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
 		return new CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
@@ -44,8 +44,7 @@ public static partial class ThatAsyncEnumerable
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
 			Are(Type type)
 		{
-			// ReSharper disable once LocalizableElement
-			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+			type.ThrowIfNull();;
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Are.cs
@@ -44,7 +44,7 @@ public static partial class ThatAsyncEnumerable
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
 			Are(Type type)
 		{
-			type.ThrowIfNull();;
+			type.ThrowIfNull();
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreExactly.cs
@@ -44,8 +44,7 @@ public static partial class ThatAsyncEnumerable
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
 			AreExactly(Type type)
 		{
-			// ReSharper disable once LocalizableElement
-			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+			type.ThrowIfNull();;
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreExactly.cs
@@ -44,7 +44,7 @@ public static partial class ThatAsyncEnumerable
 		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
 			AreExactly(Type type)
 		{
-			type.ThrowIfNull();;
+			type.ThrowIfNull();
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Satisfy.cs
@@ -21,8 +21,7 @@ public static partial class ThatAsyncEnumerable
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
 		{
-			// ReSharper disable once LocalizableElement
-			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			predicate.ThrowIfNull();
 			return new AndOrResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<string?>(
 						it, grammars,
@@ -51,8 +50,7 @@ public static partial class ThatAsyncEnumerable
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
 		{
-			// ReSharper disable once LocalizableElement
-			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			predicate.ThrowIfNull();
 			return new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<TItem>(
 						it, grammars,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.Satisfy.cs
@@ -20,7 +20,10 @@ public static partial class ThatAsyncEnumerable
 				Func<string?, bool> predicate,
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
-			=> new(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+		{
+			// ReSharper disable once LocalizableElement
+			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			return new AndOrResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<string?>(
 						it, grammars,
 						_quantifier,
@@ -34,6 +37,7 @@ public static partial class ThatAsyncEnumerable
 						predicate,
 						"did")),
 				_subject);
+		}
 	}
 
 	public partial class Elements<TItem>
@@ -46,7 +50,10 @@ public static partial class ThatAsyncEnumerable
 				Func<TItem, bool> predicate,
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
-			=> new(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+		{
+			// ReSharper disable once LocalizableElement
+			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			return new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<TItem>(
 						it, grammars,
 						_quantifier,
@@ -61,6 +68,7 @@ public static partial class ThatAsyncEnumerable
 						predicate,
 						"did")),
 				_subject);
+		}
 	}
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
@@ -50,6 +50,7 @@ public static partial class ThatAsyncEnumerable
 	{
 		private IAsyncEnumerable<TItem>? _actual;
 		private int _count;
+		private bool _isEmpty;
 
 		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TItem>? actual, IEvaluationContext context,
 			CancellationToken cancellationToken)
@@ -64,9 +65,11 @@ public static partial class ThatAsyncEnumerable
 			IAsyncEnumerable<TItem> materialized =
 				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
 			_count = 0;
+			_isEmpty = true;
 
 			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
 			{
+				_isEmpty = false;
 				if (!options.Matches(item))
 				{
 					continue;
@@ -105,7 +108,7 @@ public static partial class ThatAsyncEnumerable
 			}
 			else if (_count == 0)
 			{
-				stringBuilder.Append(it).Append(" was empty");
+				stringBuilder.Append(it).Append(_isEmpty ? " was empty" : " did not contain any matching item");
 			}
 			else
 			{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -73,8 +73,7 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
 		return new CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
@@ -184,8 +183,7 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
 		return new CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -73,6 +73,8 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		Quantifier quantifier = new();
 		return new CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
@@ -182,6 +184,8 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("predicate")]
 			string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		Quantifier quantifier = new();
 		return new CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -43,8 +43,7 @@ public static partial class ThatEnumerable
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
 			Are(Type type)
 		{
-			// ReSharper disable once LocalizableElement
-			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+			type.ThrowIfNull();;
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Are.cs
@@ -43,7 +43,7 @@ public static partial class ThatEnumerable
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
 			Are(Type type)
 		{
-			type.ThrowIfNull();;
+			type.ThrowIfNull();
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreExactly.cs
@@ -43,8 +43,7 @@ public static partial class ThatEnumerable
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
 			AreExactly(Type type)
 		{
-			// ReSharper disable once LocalizableElement
-			_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+			type.ThrowIfNull();;
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreExactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreExactly.cs
@@ -43,7 +43,7 @@ public static partial class ThatEnumerable
 		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
 			AreExactly(Type type)
 		{
-			type.ThrowIfNull();;
+			type.ThrowIfNull();
 			ObjectEqualityOptions<TItem> options = new();
 			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
 				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
@@ -19,7 +19,10 @@ public static partial class ThatEnumerable
 				Func<string?, bool> predicate,
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
-			=> new(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+		{
+			// ReSharper disable once LocalizableElement
+			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			return new AndOrResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<string?>(
 						it, grammars,
 						_quantifier,
@@ -33,6 +36,7 @@ public static partial class ThatEnumerable
 						predicate,
 						"did")),
 				_subject);
+		}
 	}
 
 	public partial class Elements<TItem>
@@ -45,7 +49,10 @@ public static partial class ThatEnumerable
 				Func<TItem, bool> predicate,
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
-			=> new(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+		{
+			// ReSharper disable once LocalizableElement
+			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			return new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<TItem>(
 						it, grammars,
 						_quantifier,
@@ -60,5 +67,6 @@ public static partial class ThatEnumerable
 						predicate,
 						"did")),
 				_subject);
+		}
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.Satisfy.cs
@@ -20,8 +20,7 @@ public static partial class ThatEnumerable
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
 		{
-			// ReSharper disable once LocalizableElement
-			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			predicate.ThrowIfNull();
 			return new AndOrResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<string?>(
 						it, grammars,
@@ -50,8 +49,7 @@ public static partial class ThatEnumerable
 				[CallerArgumentExpression("predicate")]
 				string doNotPopulateThisValue = "")
 		{
-			// ReSharper disable once LocalizableElement
-			_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+			predicate.ThrowIfNull();
 			return new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 					=> new CollectionConstraint<TItem>(
 						it, grammars,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasSingle.cs
@@ -37,6 +37,7 @@ public static partial class ThatEnumerable
 	{
 		private IEnumerable<TItem>? _actual;
 		private int _count;
+		private bool _isEmpty;
 
 		public ConstraintResult IsMetBy(IEnumerable<TItem>? actual, IEvaluationContext context)
 		{
@@ -49,9 +50,11 @@ public static partial class ThatEnumerable
 
 			IEnumerable<TItem> materialized = context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
 			_count = 0;
+			_isEmpty = true;
 
 			foreach (TItem item in materialized)
 			{
+				_isEmpty = false;
 				if (!options.Matches(item))
 				{
 					continue;
@@ -90,7 +93,7 @@ public static partial class ThatEnumerable
 			}
 			else if (_count == 0)
 			{
-				stringBuilder.Append(it).Append(" was empty");
+				stringBuilder.Append(it).Append(_isEmpty ? " was empty" : " did not contain any matching item");
 			}
 			else
 			{

--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -26,8 +26,7 @@ public static partial class ThatObject
 		Type type)
 		where T : class
 	{
-		// ReSharper disable once LocalizableElement
-		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		type.ThrowIfNull();;
 		return new AndOrResult<T?, IThat<T?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsOfTypeConstraint(it, grammars, type)),
 			source);
@@ -50,8 +49,7 @@ public static partial class ThatObject
 		Type type)
 		where T : class
 	{
-		// ReSharper disable once LocalizableElement
-		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		type.ThrowIfNull();;
 		return new AndOrResult<T?, IThat<T?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsOfTypeConstraint(it, grammars, type).Invert()),
 			source);

--- a/Source/aweXpect/That/Objects/ThatObject.Is.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.Is.cs
@@ -26,7 +26,7 @@ public static partial class ThatObject
 		Type type)
 		where T : class
 	{
-		type.ThrowIfNull();;
+		type.ThrowIfNull();
 		return new AndOrResult<T?, IThat<T?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsOfTypeConstraint(it, grammars, type)),
 			source);
@@ -49,7 +49,7 @@ public static partial class ThatObject
 		Type type)
 		where T : class
 	{
-		type.ThrowIfNull();;
+		type.ThrowIfNull();
 		return new AndOrResult<T?, IThat<T?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsOfTypeConstraint(it, grammars, type).Invert()),
 			source);

--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -24,8 +24,7 @@ public static partial class ThatObject
 		this IThat<object?> source,
 		Type type)
 	{
-		// ReSharper disable once LocalizableElement
-		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		type.ThrowIfNull();;
 		return new AndOrResult<object?, IThat<object?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsExactlyOfTypeConstraint(it, grammars, type)),
 			source);
@@ -47,8 +46,7 @@ public static partial class ThatObject
 		this IThat<object?> source,
 		Type type)
 	{
-		// ReSharper disable once LocalizableElement
-		_ = type ?? throw new ArgumentNullException(nameof(type), "The type cannot be null.");
+		type.ThrowIfNull();;
 		return new AndOrResult<object?, IThat<object?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsExactlyOfTypeConstraint(it, grammars, type).Invert()),
 			source);

--- a/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
+++ b/Source/aweXpect/That/Objects/ThatObject.IsExactly.cs
@@ -24,7 +24,7 @@ public static partial class ThatObject
 		this IThat<object?> source,
 		Type type)
 	{
-		type.ThrowIfNull();;
+		type.ThrowIfNull();
 		return new AndOrResult<object?, IThat<object?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsExactlyOfTypeConstraint(it, grammars, type)),
 			source);
@@ -46,7 +46,7 @@ public static partial class ThatObject
 		this IThat<object?> source,
 		Type type)
 	{
-		type.ThrowIfNull();;
+		type.ThrowIfNull();
 		return new AndOrResult<object?, IThat<object?>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsExactlyOfTypeConstraint(it, grammars, type).Invert()),
 			source);

--- a/Source/aweXpect/That/ThatGeneric.Satisfies.cs
+++ b/Source/aweXpect/That/ThatGeneric.Satisfies.cs
@@ -21,6 +21,8 @@ public static partial class ThatGeneric
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
 		RepeatedCheckOptions options = new();
 		return new RepeatedCheckResult<T, IThat<T>>(source.Get().ExpectationBuilder
 				.AddConstraint((it, grammars) =>
@@ -41,7 +43,10 @@ public static partial class ThatGeneric
 		Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> new(source.Get().ExpectationBuilder
+	{
+		// ReSharper disable once LocalizableElement
+		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		return new AndOrResult<T, IThat<T>>(source.Get().ExpectationBuilder
 				.AddConstraint((it, grammars) =>
 					new SatisfiesConstraint<T>(
 						it,
@@ -50,6 +55,7 @@ public static partial class ThatGeneric
 						doNotPopulateThisValue.TrimCommonWhiteSpace(),
 						null).Invert()),
 			source);
+	}
 
 	private sealed class SatisfiesConstraint<T>(
 		string it,

--- a/Source/aweXpect/That/ThatGeneric.Satisfies.cs
+++ b/Source/aweXpect/That/ThatGeneric.Satisfies.cs
@@ -21,8 +21,7 @@ public static partial class ThatGeneric
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		RepeatedCheckOptions options = new();
 		return new RepeatedCheckResult<T, IThat<T>>(source.Get().ExpectationBuilder
 				.AddConstraint((it, grammars) =>
@@ -44,8 +43,7 @@ public static partial class ThatGeneric
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
-		// ReSharper disable once LocalizableElement
-		_ = predicate ?? throw new ArgumentNullException(nameof(predicate), "The predicate cannot be null.");
+		predicate.ThrowIfNull();
 		return new AndOrResult<T, IThat<T>>(source.Get().ExpectationBuilder
 				.AddConstraint((it, grammars) =>
 					new SatisfiesConstraint<T>(

--- a/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Synchronous/SynchronouslyExtensionsTests.cs
@@ -28,7 +28,7 @@ public class SynchronouslyExtensionsTests
 			Bar = 3,
 		};
 		int value = subject.Bar;
-		void Act() => That(() => ThrowIf(value == 3)).DoesNotThrow().VerifySynchronously();;
+		void Act() => That(() => ThrowIf(value == 3)).DoesNotThrow().VerifySynchronously();
 
 		That(Act).Throws<XunitException>()
 			.WithMessage("""
@@ -47,7 +47,7 @@ public class SynchronouslyExtensionsTests
 			Bar = 3,
 		};
 		int value = subject.Bar;
-		void Act() => That(value).IsEqualTo(2).VerifySynchronously();;
+		void Act() => That(value).IsEqualTo(2).VerifySynchronously();
 
 		That(Act).Throws<XunitException>()
 			.WithMessage("""

--- a/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
+++ b/Tests/aweXpect.Internal.Tests/Results/EventTriggerResultTests.cs
@@ -33,6 +33,66 @@ public sealed class EventTriggerResultTests
 	}
 
 	[Fact]
+	public async Task WhenPredicateIsNull_ForEventArgs_ShouldThrowArgumentNullException()
+	{
+		CustomEventWithParametersClass<string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string>> recording = sut.Record().Events();
+
+		async Task Act() =>
+			await That(recording).Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+				.With<EventArgs>(null!);
+
+		await That(Act).Throws<ArgumentNullException>()
+			.WithParamName("predicate").And
+			.WithMessage("The predicate cannot be null.").AsPrefix();
+	}
+
+	[Fact]
+	public async Task WhenPredicateIsNull_ForParameter_ShouldThrowArgumentNullException()
+	{
+		CustomEventWithParametersClass<string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string>> recording = sut.Record().Events();
+
+		async Task Act() =>
+			await That(recording).Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+				.WithParameter<string>(null!);
+
+		await That(Act).Throws<ArgumentNullException>()
+			.WithParamName("predicate").And
+			.WithMessage("The predicate cannot be null.").AsPrefix();
+	}
+
+	[Fact]
+	public async Task WhenPredicateIsNull_ForParameter_WithPosition_ShouldThrowArgumentNullException()
+	{
+		CustomEventWithParametersClass<string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string>> recording = sut.Record().Events();
+
+		async Task Act() =>
+			await That(recording).Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+				.WithParameter<string>(1, null!);
+
+		await That(Act).Throws<ArgumentNullException>()
+			.WithParamName("predicate").And
+			.WithMessage("The predicate cannot be null.").AsPrefix();
+	}
+
+	[Fact]
+	public async Task WhenPredicateIsNull_ForSender_ShouldThrowArgumentNullException()
+	{
+		CustomEventWithParametersClass<string> sut = new();
+		IEventRecording<CustomEventWithParametersClass<string>> recording = sut.Record().Events();
+
+		async Task Act() =>
+			await That(recording).Triggered(nameof(CustomEventWithParametersClass<string>.CustomEvent))
+				.WithSender(null!);
+
+		await That(Act).Throws<ArgumentNullException>()
+			.WithParamName("predicate").And
+			.WithMessage("The predicate cannot be null.").AsPrefix();
+	}
+
+	[Fact]
 	public async Task WithMultipleMatchingParameters_PredicateChecksForAnyOne()
 	{
 		CustomEventWithParametersClass<string, int, string> sut = new();

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Satisfy.Tests.cs
@@ -70,6 +70,19 @@ public sealed partial class ThatAsyncEnumerable
 				}
 
 				[Fact]
+				public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+				{
+					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("predicate").And
+						.WithMessage("The predicate cannot be null.").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					IAsyncEnumerable<string>? subject = null;
@@ -124,6 +137,19 @@ public sealed partial class ThatAsyncEnumerable
 						=> await That(subject).All().Satisfy(x => x?.Length == 3);
 
 					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+				{
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["foo", "bar", "baz",]);
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("predicate").And
+						.WithMessage("The predicate cannot be null.").AsPrefix();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
@@ -936,6 +936,19 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).Contains(predicate: null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IAsyncEnumerable<int>? subject = null;

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
@@ -814,6 +814,19 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).DoesNotContain(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IAsyncEnumerable<string>? subject = null;

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
@@ -151,6 +151,19 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IAsyncEnumerable<string>? subject = null;
@@ -230,9 +243,9 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task ShouldReturnSingleItem()
 			{
-				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+				IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyClass(x));
 
-				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value == 2);
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyBaseClass>(x => x.Value == 2);
 
 				await That(result.Value).IsEqualTo(2);
 			}
@@ -240,25 +253,41 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
 			{
-				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+				IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyClass(x));
 
 				async Task Act()
-					=> await That(subject).HasSingle().Matching(x => x.Value > 1);
+					=> await That(subject).HasSingle().Matching<MyBaseClass>(x => x.Value > 1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a single item matching x => x.Value > 1,
+					             has a single item of type MyBaseClass matching x => x.Value > 1,
 					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoMatchingElements_ShouldFail()
+			{
+				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>(x => x.Value > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item of type MyClass matching x => x.Value > 1,
+					             but it did not contain any matching item
 					             """);
 			}
 
 			[Fact]
 			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
 			{
-				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+				IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyClass(x));
 
-				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value > 2);
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyBaseClass>(x => x.Value > 2);
 
 				await That(result.Value).IsEqualTo(3);
 			}
@@ -266,17 +295,30 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenEnumerableIsEmpty_ShouldFail()
 			{
-				IAsyncEnumerable<MyBaseClass> subject = ToAsyncEnumerable([], x => new MyBaseClass(x));
+				IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable([], x => new MyClass(x));
 
 				async Task Act()
-					=> await That(subject).HasSingle().Matching(_ => true);
+					=> await That(subject).HasSingle().Matching<MyBaseClass>(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a single item matching _ => true,
+					             has a single item of type MyBaseClass matching _ => true,
 					             but it was empty
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable([1, 2, 3,], x => new MyClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyBaseClass>(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
 			}
 		}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Satisfy.Tests.cs
@@ -98,6 +98,19 @@ public sealed partial class ThatEnumerable
 				}
 
 				[Fact]
+				public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+				{
+					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("predicate").And
+						.WithMessage("The predicate cannot be null.").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					IEnumerable<int>? subject = null;
@@ -152,6 +165,19 @@ public sealed partial class ThatEnumerable
 						=> await That(subject).All().Satisfy(x => x?.Length == 3);
 
 					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+				{
+					string[] subject = ["foo", "bar", "baz",];
+
+					async Task Act()
+						=> await That(subject).All().Satisfy(null!);
+
+					await That(Act).Throws<ArgumentNullException>()
+						.WithParamName("predicate").And
+						.WithMessage("The predicate cannot be null.").AsPrefix();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
@@ -1016,6 +1016,19 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).Contains(predicate: null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IEnumerable<int>? subject = null;

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
@@ -846,6 +846,19 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).DoesNotContain(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IEnumerable<string>? subject = null;

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasSingle.Tests.cs
@@ -166,6 +166,19 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				IEnumerable<string>? subject = null;
@@ -245,9 +258,9 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task ShouldReturnSingleItem()
 			{
-				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+				IEnumerable<MyClass> subject = ToEnumerable([1, 2, 3,], x => new MyClass(x));
 
-				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value == 2);
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyBaseClass>(x => x.Value == 2);
 
 				await That(result.Value).IsEqualTo(2);
 			}
@@ -255,25 +268,41 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsMoreThanOneElement_ShouldFail()
 			{
-				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+				IEnumerable<MyClass> subject = ToEnumerable([1, 2, 3,], x => new MyClass(x));
 
 				async Task Act()
-					=> await That(subject).HasSingle().Matching(x => x.Value > 1);
+					=> await That(subject).HasSingle().Matching<MyBaseClass>(x => x.Value > 1);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a single item matching x => x.Value > 1,
+					             has a single item of type MyBaseClass matching x => x.Value > 1,
 					             but it contained more than one item
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoMatchingElements_ShouldFail()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>(x => x.Value > 1);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a single item of type MyClass matching x => x.Value > 1,
+					             but it did not contain any matching item
 					             """);
 			}
 
 			[Fact]
 			public async Task WhenEnumerableContainsSingleElement_ShouldSucceed()
 			{
-				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+				IEnumerable<MyClass> subject = ToEnumerable([1, 2, 3,], x => new MyClass(x));
 
-				MyBaseClass result = await That(subject).HasSingle().Matching(x => x.Value > 2);
+				MyBaseClass result = await That(subject).HasSingle().Matching<MyBaseClass>(x => x.Value > 2);
 
 				await That(result.Value).IsEqualTo(3);
 			}
@@ -281,17 +310,30 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableIsEmpty_ShouldFail()
 			{
-				IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>();
+				IEnumerable<MyClass> subject = ToEnumerable<MyClass>();
 
 				async Task Act()
-					=> await That(subject).HasSingle().Matching(_ => true);
+					=> await That(subject).HasSingle().Matching<MyBaseClass>(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a single item matching _ => true,
+					             has a single item of type MyBaseClass matching _ => true,
 					             but it was empty
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				IEnumerable<MyBaseClass> subject = ToEnumerable([1, 2, 3,], x => new MyBaseClass(x));
+
+				async Task Act()
+					=> await That(subject).HasSingle().Matching<MyClass>(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
 			}
 		}
 

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.WithTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.DidNotSignal.WithTests.cs
@@ -50,6 +50,19 @@ public sealed partial class ThatSignaler
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				Signaler<int> signaler = new();
+
+				async Task Act()
+					=> await That(signaler).DidNotSignal().With(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenTriggeredMoreOftenMatchingPredicate_ShouldFail()
 			{
 				Signaler<int> signaler = new();

--- a/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.WithTests.cs
+++ b/Tests/aweXpect.Tests/Signaling/ThatSignaler.Signaled.WithTests.cs
@@ -67,6 +67,19 @@ public sealed partial class ThatSignaler
 			}
 
 			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				Signaler<int> signaler = new();
+
+				async Task Act()
+					=> await That(signaler).Signaled().With(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenTriggeredMoreOftenMatchingPredicate_ShouldSucceed()
 			{
 				Signaler<int> signaler = new();

--- a/Tests/aweXpect.Tests/ThatGeneric.DoesNotSatisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.DoesNotSatisfy.Tests.cs
@@ -26,6 +26,19 @@ public sealed partial class ThatGeneric
 					             }
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				Other subject = new();
+
+				async Task Act()
+					=> await That(subject).DoesNotSatisfy(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Tests/ThatGeneric.Satisfies.Tests.cs
+++ b/Tests/aweXpect.Tests/ThatGeneric.Satisfies.Tests.cs
@@ -26,6 +26,19 @@ public sealed partial class ThatGeneric
 					             }
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenPredicateIsNull_ShouldThrowArgumentNullException()
+			{
+				Other subject = new();
+
+				async Task Act()
+					=> await That(subject).Satisfies(null!);
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithParamName("predicate").And
+					.WithMessage("The predicate cannot be null.").AsPrefix();
+			}
 		}
 
 		public sealed class WithinTests


### PR DESCRIPTION
Throw an `ArgumentNullException` when providing `null` as predicate to an expectation in:
- `EventTriggerResult`
- `SignalCountResult`
- `SingleItemResult`
- `Contains` for collections
- `Satisfy` for collections
- `HasSingle().Matching` for collections
- `Satisfies`/`DoesNotSatisfy`

Also improve the error message in `HasSingle` for collections to distinguish between an empty collection and no found matching items.