### PR TITLE
feat: improve formatting for dictionaries

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -49,7 +49,9 @@ public static partial class ValueFormatters
 
 		int maxCount = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
 		int count = maxCount;
-		stringBuilder.Append('[');
+
+		bool isDictionary = value is IDictionary;
+		stringBuilder.Append(isDictionary ? '{' : '[');
 		bool hasMoreValues = false;
 		bool isNotEmpty = false;
 		foreach (object? v in value)
@@ -96,7 +98,7 @@ public static partial class ValueFormatters
 			stringBuilder.AppendLine();
 		}
 
-		stringBuilder.Append(']');
+		stringBuilder.Append(isDictionary ? '}' : ']');
 	}
 
 	/// <summary>

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Collection.cs
@@ -24,6 +24,7 @@ public static partial class ValueFormatters
 		return stringBuilder.ToString();
 	}
 
+#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />
 	///     to the <paramref name="stringBuilder" />
@@ -100,6 +101,7 @@ public static partial class ValueFormatters
 
 		stringBuilder.Append(isDictionary ? '}' : ']');
 	}
+#pragma warning restore S3776
 
 	/// <summary>
 	///     Appends the formatted <paramref name="value" /> according to the <paramref name="options" />

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -151,7 +151,7 @@ public static partial class ValueFormatters
 
 			object? key = valueType.GetProperty("Key")?.GetValue(value);
 			object? item = valueType.GetProperty("Value")?.GetValue(value);
-			stringBuilder.Append("[");
+			stringBuilder.Append('[');
 			Formatter.Format(stringBuilder, key, options);
 			stringBuilder.Append("] = ");
 			Formatter.Format(stringBuilder, item, options);

--- a/Source/aweXpect.Core/Formatting/ValueFormatters.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.cs
@@ -151,11 +151,10 @@ public static partial class ValueFormatters
 
 			object? key = valueType.GetProperty("Key")?.GetValue(value);
 			object? item = valueType.GetProperty("Value")?.GetValue(value);
-			stringBuilder.Append('[');
+			stringBuilder.Append("[");
 			Formatter.Format(stringBuilder, key, options);
-			stringBuilder.Append(", ");
+			stringBuilder.Append("] = ");
 			Formatter.Format(stringBuilder, item, options);
-			stringBuilder.Append(']');
 			return;
 		}
 

--- a/Source/aweXpect/Helpers/ICountable.cs
+++ b/Source/aweXpect/Helpers/ICountable.cs
@@ -1,0 +1,6 @@
+﻿namespace aweXpect.Helpers;
+
+internal interface ICountable
+{
+	int? Count { get; }
+}

--- a/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace aweXpect.Helpers;
 
-internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>
+internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>, ICountable
 {
 	private readonly IAsyncEnumerator<T> _enumerator;
 	private readonly List<T> _materializedItems = new();
@@ -35,6 +35,8 @@ internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>
 			_materializedItems.Add(item);
 			yield return item;
 		}
+		
+		Count = _materializedItems.Count;
 	}
 
 	#endregion
@@ -48,5 +50,7 @@ internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>
 
 		return new MaterializingAsyncEnumerable<T>(enumerable);
 	}
+
+	public int? Count { get; private set; }
 }
 #endif

--- a/Source/aweXpect/Helpers/MaterializingEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingEnumerable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace aweXpect.Helpers;
 
-internal sealed class MaterializingEnumerable<T> : IEnumerable<T>
+internal sealed class MaterializingEnumerable<T> : IEnumerable<T>, ICountable
 {
 	private readonly IEnumerator<T> _enumerator;
 	private readonly List<T> _materializedItems = new();
@@ -43,7 +43,16 @@ internal sealed class MaterializingEnumerable<T> : IEnumerable<T>
 			_materializedItems.Add(item);
 			yield return item;
 		}
+
+		Count = _materializedItems.Count;
 	}
 
 	#endregion
+
+	public int? Count { get; private set; }
+}
+
+internal interface ICountable
+{
+	int? Count { get; }
 }

