### PR TITLE
feat: add collection context information

### DIFF
--- a/Source/aweXpect/Helpers/IMaterializedEnumerable.cs
+++ b/Source/aweXpect/Helpers/IMaterializedEnumerable.cs
@@ -1,0 +1,10 @@
+#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+namespace aweXpect.Helpers;
+
+internal interface IMaterializedEnumerable<out T> : ICountable
+{
+	IReadOnlyList<T> MaterializedItems { get; }
+}
+#endif

--- a/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
+++ b/Source/aweXpect/Helpers/MaterializingAsyncEnumerable.cs
@@ -4,7 +4,7 @@ using System.Threading;
 
 namespace aweXpect.Helpers;
 
-internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>, ICountable
+internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>, IMaterializedEnumerable<T>
 {
 	private readonly IAsyncEnumerator<T> _enumerator;
 	private readonly List<T> _materializedItems = new();
@@ -35,11 +35,17 @@ internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>, ICo
 			_materializedItems.Add(item);
 			yield return item;
 		}
-		
+
 		Count = _materializedItems.Count;
 	}
 
 	#endregion
+
+	/// <inheritdoc cref="ICountable.Count" />
+	public int? Count { get; private set; }
+
+	/// <inheritdoc cref="IMaterializedEnumerable{T}.MaterializedItems" />
+	IReadOnlyList<T> IMaterializedEnumerable<T>.MaterializedItems => _materializedItems;
 
 	public static IAsyncEnumerable<T> Wrap(IAsyncEnumerable<T> enumerable)
 	{
@@ -50,7 +56,6 @@ internal sealed class MaterializingAsyncEnumerable<T> : IAsyncEnumerable<T>, ICo
 
 		return new MaterializingAsyncEnumerable<T>(enumerable);
 	}
-
-	public int? Count { get; private set; }
 }
+
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Contains.cs
@@ -29,10 +29,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		Quantifier quantifier = new();
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new ContainConstraint<TItem>(
-					it, grammars,
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(expected)}{options}"
 						: $"contains {Formatter.Format(expected)}{options} {q}",
@@ -53,10 +54,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		Quantifier quantifier = new();
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityTypeCountResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new ContainConstraint<string?>(
-					it, grammars,
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(expected)}{options}"
 						: $"contains {Formatter.Format(expected)}{options} {q}",
@@ -79,10 +81,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new ContainConstraint<TItem>(
-					it, grammars,
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}"
 						: $"contains item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} {q}",
@@ -103,9 +106,12 @@ public static partial class ThatAsyncEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionContainResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<TItem, TItem>(it, grammars, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TItem, TItem>(
+					expectationBuilder, it, grammars, 
+					doNotPopulateThisValue.TrimCommonWhiteSpace(), expected,
 					options, matchOptions)),
 			source,
 			options,
@@ -123,9 +129,12 @@ public static partial class ThatAsyncEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionContainResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<string?, string?>(it, grammars, doNotPopulateThisValue.TrimCommonWhiteSpace(),
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<string?, string?>(
+					expectationBuilder, it, grammars,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected, options, matchOptions)),
 			source,
 			options,
@@ -142,9 +151,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		Quantifier quantifier = new();
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainConstraint<TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainConstraint<TItem>(
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(unexpected)}{options}"
 						: $"does not contain {Formatter.Format(unexpected)}{options} {q.ToNegatedString()}",
@@ -165,9 +176,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		Quantifier quantifier = new();
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityTypeCountResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainConstraint<string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainConstraint<string?>(
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(unexpected)}{options}"
 						: $"does not contain {Formatter.Format(unexpected)}{options} {q.ToNegatedString()}",
@@ -190,9 +203,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CountResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainConstraint<TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainConstraint<TItem>(
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}"
 						: $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} {q.ToNegatedString()}",
@@ -203,6 +218,7 @@ public static partial class ThatAsyncEnumerable
 	}
 
 	private sealed class ContainConstraint<TItem>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		Func<Quantifier, string> expectationText,
@@ -259,10 +275,12 @@ public static partial class ThatAsyncEnumerable
 				if (_items.Count > maximumNumberOfCollectionItems && isFailed)
 				{
 					Outcome = Outcome.Failure;
+					expectationBuilder.AddCollectionContext(_items, true);
 					return this;
 				}
 			}
 
+			expectationBuilder.AddCollectionContext(_items);
 			if (quantifier.Check(_count, true) ?? _isNegated)
 			{
 				Outcome = Outcome.Success;
@@ -287,40 +305,36 @@ public static partial class ThatAsyncEnumerable
 			{
 				if (_count == 0)
 				{
-					stringBuilder.Append(it).Append(" did not contain it in ");
+					stringBuilder.Append(it).Append(" did not contain it");
 				}
 				else if (_count == 1)
 				{
-					stringBuilder.Append(it).Append(" contained it once in ");
+					stringBuilder.Append(it).Append(" contained it once");
 				}
 				else if (_count == 2)
 				{
-					stringBuilder.Append(it).Append(" contained it twice in ");
+					stringBuilder.Append(it).Append(" contained it twice");
 				}
 				else
 				{
-					stringBuilder.Append(it).Append(" contained it ").Append(_count).Append(" times in ");
+					stringBuilder.Append(it).Append(" contained it ").Append(_count).Append(" times");
 				}
-
-				Formatter.Format(stringBuilder, _items, FormattingOptions.MultipleLines);
 			}
 			else
 			{
 				stringBuilder.Append(it).Append(" contained it at least ");
 				if (_count == 1)
 				{
-					stringBuilder.Append("once in ");
+					stringBuilder.Append("once");
 				}
 				else if (_count == 2)
 				{
-					stringBuilder.Append("twice in ");
+					stringBuilder.Append("twice");
 				}
 				else
 				{
-					stringBuilder.Append(_count).Append(" times in ");
+					stringBuilder.Append(_count).Append(" times");
 				}
-
-				Formatter.Format(stringBuilder, _items, FormattingOptions.MultipleLines);
 			}
 		}
 

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.EndsWith.cs
@@ -30,9 +30,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -50,9 +51,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected,
 					options)),
@@ -71,9 +73,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -91,9 +94,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected,
 					options)),
@@ -113,9 +117,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -133,9 +138,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected,
 					options).Invert()),
@@ -155,9 +161,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -175,9 +182,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new EndsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected,
 					options).Invert()),
@@ -193,6 +201,7 @@ public static partial class ThatAsyncEnumerable
 		private readonly TItem[] _expected;
 		private readonly string _expectedExpression;
 		private readonly List<TItem> _foundValues = [];
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly string _it;
 		private readonly IOptionsEquality<TMatch> _options;
 		private TItem? _firstMismatchItem;
@@ -201,12 +210,15 @@ public static partial class ThatAsyncEnumerable
 		private int _itemsCount;
 		private int _offset;
 
-		public EndsWithConstraint(string it,
+		public EndsWithConstraint(
+			ExpectationBuilder expectationBuilder,
+			string it,
 			ExpectationGrammars grammars,
 			string expectedExpression,
 			TItem[] expected,
 			IOptionsEquality<TMatch> options) : base(it, grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_it = it;
 			_expectedExpression = expectedExpression;
 			_expected = expected;
@@ -254,6 +266,7 @@ public static partial class ThatAsyncEnumerable
 				if (_index + _offset < 0)
 				{
 					Outcome = Outcome.Failure;
+					_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 					return this;
 				}
 
@@ -263,6 +276,7 @@ public static partial class ThatAsyncEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
+					_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>, true);
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasCount.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasCount.cs
@@ -14,28 +14,42 @@ public static partial class ThatAsyncEnumerable
 	/// </summary>
 	public static CollectionCountResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>>
 		HasCount<TItem>(this IThat<IAsyncEnumerable<TItem>?> subject)
-		=> new(quantifier => new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AsyncCollectionCountConstraint<TItem>(it, grammars, quantifier)),
-			subject));
+	{
+		ExpectationBuilder expectationBuilder = subject.Get().ExpectationBuilder;
+		return new
+			CollectionCountResult<AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>>(quantifier
+				=> new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
+					expectationBuilder.AddConstraint((it, grammars)
+						=> new AsyncCollectionCountConstraint<TItem>(expectationBuilder, it, grammars, quantifier)),
+					subject));
+	}
 
 	/// <summary>
 	///     Verifies that the <paramref name="subject" /> has exactly <paramref name="expected" /> items.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>
 		HasCount<TItem>(this IThat<IAsyncEnumerable<TItem>?> subject, int expected)
-		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AsyncCollectionCountConstraint<TItem>(it, grammars, EnumerableQuantifier.Exactly(expected))),
+	{
+		ExpectationBuilder expectationBuilder = subject.Get().ExpectationBuilder;
+		return new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new AsyncCollectionCountConstraint<TItem>(expectationBuilder, it, grammars,
+					EnumerableQuantifier.Exactly(expected))),
 			subject);
+	}
 
 	/// <summary>
 	///     Verifies that the <paramref name="subject" /> does not have <paramref name="unexpected" /> items.
 	/// </summary>
 	public static AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>
 		DoesNotHaveCount<TItem>(this IThat<IAsyncEnumerable<TItem>?> subject, int unexpected)
-		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+	{
+		ExpectationBuilder expectationBuilder = subject.Get().ExpectationBuilder;
+		return new AndOrResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
+			expectationBuilder.AddConstraint((it, grammars)
 				=> new AsyncCollectionCountConstraint<TItem>(
-					it, grammars, EnumerableQuantifier.Exactly(unexpected)).Invert()),
+					expectationBuilder, it, grammars, EnumerableQuantifier.Exactly(unexpected)).Invert()),
 			subject);
+	}
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
@@ -23,9 +23,10 @@ public static partial class ThatAsyncEnumerable
 		this IThat<IAsyncEnumerable<TItem>?> source)
 	{
 		PredicateOptions<TItem> options = new();
-		return new SingleItemResult<IAsyncEnumerable<TItem>, TItem>.Async(source.Get().ExpectationBuilder
-				.AddConstraint((it, grammars) =>
-					new HasSingleConstraint<TItem>(it, grammars, options)),
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new SingleItemResult<IAsyncEnumerable<TItem>, TItem>.Async(
+			expectationBuilder.AddConstraint((it, grammars) =>
+					new HasSingleConstraint<TItem>(expectationBuilder, it, grammars, options)),
 			options,
 			async f =>
 			{
@@ -42,6 +43,7 @@ public static partial class ThatAsyncEnumerable
 	}
 
 	private sealed class HasSingleConstraint<TItem>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		PredicateOptions<TItem> options)
@@ -83,6 +85,10 @@ public static partial class ThatAsyncEnumerable
 			}
 
 			Outcome = _count == 1 ? Outcome.Success : Outcome.Failure;
+			if (_count > 1)
+			{
+				expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
+			}
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsContainedIn.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsContainedIn.cs
@@ -21,10 +21,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.IsContainedIn);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new
 			ObjectCollectionBeContainedInResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-					new IsEqualToConstraint<TItem, TItem>(it, grammars,
+				expectationBuilder.AddConstraint((it, grammars) =>
+					new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 						doNotPopulateThisValue.TrimCommonWhiteSpace(),
 						expected,
 						options,
@@ -46,10 +47,11 @@ public static partial class ThatAsyncEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.IsContainedIn);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionBeContainedInResult<IAsyncEnumerable<string?>,
 			IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsEqualTo.cs
@@ -23,9 +23,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,
@@ -48,10 +49,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<double, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>,
 			double, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double, double>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double, double>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -74,10 +76,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<double?, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>,
 			IThat<IAsyncEnumerable<double?>?>, double?, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double?, double?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double?, double?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -100,11 +103,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>
 			,
 			decimal, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal, decimal>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal, decimal>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -128,11 +132,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>,
 			IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal?, decimal?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal?, decimal?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -155,10 +160,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<float, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>,
 			float, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float, float>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float, float>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -181,10 +187,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<float?, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>,
 			float?, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float?, float?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float?, float?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -208,11 +215,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>,
 			IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime, DateTime>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime, DateTime>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -236,11 +244,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>,
 			IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime?, DateTime?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime?, DateTime?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -261,9 +270,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionMatchResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,
@@ -285,9 +295,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected,
 					options,
@@ -311,10 +322,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<double, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double>, IThat<IAsyncEnumerable<double>?>,
 			double, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double, double>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double, double>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -338,11 +350,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<double?, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<double?>, IThat<IAsyncEnumerable<double?>?>
 			,
 			double?, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double?, double?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double?, double?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -366,11 +379,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal>, IThat<IAsyncEnumerable<decimal>?>
 			,
 			decimal, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal, decimal>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal, decimal>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -395,11 +409,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<decimal?>,
 			IThat<IAsyncEnumerable<decimal?>?>,
 			decimal?, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal?, decimal?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal?, decimal?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -423,10 +438,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<float, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float>, IThat<IAsyncEnumerable<float>?>,
 			float, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float, float>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float, float>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -450,10 +466,11 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<float?, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<float?>, IThat<IAsyncEnumerable<float?>?>,
 			float?, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float?, float?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float?, float?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -478,11 +495,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime>,
 			IThat<IAsyncEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime, DateTime>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime, DateTime>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -507,11 +525,12 @@ public static partial class ThatAsyncEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IAsyncEnumerable<DateTime?>,
 			IThat<IAsyncEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime?, DateTime?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime?, DateTime?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -533,9 +552,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionMatchResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected,
 					options,

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInAscendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInAscendingOrder.cs
@@ -20,9 +20,12 @@ public static partial class ThatAsyncEnumerable
 		IsInAscendingOrder<TItem>(this IThat<IAsyncEnumerable<TItem>?> source)
 	{
 		CollectionOrderOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TItem, IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsInOrderConstraint<TItem, TItem>(it, grammars, x => x, SortOrder.Ascending, options, "")),
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsInOrderConstraint<TItem, TItem>(
+					expectationBuilder, it, grammars,
+					x => x, SortOrder.Ascending, options, "")),
 			source,
 			options);
 	}
