### PR TITLE
feat: add `IsBetween` for `DateOnly` and `TimeOnly`

### DIFF
--- a/Docs/pages/docs/expectations/11-date-time-only.md
+++ b/Docs/pages/docs/expectations/11-date-time-only.md
@@ -118,6 +118,34 @@ TimeOnly subjectB = TimeOnly.FromDateTime(DateTime.Now);
 await Expect.That(subjectB).IsBefore(TimeOnly.FromDateTime(DateTime.Now)).Within(TimeSpan.FromSeconds(1));
 ```
 
+## Between
+
+You can verify that the `DateOnly` or `TimeOnly` is between two values:
+
+```csharp
+DateOnly subjectA = DateOnly.FromDateTime(DateTime.Now);
+
+await Expect.That(subjectA).IsBetween(new DateOnly(2024, 1, 1)).And(new DateOnly(2123, 12, 31));
+
+TimeOnly subjectB = TimeOnly.FromDateTime(DateTime.Now);
+
+await Expect.That(subjectB)
+    .IsBetween(TimeOnly.FromDateTime(DateTime.Now).Add(-2.Seconds()))
+    .And(TimeOnly.FromDateTime(DateTime.Now).Add(2.Seconds()));
+```
+
+You can also specify a tolerance:
+
+```csharp
+TimeOnly subject = TimeOnly.FromDateTime(DateTime.Now);
+
+await Expect.That(subject)
+	.IsBetween(TimeOnly.FromDateTime(DateTime.Now))
+    .And(TimeOnly.FromDateTime(DateTime.Now))
+	.Within(2.Seconds())
+  .Because("it should have taken less than two seconds");
+```
+
 ## Properties
 
 You can verify, the properties of the `DateTime`:

--- a/Docs/pages/docs/expectations/12-datetime-offset.md
+++ b/Docs/pages/docs/expectations/12-datetime-offset.md
@@ -109,7 +109,6 @@ DateTime subject = DateTime.Now;
 await Expect.That(subject).IsOnOrBefore(DateTime.Now).Within(TimeSpan.FromSeconds(1))
   .Because("it should have taken less than one second");
 ```