--- a/Source/aweXpect/Helpers/MaterializingEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingEnumerable.cs
@@ -51,8 +51,3 @@ internal sealed class MaterializingEnumerable<T> : IEnumerable<T>, ICountable
 
 	public int? Count { get; private set; }
 }
-
-internal interface ICountable
-{
-	int? Count { get; }
-}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
@@ -185,7 +185,7 @@ public static partial class ThatAsyncEnumerable
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
-						Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption())
+						Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption(_matchingItems?.Count))
 							.AppendIsIncomplete(isIncomplete),
 						int.MaxValue)));
 			}
@@ -194,7 +194,7 @@ public static partial class ThatAsyncEnumerable
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
-						Formatter.Format(_notMatchingItems, typeof(TItem).GetFormattingOption())
+						Formatter.Format(_notMatchingItems, typeof(TItem).GetFormattingOption(_notMatchingItems?.Count))
 							.AppendIsIncomplete(isIncomplete),
 						int.MaxValue)));
 			}

--- a/Source/aweXpect/That/Collections/ThatDictionary.AreAllUnique.cs
+++ b/Source/aweXpect/That/Collections/ThatDictionary.AreAllUnique.cs
@@ -24,9 +24,10 @@ public static partial class ThatDictionary
 			this IThat<IDictionary<TKey, TValue>?> source)
 	{
 		ObjectEqualityOptions<TValue> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TValue>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new AllIsUniqueConstraint<TKey, TValue, TValue>(it, grammars, options)),
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new AllIsUniqueConstraint<TKey, TValue, TValue>(expectationBuilder, it, grammars, options)),
 			source, options
 		);
 	}
@@ -41,9 +42,10 @@ public static partial class ThatDictionary
 		AreAllUnique<TKey>(this IThat<IDictionary<TKey, string?>?> source)
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IDictionary<TKey, string?>, IThat<IDictionary<TKey, string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new AllIsUniqueConstraint<TKey, string?, string?>(it, grammars, options)),
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new AllIsUniqueConstraint<TKey, string?, string?>(expectationBuilder, it, grammars, options)),
 			source, options
 		);
 	}
@@ -64,11 +66,12 @@ public static partial class ThatDictionary
 			string doNotPopulateThisValue = "")
 	{
 		ObjectEqualityOptions<TMember> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>, TMember>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new AllIsUniqueWithPredicateConstraint<TKey, TValue, TMember, TMember>(
-					it,
-					grammars,
+					expectationBuilder,
+					it, grammars,
 					memberAccessor,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
@@ -92,11 +95,12 @@ public static partial class ThatDictionary
 			string doNotPopulateThisValue = "")
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new AllIsUniqueWithPredicateConstraint<TKey, TValue, string, string>(
-					it,
-					grammars,
+					expectationBuilder,
+					it, grammars,
 					memberAccessor,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					options)),
@@ -105,6 +109,7 @@ public static partial class ThatDictionary
 	}
 
 	private sealed class AllIsUniqueConstraint<TKey, TValue, TMatch>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		IOptionsEquality<TMatch> options)
@@ -139,6 +144,7 @@ public static partial class ThatDictionary
 			}
 
 			Outcome = _duplicates.Any() ? Outcome.Failure : Outcome.Success;
+			expectationBuilder.AddCollectionContext(actual);
 			return this;
 		}
 
@@ -162,6 +168,7 @@ public static partial class ThatDictionary
 	}
 
 	private sealed class AllIsUniqueWithPredicateConstraint<TKey, TValue, TMember, TMatch>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		Func<TValue, TMember> memberAccessor,
@@ -199,6 +206,7 @@ public static partial class ThatDictionary
 			}
 
 			Outcome = _duplicates.Any() ? Outcome.Failure : Outcome.Success;
+			expectationBuilder.AddCollectionContext(actual);
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -242,7 +242,7 @@ public static partial class ThatEnumerable
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
-						Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption())
+						Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption(_matchingItems?.Count))
 							.AppendIsIncomplete(isIncomplete),
 						int.MaxValue)));
 			}