@@ -37,9 +40,12 @@ public static partial class ThatAsyncEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		CollectionOrderOptions<TMember> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TMember, IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsInOrderConstraint<TItem, TMember>(it, grammars, memberAccessor, SortOrder.Ascending, options,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsInOrderConstraint<TItem, TMember>(
+					expectationBuilder, it, grammars,
+					memberAccessor, SortOrder.Ascending, options,
 					$" for {doNotPopulateThisValue.TrimCommonWhiteSpace()}")),
 			source,
 			options);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInDescendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.IsInDescendingOrder.cs
@@ -21,9 +21,12 @@ public static partial class ThatAsyncEnumerable
 			this IThat<IAsyncEnumerable<TItem>?> source)
 	{
 		CollectionOrderOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TItem, IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsInOrderConstraint<TItem, TItem>(it, grammars, x => x, SortOrder.Descending, options, "")),
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsInOrderConstraint<TItem, TItem>(
+					expectationBuilder, it, grammars,
+					x => x, SortOrder.Descending, options, "")),
 			source,
 			options);
 	}
@@ -40,9 +43,12 @@ public static partial class ThatAsyncEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		CollectionOrderOptions<TMember> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TMember, IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsInOrderConstraint<TItem, TMember>(it, grammars, memberAccessor, SortOrder.Descending, options,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsInOrderConstraint<TItem, TMember>(
+					expectationBuilder, it, grammars,
+					memberAccessor, SortOrder.Descending, options,
 					$" for {doNotPopulateThisValue.TrimCommonWhiteSpace()}")),
 			source,
 			options);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.StartsWith.cs
@@ -30,9 +30,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -50,9 +51,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected,
 					options)),
@@ -71,9 +73,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -91,9 +94,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(expected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected,
 					options)),
@@ -113,9 +117,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -133,9 +138,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IAsyncEnumerable<TItem>, IThat<IAsyncEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected,
 					options).Invert()),
@@ -155,9 +161,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -175,9 +182,10 @@ public static partial class ThatAsyncEnumerable
 	{
 		ArgumentNullException.ThrowIfNull(unexpected);
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IAsyncEnumerable<string?>, IThat<IAsyncEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new StartsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected,
 					options).Invert()),
@@ -193,18 +201,22 @@ public static partial class ThatAsyncEnumerable
 		private readonly TItem[] _expected;
 		private readonly string _expectedExpression;
 		private readonly List<TItem> _foundValues = [];
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly string _it;
 		private readonly IOptionsEquality<TMatch> _options;
 		private TItem? _firstMismatchItem;
 		private bool _foundMismatch;
 		private int _index;
 
-		public StartsWithConstraint(string it,
+		public StartsWithConstraint(
+			ExpectationBuilder expectationBuilder,
+			string it,
 			ExpectationGrammars grammars,
 			string expectedExpression,
 			TItem[] expected,
 			IOptionsEquality<TMatch> options) : base(it, grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_it = it;
 			_expectedExpression = expectedExpression;
 			_expected = expected;
@@ -247,6 +259,7 @@ public static partial class ThatAsyncEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
+					_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>, true);
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -259,6 +272,7 @@ public static partial class ThatAsyncEnumerable
 				}
 			}
 
+			_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 			Outcome = Outcome.Failure;
 			return this;
 		}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
@@ -111,7 +111,7 @@ public static partial class ThatAsyncEnumerable
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 			AppendContexts(false);
-			_expectationBuilder.AddCollectionContext(items, false);
+			_expectationBuilder.AddCollectionContext(items);
 			return this;
 		}
 
@@ -205,15 +205,21 @@ public static partial class ThatAsyncEnumerable
 		: ConstraintResult.WithNotNullValue<IAsyncEnumerable<TItem>?>,
 			IAsyncContextConstraint<IAsyncEnumerable<TItem>?>
 	{
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly ExpectationGrammars _grammars;
 		private readonly EnumerableQuantifier _quantifier;
 		private int _matchingCount;
 		private int _notMatchingCount;
 		private int? _totalCount;
 
-		public AsyncCollectionCountConstraint(string it, ExpectationGrammars grammars, EnumerableQuantifier quantifier)
+		public AsyncCollectionCountConstraint(
+			ExpectationBuilder expectationBuilder,
+			string it,
+			ExpectationGrammars grammars,
+			EnumerableQuantifier quantifier)
 			: base(it, grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_grammars = grammars;
 			_quantifier = quantifier;
 		}
@@ -242,6 +248,7 @@ public static partial class ThatAsyncEnumerable
 				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+					_expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>, true);
 					return this;
 				}
 			}
@@ -249,11 +256,13 @@ public static partial class ThatAsyncEnumerable
 			if (cancellationToken.IsCancellationRequested)
 			{
 				Outcome = Outcome.Undecided;
+				_expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>, true);
 				return this;
 			}
 
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+			_expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
 			return this;
 		}
 
@@ -300,6 +309,7 @@ public static partial class ThatAsyncEnumerable
 	}
 
 	private sealed class IsEqualToConstraint<TItem, TMatch>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		string expectedExpression,
@@ -341,15 +351,17 @@ public static partial class ThatAsyncEnumerable
 
 				if (matcher.Verify(It, item, options, maximumNumber, out _failure))
 				{
-					_failure ??= await TooManyDeviationsError(materializedEnumerable);
+					_failure ??= TooManyDeviationsError();
 					Outcome = Outcome.Failure;
+					expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>, true);
 					return this;
 				}
 			}
 
+			expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 			if (matcher.VerifyComplete(It, options, maximumNumber, out _failure))
 			{
-				_failure ??= await TooManyDeviationsError(materializedEnumerable);
+				_failure ??= TooManyDeviationsError();
 				Outcome = Outcome.Failure;
 				return this;
 			}
@@ -358,36 +370,13 @@ public static partial class ThatAsyncEnumerable
 			return this;
 		}
 
-		private async Task<string> TooManyDeviationsError(IAsyncEnumerable<TItem> materializedEnumerable)
+		private string TooManyDeviationsError()
 		{
-			StringBuilder sb = new();
-			sb.Append(It);
-			sb.Append(" was completely different: [");
-			int count = 0;
 			int maximumNumberOfCollectionItems =
 				Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
-			await foreach (TItem item in materializedEnumerable)
-			{
-				if (count++ >= maximumNumberOfCollectionItems)
-				{
-					break;
-				}
-
-				sb.AppendLine();
-				sb.Append("  ");
-				Formatter.Format(sb, item);
-				sb.Append(',');
-			}
-
-			if (count > maximumNumberOfCollectionItems)
-			{
-				sb.AppendLine();
-				sb.Append("  …,");
-			}
-
-			sb.Length--;
-			sb.AppendLine();
-			sb.Append("] had more than ");
+			StringBuilder sb = new();
+			sb.Append(It);
+			sb.Append(" had more than ");
 			sb.Append(2 * maximumNumberOfCollectionItems);
 			sb.Append(" deviations compared to ");
 			Formatter.Format(sb, expected?.Take(maximumNumberOfCollectionItems + 1),
@@ -424,13 +413,13 @@ public static partial class ThatAsyncEnumerable
 			}
 			else
 			{
-				stringBuilder.Append(It).Append(" did in ");
-				Formatter.Format(stringBuilder, _items, FormattingOptions.MultipleLines);
+				stringBuilder.Append(It).Append(" did");
 			}
 		}
 	}
 
 	private sealed class IsInOrderConstraint<TItem, TMember>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		Func<TItem, TMember> memberAccessor,
@@ -455,6 +444,7 @@ public static partial class ThatAsyncEnumerable
 
 			IAsyncEnumerable<TItem> materialized = context
 				.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
+			expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
 
 			TMember previous = default!;
 			int index = 0;
@@ -481,7 +471,7 @@ public static partial class ThatAsyncEnumerable
 				    (comparisonResult < 0 && sortOrder == SortOrder.Descending))
 				{
 					_failureText ??=
-						$"{It} had {Formatter.Format(previous)} before {Formatter.Format(current)} which is not in {sortOrder.ToString().ToLower()} order in ";
+						$"{It} had {Formatter.Format(previous)} before {Formatter.Format(current)} which is not in {sortOrder.ToString().ToLower()} order";
 				}
 
 				if (_failureText != null && _values.Count > maximumNumberOfCollectionItems)
@@ -503,10 +493,7 @@ public static partial class ThatAsyncEnumerable
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(_failureText);
-			Formatter.Format(stringBuilder, _values, FormattingOptions.MultipleLines);
-		}
+			=> stringBuilder.Append(_failureText);
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -515,10 +502,7 @@ public static partial class ThatAsyncEnumerable
 		}
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(It).Append(" was in ");
-			Formatter.Format(stringBuilder, _values, FormattingOptions.MultipleLines);
-		}
+			=> stringBuilder.Append(It).Append(" was");
 	}
 }
 #endif

--- a/Source/aweXpect/That/Collections/ThatDictionary.ContainsValue.cs
+++ b/Source/aweXpect/That/Collections/ThatDictionary.ContainsValue.cs
@@ -15,11 +15,14 @@ public static partial class ThatDictionary
 		TValue>(
 		this IThat<IDictionary<TKey, TValue>?> source,
 		TValue expected)
-		=> new(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainValueConstraint<TKey, TValue>(it, grammars, expected)),
+	{
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new AndOrResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>>(
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainValueConstraint<TKey, TValue>(expectationBuilder, it, grammars, expected)),
 			source
 		);
+	}
 
 	/// <summary>
 	///     Verifies that the dictionary does not contain the <paramref name="unexpected" /> value.
@@ -28,13 +31,17 @@ public static partial class ThatDictionary
 		DoesNotContainValue<TKey, TValue>(
 			this IThat<IDictionary<TKey, TValue>?> source,
 			TValue unexpected)
-		=> new(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainValueConstraint<TKey, TValue>(it, grammars, unexpected).Invert()),
+	{
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new AndOrResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>>(
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainValueConstraint<TKey, TValue>(expectationBuilder, it, grammars, unexpected).Invert()),
 			source
 		);
+	}
 
-	private sealed class ContainValueConstraint<TKey, TValue>(string it, ExpectationGrammars grammars, TValue expected)
+	private sealed class ContainValueConstraint<TKey, TValue>(
+		ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars, TValue expected)
 		: ConstraintResult.WithNotNullValue<IDictionary<TKey, TValue>?>(it, grammars),
 			IValueConstraint<IDictionary<TKey, TValue>?>
 	{
@@ -42,6 +49,7 @@ public static partial class ThatDictionary
 		{
 			Actual = actual;
 			Outcome = actual?.ContainsValue(expected) == true ? Outcome.Success : Outcome.Failure;
+			expectationBuilder.AddCollectionContext(actual);
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatDictionary.ContainsValues.cs
+++ b/Source/aweXpect/That/Collections/ThatDictionary.ContainsValues.cs
@@ -15,11 +15,14 @@ public static partial class ThatDictionary
 		TValue>(
 		this IThat<IDictionary<TKey, TValue>?> source,
 		params TValue[] expected)
-		=> new(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainValuesConstraint<TKey, TValue>(it, grammars, expected)),
+	{
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new AndOrResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>>(
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainValuesConstraint<TKey, TValue>(expectationBuilder, it, grammars, expected)),
 			source
 		);
+	}
 
 	/// <summary>
 	///     Verifies that the dictionary contains none of the <paramref name="unexpected" /> values.
@@ -29,16 +32,17 @@ public static partial class ThatDictionary
 			TValue>(
 			this IThat<IDictionary<TKey, TValue>?> source,
 			params TValue[] unexpected)
-		=> new(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainValuesConstraint<TKey, TValue>(it, grammars, unexpected).Invert()),
+	{
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new AndOrResult<IDictionary<TKey, TValue>, IThat<IDictionary<TKey, TValue>?>>(
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainValuesConstraint<TKey, TValue>(expectationBuilder, it, grammars, unexpected).Invert()),
 			source
 		);
+	}
 
 	private sealed class ContainValuesConstraint<TKey, TValue>(
-		string it,
-		ExpectationGrammars grammars,
-		TValue[] expected)
+		ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars, TValue[] expected)
 		: ConstraintResult.WithNotNullValue<IDictionary<TKey, TValue>?>(it, grammars),
 			IValueConstraint<IDictionary<TKey, TValue>?>
 	{
@@ -72,6 +76,7 @@ public static partial class ThatDictionary
 				(false, [], _) => Outcome.Success,
 				(false, _, _) => Outcome.Failure,
 			};
+			expectationBuilder.AddCollectionContext(actual);
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -255,6 +255,7 @@ public static partial class ThatEnumerable
 				}
 			}
 
