### PR TITLE
fix: collection formatting manipulation is platform-agnostic

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.11.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.10.1"/>
+		<PackageVersion Include="aweXpect" Version="2.12.1"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.10.2"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.MainOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect/That/Collections/CollectionHelpers.cs
+++ b/Source/aweXpect/That/Collections/CollectionHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using aweXpect.Core;
 
 namespace aweXpect;
 
@@ -34,6 +35,48 @@ internal static class CollectionHelpers
 
 	internal static string GetItemString(this EnumerableQuantifier quantifier)
 		=> quantifier.IsSingle() ? "item" : "items";
+
+	internal static ExpectationBuilder AddCollectionContext<TItem>(this ExpectationBuilder expectationBuilder, IEnumerable<TItem> value, bool isIncomplete)
+		=> expectationBuilder.UpdateContexts(contexts
+			=> contexts
+				.Add(new ResultContext("Collection",
+					Formatter.Format(value, typeof(TItem).GetFormattingOption())
+						.AppendIsIncomplete(isIncomplete),
+					1)));
+
+	internal static string AppendIsIncomplete(this string formattedItems, bool isIncomplete)
+	{
+		if (!isIncomplete || formattedItems.Length < 3)
+		{
+			return formattedItems;
+		}
+
+		if (formattedItems.EndsWith("…]"))
+		{
+			return $"{formattedItems[..^2]}(… and maybe others)]";
+		}
+
+		if (formattedItems.EndsWith($"…{Environment.NewLine}]"))
+		{
+			return $"""
+			        {formattedItems[..^(Environment.NewLine.Length + 2)]}(… and maybe others)
+			        ]
+			        """;
+		}
+
+		if (formattedItems.EndsWith($"{Environment.NewLine}]"))
+		{
+			return $"""
+			        {formattedItems[..^(Environment.NewLine.Length  + 1)]},
+			          (… and maybe others)
+			        ]
+			        """;
+		}
+
+		return $"""
+		        {formattedItems[..^1]}, (… and maybe others)]
+		        """;
+	}
 
 	internal static FormattingOptions GetFormattingOption(this Type type)
 	{

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
@@ -31,7 +31,6 @@ public static partial class ThatAsyncEnumerable
 		private readonly Func<TItem, bool> _predicate;
 		private readonly EnumerableQuantifier _quantifier;
 		private readonly string _verb;
-		private LimitedCollection<TItem>? _items;
 		private int _matchingCount;
 		private LimitedCollection<TItem>? _matchingItems;
 		private int _notMatchingCount;
@@ -73,7 +72,7 @@ public static partial class ThatAsyncEnumerable
 			_matchingCount = 0;
 			_notMatchingCount = 0;
 			int maxItems = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get() + 1;
-			_items = new LimitedCollection<TItem>(maxItems);
+			LimitedCollection<TItem> items = new(maxItems);
 			_matchingItems = new LimitedCollection<TItem>(maxItems);
 			_notMatchingItems = new LimitedCollection<TItem>(maxItems);
 
@@ -90,14 +89,14 @@ public static partial class ThatAsyncEnumerable
 					_notMatchingItems.Add(item);
 				}
 
-				_items.Add(item);
+				items.Add(item);
 
-				// _items.IsReadOnly is set to true, once the limit is reached.
-				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount) && _items.IsReadOnly)
+				// items.IsReadOnly is set to true, once the limit is reached.
+				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount) && items.IsReadOnly)
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(_items, true);
+					_expectationBuilder.AddCollectionContext(items, true);
 					return this;
 				}
 			}
@@ -105,14 +104,14 @@ public static partial class ThatAsyncEnumerable
 			if (cancellationToken.IsCancellationRequested)
 			{
 				Outcome = Outcome.Undecided;
-				_expectationBuilder.AddCollectionContext(_items, true);
+				_expectationBuilder.AddCollectionContext(items, true);
 				return this;
 			}
 
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 			AppendContexts(false);
-			_expectationBuilder.AddCollectionContext(_items, false);
+			_expectationBuilder.AddCollectionContext(items, false);
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -172,14 +172,14 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					AppendCollectionContext(materialized, true);
+					_expectationBuilder.AddCollectionContext(materialized, true);
 					return Task.FromResult<ConstraintResult>(this);
 				}
 
 				if (cancellationToken.IsCancellationRequested)
 				{
 					Outcome = Outcome.Undecided;
-					AppendCollectionContext(materialized, true);
+					_expectationBuilder.AddCollectionContext(materialized, true);
 					return Task.FromResult<ConstraintResult>(this);
 				}
 			}
@@ -187,7 +187,7 @@ public static partial class ThatEnumerable
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 			AppendContexts(false);
-			AppendCollectionContext(materialized, false);
+			_expectationBuilder.AddCollectionContext(materialized, false);
 			return Task.FromResult<ConstraintResult>(this);
 		}
 
@@ -242,9 +242,8 @@ public static partial class ThatEnumerable
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
-						AppendIsIncomplete(
-							Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption()),
-							isIncomplete),
+						Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption())
+							.AppendIsIncomplete(isIncomplete),
 						int.MaxValue)));
 			}
 
@@ -252,54 +251,10 @@ public static partial class ThatEnumerable
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
-						AppendIsIncomplete(
-							Formatter.Format(_notMatchingItems, typeof(TItem).GetFormattingOption()),
-							isIncomplete),
+						Formatter.Format(_notMatchingItems, typeof(TItem).GetFormattingOption())
+							.AppendIsIncomplete(isIncomplete),
 						int.MaxValue)));
 			}
-		}
-
-		private void AppendCollectionContext(IEnumerable<TItem> value, bool isIncomplete)
-			=> _expectationBuilder.UpdateContexts(contexts
-				=> contexts
-					.Add(new ResultContext("Collection",
-						AppendIsIncomplete(
-							Formatter.Format(value, typeof(TItem).GetFormattingOption()),
-							isIncomplete),
-						1)));
-
-		private static string AppendIsIncomplete(string formattedItems, bool isIncomplete)
-		{
-			if (!isIncomplete || formattedItems.Length < 3)
-			{
-				return formattedItems;
-			}
-
-			if (formattedItems.EndsWith("…]"))
-			{
-				return $"{formattedItems[..^2]}(… and maybe others)]";
-			}
-
-			if (formattedItems.EndsWith("…\r\n]"))
-			{
-				return $"""
-				        {formattedItems[..^4]}(… and maybe others)
-				        ]
-				        """;
-			}
-
-			if (formattedItems.EndsWith("\r\n]"))
-			{
-				return $"""
-				        {formattedItems[..^3]},
-				          (… and maybe others)
-				        ]
-				        """;
-			}
-
-			return $"""
-			        {formattedItems[..^1]}, (… and maybe others)]
-			        """;
 		}
 	}
 


### PR DESCRIPTION
Also update aweXpect to v2.12.1 and change the build scope to "Default".

The inclusion of `(… and maybe others)` in the error message is not agnostic to the newline of the platforms.