@@ -251,7 +251,7 @@ public static partial class ThatEnumerable
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
-						Formatter.Format(_notMatchingItems, typeof(TItem).GetFormattingOption())
+						Formatter.Format(_notMatchingItems, typeof(TItem).GetFormattingOption(_notMatchingItems?.Count))
 							.AppendIsIncomplete(isIncomplete),
 						int.MaxValue)));
 			}

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DictionaryTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.DictionaryTests.cs
@@ -13,7 +13,7 @@ public partial class ValueFormatters
 		[Fact]
 		public async Task ShouldFormatItems()
 		{
-			string expectedResult = "[[\"1\", 1], [\"2\", 2], [\"3\", 3], [\"4\", 4]]";
+			string expectedResult = "{[\"1\"] = 1, [\"2\"] = 2, [\"3\"] = 3, [\"4\"] = 4}";
 			Dictionary<string, int> value = Enumerable.Range(1, 4).ToDictionary(i => i.ToString(), i => i);
 			StringBuilder sb = new();
 
@@ -44,7 +44,7 @@ public partial class ValueFormatters
 		[Fact]
 		public async Task WithType_ShouldIncludeTypeInformation()
 		{
-			string expectedResult = "Dictionary<string, int> [[\"1\", 1], [\"2\", 2], [\"3\", 3]]";
+			string expectedResult = "Dictionary<string, int> {[\"1\"] = 1, [\"2\"] = 2, [\"3\"] = 3}";
 			Dictionary<string, int> value = Enumerable.Range(1, 3).ToDictionary(i => i.ToString(), i => i);
 			StringBuilder sb = new();
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEqualTo.Tests.cs
@@ -43,7 +43,19 @@ public sealed partial class ThatAsyncEnumerable
 						             [2, 3, 5, 8, 13, 21, 34, 55, 89, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -84,10 +96,34 @@ public sealed partial class ThatAsyncEnumerable
 						             but not all were
 						             
 						             Not matching items:
-						             [1, 1, 2, 3, 8, 13, 21, 34, 55, 89, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               89,
+						               (… and maybe others)
+						             ]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.AreEquivalentTo.Tests.cs
@@ -44,7 +44,19 @@ public sealed partial class ThatAsyncEnumerable
 						             [2, 3, 5, 8, 13, 21, 34, 55, 89, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             
 						             Equivalency options:
 						              - include public fields and properties
@@ -88,10 +100,34 @@ public sealed partial class ThatAsyncEnumerable
 						             but not all were
 						             
 						             Not matching items:
-						             [1, 1, 2, 3, 8, 13, 21, 34, 55, 89, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               89,
+						               (… and maybe others)
+						             ]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             
 						             Equivalency options:
 						              - include public fields and properties

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Satisfy.Tests.cs
@@ -43,7 +43,19 @@ public sealed partial class ThatAsyncEnumerable
 						             [2, 3, 5, 8, 13, 21, 34, 55, 89, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -62,10 +74,34 @@ public sealed partial class ThatAsyncEnumerable
 						             but not all did
 						             
 						             Not matching items:
-						             [1, 1, 2, 3, 8, 13, 21, 34, 55, 89, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               89,
+						               (… and maybe others)
+						             ]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.AtMost.Tests.cs
@@ -65,7 +65,19 @@ public sealed partial class ThatAsyncEnumerable
 					             [1, 1, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Between.Tests.cs
@@ -62,7 +62,19 @@ public sealed partial class ThatAsyncEnumerable
 					             but at least 2 were
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Exactly.Tests.cs
@@ -62,7 +62,19 @@ public sealed partial class ThatAsyncEnumerable
 					             but at least 2 were
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.LessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.LessThan.Tests.cs
@@ -65,7 +65,19 @@ public sealed partial class ThatAsyncEnumerable
 					             [1, 1, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.AreEqualTo.Tests.cs
@@ -64,9 +64,21 @@ public sealed partial class ThatAsyncEnumerable
 
 						             Matching items:
 						             [5, (… and maybe others)]
-
+						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Satisfy.Tests.cs
@@ -66,7 +66,19 @@ public sealed partial class ThatAsyncEnumerable
 						             [5, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.None.Tests.cs
@@ -65,7 +65,19 @@ public sealed partial class ThatAsyncEnumerable
 					             [5, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.AreAllUnique.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.AreAllUnique.Tests.cs
@@ -44,6 +44,9 @@ public sealed partial class ThatDictionary
 					             only has unique values,
 					             but it contained 1 duplicate:
 					               1
+					             
+					             Dictionary:
+					             {[0] = 1, [1] = 2, [2] = 3, [3] = 1}
 					             """);
 			}
 
@@ -62,6 +65,9 @@ public sealed partial class ThatDictionary
 					             but it contained 2 duplicates:
 					               1,
 					               2
+					             
+					             Dictionary:
+					             {[0] = 1, [1] = 2, [2] = 3, [3] = 1, [4] = 2, [5] = -1}
 					             """);
 			}
 
@@ -131,6 +137,12 @@ public sealed partial class ThatDictionary
 					             only has unique values ignoring case,
 					             but it contained 1 duplicate:
 					               "A"
+					             
+					             Dictionary:
+					             {
+					               [0] = "a",
+					               [1] = "A"
+					             }
 					             """);
 			}
 
@@ -148,6 +160,14 @@ public sealed partial class ThatDictionary
 					             only has unique values,
 					             but it contained 1 duplicate:
 					               "a"
+					             
+					             Dictionary:
+					             {
+					               [0] = "a",
+					               [1] = "b",
+					               [2] = "c",
+					               [3] = "a"
+					             }
 					             """);
 			}
 
@@ -166,6 +186,16 @@ public sealed partial class ThatDictionary
 					             but it contained 2 duplicates:
 					               "a",
 					               "b"
+					             
+					             Dictionary:
+					             {
+					               [0] = "a",
+					               [1] = "b",
+					               [2] = "c",
+					               [3] = "a",
+					               [4] = "b",
+					               [5] = "x"
+					             }
 					             """);
 			}
 
@@ -224,6 +254,26 @@ public sealed partial class ThatDictionary
 					             only has unique values for x => x.Value,
 					             but it contained 1 duplicate:
 					               1
+					             
+					             Dictionary:
+					             {
+					               [0] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 1
+					               },
+					               [1] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 2
+					               },
+					               [2] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 3
+					               },
+					               [3] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 1
+					               }
+					             }
 					             """);
 			}
 
@@ -243,6 +293,34 @@ public sealed partial class ThatDictionary
 					             but it contained 2 duplicates:
 					               1,
 					               2
+					             
+					             Dictionary:
+					             {
+					               [0] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 1
+					               },
+					               [1] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 2
+					               },
+					               [2] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 3
+					               },
+					               [3] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 1
+					               },
+					               [4] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = 2
+					               },
+					               [5] = ThatDictionary.MyClass {
+					                 Inner = <null>,
+					                 Value = -1
+					               }
+					             }
 					             """);
 			}
 
@@ -312,6 +390,16 @@ public sealed partial class ThatDictionary
 					             only has unique values for x => x.Value ignoring case,
 					             but it contained 1 duplicate:
 					               "A"
+					             
+					             Dictionary:
+					             {
+					               [0] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "a"
+					               },
+					               [1] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "A"
+					               }
+					             }
 					             """);
 			}
 