+			expectationBuilder.AddCollectionContext(_materializedEnumerable);
 			if (quantifier.Check(_count, true) ?? _isNegated)
 			{
 				Outcome = Outcome.Success;
@@ -263,7 +264,6 @@ public static partial class ThatEnumerable
 
 			_isFinished = true;
 			Outcome = Outcome.Failure;
-			expectationBuilder.AddCollectionContext(_materializedEnumerable);
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -26,9 +26,11 @@ public static partial class ThatEnumerable
 	{
 		Quantifier quantifier = new();
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new ContainConstraint<TItem>(
+					expectationBuilder,
 					it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(expected)}{options}"
@@ -49,10 +51,11 @@ public static partial class ThatEnumerable
 	{
 		Quantifier quantifier = new();
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityTypeCountResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new ContainConstraint<string?>(
-					it, grammars,
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(expected)}{options}"
 						: $"contains {Formatter.Format(expected)}{options} {q}",
@@ -75,10 +78,11 @@ public static partial class ThatEnumerable
 	{
 		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			expectationBuilder.AddConstraint((it, grammars) =>
 				new ContainConstraint<TItem>(
-					it, grammars,
+					expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}"
 						: $"contains item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} {q}",
@@ -99,9 +103,12 @@ public static partial class ThatEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionContainResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<TItem, TItem>(it, grammars, doNotPopulateThisValue.TrimCommonWhiteSpace(), expected,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
+					doNotPopulateThisValue.TrimCommonWhiteSpace(),
+					expected,
 					options, matchOptions)),
 			source,
 			options,
@@ -118,9 +125,10 @@ public static partial class ThatEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.Contains);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionContainResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<string?, string?>(it, grammars, doNotPopulateThisValue.TrimCommonWhiteSpace(),
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars, doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected, options, matchOptions)),
 			source,
 			options,
@@ -137,9 +145,10 @@ public static partial class ThatEnumerable
 	{
 		Quantifier quantifier = new();
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainConstraint<TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainConstraint<TItem>(expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(unexpected)}{options}"
 						: $"does not contain {Formatter.Format(unexpected)}{options} {q.ToNegatedString()}",
@@ -160,9 +169,10 @@ public static partial class ThatEnumerable
 	{
 		Quantifier quantifier = new();
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityTypeCountResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainConstraint<string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainConstraint<string?>(expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain {Formatter.Format(unexpected)}{options}"
 						: $"does not contain {Formatter.Format(unexpected)}{options} {q.ToNegatedString()}",
@@ -185,9 +195,10 @@ public static partial class ThatEnumerable
 	{
 		predicate.ThrowIfNull();
 		Quantifier quantifier = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CountResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new ContainConstraint<TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new ContainConstraint<TItem>(expectationBuilder, it, grammars,
 					q => q.IsNever
 						? $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}"
 						: $"does not contain item matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} {q.ToNegatedString()}",
@@ -198,6 +209,7 @@ public static partial class ThatEnumerable
 	}
 
 	private sealed class ContainConstraint<TItem>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		Func<Quantifier, string> expectationText,
@@ -234,6 +246,7 @@ public static partial class ThatEnumerable
 					{
 						case false:
 							Outcome = Outcome.Failure;
+							expectationBuilder.AddCollectionContext(_materializedEnumerable);
 							return this;
 						case true:
 							Outcome = Outcome.Success;
@@ -250,6 +263,7 @@ public static partial class ThatEnumerable
 
 			_isFinished = true;
 			Outcome = Outcome.Failure;
+			expectationBuilder.AddCollectionContext(_materializedEnumerable);
 			return this;
 		}
 
@@ -266,40 +280,36 @@ public static partial class ThatEnumerable
 			{
 				if (_count == 0)
 				{
-					stringBuilder.Append(it).Append(" did not contain it in ");
+					stringBuilder.Append(it).Append(" did not contain it");
 				}
 				else if (_count == 1)
 				{
-					stringBuilder.Append(it).Append(" contained it once in ");
+					stringBuilder.Append(it).Append(" contained it once");
 				}
 				else if (_count == 2)
 				{
-					stringBuilder.Append(it).Append(" contained it twice in ");
+					stringBuilder.Append(it).Append(" contained it twice");
 				}
 				else
 				{
-					stringBuilder.Append(it).Append(" contained it ").Append(_count).Append(" times in ");
+					stringBuilder.Append(it).Append(" contained it ").Append(_count).Append(" times");
 				}
-
-				Formatter.Format(stringBuilder, _materializedEnumerable, FormattingOptions.MultipleLines);
 			}
 			else
 			{
 				stringBuilder.Append(it).Append(" contained it at least ");
 				if (_count == 1)
 				{
-					stringBuilder.Append("once in ");
+					stringBuilder.Append("once");
 				}
 				else if (_count == 2)
 				{
-					stringBuilder.Append("twice in ");
+					stringBuilder.Append("twice");
 				}
 				else
 				{
-					stringBuilder.Append(_count).Append(" times in ");
+					stringBuilder.Append(_count).Append(" times");
 				}
-
-				Formatter.Format(stringBuilder, _materializedEnumerable, FormattingOptions.MultipleLines);
 			}
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
@@ -238,7 +238,7 @@ public static partial class ThatEnumerable
 				if (_index + _offset < 0)
 				{
 					Outcome = Outcome.Failure;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable, false);
+					_expectationBuilder.AddCollectionContext(materializedEnumerable);
 					return this;
 				}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
@@ -25,9 +25,10 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -44,9 +45,10 @@ public static partial class ThatEnumerable
 			params TItem[] expected)
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected ?? throw new ArgumentNullException(nameof(expected)),
 					options)),
@@ -64,9 +66,10 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -83,9 +86,10 @@ public static partial class ThatEnumerable
 			params string[] expected)
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected ?? throw new ArgumentNullException(nameof(expected)),
 					options)),
@@ -104,9 +108,10 @@ public static partial class ThatEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -123,9 +128,10 @@ public static partial class ThatEnumerable
 			params TItem[] unexpected)
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected ?? throw new ArgumentNullException(nameof(unexpected)),
 					options).Invert()),
@@ -144,9 +150,10 @@ public static partial class ThatEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -163,9 +170,10 @@ public static partial class ThatEnumerable
 			params string[] unexpected)
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new EndsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new EndsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected ?? throw new ArgumentNullException(nameof(unexpected)),
 					options).Invert()),
@@ -180,6 +188,7 @@ public static partial class ThatEnumerable
 	{
 		private readonly TItem[] _expected;
 		private readonly string _expectedExpression;
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly string _it;
 		private readonly IOptionsEquality<TMatch> _options;
 		private TItem? _firstMismatchItem;
@@ -188,12 +197,15 @@ public static partial class ThatEnumerable
 		private int _itemsCount;
 		private int _offset;
 
-		public EndsWithConstraint(string it,
+		public EndsWithConstraint(
+			ExpectationBuilder expectationBuilder,
+			string it,
 			ExpectationGrammars grammars,
 			string expectedExpression,
 			TItem[] expected,
 			IOptionsEquality<TMatch> options) : base(it, grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_it = it;
 			_expectedExpression = expectedExpression;
 			_expected = expected;
@@ -226,6 +238,7 @@ public static partial class ThatEnumerable
 				if (_index + _offset < 0)
 				{
 					Outcome = Outcome.Failure;
+					_expectationBuilder.AddCollectionContext(materializedEnumerable, false);
 					return this;
 				}
 
@@ -235,6 +248,7 @@ public static partial class ThatEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
+					_expectationBuilder.AddCollectionContext(materializedEnumerable, true);
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasCount.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasCount.cs
@@ -13,29 +13,39 @@ public static partial class ThatEnumerable
 	/// </summary>
 	public static CollectionCountResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>> HasCount<TItem>(
 		this IThat<IEnumerable<TItem>?> subject)
-		=> new(quantifier => new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new SyncCollectionCountConstraint<TItem>(it, grammars, quantifier)),
+	{
+		ExpectationBuilder expectationBuilder = subject.Get().ExpectationBuilder;
+		return new CollectionCountResult<AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>>(quantifier => new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new SyncCollectionCountConstraint<TItem>(expectationBuilder, it, grammars, quantifier)),
 			subject));
+	}
 
 	/// <summary>
 	///     Verifies that the <paramref name="subject" /> has exactly <paramref name="expected" /> items.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>> HasCount<TItem>(
 		this IThat<IEnumerable<TItem>?> subject, int expected)
-		=> new(
-			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new SyncCollectionCountConstraint<TItem>(it, grammars, EnumerableQuantifier.Exactly(expected))),
+	{
+		ExpectationBuilder expectationBuilder = subject.Get().ExpectationBuilder;
+		return new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new SyncCollectionCountConstraint<TItem>(expectationBuilder, it, grammars,
+					EnumerableQuantifier.Exactly(expected))),
 			subject);
+	}
 
 	/// <summary>
 	///     Verifies that the <paramref name="subject" /> does not have <paramref name="unexpected" /> items.
 	/// </summary>
 	public static AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>> DoesNotHaveCount<TItem>(
 		this IThat<IEnumerable<TItem>?> subject, int unexpected)
-		=> new(
-			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new SyncCollectionCountConstraint<TItem>(
-					it, grammars, EnumerableQuantifier.Exactly(unexpected)).Invert()),
+	{
+		ExpectationBuilder expectationBuilder = subject.Get().ExpectationBuilder;
+		return new AndOrResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new SyncCollectionCountConstraint<TItem>(expectationBuilder, it, grammars,
+					EnumerableQuantifier.Exactly(unexpected)).Invert()),
 			subject);
+	}
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasSingle.cs
@@ -21,14 +21,17 @@ public static partial class ThatEnumerable
 		this IThat<IEnumerable<TItem>?> source)
 	{
 		PredicateOptions<TItem> options = new();
-		return new SingleItemResult<IEnumerable<TItem>, TItem>(source.Get().ExpectationBuilder
-				.AddConstraint((it, grammars) => new HasSingleConstraint<TItem>(it, grammars, options)),
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new SingleItemResult<IEnumerable<TItem>, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasSingleConstraint<TItem>(expectationBuilder, it, grammars, options)),
 			options,
 			f => f.FirstOrDefault(item => options.Matches(item))
 		);
 	}
 
 	private sealed class HasSingleConstraint<TItem>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		PredicateOptions<TItem> options)
@@ -68,6 +71,11 @@ public static partial class ThatEnumerable
 			}
 
 			Outcome = _count == 1 ? Outcome.Success : Outcome.Failure;
+			if (_count > 1)
+			{
+				expectationBuilder.AddCollectionContext(materialized);
+			}
+
 			return this;
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsContainedIn.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsContainedIn.cs
@@ -20,9 +20,10 @@ public static partial class ThatEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.IsContainedIn);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionBeContainedInResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,
@@ -42,9 +43,10 @@ public static partial class ThatEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new(CollectionMatchOptions.EquivalenceRelations.IsContainedIn);
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionBeContainedInResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new IsEqualToConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars) =>
+				new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
@@ -22,9 +22,10 @@ public static partial class ThatEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,
@@ -47,10 +48,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<double, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double>, IThat<IEnumerable<double>?>,
 			double, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double, double>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double, double>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -73,10 +75,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<double?, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>,
 			double?, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double?, double?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double?, double?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -99,10 +102,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>,
 			decimal, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal, decimal>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal, decimal>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -125,10 +129,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>,
 			decimal?, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal?, decimal?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal?, decimal?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -151,10 +156,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<float, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float>, IThat<IEnumerable<float>?>,
 			float, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float, float>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float, float>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -177,10 +183,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<float?, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>,
 			float?, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float?, float?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float?, float?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -203,10 +210,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime, DateTime>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime, DateTime>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -229,10 +237,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime?, DateTime?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime?, DateTime?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					expected,
 					options,
@@ -252,9 +261,10 @@ public static partial class ThatEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionMatchResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected,
 					options,
@@ -276,9 +286,10 @@ public static partial class ThatEnumerable
 	{
 		ObjectEqualityOptions<TItem> options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected,
 					options,
@@ -302,10 +313,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<double, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double>, IThat<IEnumerable<double>?>,
 			double, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double, double>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double, double>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -329,10 +341,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<double?, double> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDouble();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<double?>, IThat<IEnumerable<double?>?>,
 			double?, double>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<double?, double?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<double?, double?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -356,10 +369,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<decimal, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal>, IThat<IEnumerable<decimal>?>,
 			decimal, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal, decimal>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal, decimal>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -383,10 +397,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<decimal?, decimal> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDecimal();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<decimal?>, IThat<IEnumerable<decimal?>?>,
 			decimal?, decimal>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<decimal?, decimal?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<decimal?, decimal?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -410,10 +425,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<float, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float>, IThat<IEnumerable<float>?>,
 			float, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float, float>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float, float>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -437,10 +453,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<float?, float> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableFloat();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<float?>, IThat<IEnumerable<float?>?>,
 			float?, float>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<float?, float?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<float?, float?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -464,10 +481,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime>, IThat<IEnumerable<DateTime>?>,
 			DateTime, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime, DateTime>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime, DateTime>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -491,10 +509,11 @@ public static partial class ThatEnumerable
 		ObjectEqualityWithToleranceOptions<DateTime?, TimeSpan> options =
 			ObjectEqualityWithToleranceOptionsFactory.CreateNullableDateTime();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectCollectionMatchWithToleranceResult<IEnumerable<DateTime?>, IThat<IEnumerable<DateTime?>?>,
 			DateTime?, TimeSpan>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<DateTime?, DateTime?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<DateTime?, DateTime?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue,
 					unexpected,
 					options,
@@ -515,9 +534,10 @@ public static partial class ThatEnumerable
 	{
 		StringEqualityOptions options = new();
 		CollectionMatchOptions matchOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringCollectionMatchResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsEqualToConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsEqualToConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected,
 					options,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsInAscendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsInAscendingOrder.cs
@@ -18,9 +18,10 @@ public static partial class ThatEnumerable
 			this IThat<IEnumerable<TItem>?> source)
 	{
 		CollectionOrderOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TItem, IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsInOrderConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsInOrderConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					x => x,
 					SortOrder.Ascending,
 					options,
@@ -41,9 +42,10 @@ public static partial class ThatEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		CollectionOrderOptions<TMember> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TMember, IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsInOrderConstraint<TItem, TMember>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsInOrderConstraint<TItem, TMember>(expectationBuilder, it, grammars,
 					memberAccessor,
 					SortOrder.Ascending,
 					options,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsInDescendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsInDescendingOrder.cs
@@ -18,9 +18,10 @@ public static partial class ThatEnumerable
 			this IThat<IEnumerable<TItem>?> source)
 	{
 		CollectionOrderOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TItem, IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsInOrderConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsInOrderConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					x => x,
 					SortOrder.Descending,
 					options,
@@ -41,9 +42,10 @@ public static partial class ThatEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		CollectionOrderOptions<TMember> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new CollectionOrderResult<TMember, IEnumerable<TItem>, IThat<IEnumerable<TItem>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsInOrderConstraint<TItem, TMember>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new IsInOrderConstraint<TItem, TMember>(expectationBuilder, it, grammars,
 					memberAccessor,
 					SortOrder.Descending,
 					options,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
@@ -247,7 +247,7 @@ public static partial class ThatEnumerable
 				}
 			}
 
-			_expectationBuilder.AddCollectionContext(materializedEnumerable, false);
+			_expectationBuilder.AddCollectionContext(materializedEnumerable);
 			Outcome = Outcome.Failure;
 			return this;
 		}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
@@ -25,9 +25,10 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -44,9 +45,10 @@ public static partial class ThatEnumerable
 			params TItem[] expected)
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected ?? throw new ArgumentNullException(nameof(expected)),
 					options)),