-```
 
 ## Between
 

--- a/Source/aweXpect.Core/Results/BetweenResult.cs
+++ b/Source/aweXpect.Core/Results/BetweenResult.cs
@@ -23,7 +23,7 @@ public class BetweenResult<TTarget, TType>(
 	Func<TType, TTarget> callback)
 {
 	/// <summary>
-	///     …and <paramref name="maximum" /> value.
+	///     …and the <paramref name="maximum" /> value.
 	/// </summary>
 	public TTarget And(TType maximum)
 		=> callback(maximum);

--- a/Source/aweXpect.Core/Results/BetweenResult.cs
+++ b/Source/aweXpect.Core/Results/BetweenResult.cs
@@ -23,7 +23,7 @@ public class BetweenResult<TTarget, TType>(
 	Func<TType, TTarget> callback)
 {
 	/// <summary>
-	///     …and <paramref name="maximum" />.
+	///     …and <paramref name="maximum" /> value.
 	/// </summary>
 	public TTarget And(TType maximum)
 		=> callback(maximum);

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsBetween.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsBetween.cs
@@ -1,0 +1,108 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatDateOnly
+{
+	/// <summary>
+	///     Verifies that the subject is between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<DateOnly, IThat<DateOnly>>, DateOnly?> IsBetween(
+		this IThat<DateOnly> source,
+		DateOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<DateOnly, IThat<DateOnly>>, DateOnly?>(maximum
+			=> new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance)),
+				source,
+				tolerance));
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<DateOnly, IThat<DateOnly>>, DateOnly?> IsNotBetween(
+		this IThat<DateOnly> source,
+		DateOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<DateOnly, IThat<DateOnly>>, DateOnly?>(maximum
+			=> new TimeToleranceResult<DateOnly, IThat<DateOnly>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance).Invert()),
+				source,
+				tolerance));
+	}
+
+	private sealed class IsBetweenConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		DateOnly? minimum,
+		DateOnly? maximum,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithNotNullValue<DateOnly>(it, grammars),
+			IValueConstraint<DateOnly>
+	{
+		public ConstraintResult IsMetBy(DateOnly actual)
+		{
+			Actual = actual;
+			if (minimum is null || maximum is null)
+			{
+				Outcome = IsNegated ? Outcome.Success : Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance
+				                         ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				if (IsNegated)
+				{
+					timeTolerance = timeTolerance.Negate();
+				}
+
+				Outcome = actual.AddDays((int)timeTolerance.TotalDays) >= minimum &&
+				          actual.AddDays((int)timeTolerance.Negate().TotalDays) <= maximum
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			ValueFormatters.Format(Formatter, stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsBetween.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsBetween.cs
@@ -1,0 +1,112 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableDateOnly
+{
+	/// <summary>
+	///     Verifies that the subject is between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<DateOnly?, IThat<DateOnly?>>, DateOnly?> IsBetween(
+		this IThat<DateOnly?> source,
+		DateOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<DateOnly?, IThat<DateOnly?>>, DateOnly?>(maximum
+			=> new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance)),
+				source,
+				tolerance));
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<DateOnly?, IThat<DateOnly?>>, DateOnly?> IsNotBetween(
+		this IThat<DateOnly?> source,
+		DateOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<DateOnly?, IThat<DateOnly?>>, DateOnly?>(maximum
+			=> new TimeToleranceResult<DateOnly?, IThat<DateOnly?>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance).Invert()),
+				source,
+				tolerance));
+	}
+
+	private sealed class IsBetweenConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		DateOnly? minimum,
+		DateOnly? maximum,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithNotNullValue<DateOnly?>(it, grammars),
+			IValueConstraint<DateOnly?>
+	{
+		public ConstraintResult IsMetBy(DateOnly? actual)
+		{
+			Actual = actual;
+			if (actual is null && minimum is null && maximum is null)
+			{
+				Outcome = Outcome.Success;
+			}
+			else if (actual is null || minimum is null || maximum is null)
+			{
+				Outcome = IsNegated ? Outcome.Success : Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance
+				                         ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				if (IsNegated)
+				{
+					timeTolerance = timeTolerance.Negate();
+				}
+
+				Outcome = actual.Value.AddDays((int)timeTolerance.TotalDays) >= minimum &&
+				          actual.Value.AddDays((int)timeTolerance.Negate().TotalDays) <= maximum
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			ValueFormatters.Format(Formatter, stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance.ToDayString());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsBetween.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsBetween.cs
@@ -1,0 +1,112 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableTimeOnly
+{
+	/// <summary>
+	///     Verifies that the subject is between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>, TimeOnly?> IsBetween(
+		this IThat<TimeOnly?> source,
+		TimeOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>, TimeOnly?>(maximum
+			=> new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance)),
+				source,
+				tolerance));
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>, TimeOnly?> IsNotBetween(
+		this IThat<TimeOnly?> source,
+		TimeOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>, TimeOnly?>(maximum
+			=> new TimeToleranceResult<TimeOnly?, IThat<TimeOnly?>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance).Invert()),
+				source,
+				tolerance));
+	}
+
+	private sealed class IsBetweenConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TimeOnly? minimum,
+		TimeOnly? maximum,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithNotNullValue<TimeOnly?>(it, grammars),
+			IValueConstraint<TimeOnly?>
+	{
+		public ConstraintResult IsMetBy(TimeOnly? actual)
+		{
+			Actual = actual;
+			if (actual is null && minimum is null && maximum is null)
+			{
+				Outcome = Outcome.Success;
+			}
+			else if (actual is null || minimum is null || maximum is null)
+			{
+				Outcome = IsNegated ? Outcome.Success : Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance
+				                         ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				if (IsNegated)
+				{
+					timeTolerance = timeTolerance.Negate();
+				}
+
+				Outcome = actual.Value.Add(timeTolerance) >= minimum &&
+				          actual.Value.Add(timeTolerance.Negate()) <= maximum
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			ValueFormatters.Format(Formatter, stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsBetween.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsBetween.cs
@@ -1,0 +1,107 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatTimeOnly
+{
+	/// <summary>
+	///     Verifies that the subject is between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeOnly, IThat<TimeOnly>>, TimeOnly?> IsBetween(
+		this IThat<TimeOnly> source,
+		TimeOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeOnly, IThat<TimeOnly>>, TimeOnly?>(maximum
+			=> new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance)),
+				source,
+				tolerance));
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeOnly, IThat<TimeOnly>>, TimeOnly?> IsNotBetween(
+		this IThat<TimeOnly> source,
+		TimeOnly? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeOnly, IThat<TimeOnly>>, TimeOnly?>(maximum
+			=> new TimeToleranceResult<TimeOnly, IThat<TimeOnly>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance).Invert()),
+				source,
+				tolerance));
+	}
+
+	private sealed class IsBetweenConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TimeOnly? minimum,
+		TimeOnly? maximum,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithNotNullValue<TimeOnly>(it, grammars),
+			IValueConstraint<TimeOnly>
+	{
+		public ConstraintResult IsMetBy(TimeOnly actual)
+		{
+			Actual = actual;
+			if (minimum is null || maximum is null)
+			{
+				Outcome = IsNegated ? Outcome.Success : Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance
+				                         ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				if (IsNegated)
+				{
+					timeTolerance = timeTolerance.Negate();
+				}
+
+				Outcome = actual.Add(timeTolerance) >= minimum && actual.Add(timeTolerance.Negate()) <= maximum
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			ValueFormatters.Format(Formatter, stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not between ");
+			ValueFormatters.Format(Formatter, stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			ValueFormatters.Format(Formatter, stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}
+#endif

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -184,9 +184,11 @@ namespace aweXpect
         public static aweXpect.Results.PropertyResult.Int<System.DateOnly> HasYear(this aweXpect.Core.IThat<System.DateOnly> source) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>>, System.DateOnly?> IsBetween(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsEqualTo(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>>, System.DateOnly?> IsNotBetween(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly, aweXpect.Core.IThat<System.DateOnly>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateOnly> source, System.DateOnly? unexpected) { }
@@ -517,9 +519,11 @@ namespace aweXpect
         public static aweXpect.Results.PropertyResult.Int<System.DateOnly?> HasYear(this aweXpect.Core.IThat<System.DateOnly?> source) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>>, System.DateOnly?> IsBetween(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsEqualTo(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>>, System.DateOnly?> IsNotBetween(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotEqualTo(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.DateOnly?, aweXpect.Core.IThat<System.DateOnly?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.DateOnly?> source, System.DateOnly? unexpected) { }
@@ -636,9 +640,11 @@ namespace aweXpect
         public static aweXpect.Results.PropertyResult.Int<System.TimeOnly?> HasSecond(this aweXpect.Core.IThat<System.TimeOnly?> source) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>>, System.TimeOnly?> IsBetween(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsEqualTo(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>>, System.TimeOnly?> IsNotBetween(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly?, aweXpect.Core.IThat<System.TimeOnly?>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.TimeOnly?> source, System.TimeOnly? unexpected) { }
@@ -866,9 +872,11 @@ namespace aweXpect
         public static aweXpect.Results.PropertyResult.Int<System.TimeOnly> HasSecond(this aweXpect.Core.IThat<System.TimeOnly> source) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>>, System.TimeOnly?> IsBetween(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsEqualTo(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>>, System.TimeOnly?> IsNotBetween(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOnOrAfter(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeOnly, aweXpect.Core.IThat<System.TimeOnly>> IsNotOnOrBefore(this aweXpect.Core.IThat<System.TimeOnly> source, System.TimeOnly? unexpected) { }

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsBetween.Tests.cs
@@ -1,0 +1,256 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed class IsBetween
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMaximumIsNull_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly? minimum = subject;
+				DateOnly? maximum = null;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsNull_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly? minimum = null;
+				DateOnly? maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between <null> and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMaximumAreMaxValue_ShouldSucceed()
+			{
+				DateOnly subject = DateOnly.MaxValue;
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMinimumAreMinValue_ShouldSucceed()
+			{
+				DateOnly subject = DateOnly.MinValue;
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsBetweenMinimumAndMaximum_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = EarlierTime();
+				DateOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEarlierThanMinimum_ShouldFail()
+			{
+				DateOnly subject = EarlierTime();
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsLaterThanMaximum_ShouldFail()
+			{
+				DateOnly subject = LaterTime();
+				DateOnly minimum = EarlierTime();
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMaximum_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = EarlierTime();
+				DateOnly maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMinimum_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = subject;
+				DateOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				DateOnly subject = LaterTime(4);
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				DateOnly subject = EarlierTime(4);
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly? maximum = LaterTime(-4);
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly? minimum = EarlierTime(-4);
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMaximumTolerance_ShouldSucceed()
+			{
+				DateOnly subject = LaterTime(3);
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMinimumTolerance_ShouldSucceed()
+			{
+				DateOnly subject = EarlierTime(3);
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotBetween.Tests.cs
@@ -1,0 +1,261 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed class IsNotBetween
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMaximumIsNull_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly? minimum = subject;
+				DateOnly? maximum = null;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsNull_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly? minimum = null;
+				DateOnly? maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between <null> and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMaximumAreMaxValue_ShouldFail()
+			{
+				DateOnly subject = DateOnly.MaxValue;
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMinimumAreMinValue_ShouldFail()
+			{
+				DateOnly subject = DateOnly.MinValue;
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotBetweenMinimumAndMaximum_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = EarlierTime();
+				DateOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEarlierThanMinimum_ShouldSucceed()
+			{
+				DateOnly subject = EarlierTime();
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsLaterThanMaximum_ShouldSucceed()
+			{
+				DateOnly subject = LaterTime();
+				DateOnly minimum = EarlierTime();
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMaximum_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = EarlierTime();
+				DateOnly maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMinimum_ShouldFail()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = subject;
+				DateOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly maximum = LaterTime(2);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = EarlierTime(2);
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly? maximum = LaterTime(2);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly? minimum = EarlierTime(2);
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMaximumTolerance_ShouldFail()
+			{
+				DateOnly subject = EarlierTime(3);
+				DateOnly minimum = DateOnly.MinValue;
+				DateOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMinimumTolerance_ShouldFail()
+			{
+				DateOnly subject = LaterTime(3);
+				DateOnly minimum = CurrentTime();
+				DateOnly maximum = DateOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Days());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsBetween.Tests.cs
@@ -1,0 +1,259 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsBetween
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenMaximumIsNull_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = subject;
+					DateOnly? maximum = null;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and <null>,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumIsNull_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = null;
+					DateOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between <null> and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMaximumAreMaxValue_ShouldSucceed()
+				{
+					DateOnly? subject = DateOnly.MaxValue;
+					DateOnly? minimum = CurrentTime();
+					DateOnly? maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMinimumAreMinValue_ShouldSucceed()
+				{
+					DateOnly? subject = DateOnly.MinValue;
+					DateOnly? minimum = DateOnly.MinValue;
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsBetweenMinimumAndMaximum_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime();
+					DateOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsEarlierThanMinimum_ShouldFail()
+				{
+					DateOnly? subject = EarlierTime();
+					DateOnly? minimum = CurrentTime();
+					DateOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsLaterThanMaximum_ShouldFail()
+				{
+					DateOnly? subject = LaterTime();
+					DateOnly? minimum = EarlierTime();
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMaximum_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime();
+					DateOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMinimum_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = subject;
+					DateOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class WithinTests
+			{
+				[Fact]
+				public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					DateOnly? subject = LaterTime(4);
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					DateOnly? subject = EarlierTime(4);
+					DateOnly? minimum = CurrentTime();
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = LaterTime(-4);
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime(-4);
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMaximumTolerance_ShouldSucceed()
+				{
+					DateOnly? subject = LaterTime(3);
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMinimumTolerance_ShouldSucceed()
+				{
+					DateOnly? subject = EarlierTime(3);
+					DateOnly? minimum = CurrentTime();
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotBetween.Tests.cs
@@ -1,0 +1,264 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatDateOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotBetween
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenMaximumIsNull_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = subject;
+					DateOnly? maximum = null;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and <null>,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumIsNull_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = null;
+					DateOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between <null> and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMaximumAreMaxValue_ShouldFail()
+				{
+					DateOnly? subject = DateOnly.MaxValue;
+					DateOnly? minimum = CurrentTime();
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMinimumAreMinValue_ShouldFail()
+				{
+					DateOnly? subject = DateOnly.MinValue;
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsEarlierThanMinimum_ShouldSucceed()
+				{
+					DateOnly? subject = EarlierTime();
+					DateOnly? minimum = CurrentTime();
+					DateOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsLaterThanMaximum_ShouldSucceed()
+				{
+					DateOnly? subject = LaterTime();
+					DateOnly? minimum = EarlierTime();
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNotBetweenMinimumAndMaximum_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime();
+					DateOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMaximum_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime();
+					DateOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMinimum_ShouldFail()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = subject;
+					DateOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+
+			public sealed class WithinTests
+			{
+				[Fact]
+				public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = LaterTime(2);
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime(2);
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = LaterTime(2);
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly? minimum = EarlierTime(2);
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMaximumTolerance_ShouldFail()
+				{
+					DateOnly? subject = EarlierTime(3);
+					DateOnly minimum = DateOnly.MinValue;
+					DateOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMinimumTolerance_ShouldFail()
+				{
+					DateOnly? subject = LaterTime(3);
+					DateOnly? minimum = CurrentTime();
+					DateOnly maximum = DateOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Days());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 3 days,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsBetween.Tests.cs
@@ -1,0 +1,256 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed class IsBetween
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMaximumIsNull_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly? minimum = subject;
+				TimeOnly? maximum = null;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsNull_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly? minimum = null;
+				TimeOnly? maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between <null> and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMaximumAreMaxValue_ShouldSucceed()
+			{
+				TimeOnly subject = TimeOnly.MaxValue;
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMinimumAreMinValue_ShouldSucceed()
+			{
+				TimeOnly subject = TimeOnly.MinValue;
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsBetweenMinimumAndMaximum_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = EarlierTime();
+				TimeOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEarlierThanMinimum_ShouldFail()
+			{
+				TimeOnly subject = EarlierTime();
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsLaterThanMaximum_ShouldFail()
+			{
+				TimeOnly subject = LaterTime();
+				TimeOnly minimum = EarlierTime();
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMaximum_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = EarlierTime();
+				TimeOnly maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMinimum_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = subject;
+				TimeOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeOnly subject = LaterTime(4);
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeOnly subject = EarlierTime(4);
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly? maximum = LaterTime(-4);
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly? minimum = EarlierTime(-4);
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMaximumTolerance_ShouldSucceed()
+			{
+				TimeOnly subject = LaterTime(3);
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMinimumTolerance_ShouldSucceed()
+			{
+				TimeOnly subject = EarlierTime(3);
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotBetween.Tests.cs
@@ -1,0 +1,261 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed class IsNotBetween
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMaximumIsNull_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly? minimum = subject;
+				TimeOnly? maximum = null;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsNull_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly? minimum = null;
+				TimeOnly? maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between <null> and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMaximumAreMaxValue_ShouldFail()
+			{
+				TimeOnly subject = TimeOnly.MaxValue;
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMinimumAreMinValue_ShouldFail()
+			{
+				TimeOnly subject = TimeOnly.MinValue;
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotBetweenMinimumAndMaximum_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = EarlierTime();
+				TimeOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEarlierThanMinimum_ShouldSucceed()
+			{
+				TimeOnly subject = EarlierTime();
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsLaterThanMaximum_ShouldSucceed()
+			{
+				TimeOnly subject = LaterTime();
+				TimeOnly minimum = EarlierTime();
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMaximum_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = EarlierTime();
+				TimeOnly maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMinimum_ShouldFail()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = subject;
+				TimeOnly maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly maximum = LaterTime(2);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = EarlierTime(2);
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly? maximum = LaterTime(2);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly? minimum = EarlierTime(2);
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMaximumTolerance_ShouldFail()
+			{
+				TimeOnly subject = EarlierTime(3);
+				TimeOnly minimum = TimeOnly.MinValue;
+				TimeOnly maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMinimumTolerance_ShouldFail()
+			{
+				TimeOnly subject = LaterTime(3);
+				TimeOnly minimum = CurrentTime();
+				TimeOnly maximum = TimeOnly.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsBetween.Tests.cs
@@ -1,0 +1,259 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsBetween
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenMaximumIsNull_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = subject;
+					TimeOnly? maximum = null;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and <null>,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumIsNull_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = null;
+					TimeOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between <null> and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMaximumAreMaxValue_ShouldSucceed()
+				{
+					TimeOnly? subject = TimeOnly.MaxValue;
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly? maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMinimumAreMinValue_ShouldSucceed()
+				{
+					TimeOnly? subject = TimeOnly.MinValue;
+					TimeOnly? minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsBetweenMinimumAndMaximum_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime();
+					TimeOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsEarlierThanMinimum_ShouldFail()
+				{
+					TimeOnly? subject = EarlierTime();
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsLaterThanMaximum_ShouldFail()
+				{
+					TimeOnly? subject = LaterTime();
+					TimeOnly? minimum = EarlierTime();
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMaximum_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime();
+					TimeOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMinimum_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = subject;
+					TimeOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class WithinTests
+			{
+				[Fact]
+				public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeOnly? subject = LaterTime(4);
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeOnly? subject = EarlierTime(4);
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = LaterTime(-4);
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime(-4);
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMaximumTolerance_ShouldSucceed()
+				{
+					TimeOnly? subject = LaterTime(3);
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMinimumTolerance_ShouldSucceed()
+				{
+					TimeOnly? subject = EarlierTime(3);
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotBetween.Tests.cs
@@ -1,0 +1,264 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeOnly
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotBetween
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenMaximumIsNull_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = subject;
+					TimeOnly? maximum = null;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and <null>,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumIsNull_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = null;
+					TimeOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between <null> and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMaximumAreMaxValue_ShouldFail()
+				{
+					TimeOnly? subject = TimeOnly.MaxValue;
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMinimumAreMinValue_ShouldFail()
+				{
+					TimeOnly? subject = TimeOnly.MinValue;
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsEarlierThanMinimum_ShouldSucceed()
+				{
+					TimeOnly? subject = EarlierTime();
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsLaterThanMaximum_ShouldSucceed()
+				{
+					TimeOnly? subject = LaterTime();
+					TimeOnly? minimum = EarlierTime();
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNotBetweenMinimumAndMaximum_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime();
+					TimeOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMaximum_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime();
+					TimeOnly? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMinimum_ShouldFail()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = subject;
+					TimeOnly? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+
+			public sealed class WithinTests
+			{
+				[Fact]
+				public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = LaterTime(2);
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime(2);
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = LaterTime(2);
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly? minimum = EarlierTime(2);
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMaximumTolerance_ShouldFail()
+				{
+					TimeOnly? subject = EarlierTime(3);
+					TimeOnly minimum = TimeOnly.MinValue;
+					TimeOnly? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMinimumTolerance_ShouldFail()
+				{
+					TimeOnly? subject = LaterTime(3);
+					TimeOnly? minimum = CurrentTime();
+					TimeOnly maximum = TimeOnly.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
This PR adds `IsBetween` and `IsNotBetween` expectations (with optional tolerance) for both `DateOnly` and `TimeOnly`, including their nullable variants, along with corresponding tests, API updates, and documentation.

- Introduced new BetweenResult-based APIs in `ThatTimeOnly` and `ThatDateOnly` (nullable and non-nullable)
- Implemented `IsBetweenConstraint` logic handling null bounds and tolerance
- Added comprehensive unit tests and updated API contract and docs for the new methods

## Between

You can verify that the `DateOnly` or `TimeOnly` is between two values:

```csharp
DateOnly subjectA = DateOnly.FromDateTime(DateTime.Now);

await Expect.That(subjectA).IsBetween(new DateOnly(2024, 1, 1)).And(new DateOnly(2123, 12, 31));

TimeOnly subjectB = TimeOnly.FromDateTime(DateTime.Now);

await Expect.That(subjectB)
    .IsBetween(TimeOnly.FromDateTime(DateTime.Now).Add(-2.Seconds()))
    .And(TimeOnly.FromDateTime(DateTime.Now).Add(2.Seconds()));
```

You can also specify a tolerance:

```csharp
TimeOnly subject = TimeOnly.FromDateTime(DateTime.Now);

await Expect.That(subject)
	.IsBetween(TimeOnly.FromDateTime(DateTime.Now))
    .And(TimeOnly.FromDateTime(DateTime.Now))
	.Within(2.Seconds())
  .Because("it should have taken less than two seconds");
```