### PR TITLE
feat: support tolerance with collection elements

### DIFF
--- a/Docs/pages/docs/expectations/07-collections.md
+++ b/Docs/pages/docs/expectations/07-collections.md
@@ -82,6 +82,16 @@ white-space, or use a custom `IEqualityComparer<string>`:
 await Expect.That(["foo", "FOO", "Foo"]).All().AreEqualTo("foo").IgnoringCase();
 ```
 
+For certain types you can also specify a tolerance:
+
+```csharp
+IEnumerable<double> values = [2.04, 2.02, 2.01];
+
+await Expect.That(values).All().AreEqualTo(2.0).Within(0.1);
+```
+
+This tolerance can be applied to `double`, `float`, `decimal` and `DateTime`.
+
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
 
 ## All be unique

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Options/ObjectEqualityWithToleranceOptions.cs
+++ b/Source/aweXpect.Core/Options/ObjectEqualityWithToleranceOptions.cs
@@ -8,7 +8,8 @@ namespace aweXpect.Options;
 ///     Checks equality of objects with an optional tolerance.
 /// </summary>
 public class ObjectEqualityWithToleranceOptions<TSubject, TTolerance>(
-	Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance)
+	Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance,
+	Func<TTolerance, string>? toString = null)
 	: ObjectEqualityOptions<TSubject>
 {
 	/// <summary>
@@ -16,13 +17,18 @@ public class ObjectEqualityWithToleranceOptions<TSubject, TTolerance>(
 	/// </summary>
 	public ObjectEqualityOptions<TSubject> Within(TTolerance tolerance)
 	{
-		MatchType = new WithinMatchType(tolerance, isWithinTolerance);
+		MatchType = new WithinMatchType(tolerance, isWithinTolerance, toString ?? ToString);
 		return this;
 	}
 
+	private static string ToString(TTolerance tolerance)
+		=> $" within {Formatter.Format(tolerance)}";
+
 	private sealed class WithinMatchType(
 		TTolerance tolerance,
-		Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance) : IObjectMatchType
+		Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance,
+		Func<TTolerance, string> toString)
+		: IObjectMatchType
 	{
 		#region IEquality Members
 
@@ -48,7 +54,7 @@ public class ObjectEqualityWithToleranceOptions<TSubject, TTolerance>(
 
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
-			=> $" within {Formatter.Format(tolerance)}";
+			=> toString.Invoke(tolerance);
 
 		#endregion
 	}

--- a/Source/aweXpect.Core/Options/ObjectEqualityWithToleranceOptions.cs
+++ b/Source/aweXpect.Core/Options/ObjectEqualityWithToleranceOptions.cs
@@ -17,11 +17,11 @@ public class ObjectEqualityWithToleranceOptions<TSubject, TTolerance>(
 	/// </summary>
 	public ObjectEqualityOptions<TSubject> Within(TTolerance tolerance)
 	{
-		MatchType = new WithinMatchType(tolerance, isWithinTolerance, toString ?? ToString);
+		MatchType = new WithinMatchType(tolerance, isWithinTolerance, toString ?? DefaultToleranceFormatter);
 		return this;
 	}
 
-	private static string ToString(TTolerance tolerance)
+	private static string DefaultToleranceFormatter(TTolerance tolerance)
 		=> $" within {Formatter.Format(tolerance)}";
 
 	private sealed class WithinMatchType(

--- a/Source/aweXpect.Core/Results/ToleranceEqualityResult.cs
+++ b/Source/aweXpect.Core/Results/ToleranceEqualityResult.cs
@@ -1,0 +1,49 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />
+///     that allows specifying a <typeparamref name="TTolerance" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrResult{TType,TThat}" />, allows specifying
+///     options on the <see cref="ObjectEqualityOptions" />.
+/// </summary>
+public class ToleranceEqualityResult<TType, TThat, TElement, TTolerance>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	ObjectEqualityWithToleranceOptions<TElement, TTolerance> options)
+	: ToleranceEqualityResult<TType, TThat, TElement, TTolerance,
+		ToleranceEqualityResult<TType, TThat, TElement, TTolerance>>(
+		expectationBuilder,
+		returnValue,
+		options);
+
+/// <summary>
+///     The result of an expectation with an underlying value of type <typeparamref name="TType" />
+///     that allows specifying a <typeparamref name="TTolerance" />.
+///     <para />
+///     In addition to the combinations from <see cref="AndOrResult{TType,TThat}" />, allows specifying
+///     options on the <see cref="ObjectEqualityOptions" />.
+/// </summary>
+public class ToleranceEqualityResult<TType, TThat, TElement, TTolerance, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	TThat returnValue,
+	ObjectEqualityWithToleranceOptions<TElement, TTolerance> options)
+	: AndOrResult<TType, TThat, TSelf>(expectationBuilder, returnValue),
+		IOptionsProvider<ObjectEqualityOptions<TElement>>
+	where TSelf : ToleranceEqualityResult<TType, TThat, TElement, TTolerance, TSelf>
+{
+	/// <inheritdoc cref="IOptionsProvider{TOptions}.Options" />
+	ObjectEqualityOptions<TElement> IOptionsProvider<ObjectEqualityOptions<TElement>>.Options => options;
+
+	/// <summary>
+	///     Specifies a <paramref name="tolerance" /> to apply.
+	/// </summary>
+	public AndOrResult<TType, TThat, TSelf> Within(TTolerance tolerance)
+	{
+		options.Within(tolerance);
+		return this;
+	}
+}

--- a/Source/aweXpect/Helpers/ObjectEqualityWithToleranceOptionsFactory.cs
+++ b/Source/aweXpect/Helpers/ObjectEqualityWithToleranceOptionsFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using aweXpect.Options;
+
+namespace aweXpect.Helpers;
+
+internal static class ObjectEqualityWithToleranceOptionsFactory
+{
+	public static ObjectEqualityWithToleranceOptions<double, double> CreateDouble() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<double?, double> CreateNullableDouble() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<float, float> CreateFloat() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<float?, float> CreateNullableFloat() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<decimal, decimal> CreateDecimal() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<decimal?, decimal> CreateNullableDecimal() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> CreateDateTime() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
+
+	public static ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> CreateNullableDateTime() =>
+		new((a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
+}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEqualTo.cs
@@ -17,9 +17,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<double> elements, double expected)
 	{
 		IElements<double> iElements = elements;
-		ObjectEqualityWithToleranceOptions<double, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		return new ToleranceEqualityResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>, double, double>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<double>(
@@ -46,9 +45,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<double?> elements, double? expected)
 	{
 		IElements<double?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<double?, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double?, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		return new ToleranceEqualityResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>, double?,
 			double>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
@@ -76,9 +74,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<float> elements, float expected)
 	{
 		IElements<float> iElements = elements;
-		ObjectEqualityWithToleranceOptions<float, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		return new ToleranceEqualityResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>, float, float>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<float>(
@@ -105,9 +102,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<float?> elements, float? expected)
 	{
 		IElements<float?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<float?, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float?, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		return new ToleranceEqualityResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>, float?, float>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<float?>(
@@ -135,9 +131,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<decimal> elements, decimal expected)
 	{
 		IElements<decimal> iElements = elements;
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		return new ToleranceEqualityResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>, decimal,
 			decimal>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
@@ -166,9 +161,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<decimal?> elements, decimal? expected)
 	{
 		IElements<decimal?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		return new ToleranceEqualityResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>, decimal?,
 			decimal>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
@@ -197,9 +191,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<DateTime> elements, DateTime expected)
 	{
 		IElements<DateTime> iElements = elements;
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		return new ToleranceEqualityResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>, DateTime,
 			TimeSpan>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
@@ -228,9 +221,8 @@ public static partial class ThatAsyncEnumerable
 		AreEqualTo(this Elements<DateTime?> elements, DateTime? expected)
 	{
 		IElements<DateTime?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		return new ToleranceEqualityResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>, DateTime?,
 			TimeSpan>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.AreEqualTo.cs
@@ -1,4 +1,5 @@
 ﻿#if NET8_0_OR_GREATER
+using System;
 using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Helpers;
@@ -9,62 +10,300 @@ namespace aweXpect;
 
 public static partial class ThatAsyncEnumerable
 {
-	public partial class Elements
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>, double, double>
+		AreEqualTo(this Elements<double> elements, double expected)
 	{
-		/// <summary>
-		///     …are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>> AreEqualTo(
-			string? expected)
-		{
-			StringEqualityOptions options = new();
-			return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-					=> new CollectionConstraint<string?>(
-						it, grammars,
-						_quantifier,
-						g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
-								g.IsNegated()) switch
-							{
-								(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
-								(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
-								(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
-								(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
-							},
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
+		IElements<double> iElements = elements;
+		ObjectEqualityWithToleranceOptions<double, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>, double, double>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<double>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
 	}
 
-	public partial class Elements<TItem>
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>, double?, double>
+		AreEqualTo(this Elements<double?> elements, double? expected)
 	{
-		/// <summary>
-		///     …are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>
-			AreEqualTo(TItem expected)
-		{
-			ObjectEqualityOptions<TItem> options = new();
-			return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-					=> new CollectionConstraint<TItem>(
-						it, grammars,
-						_quantifier,
-						g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
-								g.IsNegated()) switch
-							{
-								(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
-								(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
-								(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
-								(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
-							},
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
+		IElements<double?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<double?, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>, double?,
+			double>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<double?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>, float, float>
+		AreEqualTo(this Elements<float> elements, float expected)
+	{
+		IElements<float> iElements = elements;
+		ObjectEqualityWithToleranceOptions<float, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>, float, float>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<float>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>, float?, float>
+		AreEqualTo(this Elements<float?> elements, float? expected)
+	{
+		IElements<float?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<float?, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>, float?, float>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<float?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>, decimal,
+			decimal>
+		AreEqualTo(this Elements<decimal> elements, decimal expected)
+	{
+		IElements<decimal> iElements = elements;
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>, decimal,
+			decimal>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<decimal>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>, decimal?,
+			decimal>
+		AreEqualTo(this Elements<decimal?> elements, decimal? expected)
+	{
+		IElements<decimal?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>, decimal?,
+			decimal>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<decimal?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>, DateTime,
+			TimeSpan>
+		AreEqualTo(this Elements<DateTime> elements, DateTime expected)
+	{
+		IElements<DateTime> iElements = elements;
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>, DateTime,
+			TimeSpan>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<DateTime>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>, DateTime?,
+			TimeSpan>
+		AreEqualTo(this Elements<DateTime?> elements, DateTime? expected)
+	{
+		IElements<DateTime?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>, DateTime?,
+			TimeSpan>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<DateTime?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ObjectEqualityResult<IAsyncEnumerable<TItem>?, IThat<IAsyncEnumerable<TItem>?>, TItem>
+		AreEqualTo<TItem>(this Elements<TItem> elements, TItem expected)
+	{
+		IElements<TItem> iElements = elements;
+		ObjectEqualityOptions<TItem> options = new();
+		return new ObjectEqualityResult<IAsyncEnumerable<TItem>?, IThat<IAsyncEnumerable<TItem>?>, TItem>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<TItem>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>> AreEqualTo(
+		this Elements elements,
+		string? expected)
+	{
+		IElements iElements = elements;
+		StringEqualityOptions options = new();
+		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<string?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
 	}
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.cs
@@ -9,9 +9,43 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerable
 {
 	/// <summary>
+	///     Interface for <see cref="Elements" /> to get access to the <see cref="Quantifier" />
+	///     and the <see cref="Subject" />.
+	/// </summary>
+	public interface IElements
+	{
+		/// <summary>
+		///     The quantifier for the elements.
+		/// </summary>
+		public EnumerableQuantifier Quantifier { get; }
+
+		/// <summary>
+		///     The subject of the expectation.
+		/// </summary>
+		public IThat<IAsyncEnumerable<string?>?> Subject { get; }
+	}
+
+	/// <summary>
+	///     Interface for <see cref="Elements{TItem}" /> to get access to the <see cref="Quantifier" />
+	///     and the <see cref="Subject" />.
+	/// </summary>
+	public interface IElements<TItem>
+	{
+		/// <summary>
+		///     The quantifier for the elements.
+		/// </summary>
+		public EnumerableQuantifier Quantifier { get; }
+
+		/// <summary>
+		///     The subject of the expectation.
+		/// </summary>
+		public IThat<IAsyncEnumerable<TItem>?> Subject { get; }
+	}
+
+	/// <summary>
 	///     Result class for expectations on the elements of a <see cref="IAsyncEnumerable{T}" /> of <see langword="string" />.
 	/// </summary>
-	public partial class Elements
+	public partial class Elements : IElements
 	{
 		private readonly EnumerableQuantifier _quantifier;
 		private readonly IThat<IAsyncEnumerable<string?>?> _subject;
@@ -21,13 +55,16 @@ public static partial class ThatAsyncEnumerable
 			_subject = subject;
 			_quantifier = quantifier;
 		}
+
+		EnumerableQuantifier IElements.Quantifier => _quantifier;
+		IThat<IAsyncEnumerable<string?>?> IElements.Subject => _subject;
 	}
 
 	/// <summary>
 	///     Result class for expectations on the elements of a <see cref="IAsyncEnumerable{TItem}" /> of
 	///     <typeparamref name="TItem" />.
 	/// </summary>
-	public partial class Elements<TItem>
+	public partial class Elements<TItem> : IElements<TItem>
 	{
 		private readonly EnumerableQuantifier _quantifier;
 		private readonly IThat<IAsyncEnumerable<TItem>?> _subject;
@@ -37,6 +74,9 @@ public static partial class ThatAsyncEnumerable
 			_subject = subject;
 			_quantifier = quantifier;
 		}
+
+		EnumerableQuantifier IElements<TItem>.Quantifier => _quantifier;
+		IThat<IAsyncEnumerable<TItem>?> IElements<TItem>.Subject => _subject;
 	}
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
@@ -45,7 +45,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<double> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>,
 			double, double>(
@@ -70,7 +72,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<double?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double?, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>,
 			double?, double>(
@@ -95,7 +99,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<decimal> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>,
 			decimal, decimal>(
@@ -120,7 +126,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<decimal?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>(
@@ -145,7 +153,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<float> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>,
 			float, float>(
@@ -170,7 +180,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<float?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float?, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>,
 			float?, float>(
@@ -195,7 +207,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<DateTime> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
@@ -220,7 +234,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<DateTime?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
@@ -290,7 +306,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<double> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>,
 			double, double>(
@@ -315,7 +333,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<double?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double?, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>,
 			double?, double>(
@@ -340,7 +360,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<decimal> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>,
 			decimal, decimal>(
@@ -365,7 +387,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<decimal?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>(
@@ -390,7 +414,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<float> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>,
 			float, float>(
@@ -415,7 +441,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<float?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float?, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>,
 			float?, float>(
@@ -440,7 +468,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<DateTime> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
@@ -465,7 +495,9 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<DateTime?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
@@ -45,9 +45,8 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<double> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>,
 			double, double>(
@@ -72,12 +71,11 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<double?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double?, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>,
-			double?, double>(
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>,
+			IThat<IAsyncEnumerable<double?>?>, double?, double>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<double?, double?>(it, grammars,
 					doNotPopulateThisValue,
@@ -99,11 +97,11 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<decimal> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>
+			,
 			decimal, decimal>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<decimal, decimal>(it, grammars,
@@ -119,18 +117,19 @@ public static partial class ThatAsyncEnumerable
 	/// <summary>
 	///     Verifies that the collection matches the <paramref name="expected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>,
+	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>,
+			IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>
 		IsEqualTo(
 			this IThat<IAsyncEnumerable<decimal?>?> source,
 			IEnumerable<decimal?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>,
+			IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<decimal?, decimal?>(it, grammars,
@@ -153,9 +152,8 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<float> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>,
 			float, float>(
@@ -180,9 +178,8 @@ public static partial class ThatAsyncEnumerable
 			IEnumerable<float?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float?, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>,
 			float?, float>(
@@ -200,18 +197,19 @@ public static partial class ThatAsyncEnumerable
 	/// <summary>
 	///     Verifies that the collection matches the <paramref name="expected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>,
+	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>,
+			IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>
 		IsEqualTo(
 			this IThat<IAsyncEnumerable<DateTime>?> source,
 			IEnumerable<DateTime> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>,
+			IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<DateTime, DateTime>(it, grammars,
@@ -227,18 +225,19 @@ public static partial class ThatAsyncEnumerable
 	/// <summary>
 	///     Verifies that the collection matches the <paramref name="expected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>,
+	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>,
+			IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>
 		IsEqualTo(
 			this IThat<IAsyncEnumerable<DateTime?>?> source,
 			IEnumerable<DateTime?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>,
+			IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<DateTime?, DateTime?>(it, grammars,
@@ -273,6 +272,7 @@ public static partial class ThatAsyncEnumerable
 			options,
 			matchOptions);
 	}
+
 	/// <summary>
 	///     Verifies that the collection does not match the <paramref name="unexpected" /> collection.
 	/// </summary>
@@ -280,7 +280,8 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo<TItem>(
 			this IThat<IAsyncEnumerable<TItem>?> source,
 			IEnumerable<TItem> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new();
@@ -304,11 +305,11 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<double>?> source,
 			IEnumerable<double> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>,
 			double, double>(
@@ -331,13 +332,14 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<double?>?> source,
 			IEnumerable<double?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double?, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>
+			,
 			double?, double>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<double?, double?>(it, grammars,
@@ -358,13 +360,14 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<decimal>?> source,
 			IEnumerable<decimal> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>
+			,
 			decimal, decimal>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<decimal, decimal>(it, grammars,
@@ -380,18 +383,20 @@ public static partial class ThatAsyncEnumerable
 	/// <summary>
 	///     Verifies that the collection does not match the <paramref name="unexpected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>,
+	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>,
+			IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<decimal?>?> source,
 			IEnumerable<decimal?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>, IThat<IAsyncEnumerable<decimal?>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>,
+			IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<decimal?, decimal?>(it, grammars,
@@ -412,11 +417,11 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<float>?> source,
 			IEnumerable<float> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>,
 			float, float>(
@@ -439,11 +444,11 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<float?>?> source,
 			IEnumerable<float?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float?, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>,
 			float?, float>(
@@ -461,18 +466,20 @@ public static partial class ThatAsyncEnumerable
 	/// <summary>
 	///     Verifies that the collection does not match the <paramref name="unexpected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>,
+	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>,
+			IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<DateTime>?> source,
 			IEnumerable<DateTime> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>, IThat<IAsyncEnumerable<DateTime>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>,
+			IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<DateTime, DateTime>(it, grammars,
@@ -488,18 +495,20 @@ public static partial class ThatAsyncEnumerable
 	/// <summary>
 	///     Verifies that the collection does not match the <paramref name="unexpected" /> collection.
 	/// </summary>
-	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>,
+	public static ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>,
+			IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<DateTime?>?> source,
 			IEnumerable<DateTime?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
-		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>, IThat<IAsyncEnumerable<DateTime?>?>,
+		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>,
+			IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new IsEqualToConstraint<DateTime?, DateTime?>(it, grammars,
@@ -519,7 +528,8 @@ public static partial class ThatAsyncEnumerable
 		IsNotEqualTo(
 			this IThat<IAsyncEnumerable<string?>?> source,
 			IEnumerable<string?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new();

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
@@ -8,61 +9,290 @@ namespace aweXpect;
 
 public static partial class ThatEnumerable
 {
-	public partial class Elements
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<double>, IThat<IEnumerable<double>?>, double, double>
+		AreEqualTo(this Elements<double> elements, double expected)
 	{
-		/// <summary>
-		///     …are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>> AreEqualTo(
-			string? expected)
-		{
-			StringEqualityOptions options = new();
-			return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-					=> new CollectionConstraint<string?>(
-						it, grammars,
-						_quantifier,
-						g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
-								g.IsNegated()) switch
-							{
-								(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
-								(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
-								(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
-								(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
-							},
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
+		IElements<double> iElements = elements;
+		ObjectEqualityWithToleranceOptions<double, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<double>, IThat<IEnumerable<double>?>, double, double>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<double>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
 	}
 
-	public partial class Elements<TItem>
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>, double?, double>
+		AreEqualTo(this Elements<double?> elements, double? expected)
 	{
-		/// <summary>
-		///     …are equal to the <paramref name="expected" /> value.
-		/// </summary>
-		public ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>
-			AreEqualTo(TItem expected)
-		{
-			ObjectEqualityOptions<TItem> options = new();
-			return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-				_subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-					=> new CollectionConstraint<TItem>(
-						it, grammars,
-						_quantifier,
-						g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
-								g.IsNegated()) switch
-							{
-								(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
-								(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
-								(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
-								(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
-							},
-						a => options.AreConsideredEqual(a, expected),
-						"were")),
-				_subject,
-				options);
-		}
+		IElements<double?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<double?, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>, double?, double>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<double?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<float>, IThat<IEnumerable<float>?>, float, float>
+		AreEqualTo(this Elements<float> elements, float expected)
+	{
+		IElements<float> iElements = elements;
+		ObjectEqualityWithToleranceOptions<float, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<float>, IThat<IEnumerable<float>?>, float, float>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<float>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>, float?, float>
+		AreEqualTo(this Elements<float?> elements, float? expected)
+	{
+		IElements<float?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<float?, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>, float?, float>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<float?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>, decimal, decimal>
+		AreEqualTo(this Elements<decimal> elements, decimal expected)
+	{
+		IElements<decimal> iElements = elements;
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>, decimal, decimal>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<decimal>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>, decimal?, decimal>
+		AreEqualTo(this Elements<decimal?> elements, decimal? expected)
+	{
+		IElements<decimal?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>, decimal?, decimal>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<decimal?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>, DateTime, TimeSpan>
+		AreEqualTo(this Elements<DateTime> elements, DateTime expected)
+	{
+		IElements<DateTime> iElements = elements;
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>, DateTime, TimeSpan>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<DateTime>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ToleranceEqualityResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>, DateTime?, TimeSpan>
+		AreEqualTo(this Elements<DateTime?> elements, DateTime? expected)
+	{
+		IElements<DateTime?> iElements = elements;
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
+		return new ToleranceEqualityResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>, DateTime?, TimeSpan>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<DateTime?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static ObjectEqualityResult<IEnumerable<TItem>?, IThat<IEnumerable<TItem>?>, TItem>
+		AreEqualTo<TItem>(this Elements<TItem> elements, TItem expected)
+	{
+		IElements<TItem> iElements = elements;
+		ObjectEqualityOptions<TItem> options = new();
+		return new ObjectEqualityResult<IEnumerable<TItem>?, IThat<IEnumerable<TItem>?>, TItem>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<TItem>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
+	}
+
+	/// <summary>
+	///     …are equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>> AreEqualTo(
+		this Elements elements,
+		string? expected)
+	{
+		IElements iElements = elements;
+		StringEqualityOptions options = new();
+		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
+			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new CollectionConstraint<string?>(
+					it, grammars,
+					iElements.Quantifier,
+					g => (g.HasAnyFlag(ExpectationGrammars.Nested, ExpectationGrammars.Plural),
+							g.IsNegated()) switch
+						{
+							(true, false) => $"are equal to {Formatter.Format(expected)}{options}",
+							(false, false) => $"is equal to {Formatter.Format(expected)}{options}",
+							(true, true) => $"are not equal to {Formatter.Format(expected)}{options}",
+							(false, true) => $"is not equal to {Formatter.Format(expected)}{options}",
+						},
+					a => options.AreConsideredEqual(a, expected),
+					"were")),
+			iElements.Subject,
+			options);
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
@@ -16,9 +16,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<double> elements, double expected)
 	{
 		IElements<double> iElements = elements;
-		ObjectEqualityWithToleranceOptions<double, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		return new ToleranceEqualityResult<IEnumerable<double>, IThat<IEnumerable<double>?>, double, double>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<double>(
@@ -45,9 +44,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<double?> elements, double? expected)
 	{
 		IElements<double?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<double?, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double?, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		return new ToleranceEqualityResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>, double?, double>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<double?>(
@@ -74,9 +72,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<float> elements, float expected)
 	{
 		IElements<float> iElements = elements;
-		ObjectEqualityWithToleranceOptions<float, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		return new ToleranceEqualityResult<IEnumerable<float>, IThat<IEnumerable<float>?>, float, float>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<float>(
@@ -103,9 +100,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<float?> elements, float? expected)
 	{
 		IElements<float?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<float?, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float?, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		return new ToleranceEqualityResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>, float?, float>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<float?>(
@@ -132,9 +128,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<decimal> elements, decimal expected)
 	{
 		IElements<decimal> iElements = elements;
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		return new ToleranceEqualityResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>, decimal, decimal>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<decimal>(
@@ -161,9 +156,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<decimal?> elements, decimal? expected)
 	{
 		IElements<decimal?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		return new ToleranceEqualityResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>, decimal?, decimal>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<decimal?>(
@@ -190,9 +184,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<DateTime> elements, DateTime expected)
 	{
 		IElements<DateTime> iElements = elements;
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		return new ToleranceEqualityResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>, DateTime, TimeSpan>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<DateTime>(
@@ -219,9 +212,8 @@ public static partial class ThatEnumerable
 		AreEqualTo(this Elements<DateTime?> elements, DateTime? expected)
 	{
 		IElements<DateTime?> iElements = elements;
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		return new ToleranceEqualityResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>, DateTime?, TimeSpan>(
 			iElements.Subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new CollectionConstraint<DateTime?>(

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.cs
@@ -8,9 +8,43 @@ namespace aweXpect;
 public static partial class ThatEnumerable
 {
 	/// <summary>
+	///     Interface for <see cref="Elements" /> to get access to the <see cref="Quantifier" />
+	///     and the <see cref="Subject" />.
+	/// </summary>
+	public interface IElements
+	{
+		/// <summary>
+		///     The quantifier for the elements.
+		/// </summary>
+		public EnumerableQuantifier Quantifier { get; }
+
+		/// <summary>
+		///     The subject of the expectation.
+		/// </summary>
+		public IThat<IEnumerable<string?>?> Subject { get; }
+	}
+
+	/// <summary>
+	///     Interface for <see cref="Elements{TItem}" /> to get access to the <see cref="Quantifier" />
+	///     and the <see cref="Subject" />.
+	/// </summary>
+	public interface IElements<TItem>
+	{
+		/// <summary>
+		///     The quantifier for the elements.
+		/// </summary>
+		public EnumerableQuantifier Quantifier { get; }
+
+		/// <summary>
+		///     The subject of the expectation.
+		/// </summary>
+		public IThat<IEnumerable<TItem>?> Subject { get; }
+	}
+
+	/// <summary>
 	///     Result class for expectations on the elements of a <see cref="IEnumerable{T}" /> of <see langword="string" />.
 	/// </summary>
-	public partial class Elements
+	public partial class Elements : IElements
 	{
 		private readonly EnumerableQuantifier _quantifier;
 		private readonly IThat<IEnumerable<string?>?> _subject;
@@ -20,13 +54,16 @@ public static partial class ThatEnumerable
 			_subject = subject;
 			_quantifier = quantifier;
 		}
+
+		EnumerableQuantifier IElements.Quantifier => _quantifier;
+		IThat<IEnumerable<string?>?> IElements.Subject => _subject;
 	}
 
 	/// <summary>
 	///     Result class for expectations on the elements of a <see cref="IEnumerable{TItem}" /> of
 	///     <typeparamref name="TItem" />.
 	/// </summary>
-	public partial class Elements<TItem>
+	public partial class Elements<TItem> : IElements<TItem>
 	{
 		private readonly EnumerableQuantifier _quantifier;
 		private readonly IThat<IEnumerable<TItem>?> _subject;
@@ -36,5 +73,8 @@ public static partial class ThatEnumerable
 			_subject = subject;
 			_quantifier = quantifier;
 		}
+
+		EnumerableQuantifier IElements<TItem>.Quantifier => _quantifier;
+		IThat<IEnumerable<TItem>?> IElements<TItem>.Subject => _subject;
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
@@ -44,9 +44,8 @@ public static partial class ThatEnumerable
 			IEnumerable<double> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double>, IThat<IEnumerable<double>?>,
 			double, double>(
@@ -71,9 +70,8 @@ public static partial class ThatEnumerable
 			IEnumerable<double?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double?, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>,
 			double?, double>(
@@ -98,9 +96,8 @@ public static partial class ThatEnumerable
 			IEnumerable<decimal> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>,
 			decimal, decimal>(
@@ -125,9 +122,8 @@ public static partial class ThatEnumerable
 			IEnumerable<decimal?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>,
 			decimal?, decimal>(
@@ -152,9 +148,8 @@ public static partial class ThatEnumerable
 			IEnumerable<float> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float>, IThat<IEnumerable<float>?>,
 			float, float>(
@@ -179,9 +174,8 @@ public static partial class ThatEnumerable
 			IEnumerable<float?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float?, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>,
 			float?, float>(
@@ -206,9 +200,8 @@ public static partial class ThatEnumerable
 			IEnumerable<DateTime> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
@@ -233,9 +226,8 @@ public static partial class ThatEnumerable
 			IEnumerable<DateTime?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
@@ -304,11 +296,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<double>?> source,
 			IEnumerable<double> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double>, IThat<IEnumerable<double>?>,
 			double, double>(
@@ -331,11 +323,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<double?>?> source,
 			IEnumerable<double?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<double?, double> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>,
 			double?, double>(
@@ -358,11 +350,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<decimal>?> source,
 			IEnumerable<decimal> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>,
 			decimal, decimal>(
@@ -385,11 +377,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<decimal?>?> source,
 			IEnumerable<decimal?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>,
 			decimal?, decimal>(
@@ -412,11 +404,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<float>?> source,
 			IEnumerable<float> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float>, IThat<IEnumerable<float>?>,
 			float, float>(
@@ -439,11 +431,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<float?>?> source,
 			IEnumerable<float?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" ± {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<float?, float> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>,
 			float?, float>(
@@ -466,11 +458,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<DateTime>?> source,
 			IEnumerable<DateTime> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
@@ -493,11 +485,11 @@ public static partial class ThatEnumerable
 		IsNotEqualTo(
 			this IThat<IEnumerable<DateTime?>?> source,
 			IEnumerable<DateTime?> unexpected,
-			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
+			[CallerArgumentExpression("unexpected")]
+			string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
-			(a, e, t) => a.IsConsideredEqualTo(e, t),
-			t => $" within {Formatter.Format(t)}");
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
+			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
@@ -44,7 +44,9 @@ public static partial class ThatEnumerable
 			IEnumerable<double> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double>, IThat<IEnumerable<double>?>,
 			double, double>(
@@ -69,7 +71,9 @@ public static partial class ThatEnumerable
 			IEnumerable<double?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double?, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>,
 			double?, double>(
@@ -94,7 +98,9 @@ public static partial class ThatEnumerable
 			IEnumerable<decimal> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>,
 			decimal, decimal>(
@@ -119,7 +125,9 @@ public static partial class ThatEnumerable
 			IEnumerable<decimal?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>,
 			decimal?, decimal>(
@@ -144,7 +152,9 @@ public static partial class ThatEnumerable
 			IEnumerable<float> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float>, IThat<IEnumerable<float>?>,
 			float, float>(
@@ -169,7 +179,9 @@ public static partial class ThatEnumerable
 			IEnumerable<float?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float?, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>,
 			float?, float>(
@@ -194,7 +206,9 @@ public static partial class ThatEnumerable
 			IEnumerable<DateTime> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
@@ -219,7 +233,9 @@ public static partial class ThatEnumerable
 			IEnumerable<DateTime?> expected,
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
@@ -290,7 +306,9 @@ public static partial class ThatEnumerable
 			IEnumerable<double> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double>, IThat<IEnumerable<double>?>,
 			double, double>(
@@ -315,7 +333,9 @@ public static partial class ThatEnumerable
 			IEnumerable<double?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<double?, double> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<double?, double> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>,
 			double?, double>(
@@ -340,7 +360,9 @@ public static partial class ThatEnumerable
 			IEnumerable<decimal> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>,
 			decimal, decimal>(
@@ -365,7 +387,9 @@ public static partial class ThatEnumerable
 			IEnumerable<decimal?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<decimal?, decimal> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>,
 			decimal?, decimal>(
@@ -390,7 +414,9 @@ public static partial class ThatEnumerable
 			IEnumerable<float> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float>, IThat<IEnumerable<float>?>,
 			float, float>(
@@ -415,7 +441,9 @@ public static partial class ThatEnumerable
 			IEnumerable<float?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<float?, float> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<float?, float> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" ± {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>,
 			float?, float>(
@@ -440,7 +468,9 @@ public static partial class ThatEnumerable
 			IEnumerable<DateTime> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
@@ -465,7 +495,9 @@ public static partial class ThatEnumerable
 			IEnumerable<DateTime?> unexpected,
 			[CallerArgumentExpression("unexpected")] string doNotPopulateThisValue = "")
 	{
-		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new((a, e, t) => a.IsConsideredEqualTo(e, t));
+		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options = new(
+			(a, e, t) => a.IsConsideredEqualTo(e, t),
+			t => $" within {Formatter.Format(t)}");
 		CollectionMatchOptions matchOptions = new();
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -37,6 +37,16 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Func<TItem, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TMember> AreAllUnique<TItem, TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Func<TItem, TMember> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements elements, string? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<System.DateTime>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.DateTime>?>, System.DateTime, System.TimeSpan> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<System.DateTime> elements, System.DateTime expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<System.DateTime?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.DateTime?>?>, System.DateTime?, System.TimeSpan> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<System.DateTime?> elements, System.DateTime? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<decimal>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<decimal>?>, decimal, decimal> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<decimal> elements, decimal expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<decimal?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<decimal?>?>, decimal?, decimal> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<decimal?> elements, decimal? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<double>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<double>?>, double, double> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<double> elements, double expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<double?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<double?>?>, double?, double> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<double?> elements, double? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<float>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<float>?>, float, float> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<float> elements, float expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IAsyncEnumerable<float?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<float?>?>, float?, float> AreEqualTo(this aweXpect.ThatAsyncEnumerable.Elements<float?> elements, float? expected) { }
+        public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>?, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreEqualTo<TItem>(this aweXpect.ThatAsyncEnumerable.Elements<TItem> elements, TItem expected) { }
         public static aweXpect.ThatAsyncEnumerable.Elements AtLeast(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject, int minimum) { }
         public static aweXpect.ThatAsyncEnumerable.Elements<TItem> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject, int minimum) { }
         public static aweXpect.ThatAsyncEnumerable.Elements AtMost(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject, int maximum) { }
@@ -103,21 +113,29 @@ namespace aweXpect
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> StartsWith(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, params TItem[] expected) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public class Elements
+        public class Elements : aweXpect.ThatAsyncEnumerable.IElements
         {
-            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> AreEqualTo(string? expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> Satisfy(System.Func<string?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
-        public class Elements<TItem>
+        public class Elements<TItem> : aweXpect.ThatAsyncEnumerable.IElements<TItem>
         {
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> Are(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> Are<TType>() { }
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreEqualTo(TItem expected) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreEquivalentTo<TExpected>(TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreExactly(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreExactly<TType>() { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> ComplyWith(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        }
+        public interface IElements
+        {
+            aweXpect.EnumerableQuantifier Quantifier { get; }
+            aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> Subject { get; }
+        }
+        public interface IElements<TItem>
+        {
+            aweXpect.EnumerableQuantifier Quantifier { get; }
+            aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> Subject { get; }
         }
     }
     public static class ThatBool
@@ -295,6 +313,16 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TMember> AreAllUnique<TItem, TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, TMember> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreEqualTo(this aweXpect.ThatEnumerable.Elements elements, string? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<System.DateTime>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.DateTime>?>, System.DateTime, System.TimeSpan> AreEqualTo(this aweXpect.ThatEnumerable.Elements<System.DateTime> elements, System.DateTime expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<System.DateTime?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.DateTime?>?>, System.DateTime?, System.TimeSpan> AreEqualTo(this aweXpect.ThatEnumerable.Elements<System.DateTime?> elements, System.DateTime? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<decimal>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<decimal>?>, decimal, decimal> AreEqualTo(this aweXpect.ThatEnumerable.Elements<decimal> elements, decimal expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<decimal?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<decimal?>?>, decimal?, decimal> AreEqualTo(this aweXpect.ThatEnumerable.Elements<decimal?> elements, decimal? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<double>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<double>?>, double, double> AreEqualTo(this aweXpect.ThatEnumerable.Elements<double> elements, double expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<double?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<double?>?>, double?, double> AreEqualTo(this aweXpect.ThatEnumerable.Elements<double?> elements, double? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<float>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<float>?>, float, float> AreEqualTo(this aweXpect.ThatEnumerable.Elements<float> elements, float expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<float?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<float?>?>, float?, float> AreEqualTo(this aweXpect.ThatEnumerable.Elements<float?> elements, float? expected) { }
+        public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>?, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreEqualTo<TItem>(this aweXpect.ThatEnumerable.Elements<TItem> elements, TItem expected) { }
         public static aweXpect.ThatEnumerable.Elements AtLeast(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject, int minimum) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int minimum) { }
         public static aweXpect.ThatEnumerable.Elements AtMost(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject, int maximum) { }
@@ -361,21 +389,29 @@ namespace aweXpect
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> StartsWith(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, params TItem[] expected) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public class Elements
+        public class Elements : aweXpect.ThatEnumerable.IElements
         {
-            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreEqualTo(string? expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> Satisfy(System.Func<string?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
-        public class Elements<TItem>
+        public class Elements<TItem> : aweXpect.ThatEnumerable.IElements<TItem>
         {
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> Are(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> Are<TType>() { }
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreEqualTo(TItem expected) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreEquivalentTo<TExpected>(TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreExactly(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreExactly<TType>() { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> ComplyWith(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        }
+        public interface IElements
+        {
+            aweXpect.EnumerableQuantifier Quantifier { get; }
+            aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> Subject { get; }
+        }
+        public interface IElements<TItem>
+        {
+            aweXpect.EnumerableQuantifier Quantifier { get; }
+            aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> Subject { get; }
         }
     }
     public static class ThatEventRecording

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -178,6 +178,16 @@ namespace aweXpect
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TMember> AreAllUnique<TItem, TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, TMember> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreEqualTo(this aweXpect.ThatEnumerable.Elements elements, string? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<System.DateTime>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.DateTime>?>, System.DateTime, System.TimeSpan> AreEqualTo(this aweXpect.ThatEnumerable.Elements<System.DateTime> elements, System.DateTime expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<System.DateTime?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.DateTime?>?>, System.DateTime?, System.TimeSpan> AreEqualTo(this aweXpect.ThatEnumerable.Elements<System.DateTime?> elements, System.DateTime? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<decimal>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<decimal>?>, decimal, decimal> AreEqualTo(this aweXpect.ThatEnumerable.Elements<decimal> elements, decimal expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<decimal?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<decimal?>?>, decimal?, decimal> AreEqualTo(this aweXpect.ThatEnumerable.Elements<decimal?> elements, decimal? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<double>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<double>?>, double, double> AreEqualTo(this aweXpect.ThatEnumerable.Elements<double> elements, double expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<double?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<double?>?>, double?, double> AreEqualTo(this aweXpect.ThatEnumerable.Elements<double?> elements, double? expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<float>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<float>?>, float, float> AreEqualTo(this aweXpect.ThatEnumerable.Elements<float> elements, float expected) { }
+        public static aweXpect.Results.ToleranceEqualityResult<System.Collections.Generic.IEnumerable<float?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<float?>?>, float?, float> AreEqualTo(this aweXpect.ThatEnumerable.Elements<float?> elements, float? expected) { }
+        public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>?, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreEqualTo<TItem>(this aweXpect.ThatEnumerable.Elements<TItem> elements, TItem expected) { }
         public static aweXpect.ThatEnumerable.Elements AtLeast(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject, int minimum) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> AtLeast<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int minimum) { }
         public static aweXpect.ThatEnumerable.Elements AtMost(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject, int maximum) { }
@@ -244,21 +254,29 @@ namespace aweXpect
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> StartsWith(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, params TItem[] expected) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> StartsWith<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
-        public class Elements
+        public class Elements : aweXpect.ThatEnumerable.IElements
         {
-            public aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreEqualTo(string? expected) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> Satisfy(System.Func<string?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         }
-        public class Elements<TItem>
+        public class Elements<TItem> : aweXpect.ThatEnumerable.IElements<TItem>
         {
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> Are(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> Are<TType>() { }
-            public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreEqualTo(TItem expected) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreEquivalentTo<TExpected>(TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreExactly(System.Type type) { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreExactly<TType>() { }
             public aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> ComplyWith(System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
             public aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> Satisfy(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        }
+        public interface IElements
+        {
+            aweXpect.EnumerableQuantifier Quantifier { get; }
+            aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> Subject { get; }
+        }
+        public interface IElements<TItem>
+        {
+            aweXpect.EnumerableQuantifier Quantifier { get; }
+            aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> Subject { get; }
         }
     }
     public static class ThatEventRecording

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -788,7 +788,7 @@ namespace aweXpect.Options
     }
     public class ObjectEqualityWithToleranceOptions<TSubject, TTolerance> : aweXpect.Options.ObjectEqualityOptions<TSubject>
     {
-        public ObjectEqualityWithToleranceOptions(System.Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance) { }
+        public ObjectEqualityWithToleranceOptions(System.Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance, System.Func<TTolerance, string>? toString = null) { }
         public aweXpect.Options.ObjectEqualityOptions<TSubject> Within(TTolerance tolerance) { }
     }
     public class Quantifier
@@ -1191,6 +1191,16 @@ namespace aweXpect.Results
     {
         public TimeToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.TimeTolerance options) { }
         public TSelf Within(System.TimeSpan tolerance) { }
+    }
+    public class ToleranceEqualityResult<TType, TThat, TElement, TTolerance> : aweXpect.Results.ToleranceEqualityResult<TType, TThat, TElement, TTolerance, aweXpect.Results.ToleranceEqualityResult<TType, TThat, TElement, TTolerance>>
+    {
+        public ToleranceEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityWithToleranceOptions<TElement, TTolerance> options) { }
+    }
+    public class ToleranceEqualityResult<TType, TThat, TElement, TTolerance, TSelf> : aweXpect.Results.AndOrResult<TType, TThat, TSelf>, aweXpect.Core.IOptionsProvider<aweXpect.Options.ObjectEqualityOptions<TElement>>
+        where TSelf : aweXpect.Results.ToleranceEqualityResult<TType, TThat, TElement, TTolerance, TSelf>
+    {
+        public ToleranceEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityWithToleranceOptions<TElement, TTolerance> options) { }
+        public aweXpect.Results.AndOrResult<TType, TThat, TSelf> Within(TTolerance tolerance) { }
     }
 }
 namespace aweXpect.Signaling

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -771,7 +771,7 @@ namespace aweXpect.Options
     }
     public class ObjectEqualityWithToleranceOptions<TSubject, TTolerance> : aweXpect.Options.ObjectEqualityOptions<TSubject>
     {
-        public ObjectEqualityWithToleranceOptions(System.Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance) { }
+        public ObjectEqualityWithToleranceOptions(System.Func<TSubject, TSubject, TTolerance, bool> isWithinTolerance, System.Func<TTolerance, string>? toString = null) { }
         public aweXpect.Options.ObjectEqualityOptions<TSubject> Within(TTolerance tolerance) { }
     }
     public class Quantifier
@@ -1174,6 +1174,16 @@ namespace aweXpect.Results
     {
         public TimeToleranceResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.TimeTolerance options) { }
         public TSelf Within(System.TimeSpan tolerance) { }
+    }
+    public class ToleranceEqualityResult<TType, TThat, TElement, TTolerance> : aweXpect.Results.ToleranceEqualityResult<TType, TThat, TElement, TTolerance, aweXpect.Results.ToleranceEqualityResult<TType, TThat, TElement, TTolerance>>
+    {
+        public ToleranceEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityWithToleranceOptions<TElement, TTolerance> options) { }
+    }
+    public class ToleranceEqualityResult<TType, TThat, TElement, TTolerance, TSelf> : aweXpect.Results.AndOrResult<TType, TThat, TSelf>, aweXpect.Core.IOptionsProvider<aweXpect.Options.ObjectEqualityOptions<TElement>>
+        where TSelf : aweXpect.Results.ToleranceEqualityResult<TType, TThat, TElement, TTolerance, TSelf>
+    {
+        public ToleranceEqualityResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityWithToleranceOptions<TElement, TTolerance> options) { }
+        public aweXpect.Results.AndOrResult<TType, TThat, TSelf> Within(TTolerance tolerance) { }
     }
 }
 namespace aweXpect.Signaling

--- a/Tests/aweXpect.Core.Tests/TraceWriterTests.cs
+++ b/Tests/aweXpect.Core.Tests/TraceWriterTests.cs
@@ -92,9 +92,9 @@ public class TraceWriterTests
 		}
 
 		await That(traceWriter.Messages).IsEqualTo([
-			"Checking expectation for callback delegate returning in 0:00",
+			"Checking expectation for callback delegate returning in 0:*",
 			"  Successfully verified that callback executes within 0:00.500",
-		]);
+		]).AsWildcard();
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Tests.cs
@@ -9,7 +9,7 @@ public sealed partial class ThatAsyncEnumerable
 {
 	public sealed partial class All
 	{
-		public sealed class AreEqualTo
+		public sealed partial class AreEqualTo
 		{
 			public sealed class ItemTests
 			{

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Within.Tests.cs
@@ -1,0 +1,267 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatAsyncEnumerable
+{
+	public sealed partial class All
+	{
+		public sealed partial class AreEqualTo
+		{
+			public sealed class Within
+			{
+				public sealed class DoubleTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IAsyncEnumerable<double> subject = ToAsyncEnumerable(1.0, 1.3, 0.9);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but not all were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IAsyncEnumerable<double> subject = ToAsyncEnumerable(1.0, 1.1, 0.9);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableDoubleTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IAsyncEnumerable<double?> subject = ToAsyncEnumerable<double?>(1.0, 1.3, 0.9);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but not all were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IAsyncEnumerable<double?> subject = ToAsyncEnumerable<double?>(1.0, 1.1, 0.9);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class FloatTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IAsyncEnumerable<float> subject = ToAsyncEnumerable(1.0F, 1.3F, 0.9F);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but not all were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IAsyncEnumerable<float> subject = ToAsyncEnumerable(1.0F, 1.1F, 0.9F);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableFloatTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IAsyncEnumerable<float?> subject = ToAsyncEnumerable<float?>(1.0F, 1.3F, 0.9F);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but not all were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IAsyncEnumerable<float?> subject = ToAsyncEnumerable<float?>(1.0F, 1.1F, 0.9F);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class DecimalTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IAsyncEnumerable<decimal> subject = ToAsyncEnumerable(1.0m, 1.3m, 0.9m);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but not all were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IAsyncEnumerable<decimal> subject = ToAsyncEnumerable(1.0m, 1.1m, 0.9m);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableDecimalTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IAsyncEnumerable<decimal?> subject = ToAsyncEnumerable<decimal?>(1.0m, 1.3m, 0.9m);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but not all were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IAsyncEnumerable<decimal?> subject = ToAsyncEnumerable<decimal?>(1.0m, 1.1m, 0.9m);
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class DateTimeTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						DateTime now = DateTime.Now;
+						IAsyncEnumerable<DateTime> subject =
+							ToAsyncEnumerable(now.AddMinutes(1), now, now.AddMinutes(-2));
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage($"""
+							              Expected that subject
+							              is equal to {Formatter.Format(now)} within 1:00 for all items,
+							              but not all were
+							              """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						DateTime now = DateTime.Now;
+						IAsyncEnumerable<DateTime> subject =
+							ToAsyncEnumerable(now.AddMinutes(1), now, now.AddMinutes(-1));
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableDateTimeTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						DateTime now = DateTime.Now;
+						IAsyncEnumerable<DateTime?> subject =
+							ToAsyncEnumerable<DateTime?>(now.AddMinutes(1), now, null, now.AddMinutes(-2));
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage($"""
+							              Expected that subject
+							              is equal to {Formatter.Format(now)} within 1:00 for all items,
+							              but not all were
+							              """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						DateTime now = DateTime.Now;
+						IAsyncEnumerable<DateTime?> subject =
+							ToAsyncEnumerable<DateTime?>(now.AddMinutes(1), now, now.AddMinutes(-1));
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.WithinTests.cs
@@ -35,7 +35,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0m, 2.0m, 3.0m,] in any order within 0.2,
+						             matches collection [1.0m, 2.0m, 3.0m,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
@@ -67,7 +67,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0m, null, 2.0m, 3.0m,] in any order within 0.2,
+						             matches collection [1.0m, null, 2.0m, 3.0m,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
@@ -110,7 +110,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0, 2.0, 3.0,] in any order within 0.2,
+						             matches collection [1.0, 2.0, 3.0,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
@@ -153,7 +153,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0, null, 2.0, 3.0,] in any order within 0.2,
+						             matches collection [1.0, null, 2.0, 3.0,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
@@ -196,7 +196,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0F, 2.0F, 3.0F,] in any order within 0.2,
+						             matches collection [1.0F, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
@@ -239,7 +239,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0F, null, 2.0F, 3.0F,] in any order within 0.2,
+						             matches collection [1.0F, null, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsNotEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsNotEqualTo.WithinTests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0m, 2.0m, 3.0m,] in any order within 0.2,
+						             does not match collection [1.0m, 2.0m, 3.0m,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               2.1,
@@ -58,7 +58,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0m, null, 2.0m, 3.0m,] in order within 0.2,
+						             does not match collection [1.0m, null, 2.0m, 3.0m,] in order ± 0.2,
 						             but it did in [
 						               1.1,
 						               <null>,
@@ -93,7 +93,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order within 0.2,
+						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -114,7 +114,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, 2.0, 3.0,] in order within 0.2,
+						             does not match collection [1.0, 2.0, 3.0,] in order ± 0.2,
 						             but it did in [
 						               1.1,
 						               2.1,
@@ -148,7 +148,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order within 0.2,
+						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -169,7 +169,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, null, 2.0, 3.0,] in any order within 0.2,
+						             does not match collection [1.0, null, 2.0, 3.0,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               <null>,
@@ -204,7 +204,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -225,7 +225,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               2.1,
@@ -259,7 +259,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -280,7 +280,7 @@ public sealed partial class ThatAsyncEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, null, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, null, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               <null>,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Tests.cs
@@ -9,8 +9,47 @@ public sealed partial class ThatEnumerable
 {
 	public sealed partial class All
 	{
-		public sealed class AreEqualTo
+		public sealed partial class AreEqualTo
 		{
+			public sealed class Tests
+			{
+				[Theory]
+				[InlineData(double.NaN, false)]
+				[InlineData(1.0, true)]
+				public async Task DoubleNaNValues_ShouldBeConsideredEqual(double additionalValue, bool expectFailure)
+				{
+					IEnumerable<double> subject = [double.NaN, double.NaN, additionalValue,];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(double.NaN);
+
+					await That(Act).Throws<XunitException>().OnlyIf(expectFailure)
+						.WithMessage("""
+						             Expected that subject
+						             is equal to NaN for all items,
+						             but only 2 of 3 were
+						             """);
+				}
+
+				[Theory]
+				[InlineData(float.NaN, false)]
+				[InlineData(1.0F, true)]
+				public async Task FloatNaNValues_ShouldBeConsideredEqual(float additionalValue, bool expectFailure)
+				{
+					IEnumerable<float> subject = [float.NaN, float.NaN, additionalValue,];
+
+					async Task Act()
+						=> await That(subject).All().AreEqualTo(float.NaN);
+
+					await That(Act).Throws<XunitException>().OnlyIf(expectFailure)
+						.WithMessage("""
+						             Expected that subject
+						             is equal to NaN for all items,
+						             but only 2 of 3 were
+						             """);
+				}
+			}
+
 			public sealed class ItemTests
 			{
 				[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Within.Tests.cs
@@ -1,0 +1,261 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class All
+	{
+		public sealed partial class AreEqualTo
+		{
+			public sealed class Within
+			{
+				public sealed class DoubleTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IEnumerable<double> subject = [1.0, 1.3, 0.9,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but only 2 of 3 were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IEnumerable<double> subject = [1.0, 1.1, 0.9,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableDoubleTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IEnumerable<double?> subject = [1.0, 1.3, 0.9,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but only 2 of 3 were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IEnumerable<double?> subject = [1.0, 1.1, 0.9,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0).Within(0.2);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class FloatTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IEnumerable<float> subject = [1.0F, 1.3F, 0.9F,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but only 2 of 3 were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IEnumerable<float> subject = [1.0F, 1.1F, 0.9F,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableFloatTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IEnumerable<float?> subject = [1.0F, 1.3F, 0.9F,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but only 2 of 3 were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IEnumerable<float?> subject = [1.0F, 1.1F, 0.9F,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0F).Within(0.2F);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class DecimalTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IEnumerable<decimal> subject = [1.0m, 1.3m, 0.9m,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but only 2 of 3 were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IEnumerable<decimal> subject = [1.0m, 1.1m, 0.9m,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableDecimalTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						IEnumerable<decimal?> subject = [1.0m, 1.3m, 0.9m,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage("""
+							             Expected that subject
+							             is equal to 1.0 ± 0.2 for all items,
+							             but only 2 of 3 were
+							             """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						IEnumerable<decimal?> subject = [1.0m, 1.1m, 0.9m,];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(1.0m).Within(0.2m);
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class DateTimeTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						DateTime now = DateTime.Now;
+						IEnumerable<DateTime> subject = [now.AddMinutes(1), now, now.AddMinutes(-2),];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage($"""
+							              Expected that subject
+							              is equal to {Formatter.Format(now)} within 1:00 for all items,
+							              but only 2 of 3 were
+							              """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						DateTime now = DateTime.Now;
+						IEnumerable<DateTime> subject = [now.AddMinutes(1), now, now.AddMinutes(-1),];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+
+				public sealed class NullableDateTimeTests
+				{
+					[Fact]
+					public async Task WhenValuesAreNotWithinTolerance_ShouldFail()
+					{
+						DateTime now = DateTime.Now;
+						IEnumerable<DateTime?> subject = [now.AddMinutes(1), now, null, now.AddMinutes(-2),];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).Throws<XunitException>()
+							.WithMessage($"""
+							              Expected that subject
+							              is equal to {Formatter.Format(now)} within 1:00 for all items,
+							              but only 2 of 4 were
+							              """);
+					}
+
+					[Fact]
+					public async Task WhenValuesAreWithinTolerance_ShouldSucceed()
+					{
+						DateTime now = DateTime.Now;
+						IEnumerable<DateTime?> subject = [now.AddMinutes(1), now, now.AddMinutes(-1),];
+
+						async Task Act()
+							=> await That(subject).All().AreEqualTo(now).Within(1.Minutes());
+
+						await That(Act).DoesNotThrow();
+					}
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.WithinTests.cs
@@ -34,7 +34,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0m, 2.0m, 3.0m,] in any order within 0.2,
+						             matches collection [1.0m, 2.0m, 3.0m,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
@@ -66,7 +66,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0m, null, 2.0m, 3.0m,] in any order within 0.2,
+						             matches collection [1.0m, null, 2.0m, 3.0m,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
@@ -109,7 +109,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0, 2.0, 3.0,] in any order within 0.2,
+						             matches collection [1.0, 2.0, 3.0,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
@@ -152,7 +152,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0, null, 2.0, 3.0,] in any order within 0.2,
+						             matches collection [1.0, null, 2.0, 3.0,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
@@ -195,7 +195,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0F, 2.0F, 3.0F,] in any order within 0.2,
+						             matches collection [1.0F, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
@@ -238,7 +238,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             matches collection [1.0F, null, 2.0F, 3.0F,] in any order within 0.2,
+						             matches collection [1.0F, null, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsNotEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsNotEqualTo.WithinTests.cs
@@ -23,7 +23,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0m, 2.0m, 3.0m,] in any order within 0.2,
+						             does not match collection [1.0m, 2.0m, 3.0m,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               2.1,
@@ -57,7 +57,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0m, null, 2.0m, 3.0m,] in order within 0.2,
+						             does not match collection [1.0m, null, 2.0m, 3.0m,] in order ± 0.2,
 						             but it did in [
 						               1.1,
 						               <null>,
@@ -92,7 +92,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order within 0.2,
+						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -113,7 +113,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, 2.0, 3.0,] in order within 0.2,
+						             does not match collection [1.0, 2.0, 3.0,] in order ± 0.2,
 						             but it did in [
 						               1.1,
 						               2.1,
@@ -147,7 +147,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order within 0.2,
+						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -168,7 +168,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0, null, 2.0, 3.0,] in any order within 0.2,
+						             does not match collection [1.0, null, 2.0, 3.0,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               <null>,
@@ -203,7 +203,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -224,7 +224,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               2.1,
@@ -258,7 +258,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               NaN,
@@ -279,7 +279,7 @@ public sealed partial class ThatEnumerable
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             does not match collection [1.0F, null, 2.0F, 3.0F,] in any order within 0.2,
+						             does not match collection [1.0F, null, 2.0F, 3.0F,] in any order ± 0.2,
 						             but it did in [
 						               1.1,
 						               <null>,


### PR DESCRIPTION
For certain types you can now specify a tolerance:

```csharp
IEnumerable<double> values = [2.04, 2.02, 2.01];

await Expect.That(values).All().AreEqualTo(2.0).Within(0.1);
```

This tolerance can be applied to `double`, `float`, `decimal` and `DateTime`.

---
- *Implements part of #594*