@@ -64,9 +66,10 @@ public static partial class ThatEnumerable
 			[CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					expected.ToArray(),
 					options)),
@@ -83,9 +86,10 @@ public static partial class ThatEnumerable
 			params string[] expected)
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(expected),
 					expected ?? throw new ArgumentNullException(nameof(expected)),
 					options)),
@@ -104,9 +108,10 @@ public static partial class ThatEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -123,9 +128,10 @@ public static partial class ThatEnumerable
 			params TItem[] unexpected)
 	{
 		ObjectEqualityOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new ObjectEqualityResult<IEnumerable<TItem>, IThat<IEnumerable<TItem>?>, TItem>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<TItem, TItem>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<TItem, TItem>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected ?? throw new ArgumentNullException(nameof(unexpected)),
 					options).Invert()),
@@ -144,9 +150,10 @@ public static partial class ThatEnumerable
 			string doNotPopulateThisValue = "")
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<string?, string?>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<string?, string?>(expectationBuilder, it, grammars,
 					doNotPopulateThisValue.TrimCommonWhiteSpace(),
 					unexpected.ToArray(),
 					options).Invert()),
@@ -163,9 +170,10 @@ public static partial class ThatEnumerable
 			params string[] unexpected)
 	{
 		StringEqualityOptions options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		return new StringEqualityResult<IEnumerable<string?>, IThat<IEnumerable<string?>?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new StartsWithConstraint<string, string>(it, grammars,
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new StartsWithConstraint<string, string>(expectationBuilder, it, grammars,
 					Formatter.Format(unexpected),
 					unexpected ?? throw new ArgumentNullException(nameof(unexpected)),
 					options).Invert()),
@@ -180,18 +188,22 @@ public static partial class ThatEnumerable
 	{
 		private readonly TItem[] _expected;
 		private readonly string _expectedExpression;
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly string _it;
 		private readonly IOptionsEquality<TMatch> _options;
 		private TItem? _firstMismatchItem;
 		private bool _foundMismatch;
 		private int _index;
 
-		public StartsWithConstraint(string it,
+		public StartsWithConstraint(
+			ExpectationBuilder expectationBuilder,
+			string it,
 			ExpectationGrammars grammars,
 			string expectedExpression,
 			TItem[] expected,
 			IOptionsEquality<TMatch> options) : base(it, grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_it = it;
 			_expectedExpression = expectedExpression;
 			_expected = expected;
@@ -223,6 +235,7 @@ public static partial class ThatEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
+					_expectationBuilder.AddCollectionContext(materializedEnumerable, true);
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -234,6 +247,7 @@ public static partial class ThatEnumerable
 				}
 			}
 
+			_expectationBuilder.AddCollectionContext(materializedEnumerable, false);
 			Outcome = Outcome.Failure;
 			return this;
 		}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -19,6 +19,7 @@ namespace aweXpect;
 public static partial class ThatEnumerable
 {
 	private sealed class IsEqualToConstraint<TItem, TMatch>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		string expectedExpression,
@@ -59,6 +60,7 @@ public static partial class ThatEnumerable
 			{
 				_failure ??= TooManyDeviationsError(materializedEnumerable);
 				Outcome = Outcome.Failure;
+				expectationBuilder.AddCollectionContext(materializedEnumerable);
 				return this;
 			}
 
@@ -262,14 +264,20 @@ public static partial class ThatEnumerable
 		: ConstraintResult.WithNotNullValue<IEnumerable<TItem>?>,
 			IAsyncContextConstraint<IEnumerable<TItem>?>
 	{
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly EnumerableQuantifier _quantifier;
 		private int _matchingCount;
 		private int _notMatchingCount;
 		private int? _totalCount;
 
-		public SyncCollectionCountConstraint(string it, ExpectationGrammars grammars, EnumerableQuantifier quantifier)
+		public SyncCollectionCountConstraint(
+			ExpectationBuilder expectationBuilder,
+			string it,
+			ExpectationGrammars grammars,
+			EnumerableQuantifier quantifier)
 			: base(it, grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_quantifier = quantifier;
 		}
 
@@ -293,6 +301,7 @@ public static partial class ThatEnumerable
 				_matchingCount = collectionOfT.Count;
 				_totalCount = _matchingCount;
 				Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+				_expectationBuilder.AddCollectionContext(actual);
 				return Task.FromResult<ConstraintResult>(this);
 			}
 
@@ -305,6 +314,7 @@ public static partial class ThatEnumerable
 
 				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 				{
+					_expectationBuilder.AddCollectionContext(materialized, true);
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					return Task.FromResult<ConstraintResult>(this);
 				}
@@ -312,11 +322,13 @@ public static partial class ThatEnumerable
 				if (cancellationToken.IsCancellationRequested)
 				{
 					Outcome = Outcome.Undecided;
+					_expectationBuilder.AddCollectionContext(materialized, true);
 					return Task.FromResult<ConstraintResult>(this);
 				}
 			}
 
 			_totalCount = _matchingCount + _notMatchingCount;
+			_expectationBuilder.AddCollectionContext(materialized);
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 			return Task.FromResult<ConstraintResult>(this);
 		}
@@ -346,6 +358,7 @@ public static partial class ThatEnumerable
 	}
 
 	private sealed class IsInOrderConstraint<TItem, TMember>(
+		ExpectationBuilder expectationBuilder,
 		string it,
 		ExpectationGrammars grammars,
 		Func<TItem, TMember> memberAccessor,
@@ -368,6 +381,7 @@ public static partial class ThatEnumerable
 
 			IEnumerable<TItem> materialized = context
 				.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
+			expectationBuilder.AddCollectionContext(materialized);
 
 			TMember previous = default!;
 			int index = 0;
@@ -386,7 +400,7 @@ public static partial class ThatEnumerable
 				    (comparisonResult < 0 && sortOrder == SortOrder.Descending))
 				{
 					_failureText =
-						$"{It} had {Formatter.Format(previous)} before {Formatter.Format(current)} which is not in {sortOrder.ToString().ToLower()} order in ";
+						$"{It} had {Formatter.Format(previous)} before {Formatter.Format(current)} which is not in {sortOrder.ToString().ToLower()} order";
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -405,10 +419,7 @@ public static partial class ThatEnumerable
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(_failureText);
-			Formatter.Format(stringBuilder, Actual, FormattingOptions.MultipleLines);
-		}
+			=> stringBuilder.Append(_failureText);
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -417,9 +428,6 @@ public static partial class ThatEnumerable
 		}
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(It).Append(" was in ");
-			Formatter.Format(stringBuilder, Actual, FormattingOptions.MultipleLines);
-		}
+			=> stringBuilder.Append(It).Append(" was");
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -50,7 +50,7 @@ public static partial class ThatEnumerable
 			{
 				if (matcher.Verify(It, item, options, maximumNumber, out _failure))
 				{
-					_failure ??= TooManyDeviationsError(materializedEnumerable);
+					_failure ??= TooManyDeviationsError();
 					Outcome = Outcome.Failure;
 					expectationBuilder.AddCollectionContext(materializedEnumerable, true);
 					return this;
@@ -59,7 +59,7 @@ public static partial class ThatEnumerable
 
 			if (matcher.VerifyComplete(It, options, maximumNumber, out _failure))
 			{
-				_failure ??= TooManyDeviationsError(materializedEnumerable);
+				_failure ??= TooManyDeviationsError();
 				Outcome = Outcome.Failure;
 				expectationBuilder.AddCollectionContext(materializedEnumerable);
 				return this;
@@ -69,7 +69,7 @@ public static partial class ThatEnumerable
 			return this;
 		}
 
-		private string TooManyDeviationsError(IEnumerable<TItem> materializedEnumerable)
+		private string TooManyDeviationsError()
 			=> $"{It} had more than {2 * Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get()} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -52,6 +52,7 @@ public static partial class ThatEnumerable
 				{
 					_failure ??= TooManyDeviationsError(materializedEnumerable);
 					Outcome = Outcome.Failure;
+					expectationBuilder.AddCollectionContext(materializedEnumerable, true);
 					return this;
 				}
 			}
@@ -69,7 +70,7 @@ public static partial class ThatEnumerable
 		}
 
 		private string TooManyDeviationsError(IEnumerable<TItem> materializedEnumerable)
-			=> $"{It} was completely different: {Formatter.Format(materializedEnumerable, FormattingOptions.MultipleLines)} had more than {2 * Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get()} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
+			=> $"{It} had more than {2 * Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get()} deviations compared to {Formatter.Format(expected, FormattingOptions.MultipleLines)}";
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -189,7 +190,7 @@ public static partial class ThatEnumerable
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 			AppendContexts(false);
-			_expectationBuilder.AddCollectionContext(materialized, false);
+			_expectationBuilder.AddCollectionContext(materialized);
 			return Task.FromResult<ConstraintResult>(this);
 		}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
@@ -25,19 +25,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -48,6 +36,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -70,6 +73,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -97,6 +103,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -150,6 +170,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -169,6 +198,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 6 expected items:
 					               "a",
 					               "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -212,6 +249,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -241,6 +285,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked 1 of 4 expected items: "c"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -273,6 +324,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "b" at index 1 instead of "a" and
 					               contained item "c" at index 2 instead of "b" and
 					               lacked 1 of 4 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -302,6 +360,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -321,6 +386,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -352,19 +424,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -375,6 +435,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -397,6 +472,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -416,6 +494,9 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -443,6 +524,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -463,6 +558,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -482,6 +586,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "a",
 					               "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -525,6 +637,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -602,6 +721,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -621,6 +747,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -652,19 +785,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -675,6 +796,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -697,6 +833,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -724,6 +863,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -744,6 +897,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -763,6 +925,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 6 expected items:
 					               "a",
 					               "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -828,6 +998,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked 1 of 4 expected items: "c"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -857,6 +1034,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked 1 of 4 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -886,6 +1070,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -905,6 +1096,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -936,19 +1134,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -959,6 +1145,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -981,6 +1182,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1000,6 +1204,9 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1027,6 +1234,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1047,6 +1268,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1066,6 +1296,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "a",
 					               "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1179,6 +1417,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1198,6 +1443,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1229,19 +1481,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1252,6 +1492,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1276,6 +1531,9 @@ public sealed partial class ThatAsyncEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1303,6 +1561,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1325,6 +1597,15 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1344,6 +1625,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 6 expected items:
 					               "a",
 					               "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1388,6 +1677,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1419,6 +1715,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "c"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1452,6 +1755,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "c" at index 2 instead of "b" and
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1483,6 +1793,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1504,6 +1821,13 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1521,6 +1845,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1540,19 +1871,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1563,6 +1882,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1587,6 +1921,9 @@ public sealed partial class ThatAsyncEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1608,6 +1945,9 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 2 expected items:
 					                 "a",
 					                 "b"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1635,6 +1975,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1655,6 +2009,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1674,6 +2037,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "a",
 					               "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1718,6 +2089,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1735,6 +2113,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1752,6 +2138,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1769,6 +2162,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1786,6 +2187,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1803,6 +2211,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1822,6 +2238,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1843,6 +2266,13 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1860,6 +2290,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1879,19 +2316,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1902,6 +2327,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1926,6 +2366,9 @@ public sealed partial class ThatAsyncEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1953,6 +2396,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1973,6 +2430,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1994,6 +2460,14 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 6 expected items:
 					                 "a",
 					                 "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -2035,6 +2509,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -2066,6 +2547,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "c"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2097,6 +2585,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2128,6 +2623,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2149,6 +2651,13 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2166,6 +2675,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -2185,19 +2701,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -2208,6 +2712,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -2232,6 +2751,9 @@ public sealed partial class ThatAsyncEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -2253,6 +2775,9 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 2 expected items:
 					                 "a",
 					                 "b"
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -2280,6 +2805,20 @@ public sealed partial class ThatAsyncEnumerable
 					               108,
 					               109,
 					               110
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -2300,6 +2839,15 @@ public sealed partial class ThatAsyncEnumerable
 					               "x",
 					               "y",
 					               "z"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -2321,6 +2869,14 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 5 expected items:
 					                 "a",
 					                 "e"
