### PR TITLE
feat: add `Which` for thrown exceptions

### DIFF
--- a/Docs/pages/docs/expectations/06-delegates.md
+++ b/Docs/pages/docs/expectations/06-delegates.md
@@ -116,15 +116,19 @@ await Expect.That(Act).ThrowsException().WithRecursiveInnerExceptions(innerExcep
 You can recursively verify additional members of the exception:
 
 ```csharp
-void Act() => throw new MyException("outer", paramName: "paramName", hResult: 12345);
+var exception = new MyException("outer", paramName: "paramName", hResult: 12345);
+void Act() => throw exception;
 
 await Expect.That(Act).ThrowsException().WithParamName("paramName")
   .Because("you can verify the `paramName`");
 await Expect.That(Act).ThrowsException().WithHResult(12345)
   .Because("you can verify the `HResult`");
 await Expect.That(Act).ThrowsException()
-  .Which(e => e.HResult, h => h.IsGreaterThan(12340))
+  .Whose(e => e.HResult, h => h.IsGreaterThan(12340))
   .Because("you can verify arbitrary additional members");
+await Expect.That(Act).ThrowsException()
+  .Which.IsSameAs(exception)
+  .Because("you can access the thrown exception");
 
 ```
 

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Which.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Which.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.Linq.Expressions;
 using aweXpect.Core;
+using aweXpect.Core.Sources;
 using aweXpect.Results;
 
 namespace aweXpect.Delegates;
 
 public partial class ThatDelegateThrows<TException>
 {
+
 	/// <summary>
-	///     Verifies the <paramref name="expectations" /> on the member selected by the <paramref name="memberSelector" />.
+	///     Further expectations on the <typeparamref name="TException" />
 	/// </summary>
-	public AndOrResult<TException, ThatDelegateThrows<TException>> Whose<TMember>(
-		Expression<Func<TException, TMember?>> memberSelector,
-		Action<IThat<TMember?>> expectations)
-		=> new(ExpectationBuilder.ForMember(
-					MemberAccessor<TException, TMember?>.FromExpression(memberSelector),
-					(member, expectation) => expectation.Append("whose ").Append(member))
-				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
-			this);
+	public IThat<TException> Which
+		=> new ThatSubject<TException>(ExpectationBuilder.And(" which "));
+	
 }

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Whose.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Whose.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Linq.Expressions;
+using aweXpect.Core;
+using aweXpect.Results;
+
+namespace aweXpect.Delegates;
+
+public partial class ThatDelegateThrows<TException>
+{
+	/// <summary>
+	///     Verifies the <paramref name="expectations" /> on the member selected by the <paramref name="memberSelector" />.
+	/// </summary>
+	public AndOrResult<TException, ThatDelegateThrows<TException>> Whose<TMember>(
+		Expression<Func<TException, TMember?>> memberSelector,
+		Action<IThat<TMember?>> expectations)
+		=> new(ExpectationBuilder.ForMember(
+					MemberAccessor<TException, TMember?>.FromExpression(memberSelector),
+					(member, expectation) => expectation.Append("whose ").Append(member))
+				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
+			this);
+}

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -486,6 +486,7 @@ namespace aweXpect.Delegates
         where TException : System.Exception?
     {
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public aweXpect.Core.IThat<TException> Which { get; }
         public aweXpect.Delegates.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Linq.Expressions.Expression<System.Func<TException, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -486,6 +486,7 @@ namespace aweXpect.Delegates
         where TException : System.Exception?
     {
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public aweXpect.Core.IThat<TException> Which { get; }
         public aweXpect.Delegates.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Linq.Expressions.Expression<System.Func<TException, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WhichTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WhichTests.cs
@@ -1,0 +1,51 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ThrowsException
+	{
+		public class WhichTests
+		{
+			[Theory]
+			[AutoData]
+			public async Task ShouldGiveAccessToThrowsException(int hResult)
+			{
+				Exception exception = new HResultException(hResult);
+				void Delegate() => throw exception;
+
+				async Task Act()
+					=> await That(Delegate).ThrowsException()
+						.Which.IsSameAs(exception);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("foo", "bar")]
+			public async Task ShouldIncludeWhichInErrorMessage(string paramName, string expectedParamName)
+			{
+				Exception exception = new ArgumentNullException(paramName, "Must not be null");
+				void Delegate() => throw exception;
+
+				async Task Act()
+					=> await That(Delegate).Throws<ArgumentNullException>()
+						.Which.For(h => h.ParamName, r => r.IsEqualTo(expectedParamName));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that Delegate
+					             throws an ArgumentNullException which for .ParamName is equal to "bar",
+					             but .ParamName was "foo" which differs at index 0:
+					                ↓ (actual)
+					               "foo"
+					               "bar"
+					                ↑ (expected)
+					             
+					             Actual:
+					             foo
+					             """);
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
Supports the following syntax:
```csharp
var exception = new MyException("outer", paramName: "paramName", hResult: 12345);
void Act() => throw exception;

await Expect.That(Act).Throws<MyException>()
  .Which.IsSameAs(exception)
  .Because("you can access the thrown exception");
```