@@ -330,6 +418,22 @@ public sealed partial class ThatDictionary
 					             only has unique values for x => x.Value,
 					             but it contained 1 duplicate:
 					               "a"
+					             
+					             Dictionary:
+					             {
+					               [0] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "a"
+					               },
+					               [1] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "b"
+					               },
+					               [2] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "c"
+					               },
+					               [3] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "a"
+					               }
+					             }
 					             """);
 			}
 
@@ -349,6 +453,28 @@ public sealed partial class ThatDictionary
 					             but it contained 2 duplicates:
 					               "a",
 					               "b"
+					             
+					             Dictionary:
+					             {
+					               [0] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "a"
+					               },
+					               [1] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "b"
+					               },
+					               [2] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "c"
+					               },
+					               [3] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "a"
+					               },
+					               [4] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "b"
+					               },
+					               [5] = ThatDictionary.AreAllUnique.StringMemberTests.MyStringClass {
+					                 Value = "x"
+					               }
+					             }
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEqualTo.Tests.cs
@@ -94,7 +94,19 @@ public sealed partial class ThatEnumerable
 						             [2, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -135,10 +147,34 @@ public sealed partial class ThatEnumerable
 						             but only 1 of 20 were
 						             
 						             Not matching items:
-						             [1, 1, 2, 3, 8, 13, 21, 34, 55, 89, …]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               89,
+						               …
+						             ]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, …]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               …
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreEquivalentTo.Tests.cs
@@ -44,7 +44,19 @@ public sealed partial class ThatEnumerable
 						             [2, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             
 						             Equivalency options:
 						              - include public fields and properties
@@ -77,10 +89,34 @@ public sealed partial class ThatEnumerable
 						             but only 1 of 20 were
 						             
 						             Not matching items:
-						             [1, 1, 2, 3, 8, 13, 21, 34, 55, 89, …]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               89,
+						               …
+						             ]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, …]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               …
+						             ]
 						             
 						             Equivalency options:
 						              - include public fields and properties

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Satisfy.Tests.cs
@@ -30,7 +30,19 @@ public sealed partial class ThatEnumerable
 						             but could not verify, because it was already cancelled
 						             
 						             Collection:
-						             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+						             [
+						               0,
+						               1,
+						               2,
+						               3,
+						               4,
+						               5,
+						               6,
+						               7,
+						               8,
+						               9,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -64,7 +76,19 @@ public sealed partial class ThatEnumerable
 						             [2, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.Tests.cs
@@ -29,7 +29,19 @@ public sealed partial class ThatEnumerable
 					             but could not verify, because it was already cancelled
 					             
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
@@ -29,7 +29,19 @@ public sealed partial class ThatEnumerable
 					             but could not verify, because it was already cancelled
 					             
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -63,7 +75,19 @@ public sealed partial class ThatEnumerable
 					             [1, 1, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -129,7 +153,16 @@ public sealed partial class ThatEnumerable
 					             [1, 1, 1, 1, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               1,
+					               1,
+					               2,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
@@ -29,7 +29,19 @@ public sealed partial class ThatEnumerable
 					             but could not verify, because it was already cancelled
 					             
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -60,7 +72,19 @@ public sealed partial class ThatEnumerable
 					             but at least 2 were
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -109,7 +133,16 @@ public sealed partial class ThatEnumerable
 					             but at least 4 were
 					             
 					             Collection:
-					             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               1,
+					               1,
+					               2,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
@@ -30,7 +30,19 @@ public sealed partial class ThatEnumerable
 					             but could not verify, because it was already cancelled
 					             
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -61,7 +73,19 @@ public sealed partial class ThatEnumerable
 					             but at least 2 were
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -110,7 +134,16 @@ public sealed partial class ThatEnumerable
 					             but at least 4 were
 					             
 					             Collection:
-					             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               1,
+					               1,
+					               2,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.LessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.LessThan.Tests.cs
@@ -29,7 +29,19 @@ public sealed partial class ThatEnumerable
 					             but could not verify, because it was already cancelled
 					             
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -63,7 +75,19 @@ public sealed partial class ThatEnumerable
 					             [1, 1, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -129,7 +153,16 @@ public sealed partial class ThatEnumerable
 					             [1, 1, 1, 1, (… and maybe others)]
 					             
 					             Collection:
-					             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+					             [
+					               1,
+					               1,
+					               1,
+					               1,
+					               2,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.MoreThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.MoreThan.Tests.cs
@@ -27,9 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             satisfies y => y < 6 for more than 6 items,
 					             but could not verify, because it was already cancelled
-
+					             
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.Tests.cs
@@ -31,7 +31,19 @@ public sealed partial class ThatEnumerable
 						             but could not verify, because it was already cancelled
 						             
 						             Collection:
-						             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+						             [
+						               0,
+						               1,
+						               2,
+						               3,
+						               4,
+						               5,
+						               6,
+						               7,
+						               8,
+						               9,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -65,7 +77,19 @@ public sealed partial class ThatEnumerable
 						             [5, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -87,7 +111,16 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               1,
+						               1,
+						               2,
+						               2,
+						               3,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.Satisfy.Tests.cs
@@ -31,7 +31,19 @@ public sealed partial class ThatEnumerable
 						             but could not verify, because it was already cancelled
 						             
 						             Collection:
-						             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
+						             [
+						               0,
+						               1,
+						               2,
+						               3,
+						               4,
+						               5,
+						               6,
+						               7,
+						               8,
+						               9,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -65,7 +77,19 @@ public sealed partial class ThatEnumerable
 						             [5, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -87,7 +111,16 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 						             
 						             Collection:
-						             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+						             [
+						               1,
+						               1,
+						               1,
+						               1,
+						               2,
+						               2,
+						               3,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -478,11 +478,11 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equivalent to [
-					               [1, 2],
-					               [3, 3],
-					               [4, 4]
-					             ],
+					             is equivalent to {
+					               [1] = 2,
+					               [3] = 3,
+					               [4] = 4
+					             },
 					             but it was not:
 					               Element [2] had superfluous 3
 					             and
@@ -491,7 +491,7 @@ public sealed partial class ThatObject
 					                 Expected: 3
 					             and
 					               Element [4] was missing 4
-
+					             
 					             Equivalency options:
 					              - include public fields and properties
 					              - ignore collection order
@@ -532,11 +532,11 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equivalent to [
-					               [1, 2],
-					               [2, 4],
-					               [3, 5]
-					             ],
+					             is equivalent to {
+					               [1] = 2,
+					               [2] = 4,
+					               [3] = 5
+					             },
 					             but it was not:
 					               Element [2] differed:
 					                    Found: 3
@@ -545,7 +545,7 @@ public sealed partial class ThatObject
 					               Element [3] differed:
 					                    Found: 4
 					                 Expected: 5
-
+					             
 					             Equivalency options:
 					              - include public fields and properties
 					              - ignore collection order
@@ -578,10 +578,10 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equivalent to [
-					               ["A", "A"],
-					               ["B", <null>]
-					             ],
+					             is equivalent to {
+					               ["A"] = "A",
+					               ["B"] = <null>
+					             },
 					             but it was not:
 					               Element [B] was missing <null>
 					             
@@ -674,12 +674,12 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is equivalent to [
-					               ["A", "A"]
-					             ],
+					             is equivalent to {
+					               ["A"] = "A"
+					             },
 					             but it was not:
 					               Element [B] had superfluous <null>
-
+					             
 					             Equivalency options:
 					              - include public fields and properties
 					             """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