+
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -2362,6 +2918,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -2379,6 +2942,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2396,6 +2967,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2413,6 +2991,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2430,6 +3016,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2447,6 +3040,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2466,6 +3067,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2487,6 +3095,13 @@ public sealed partial class ThatAsyncEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2504,6 +3119,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.Tests.cs
@@ -52,7 +52,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 at least {minimum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -83,7 +86,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains 1 at most once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -94,7 +100,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -114,7 +120,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -157,7 +166,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 exactly {(times == 1 ? "once" : $"{times} times")},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -168,7 +180,7 @@ public sealed partial class ThatAsyncEnumerable
 					                21,
 					                34,
 					                55,
-					                …
+					                {(times == 1 ? "(… and maybe others)" : "…")}
 					              ]
 					              """);
 			}
@@ -187,7 +199,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains 1 less than twice,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -198,7 +213,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -218,7 +233,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 more than {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -246,7 +264,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 2,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -257,7 +278,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -295,7 +316,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains {Formatter.Format(expected)} at least once,
-					              but it did not contain it in {Formatter.Format(values, FormattingOptions.MultipleLines)}
+					              but it did not contain it
+					              
+					              Collection:
+					              {Formatter.Format(values)}
 					              """);
 			}
 
@@ -333,7 +357,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "{regex}" as regex at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -355,7 +382,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "{wildcard}" as wildcard at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -382,7 +412,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "{match}" at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -402,7 +435,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that sut
 					             contains "GREEN" at least once,
-					             but it did not contain it in [
+					             but it did not contain it
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "yellow"
@@ -425,7 +461,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "blue" at least {minimum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -449,7 +488,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains "blue" at most once,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -473,7 +515,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "blue" between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -497,7 +542,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "yellow" exactly {times.ToTimesString()},
-					              but it contained it once in [
+					              but it contained it once
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -520,7 +568,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains "blue" less than twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -544,7 +595,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "blue" more than {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -565,7 +619,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "yellow",
-					             but it contained it once in [
+					             but it contained it once
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -586,7 +643,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that sut
 					             contains "red" at least once,
-					             but it did not contain it in [
+					             but it did not contain it
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "yellow"
@@ -631,7 +691,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that sut
 					              contains {Formatter.Format(match)} ignoring newline style at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "fo
 					                o",
 					                "ba
@@ -700,7 +763,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 at least {minimum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -731,7 +797,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains item matching x => x == 1 at most once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -742,7 +811,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -762,7 +831,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -793,7 +865,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 exactly {(times == 1 ? "once" : $"{times} times")},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -804,7 +879,7 @@ public sealed partial class ThatAsyncEnumerable
 					                21,
 					                34,
 					                55,
-					                …
+					                {(times == 1 ? "(… and maybe others)" : "…")}
 					              ]
 					              """);
 			}
@@ -823,7 +898,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains item matching x => x == 1 less than twice,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -834,7 +912,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -854,7 +932,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 more than {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -882,7 +963,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 2,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -893,7 +977,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -931,7 +1015,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == expected at least once,
-					              but it did not contain it in {Formatter.Format(values, FormattingOptions.MultipleLines)}
+					              but it did not contain it
+					              
+					              Collection:
+					              {Formatter.Format(values)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotContain.Tests.cs
@@ -37,7 +37,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 5,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -48,7 +51,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -67,7 +70,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain 1 at least {minimum.ToTimesString()},
-					              but it contained it at least twice in [
+					              but it contained it at least twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -78,7 +84,7 @@ public sealed partial class ThatAsyncEnumerable
 					                21,
 					                34,
 					                55,
-					                …
+					                (… and maybe others)
 					              ]
 					              """);
 			}
@@ -97,7 +103,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1 at most twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -128,7 +137,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -160,7 +172,10 @@ public sealed partial class ThatAsyncEnumerable
 					               StringValue = "",
 					               Value = 5
 					             } equivalent,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               MyClass {
 					                 StringValue = "",
 					                 Value = 1
@@ -201,7 +216,7 @@ public sealed partial class ThatAsyncEnumerable
 					                 StringValue = "",
 					                 Value = 55
 					               },
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -221,7 +236,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain 1 exactly {times.ToTimesString()},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -251,7 +269,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1 less than 3 times,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -282,7 +303,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1 more than once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -293,7 +317,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -313,7 +337,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain {Formatter.Format(unexpected)},
-					              but it contained it once in {Formatter.Format(values, FormattingOptions.MultipleLines)}
+					              but it contained it once
+					              
+					              Collection:
+					              {Formatter.Format(values)}
 					              """);
 			}
 
@@ -369,7 +396,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain "blue" at least {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -392,7 +422,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue" at most twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -416,7 +449,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain "blue" between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -440,7 +476,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain "blue" exactly {times.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -463,7 +502,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue" less than 3 times,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -487,7 +529,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue" more than once,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -525,7 +570,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "A" ignoring case,
-					             but it contained it once in [
+					             but it contained it once
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -577,7 +625,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 5,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -588,7 +639,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -607,7 +658,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == 1 at least {minimum.ToTimesString()},
-					              but it contained it at least twice in [
+					              but it contained it at least twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -618,7 +672,7 @@ public sealed partial class ThatAsyncEnumerable
 					                21,
 					                34,
 					                55,
-					                …
+					                (… and maybe others)
 					              ]
 					              """);
 			}
@@ -637,7 +691,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1 at most twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -668,7 +725,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -699,7 +759,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == 1 exactly {times.ToTimesString()},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -729,7 +792,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1 less than 3 times,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -760,7 +826,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1 more than once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -771,7 +840,7 @@ public sealed partial class ThatAsyncEnumerable
 					               21,
 					               34,
 					               55,
-					               …
+					               (… and maybe others)
 					             ]
 					             """);
 			}
@@ -791,7 +860,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == unexpected,
-					              but it contained it once in {Formatter.Format(values, FormattingOptions.MultipleLines)}
+					              but it contained it once
+					              
+					              Collection:
+					              {Formatter.Format(values)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotHaveCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotHaveCount.Tests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             does not have exactly 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
 					             """);
 			}
 
@@ -45,6 +48,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             does not have exactly 3 items,
 					             but it did
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.EndsWith.Tests.cs
@@ -64,6 +64,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             ends with expected,
 					             but it contained 2 at index 3 instead of 1
+					             
+					             Collection:
+					             [0, 0, 1, 2, 3, (… and maybe others)]
 					             """);
 			}
 
@@ -83,6 +86,9 @@ public sealed partial class ThatAsyncEnumerable
 					               0,
 					               0
 					             ]
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -141,6 +147,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             ends with ["FOO", "BAZ"] ignoring case,
 					             but it contained "bar" at index 1 instead of "FOO"
+					             
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz",
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtLeastTests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has at least 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, (… and maybe others)]
 					             """);
 			}
 
@@ -56,6 +59,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has at least 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtMostTests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has at most 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
 					             """);
 			}
 
@@ -67,6 +70,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has at most 2 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.BetweenTests.cs
@@ -28,6 +28,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
 					             """);
 			}
 
@@ -55,6 +58,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but found only 2
+					             
+					             Collection:
+					             [1, 2]
 					             """);
 			}
 
@@ -71,6 +77,18 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but found at least 7
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.EqualToTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.EqualToTests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has exactly 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
 					             """);
 			}
 
@@ -56,6 +59,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has exactly 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -72,6 +78,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has exactly 2 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.LessThanTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.LessThanTests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has less than 7 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
 					             """);
 			}
 
@@ -45,6 +48,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has less than 3 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -72,6 +83,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has less than 2 items,
 					             but found at least 2
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.MoreThanTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.MoreThanTests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has more than 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [0, 1, 2, 3, (… and maybe others)]
 					             """);
 			}
 
@@ -45,6 +48,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has more than 3 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -61,6 +67,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has more than 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.Tests.cs
@@ -29,13 +29,16 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has exactly 6 items,
 					             but could not verify, because it was already cancelled
+
+					             Collection:
+					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
 					             """);
 			}
 
 			[Fact]
 			public async Task WhenEnumerableContainsMatchingItems_ShouldSucceed()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
 
 				async Task Act()
 					=> await That(subject).HasCount(3);
@@ -46,7 +49,7 @@ public sealed partial class ThatAsyncEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsTooFewItems_ShouldFail()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
 
 				async Task Act()
 					=> await That(subject).HasCount(4);
@@ -56,13 +59,16 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has exactly 4 items,
 					             but found only 3
+
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
 			[Fact]
 			public async Task WhenEnumerableContainsTooManyItems_ShouldFail()
 			{
-				IAsyncEnumerable<int> subject = ToAsyncEnumerable([1, 2, 3,]);
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
 
 				async Task Act()
 					=> await That(subject).HasCount(2);
@@ -72,6 +78,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has exactly 2 items,
 					             but found at least 3
+
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
@@ -34,6 +34,12 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has a single item,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               2
+					             ]
 					             """);
 			}
 
@@ -95,6 +101,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has a single item matching x => x > 1,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3
+					             ]
 					             """);
 			}
 
@@ -121,6 +135,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has a single item matching x => x > 1,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3
+					             ]
 					             """);
 			}
 
@@ -207,6 +228,21 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has a single item of type MyClass,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyOtherClass {
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               }
+					             ]
 					             """);
 			}
 
@@ -263,6 +299,22 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has a single item of type MyBaseClass matching x => x.Value > 1,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               }
+					             ]
 					             """);
 			}
 
@@ -389,6 +441,12 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has a single item which is greater than 4,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               2
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsContainedIn.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsContainedIn.Tests.cs
@@ -25,19 +25,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -48,6 +36,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -89,6 +92,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -141,6 +158,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -170,6 +196,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -189,6 +223,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -208,6 +251,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -225,6 +275,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "c" at index 0 that was not expected
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -254,6 +312,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -283,6 +349,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "a" at index 0 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -338,19 +412,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -361,6 +423,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -414,6 +491,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -433,6 +524,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -462,6 +562,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -481,6 +589,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -500,6 +617,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -615,19 +739,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -638,6 +750,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -679,6 +806,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -698,6 +839,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -727,6 +877,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -746,6 +904,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -775,6 +942,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -804,6 +979,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -833,6 +1016,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "a" at index 1 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -888,19 +1079,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -911,6 +1090,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -964,6 +1158,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -983,6 +1191,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1012,6 +1229,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1031,6 +1256,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1158,19 +1392,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1181,6 +1403,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1222,6 +1459,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1241,6 +1492,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1272,6 +1532,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1292,6 +1560,15 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1312,6 +1589,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1331,6 +1615,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 0 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1362,6 +1654,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1393,6 +1693,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "a" at index 0 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1434,6 +1742,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1453,19 +1768,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1476,6 +1779,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1529,6 +1847,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1548,6 +1880,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1579,6 +1920,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1599,6 +1948,15 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1619,6 +1977,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1636,6 +2001,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1653,6 +2026,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1670,6 +2050,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1687,6 +2075,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1704,6 +2099,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1745,6 +2148,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1764,19 +2174,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1787,6 +2185,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1828,6 +2241,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1847,6 +2274,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1878,6 +2314,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1898,6 +2342,15 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1915,6 +2368,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1934,6 +2394,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1965,6 +2433,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1996,6 +2472,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "a" at index 1 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2037,6 +2521,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -2057,19 +2548,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -2080,6 +2559,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -2136,6 +2630,20 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -2156,6 +2664,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -2189,6 +2706,14 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -2210,6 +2735,15 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -2228,6 +2762,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -2246,6 +2787,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2264,6 +2813,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2282,6 +2838,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2300,6 +2864,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2318,6 +2889,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2362,6 +2941,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.Tests.cs
@@ -24,7 +24,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in order,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -35,8 +38,8 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -53,19 +56,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -76,6 +67,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -98,6 +104,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -136,6 +145,20 @@ public sealed partial class ThatAsyncEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -204,6 +227,15 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -221,6 +253,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -240,6 +280,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -259,6 +308,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -276,6 +332,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it contained item "c" at index 0 that was not expected
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -293,6 +357,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -310,6 +381,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -330,6 +409,13 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item "b" at index 1 instead of "a" and
 					               contained item "c" at index 2 instead of "b" and
 					               lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -347,6 +433,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -366,6 +459,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -396,7 +496,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in order ignoring duplicates,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -407,8 +510,8 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -425,19 +528,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -448,6 +539,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -470,6 +576,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -489,6 +598,9 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -527,6 +639,20 @@ public sealed partial class ThatAsyncEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -550,6 +676,15 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -567,6 +702,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -586,6 +729,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -605,6 +757,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -682,6 +841,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -701,6 +867,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -731,7 +904,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in any order,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -742,8 +918,8 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -760,19 +936,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -783,6 +947,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -805,6 +984,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -843,6 +1025,20 @@ public sealed partial class ThatAsyncEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -866,6 +1062,15 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -883,6 +1088,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -902,6 +1115,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -931,6 +1153,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -948,6 +1178,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -965,6 +1202,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -982,6 +1227,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -999,6 +1251,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "a" at index 1 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1016,6 +1276,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1035,6 +1302,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1065,7 +1339,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in any order ignoring duplicates,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -1076,8 +1353,8 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -1094,19 +1371,7 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1117,6 +1382,21 @@ public sealed partial class ThatAsyncEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1139,6 +1419,9 @@ public sealed partial class ThatAsyncEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1158,6 +1441,9 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1196,6 +1482,20 @@ public sealed partial class ThatAsyncEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1219,6 +1519,15 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1236,6 +1545,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1255,6 +1572,15 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1344,6 +1670,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1363,6 +1696,13 @@ public sealed partial class ThatAsyncEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.WithinTests.cs
@@ -39,6 +39,9 @@ public sealed partial class ThatAsyncEnumerable
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -71,6 +74,9 @@ public sealed partial class ThatAsyncEnumerable
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, <null>, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -114,6 +120,9 @@ public sealed partial class ThatAsyncEnumerable
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -157,6 +166,9 @@ public sealed partial class ThatAsyncEnumerable
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, <null>, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -200,6 +212,9 @@ public sealed partial class ThatAsyncEnumerable
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -243,6 +258,9 @@ public sealed partial class ThatAsyncEnumerable
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, <null>, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -283,6 +301,13 @@ public sealed partial class ThatAsyncEnumerable
 						              but it
 						                contained item {Formatter.Format(now.AddHours(2))} at index 1 that was not expected and
 						                lacked 1 of 3 expected items: {Formatter.Format(now.AddHours(2).AddMinutes(-2))}
+						              
+						              Collection:
+						              [
+						                {Formatter.Format(now.AddHours(1))},
+						                {Formatter.Format(now.AddHours(2))},
+						                {Formatter.Format(now.AddHours(3))}
+						              ]
 						              """);
 				}
 			}
@@ -323,6 +348,14 @@ public sealed partial class ThatAsyncEnumerable
 						              but it
 						                contained item {Formatter.Format(now.AddHours(2))} at index 2 that was not expected and
 						                lacked 1 of 4 expected items: {Formatter.Format(now.AddHours(2).AddMinutes(-2))}
+						              
+						              Collection:
+						              [
+						                {Formatter.Format(now.AddHours(1))},
+						                <null>,
+						                {Formatter.Format(now.AddHours(2))},
+						                {Formatter.Format(now.AddHours(3))}
+						              ]
 						              """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInAscendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInAscendingOrder.Tests.cs
@@ -23,13 +23,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order,
-					             but it had 3 before 1 which is not in ascending order in [
-					               1,
-					               1,
-					               2,
-					               3,
-					               1
-					             ]
+					             but it had 3 before 1 which is not in ascending order
+					             
+					             Collection:
+					             [1, 1, 2, 3, 1]
 					             """);
 			}
 
@@ -86,11 +83,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in ascending order,
-					             but it was in [
-					               1,
-					               2,
-					               3
-					             ]
+					             but it was
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 		}
@@ -109,7 +105,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order,
-					             but it had "a" before "A" which is not in ascending order in [
+					             but it had "a" before "A" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               "a",
 					               "A"
 					             ]
@@ -139,7 +138,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order,
-					             but it had "c" before "a" which is not in ascending order in [
+					             but it had "c" before "a" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c",
@@ -190,7 +192,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order for x => x.Value,
-					             but it had 3 before 1 which is not in ascending order in [
+					             but it had 3 before 1 which is not in ascending order
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
@@ -247,7 +252,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in ascending order for x => x.Value,
-					             but it was in [
+					             but it was
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
@@ -276,7 +284,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order for x => x.Value,
-					             but it had "a" before "A" which is not in ascending order in [
+					             but it had "a" before "A" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
@@ -312,7 +323,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order for x => x.Value,
-					             but it had "c" before "a" which is not in ascending order in [
+					             but it had "c" before "a" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInDescendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsInDescendingOrder.Tests.cs
@@ -23,13 +23,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order,
-					             but it had 1 before 3 which is not in descending order in [
-					               3,
-					               3,
-					               2,
-					               1,
-					               3
-					             ]
+					             but it had 1 before 3 which is not in descending order
+					             
+					             Collection:
+					             [3, 3, 2, 1, 3]
 					             """);
 			}
 
@@ -86,11 +83,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in descending order,
-					             but it was in [
-					               3,
-					               2,
-					               1
-					             ]
+					             but it was
+					             
+					             Collection:
+					             [3, 2, 1]
 					             """);
 			}
 		}
@@ -109,7 +105,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order,
-					             but it had "A" before "a" which is not in descending order in [
+					             but it had "A" before "a" which is not in descending order
+					             
+					             Collection:
+					             [
 					               "A",
 					               "a"
 					             ]
@@ -139,7 +138,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order,
-					             but it had "a" before "c" which is not in descending order in [
+					             but it had "a" before "c" which is not in descending order
+					             
+					             Collection:
+					             [
 					               "c",
 					               "b",
 					               "a",
@@ -190,7 +192,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order for x => x.Value,
-					             but it had 1 before 3 which is not in descending order in [
+					             but it had 1 before 3 which is not in descending order
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
@@ -247,7 +252,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in descending order for x => x.Value,
-					             but it was in [
+					             but it was
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
@@ -276,7 +284,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order for x => x.Value,
-					             but it had "A" before "a" which is not in descending order in [
+					             but it had "A" before "a" which is not in descending order
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "A"
 					               },
@@ -312,7 +323,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order for x => x.Value,
-					             but it had "a" before "c" which is not in descending order in [
+					             but it had "a" before "c" which is not in descending order
+					             
+					             Collection:
+					             [
 					               ThatAsyncEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               },

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsNotEqualTo.Tests.cs
@@ -232,7 +232,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -363,7 +366,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "c",
 					               "a",
 					               "b",
@@ -385,7 +391,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -406,7 +415,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c",
@@ -428,7 +440,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -449,7 +464,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "a",
 					               "b",
@@ -495,7 +513,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -602,7 +623,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "c",
 					               "b"
@@ -707,7 +731,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -826,7 +853,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "c",
 					               "b"
@@ -847,7 +877,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "c",
 					               "a",
 					               "b",
@@ -869,7 +902,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -890,7 +926,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c",
@@ -912,7 +951,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -933,7 +975,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "a",
 					               "b",
@@ -979,7 +1024,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in any order ignoring duplicates,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c"
@@ -1003,7 +1051,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order as wildcard,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "foo",
 					               "bar",
 					               "baz"
@@ -1025,7 +1076,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring leading white-space,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               " a",
 					               "b",
 					               "	c"
@@ -1047,7 +1101,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not match collection unexpected in order ignoring trailing white-space,
-					             but it did in [
+					             but it did
+					             
+					             Collection:
+					             [
 					               "a ",
 					               "b",
 					               "c	"

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsNotEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsNotEqualTo.WithinTests.cs
@@ -25,11 +25,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0m, 2.0m, 3.0m,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, 2.1, 3.1]
 						             """);
 				}
 
@@ -59,12 +58,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0m, null, 2.0m, 3.0m,] in order ± 0.2,
-						             but it did in [
-						               1.1,
-						               <null>,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, <null>, 2.1, 3.1]
 						             """);
 				}
 
@@ -94,12 +91,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               NaN,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, NaN, 2.1, 3.1]
 						             """);
 				}
 
@@ -115,11 +110,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0, 2.0, 3.0,] in order ± 0.2,
-						             but it did in [
-						               1.1,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, 2.1, 3.1]
 						             """);
 				}
 
@@ -149,12 +143,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0, double.NaN, 2.0, 3.0,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               NaN,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, NaN, 2.1, 3.1]
 						             """);
 				}
 
@@ -170,12 +162,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0, null, 2.0, 3.0,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               <null>,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, <null>, 2.1, 3.1]
 						             """);
 				}
 
@@ -205,12 +195,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               NaN,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, NaN, 2.1, 3.1]
 						             """);
 				}
 
@@ -226,11 +214,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0F, 2.0F, 3.0F,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, 2.1, 3.1]
 						             """);
 				}
 
@@ -260,12 +247,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0F, float.NaN, 2.0F, 3.0F,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               NaN,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, NaN, 2.1, 3.1]
 						             """);
 				}
 
@@ -281,12 +266,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             does not match collection [1.0F, null, 2.0F, 3.0F,] in any order ± 0.2,
-						             but it did in [
-						               1.1,
-						               <null>,
-						               2.1,
-						               3.1
-						             ]
+						             but it did
+						             
+						             Collection:
+						             [1.1, <null>, 2.1, 3.1]
 						             """);
 				}
 
@@ -320,7 +303,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage($"""
 						              Expected that subject
 						              does not match collection expected in any order within 1:00,
-						              but it did in [
+						              but it did
+						              
+						              Collection:
+						              [
 						                {Formatter.Format(now.AddHours(1))},
 						                {Formatter.Format(now.AddHours(2))},
 						                {Formatter.Format(now.AddHours(3))}
@@ -362,7 +348,10 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage($"""
 						              Expected that subject
 						              does not match collection expected in any order within 1:00,
-						              but it did in [
+						              but it did
+						              
+						              Collection:
+						              [
 						                {Formatter.Format(now.AddHours(1))},
 						                <null>,
 						                {Formatter.Format(now.AddHours(2))},

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.StartsWith.Tests.cs
@@ -75,6 +75,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             starts with expected,
 					             but it contained 2 at index 1 instead of 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -93,6 +100,9 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained only 3 items and misses 1 items: [
 					               4
 					             ]
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -151,6 +161,13 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             starts with ["FOO", "BAZ"] ignoring case,
 					             but it contained "bar" at index 1 instead of "BAZ"
+					             
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKey.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKey.Tests.cs
@@ -36,6 +36,9 @@ public sealed partial class ThatDictionary
 					               2,
 					               3
 					             ]
+					             
+					             Dictionary:
+					             {[1] = 0, [2] = 0, [3] = 0}
 					             """);
 			}
 
@@ -78,6 +81,13 @@ public sealed partial class ThatDictionary
 
 					             Actual:
 					             bar
+					             
+					             Dictionary:
+					             {
+					               [1] = "foo",
+					               [2] = "bar",
+					               [3] = "baz"
+					             }
 					             """);
 			}
 
@@ -109,6 +119,13 @@ public sealed partial class ThatDictionary
 					               2,
 					               3
 					             ]
+					             
+					             Dictionary:
+					             {
+					               [1] = "foo",
+					               [2] = "bar",
+					               [3] = "baz"
+					             }
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKeys.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKeys.Tests.cs
@@ -38,6 +38,9 @@ public sealed partial class ThatDictionary
 					               2,
 					               3
 					             ]
+					             
+					             Dictionary:
+					             {[1] = 0, [2] = 0, [3] = 0}
 					             """);
 			}
 
@@ -105,6 +108,13 @@ public sealed partial class ThatDictionary
 					               <null>,
 					               (… and maybe others)
 					             ]
+					             
+					             Dictionary:
+					             {
+					               [1] = "foo",
+					               [2] = "bar",
+					               [3] = "baz"
+					             }
 					             """);
 			}
 
@@ -134,6 +144,13 @@ public sealed partial class ThatDictionary
 					               "bar",
 					               (… and maybe others)
 					             ]
+					             
+					             Dictionary:
+					             {
+					               [1] = "foo",
+					               [2] = "bar",
+					               [3] = "baz"
+					             }
 					             """);
 			}
 
@@ -162,6 +179,13 @@ public sealed partial class ThatDictionary
 					               "bar",
 					               (… and maybe others)
 					             ]