@@ -564,14 +564,14 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not equivalent to [
-					               [2, 3],
-					               [1, 4]
-					             ],
-					             but it was considered equivalent to [
-					               [2, 3],
-					               [1, 4]
-					             ]
+					             is not equivalent to {
+					               [2] = 3,
+					               [1] = 4
+					             },
+					             but it was considered equivalent to {
+					               [2] = 3,
+					               [1] = 4
+					             }
 					             
 					             Equivalency options:
 					              - include public fields and properties
@@ -607,14 +607,14 @@ public sealed partial class ThatObject
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is not equivalent to [
-					               ["B", "B"],
-					               ["A", "A"]
-					             ],
-					             but it was considered equivalent to [
-					               ["A", "A"],
-					               ["B", "B"]
-					             ]
+					             is not equivalent to {
+					               ["B"] = "B",
+					               ["A"] = "A"
+					             },
+					             but it was considered equivalent to {
+					               ["A"] = "A",
+					               ["B"] = "B"
+					             }
 					             
 					             Equivalency options:
 					              - include public fields and properties


### PR DESCRIPTION
This PR enhances how dictionaries are formatted and integrates dictionary context into uniqueness checks, while also enabling count-sensitive formatting for collections and async enumerables.

- Use `{…}` with `"[key] = value"` syntax for dictionaries in both formatter and context helpers  
- Track element counts via a new `ICountable` interface to decide single- vs. multi-line formatting  
- Inject dictionary contexts into `AreAllUnique` constraints and update related tests accordingly