+					             
+					             Dictionary:
+					             {
+					               [1] = "foo",
+					               [2] = "bar",
+					               [3] = "baz"
+					             }
 					             """);
 			}
 
@@ -209,6 +233,13 @@ public sealed partial class ThatDictionary
 					               "baz",
 					               (… and maybe others)
 					             ]
+					             
+					             Dictionary:
+					             {
+					               [1] = "foo",
+					               [2] = "bar",
+					               [3] = "baz"
+					             }
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsValue.Tests.cs
@@ -52,6 +52,9 @@ public sealed partial class ThatDictionary
 					               42,
 					               43
 					             ]
+					             
+					             Dictionary:
+					             {[1] = 41, [2] = 42, [3] = 43}
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsValues.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsValues.Tests.cs
@@ -38,6 +38,9 @@ public sealed partial class ThatDictionary
 					               42,
 					               43
 					             ]
+					             
+					             Dictionary:
+					             {[1] = 41, [2] = 42, [3] = 43}
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainKey.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainKey.Tests.cs
@@ -21,6 +21,9 @@ public sealed partial class ThatDictionary
 					             Expected that subject
 					             does not contain key 2,
 					             but it did
+					             
+					             Dictionary:
+					             {[1] = 0, [2] = 0, [3] = 0}
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainKeys.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainKeys.Tests.cs
@@ -34,6 +34,9 @@ public sealed partial class ThatDictionary
 					             but it did contain [
 					               2
 					             ]
+					             
+					             Dictionary:
+					             {[1] = 0, [2] = 0, [3] = 0}
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainValue.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainValue.Tests.cs
@@ -37,6 +37,9 @@ public sealed partial class ThatDictionary
 					             Expected that subject
 					             does not contain value 42,
 					             but it did
+					             
+					             Dictionary:
+					             {[1] = 41, [2] = 42, [3] = 43}
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainValues.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.DoesNotContainValues.Tests.cs
@@ -34,6 +34,9 @@ public sealed partial class ThatDictionary
 					             but it did contain [
 					               42
 					             ]
+					             
+					             Dictionary:
+					             {[1] = 41, [2] = 42, [3] = 43}
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
@@ -24,19 +24,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -436,19 +424,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -809,19 +785,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1171,19 +1135,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1530,19 +1482,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1933,19 +1873,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -2390,19 +2318,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -2788,19 +2704,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
@@ -49,6 +49,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -69,6 +84,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -96,6 +114,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -149,6 +181,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -168,6 +209,14 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 6 expected items:
 					               "a",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -211,6 +260,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -240,6 +296,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -272,6 +335,13 @@ public sealed partial class ThatEnumerable
 					               contained item "b" at index 1 instead of "a" and
 					               contained item "c" at index 2 instead of "b" and
 					               lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -301,6 +371,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -320,6 +397,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -377,6 +461,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -397,6 +496,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -416,6 +518,9 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -443,6 +548,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -463,6 +582,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -482,6 +610,14 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "a",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -525,6 +661,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -602,6 +745,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -621,6 +771,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -677,6 +834,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -697,6 +869,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -724,6 +899,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -744,6 +933,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -763,6 +961,14 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 6 expected items:
 					               "a",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -828,6 +1034,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -857,6 +1070,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -886,6 +1106,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -905,6 +1132,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -962,6 +1196,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -982,6 +1231,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1001,6 +1253,9 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1028,6 +1283,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1048,6 +1317,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1067,6 +1345,14 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "a",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1180,6 +1466,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1199,6 +1492,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1255,6 +1555,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -1277,6 +1592,9 @@ public sealed partial class ThatEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1304,6 +1622,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1326,6 +1658,15 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1345,6 +1686,14 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 6 expected items:
 					               "a",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1389,6 +1738,13 @@ public sealed partial class ThatEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1420,6 +1776,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1453,6 +1816,13 @@ public sealed partial class ThatEnumerable
 					               contained item "c" at index 2 instead of "b" and
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1484,6 +1854,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1505,6 +1882,13 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1523,6 +1907,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1567,6 +1958,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -1589,6 +1995,9 @@ public sealed partial class ThatEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1610,6 +2019,9 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 2 expected items:
 					                 "a",
 					                 "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1637,6 +2049,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1657,6 +2083,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1676,6 +2111,14 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "a",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1720,6 +2163,13 @@ public sealed partial class ThatEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1737,6 +2187,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1754,6 +2212,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1771,6 +2236,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1788,6 +2261,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1805,6 +2285,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1824,6 +2312,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1845,6 +2340,13 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1862,6 +2364,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1906,6 +2415,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -1928,6 +2452,9 @@ public sealed partial class ThatEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1955,6 +2482,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1975,6 +2516,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1996,6 +2546,14 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 6 expected items:
 					                 "a",
 					                 "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -2037,6 +2595,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -2068,6 +2633,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2099,6 +2671,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2130,6 +2709,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2151,6 +2737,13 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2169,6 +2762,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -2213,6 +2813,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -2235,6 +2850,9 @@ public sealed partial class ThatEnumerable
 					                 "a",
 					                 "b",
 					                 "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -2256,6 +2874,9 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 2 expected items:
 					                 "a",
 					                 "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -2283,6 +2904,20 @@ public sealed partial class ThatEnumerable
 					               108,
 					               109,
 					               110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -2303,6 +2938,15 @@ public sealed partial class ThatEnumerable
 					               "x",
 					               "y",
 					               "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -2324,6 +2968,14 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 5 expected items:
 					                 "a",
 					                 "e"
+					             
+					             Collection:
+					             [
+					               "b",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -2365,6 +3017,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -2382,6 +3041,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2399,6 +3066,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2416,6 +3090,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2433,6 +3115,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2450,6 +3139,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2469,6 +3166,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2490,6 +3194,13 @@ public sealed partial class ThatEnumerable
 					               lacked 2 of 5 expected items:
 					                 "d",
 					                 "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2507,6 +3218,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -2528,6 +3246,13 @@ public sealed partial class ThatEnumerable
 					              Expected that subject
 					              contains collection [regex,] in order as regex,
 					              but it lacked 1 of 1 expected items: "{regex}"
+					              
+					              Collection:
+					              [
+					                "foo",
+					                "bar",
+					                "baz"
+					              ]
 					              """);
 			}
 
@@ -2546,6 +3271,13 @@ public sealed partial class ThatEnumerable
 					              Expected that subject
 					              contains collection [wildcard,] in order as wildcard,
 					              but it lacked 1 of 1 expected items: "{wildcard}"
+					              
+					              Collection:
+					              [
+					                "foo",
+					                "bar",
+					                "baz"
+					              ]
 					              """);
 			}
 
@@ -2564,6 +3296,13 @@ public sealed partial class ThatEnumerable
 					              Expected that subject
 					              contains collection [match,] in order,
 					              but it lacked 1 of 1 expected items: "{match}"
+					              
+					              Collection:
+					              [
+					                "foo",
+					                "bar",
+					                "baz"
+					              ]
 					              """);
 			}
 
@@ -2582,6 +3321,13 @@ public sealed partial class ThatEnumerable
 					              Expected that subject
 					              contains collection [match,] in order ignoring case,
 					              but it lacked 1 of 1 expected items: "{match}"
+					              
+					              Collection:
+					              [
+					                "foo",
+					                "bar",
+					                "baz"
+					              ]
 					              """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.Tests.cs
@@ -49,7 +49,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains [2, 1] equivalent at least once,
-					             but it did not contain it in [
+					             but it did not contain it
+					             
+					             Collection:
+					             [
 					               [
 					                 1,
 					                 2
@@ -88,7 +91,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 at least {minimum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -119,7 +125,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains 1 at most once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -150,7 +159,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -193,7 +205,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 exactly {(times == 1 ? "once" : $"{times} times")},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -223,7 +238,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains 1 less than twice,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -254,7 +272,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains 1 more than {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -282,7 +303,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -310,7 +334,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains 1 using AllDifferentComparer at least once,
-					             but it did not contain it in [
+					             but it did not contain it
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -367,7 +394,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains {Formatter.Format(expected)} at least once,
-					              but it did not contain it in {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+					              but it did not contain it
+					              
+					              Collection:
+					              {Formatter.Format(subject)}
 					              """);
 			}
 
@@ -405,7 +435,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "{regex}" as regex at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -427,7 +460,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "{wildcard}" as wildcard at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -454,7 +490,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "{match}" at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -474,7 +513,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that sut
 					             contains "GREEN" at least once,
-					             but it did not contain it in [
+					             but it did not contain it
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "yellow"
@@ -497,7 +539,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "blue" at least {minimum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -521,7 +566,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains "blue" at most once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -545,7 +593,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "blue" between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -569,7 +620,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "yellow" exactly {times.ToTimesString()},
-					              but it contained it once in [
+					              but it contained it once
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -592,7 +646,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains "blue" less than twice,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -616,7 +673,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains "blue" more than {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -637,7 +697,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue",
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -658,7 +721,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that sut
 					             contains "red" at least once,
-					             but it did not contain it in [
+					             but it did not contain it
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "yellow"
@@ -691,7 +757,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains {Formatter.Format(match)} ignoring case at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "foo",
 					                "bar",
 					                "baz"
@@ -714,7 +783,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains {Formatter.Format(match)} ignoring newline style at least once,
-					              but it did not contain it in [
+					              but it did not contain it
+					              
+					              Collection:
+					              [
 					                "fo
 					                o",
 					                "ba
@@ -783,7 +855,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 at least {minimum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -814,7 +889,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains item matching x => x == 1 at most once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -845,7 +923,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -876,7 +957,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 exactly {(times == 1 ? "once" : $"{times} times")},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -906,7 +990,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains item matching x => x == 1 less than twice,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -937,7 +1024,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == 1 more than {minimum.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -965,7 +1055,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -1011,7 +1104,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains item matching x => x == expected at least once,
-					              but it did not contain it in {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+					              but it did not contain it
+					              
+					              Collection:
+					              {Formatter.Format(subject)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotContain.Tests.cs
@@ -36,7 +36,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 5,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -66,7 +69,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain 1 at least {minimum.ToTimesString()},
-					              but it contained it at least twice in [
+					              but it contained it at least twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -96,7 +102,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1 at most twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -127,7 +136,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -159,7 +171,10 @@ public sealed partial class ThatEnumerable
 					               StringValue = "",
 					               Value = 5
 					             } equivalent,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               MyClass {
 					                 StringValue = "",
 					                 Value = 1
@@ -220,7 +235,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain 1 exactly {times.ToTimesString()},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -250,7 +268,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1 less than 3 times,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -281,7 +302,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain 1 more than once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -311,7 +335,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain {Formatter.Format(unexpected)},
-					              but it contained it at least once in {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+					              but it contained it at least once
+					              
+					              Collection:
+					              {Formatter.Format(subject)}
 					              """);
 			}
 
@@ -363,7 +390,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "item-5",
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               "item-1",
 					               "item-1",
 					               "item-2",
@@ -393,7 +423,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain "blue" at least {minimum.ToTimesString()},
-					              but it contained it at least twice in [
+					              but it contained it at least twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -416,7 +449,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue" at most twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -440,7 +476,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain "blue" between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -461,7 +500,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "foo" ignoring case,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               "FOO"
 					             ]
 					             """);
@@ -482,7 +524,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain "blue" exactly {times.ToTimesString()},
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                "green",
 					                "blue",
 					                "blue",
@@ -505,7 +550,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue" less than 3 times,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -529,7 +577,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "blue" more than once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               "green",
 					               "blue",
 					               "blue",
@@ -550,7 +601,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain "foo",
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               "FOO",
 					               "foo"
 					             ]
@@ -612,7 +666,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 5,
-					             but it contained it at least once in [
+					             but it contained it at least once
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -642,7 +699,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == 1 at least {minimum.ToTimesString()},
-					              but it contained it at least twice in [
+					              but it contained it at least twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -672,7 +732,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1 at most twice,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -703,7 +766,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == 1 between {minimum} and {maximum} times,
-					              but it contained it twice in [
+					              but it contained it twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -734,7 +800,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == 1 exactly {times.ToTimesString()},
-					              but it contained it {(times == 1 ? "at least " : "")}twice in [
+					              but it contained it {(times == 1 ? "at least " : "")}twice
+					              
+					              Collection:
+					              [
 					                1,
 					                1,
 					                2,
@@ -764,7 +833,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1 less than 3 times,
-					             but it contained it twice in [
+					             but it contained it twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -795,7 +867,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             does not contain item matching x => x == 1 more than once,
-					             but it contained it at least twice in [
+					             but it contained it at least twice
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -825,7 +900,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              does not contain item matching x => x == unexpected,
-					              but it contained it at least once in {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+					              but it contained it at least once
+					              
+					              Collection:
+					              {Formatter.Format(subject)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotHaveCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.DoesNotHaveCount.Tests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             does not have exactly 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -43,6 +58,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             does not have exactly 2 items,
 					             but it did
+					             
+					             Collection:
+					             [1, 2]
 					             """);
 			}
 
@@ -81,6 +99,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             does not have exactly 3 items,
 					             but it did
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.Tests.cs
@@ -64,6 +64,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             ends with expected,
 					             but it contained 2 at index 3 instead of 1
+					             
+					             Collection:
+					             [0, 0, 1, 2, 3, (… and maybe others)]
 					             """);
 			}
 
@@ -83,6 +86,9 @@ public sealed partial class ThatEnumerable
 					               0,
 					               0
 					             ]
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -141,6 +147,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             ends with ["FOO", "BAZ"] ignoring case,
 					             but it contained "bar" at index 1 instead of "FOO"
+					             
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz",
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtLeastTests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has at least 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -54,6 +69,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has at least 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -92,6 +110,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has at least 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtMostTests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has at most 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -65,6 +80,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has at most 2 items,
 					             but found 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -103,6 +121,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has at most 2 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.BetweenTests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -54,6 +69,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but found only 2
+					             
+					             Collection:
+					             [1, 2]
 					             """);
 			}
 
@@ -70,6 +88,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but found 7
+					             
+					             Collection:
+					             [1, 2, 3, 4, 5, 6, 7]
 					             """);
 			}
 
@@ -97,6 +118,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but found only 2
+					             
+					             Collection:
+					             [1, 2]
 					             """);
 			}
 
@@ -113,6 +137,18 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has between 3 and 6 items,
 					             but found at least 7
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.EqualToTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.EqualToTests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -54,6 +69,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -70,6 +88,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 2 items,
 					             but found 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -97,6 +118,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -113,6 +137,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 2 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.LessThanTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.LessThanTests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has less than 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -43,6 +58,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has less than 3 items,
 					             but found 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -70,6 +88,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has less than 2 items,
 					             but found 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -86,6 +107,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has less than 3 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -113,6 +142,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has less than 2 items,
 					             but found at least 2
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.MoreThanTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.MoreThanTests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has more than 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -43,6 +58,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has more than 3 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -59,6 +77,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has more than 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -86,6 +107,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has more than 3 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -102,6 +126,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has more than 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.Tests.cs
@@ -27,6 +27,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 6 items,
 					             but could not verify, because it was already cancelled
+					             
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -54,6 +69,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -70,6 +88,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 2 items,
 					             but found 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -97,6 +118,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 4 items,
 					             but found only 3
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -113,6 +137,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has exactly 2 items,
 					             but found at least 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasSingle.Tests.cs
@@ -23,6 +23,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has a single item,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
+					             ]
 					             """);
 			}
 
@@ -49,6 +64,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has a single item,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3
+					             ]
 					             """);
 			}
 
@@ -110,6 +132,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has a single item matching x => x > 1,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
+					             ]
 					             """);
 			}
 
@@ -136,6 +173,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has a single item matching x => x > 1,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3
+					             ]
 					             """);
 			}
 
@@ -222,6 +266,21 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has a single item of type MyClass,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyOtherClass {
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               }
+					             ]
 					             """);
 			}
 
@@ -278,6 +337,22 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has a single item of type MyBaseClass matching x => x.Value > 1,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               }
+					             ]
 					             """);
 			}
 
@@ -397,13 +472,20 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = ToEnumerable([1, 2, 3,]);
 
 				async Task Act()
-					=> await That(subject).HasSingle().Which.IsGreaterThan(4);
+					=> await That(subject).HasSingle().Which.IsGreaterThan(2);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a single item which is greater than 4,
+					             has a single item which is greater than 2,
 					             but it contained more than one item
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsContainedIn.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsContainedIn.Tests.cs
@@ -24,19 +24,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -424,19 +412,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -763,19 +739,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1116,19 +1080,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1441,19 +1393,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1830,19 +1770,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -2248,19 +2176,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -2635,19 +2551,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsContainedIn.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsContainedIn.Tests.cs
@@ -49,6 +49,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -88,6 +103,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -140,6 +169,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -169,6 +207,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -188,6 +234,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -207,6 +262,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -224,6 +286,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "c" at index 0 that was not expected
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -253,6 +323,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -282,6 +360,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in order,
 					             but it contained item "a" at index 0 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -363,6 +449,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -414,6 +515,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -433,6 +548,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -462,6 +586,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -481,6 +613,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -500,6 +641,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -640,6 +788,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -679,6 +842,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -698,6 +875,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -727,6 +913,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -746,6 +940,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -775,6 +978,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -804,6 +1015,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -833,6 +1052,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order,
 					             but it contained item "a" at index 1 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -914,6 +1141,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -965,6 +1207,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -984,6 +1240,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1013,6 +1278,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected in any order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1032,6 +1305,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1184,6 +1466,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -1223,6 +1520,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1242,6 +1553,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1273,6 +1593,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1293,6 +1621,15 @@ public sealed partial class ThatEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1313,6 +1650,13 @@ public sealed partial class ThatEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1332,6 +1676,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 0 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1363,6 +1715,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1394,6 +1754,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "a" at index 0 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1436,6 +1804,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1478,6 +1853,21 @@ public sealed partial class ThatEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -1531,6 +1921,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1550,6 +1954,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 instead of "x" and
 					               contained item "e" at index 4 instead of "y"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1581,6 +1994,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1601,6 +2022,15 @@ public sealed partial class ThatEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1621,6 +2051,13 @@ public sealed partial class ThatEnumerable
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c" and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1638,6 +2075,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1655,6 +2100,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1672,6 +2124,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1689,6 +2149,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1706,6 +2173,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1747,6 +2222,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -1791,6 +2273,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -1830,6 +2327,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1849,6 +2360,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1880,6 +2400,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1900,6 +2428,15 @@ public sealed partial class ThatEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1917,6 +2454,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -1936,6 +2480,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1967,6 +2519,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1998,6 +2558,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "a" at index 1 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2040,6 +2608,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}
@@ -2083,6 +2658,21 @@ public sealed partial class ThatEnumerable
 					               107,
 					               108,
 					               109,
+					               …
+					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
 					               …
 					             ]
 					             """);
@@ -2139,6 +2729,20 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -2159,6 +2763,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -2192,6 +2805,14 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -2213,6 +2834,15 @@ public sealed partial class ThatEnumerable
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected and
 					               contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -2231,6 +2861,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -2249,6 +2886,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "c",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2267,6 +2912,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2285,6 +2937,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2303,6 +2963,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2321,6 +2988,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -2365,6 +3040,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is contained in collection expected which has at least one additional item in any order ignoring duplicates,
 					             but it contained all expected items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
@@ -78,6 +78,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -98,6 +113,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -136,6 +154,20 @@ public sealed partial class ThatEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -204,6 +236,15 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -221,6 +262,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -240,6 +289,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -259,6 +317,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -276,6 +341,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -293,6 +365,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -313,6 +393,13 @@ public sealed partial class ThatEnumerable
 					               contained item "b" at index 1 instead of "a" and
 					               contained item "c" at index 2 instead of "b" and
 					               lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -330,6 +417,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it contained item "a" at index 0 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -347,6 +442,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -366,6 +468,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -451,6 +560,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -471,6 +595,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -490,6 +617,9 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -528,6 +658,20 @@ public sealed partial class ThatEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -551,6 +695,15 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -568,6 +721,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -587,6 +748,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -606,6 +776,13 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "c" at index 1 instead of "b" and
 					               contained item "b" at index 2 instead of "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "c",
+					               "b"
+					             ]
 					             """);
 			}
 
@@ -671,6 +848,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -690,6 +874,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -774,6 +965,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -794,6 +1000,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -832,6 +1041,20 @@ public sealed partial class ThatEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -855,6 +1078,15 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -872,6 +1104,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -891,6 +1131,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -920,6 +1169,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it lacked 1 of 4 expected items: "c"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -937,6 +1193,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "c" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -954,6 +1218,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it lacked 1 of 4 expected items: "a"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -971,6 +1242,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it contained item "a" at index 1 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -988,6 +1267,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1007,6 +1293,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1093,6 +1386,21 @@ public sealed partial class ThatEnumerable
 					               109,
 					               …
 					             ]
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10,
+					               …
+					             ]
 					             """);
 			}
 
@@ -1113,6 +1421,9 @@ public sealed partial class ThatEnumerable
 					               "a",
 					               "b",
 					               "c"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1132,6 +1443,9 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 2 expected items:
 					               "a",
 					               "b"
+					             
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -1170,6 +1484,20 @@ public sealed partial class ThatEnumerable
 					                 108,
 					                 109,
 					                 110
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               4,
+					               5,
+					               6,
+					               7,
+					               8,
+					               9,
+					               10
+					             ]
 					             """);
 			}
 
@@ -1193,6 +1521,15 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1210,6 +1547,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
 					             but it contained item "d" at index 3 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d"
+					             ]
 					             """);
 			}
 
@@ -1229,6 +1574,15 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item "d" at index 3 that was not expected and
 					               contained item "e" at index 4 that was not expected
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c",
+					               "d",
+					               "e"
+					             ]
 					             """);
 			}
 
@@ -1306,6 +1660,13 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
 					             but it lacked 1 of 4 expected items: "d"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 
@@ -1325,6 +1686,13 @@ public sealed partial class ThatEnumerable
 					             but it lacked 2 of 5 expected items:
 					               "d",
 					               "e"
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
@@ -23,7 +23,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in order,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -34,8 +37,8 @@ public sealed partial class ThatEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -53,19 +56,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -506,7 +497,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in order ignoring duplicates,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -517,8 +511,8 @@ public sealed partial class ThatEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -535,19 +529,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -911,7 +893,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in any order,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -922,8 +907,8 @@ public sealed partial class ThatEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -940,19 +925,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,
@@ -1331,7 +1304,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection [] in any order ignoring duplicates,
-					             but it was completely different: [
+					             but it had more than 20 deviations compared to []
+					             
+					             Collection:
+					             [
 					               1,
 					               2,
 					               3,
@@ -1342,8 +1318,8 @@ public sealed partial class ThatEnumerable
 					               8,
 					               9,
 					               10,
-					               …
-					             ] had more than 20 deviations compared to []
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -1361,19 +1337,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it was completely different: [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               8,
-					               9,
-					               10,
-					               …
-					             ] had more than 20 deviations compared to [
+					             but it had more than 20 deviations compared to [
 					               100,
 					               101,
 					               102,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.WithinTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.WithinTests.cs
@@ -38,6 +38,9 @@ public sealed partial class ThatEnumerable
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -70,6 +73,9 @@ public sealed partial class ThatEnumerable
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, <null>, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -113,6 +119,9 @@ public sealed partial class ThatEnumerable
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -156,6 +165,9 @@ public sealed partial class ThatEnumerable
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, <null>, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -199,6 +211,9 @@ public sealed partial class ThatEnumerable
 						             but it
 						               contained item 2.3 at index 1 that was not expected and
 						               lacked 1 of 3 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -242,6 +257,9 @@ public sealed partial class ThatEnumerable
 						             but it
 						               contained item 2.3 at index 2 that was not expected and
 						               lacked 1 of 4 expected items: 2.0
+						             
+						             Collection:
+						             [1.1, <null>, 2.3, 3.1]
 						             """);
 				}
 			}
@@ -282,6 +300,13 @@ public sealed partial class ThatEnumerable
 						              but it
 						                contained item {Formatter.Format(now.AddHours(2))} at index 1 that was not expected and
 						                lacked 1 of 3 expected items: {Formatter.Format(now.AddHours(2).AddMinutes(-2))}
+						              
+						              Collection:
+						              [
+						                {Formatter.Format(now.AddHours(1))},
+						                {Formatter.Format(now.AddHours(2))},
+						                {Formatter.Format(now.AddHours(3))}
+						              ]
 						              """);
 				}
 			}
@@ -322,6 +347,14 @@ public sealed partial class ThatEnumerable
 						              but it
 						                contained item {Formatter.Format(now.AddHours(2))} at index 2 that was not expected and
 						                lacked 1 of 4 expected items: {Formatter.Format(now.AddHours(2).AddMinutes(-2))}
+						              
+						              Collection:
+						              [
+						                {Formatter.Format(now.AddHours(1))},
+						                <null>,
+						                {Formatter.Format(now.AddHours(2))},
+						                {Formatter.Format(now.AddHours(3))}
+						              ]
 						              """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInAscendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInAscendingOrder.Tests.cs
@@ -22,7 +22,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order,
-					             but it had 3 before 1 which is not in ascending order in [
+					             but it had 3 before 1 which is not in ascending order
+					             
+					             Collection:
+					             [
 					               1,
 					               1,
 					               2,
@@ -85,11 +88,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in ascending order,
-					             but it was in [
-					               1,
-					               2,
-					               3
-					             ]
+					             but it was
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 		}
@@ -108,7 +110,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order,
-					             but it had "a" before "A" which is not in ascending order in [
+					             but it had "a" before "A" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               "a",
 					               "A"
 					             ]
@@ -138,7 +143,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order,
-					             but it had "c" before "a" which is not in ascending order in [
+					             but it had "c" before "a" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               "a",
 					               "b",
 					               "c",
@@ -189,7 +197,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order for x => x.Value,
-					             but it had 3 before 1 which is not in ascending order in [
+					             but it had 3 before 1 which is not in ascending order
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
@@ -246,7 +257,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in ascending order for x => x.Value,
-					             but it was in [
+					             but it was
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInAscendingOrder.MyIntClass {
 					                 Value = 1
 					               },
@@ -275,7 +289,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order for x => x.Value,
-					             but it had "a" before "A" which is not in ascending order in [
+					             but it had "a" before "A" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },
@@ -310,7 +327,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in ascending order for x => x.Value,
-					             but it had "c" before "a" which is not in ascending order in [
+					             but it had "c" before "a" which is not in ascending order
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInAscendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "a"
 					               },

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInDescendingOrder.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsInDescendingOrder.Tests.cs
@@ -22,7 +22,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order,
-					             but it had 1 before 3 which is not in descending order in [
+					             but it had 1 before 3 which is not in descending order
+					             
+					             Collection:
+					             [
 					               3,
 					               3,
 					               2,
@@ -85,11 +88,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in descending order,
-					             but it was in [
-					               3,
-					               2,
-					               1
-					             ]
+					             but it was
+					             
+					             Collection:
+					             [3, 2, 1]
 					             """);
 			}
 		}
@@ -108,7 +110,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order,
-					             but it had "A" before "a" which is not in descending order in [
+					             but it had "A" before "a" which is not in descending order
+					             
+					             Collection:
+					             [
 					               "A",
 					               "a"
 					             ]
@@ -138,7 +143,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order,
-					             but it had "a" before "c" which is not in descending order in [
+					             but it had "a" before "c" which is not in descending order
+					             
+					             Collection:
+					             [
 					               "c",
 					               "b",
 					               "a",
@@ -189,7 +197,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order for x => x.Value,
-					             but it had 1 before 3 which is not in descending order in [
+					             but it had 1 before 3 which is not in descending order
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
@@ -246,7 +257,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is not in descending order for x => x.Value,
-					             but it was in [
+					             but it was
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInDescendingOrder.MyIntClass {
 					                 Value = 3
 					               },
@@ -275,7 +289,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order for x => x.Value,
-					             but it had "A" before "a" which is not in descending order in [
+					             but it had "A" before "a" which is not in descending order
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "A"
 					               },
@@ -310,7 +327,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is in descending order for x => x.Value,
-					             but it had "a" before "c" which is not in descending order in [
+					             but it had "a" before "c" which is not in descending order
+					             
+					             Collection:
+					             [
 					               ThatEnumerable.IsInDescendingOrder.StringMemberTests.MyStringClass {
 					                 Value = "c"
 					               },

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.Tests.cs
@@ -70,6 +70,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             starts with expected,
 					             but it contained 2 at index 1 instead of 3
+					             
+					             Collection:
+					             [
+					               1,
+					               2,
+					               3,
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 
@@ -89,6 +97,9 @@ public sealed partial class ThatEnumerable
 					             but it contained only 3 items and misses 1 items: [
 					               4
 					             ]
+					             
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -147,6 +158,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             starts with ["FOO", "BAZ"] ignoring case,
 					             but it contained "bar" at index 1 instead of "BAZ"
+					             
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz",
+					               (… and maybe others)
+					             ]
 					             """);
 			}
 


### PR DESCRIPTION
Add a collection context to the following expectations for `IEnumerable<T>` and `IAsyncEnumerable<T>`:
- `Contains` / `IsContainedIn`
- `IsEqualTo`
- `StartsWith` / `EndsWith`
- `HasCount`
- `HasSingle`
- `IsInAscendingOrder` / `IsInDescendingOrder`

Add a collection context to the following expectations for `IDictionary<TKey, TValue>`:
- `ContainsKey` / `ContainsKeys`
- `ContainsValue` / `ContainsValues`

---

- *Fixes remaining expectations for #591* 