### PR TITLE
feat: add `IsBetween` for `TimeSpan`

### DIFF
--- a/Docs/pages/docs/expectations/10-timespan.md
+++ b/Docs/pages/docs/expectations/10-timespan.md
@@ -82,6 +82,28 @@ await Expect.That(subject).IsLessThan(42).Within(TimeSpan.FromSeconds(2))
   .Because("we accept values less than 0:44 (0:42 ± 2s)");
 ```
 
+## Between
+
+You can verify that the `TimeSpan` is between two values:
+
+```csharp
+TimeSpan subject = TimeSpan.FromSeconds(42);
+
+await Expect.That(subject).IsBetween(TimeSpan.FromSeconds(40)).And(TimeSpan.FromSeconds(50));
+```
+
+You can also specify a tolerance:
+
+```csharp
+TimeSpan subject = TimeSpan.FromSeconds(42);
+
+await Expect.That(subject)
+	.IsBetween(43.Seconds())
+    .And(45.Seconds())
+	.Within(1.Seconds())
+  .Because("it should expand the interval by 1 second");
+```
+
 ## Positive / negative
 
 You can verify that the `TimeSpan` is positive or negative:

--- a/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsBetween.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsBetween.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatNullableTimeSpan
+{
+	/// <summary>
+	///     Verifies that the subject is between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>, TimeSpan?> IsBetween(
+		this IThat<TimeSpan?> source,
+		TimeSpan? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>, TimeSpan?>(maximum
+			=> new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance)),
+				source,
+				tolerance));
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>, TimeSpan?> IsNotBetween(
+		this IThat<TimeSpan?> source,
+		TimeSpan? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>, TimeSpan?>(maximum
+			=> new TimeToleranceResult<TimeSpan?, IThat<TimeSpan?>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance).Invert()),
+				source,
+				tolerance));
+	}
+
+	private sealed class IsBetweenConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TimeSpan? minimum,
+		TimeSpan? maximum,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithNotNullValue<TimeSpan?>(it, grammars),
+			IValueConstraint<TimeSpan?>
+	{
+		public ConstraintResult IsMetBy(TimeSpan? actual)
+		{
+			Actual = actual;
+			if (actual is null && minimum is null && maximum is null)
+			{
+				Outcome = Outcome.Success;
+			}
+			else if (actual is null || minimum is null || maximum is null)
+			{
+				Outcome = IsNegated ? Outcome.Success : Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance
+				                         ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				if (IsNegated)
+				{
+					timeTolerance = timeTolerance.Negate();
+				}
+
+				Outcome = actual.Value.Add(timeTolerance) >= minimum && actual.Value.Add(timeTolerance.Negate()) <= maximum
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is between ");
+			Formatter.Format(stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			Formatter.Format(stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not between ");
+			Formatter.Format(stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			Formatter.Format(stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsBetween.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsBetween.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Customization;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatTimeSpan
+{
+	/// <summary>
+	///     Verifies that the subject is between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeSpan, IThat<TimeSpan>>, TimeSpan?> IsBetween(
+		this IThat<TimeSpan> source,
+		TimeSpan? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeSpan, IThat<TimeSpan>>, TimeSpan?>(maximum
+			=> new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance)),
+				source,
+				tolerance));
+	}
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<TimeToleranceResult<TimeSpan, IThat<TimeSpan>>, TimeSpan?> IsNotBetween(
+		this IThat<TimeSpan> source,
+		TimeSpan? minimum)
+	{
+		TimeTolerance tolerance = new();
+		return new BetweenResult<TimeToleranceResult<TimeSpan, IThat<TimeSpan>>, TimeSpan?>(maximum
+			=> new TimeToleranceResult<TimeSpan, IThat<TimeSpan>>(
+				source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+					new IsBetweenConstraint(it, grammars, minimum, maximum, tolerance).Invert()),
+				source,
+				tolerance));
+	}
+
+	private sealed class IsBetweenConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TimeSpan? minimum,
+		TimeSpan? maximum,
+		TimeTolerance tolerance)
+		: ConstraintResult.WithNotNullValue<TimeSpan>(it, grammars),
+			IValueConstraint<TimeSpan>
+	{
+		public ConstraintResult IsMetBy(TimeSpan actual)
+		{
+			Actual = actual;
+			if (minimum is null || maximum is null)
+			{
+				Outcome = IsNegated ? Outcome.Success : Outcome.Failure;
+			}
+			else
+			{
+				TimeSpan timeTolerance = tolerance.Tolerance
+				                         ?? Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
+				if (IsNegated)
+				{
+					timeTolerance = timeTolerance.Negate();
+				}
+
+				Outcome = actual.Add(timeTolerance) >= minimum && actual.Add(timeTolerance.Negate()) <= maximum
+					? Outcome.Success
+					: Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is between ");
+			Formatter.Format(stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			Formatter.Format(stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not between ");
+			Formatter.Format(stringBuilder, minimum);
+			stringBuilder.Append(" and ");
+			Formatter.Format(stringBuilder, maximum);
+			stringBuilder.Append(tolerance);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -653,12 +653,14 @@ namespace aweXpect
     }
     public static class ThatNullableTimeSpan
     {
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>>, System.TimeSpan?> IsBetween(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsGreaterThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsLessThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNegative(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>>, System.TimeSpan?> IsNotBetween(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotGreaterThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
@@ -881,12 +883,14 @@ namespace aweXpect
     }
     public static class ThatTimeSpan
     {
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>>, System.TimeSpan?> IsBetween(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsGreaterThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsLessThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNegative(this aweXpect.Core.IThat<System.TimeSpan> source) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>>, System.TimeSpan?> IsNotBetween(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotGreaterThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -469,12 +469,14 @@ namespace aweXpect
     }
     public static class ThatNullableTimeSpan
     {
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>>, System.TimeSpan?> IsBetween(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsGreaterThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsLessThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNegative(this aweXpect.Core.IThat<System.TimeSpan?> source) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>>, System.TimeSpan?> IsNotBetween(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotGreaterThan(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan?, aweXpect.Core.IThat<System.TimeSpan?>> IsNotGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan?> source, System.TimeSpan? unexpected) { }
@@ -928,12 +930,14 @@ namespace aweXpect
     }
     public static class ThatTimeSpan
     {
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>>, System.TimeSpan?> IsBetween(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsGreaterThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsLessThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsLessThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNegative(this aweXpect.Core.IThat<System.TimeSpan> source) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>>, System.TimeSpan?> IsNotBetween(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? minimum) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotGreaterThan(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsNotGreaterThanOrEqualTo(this aweXpect.Core.IThat<System.TimeSpan> source, System.TimeSpan? unexpected) { }

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeSettingsTests.cs
@@ -11,7 +11,12 @@ public sealed class CustomizeSettingsTests
 	[Fact]
 	public async Task DefaultCheckInterval_ShouldBeUsedInTimeComparisons()
 	{
+#if DEBUG
 		TimeSpan timeout = 2.Seconds();
+#else
+		TimeSpan timeout = 4.Seconds();
+#endif
+
 		ChangingClass sut1 = new();
 		ChangingClass sut2 = new();
 

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsBetween.Tests.cs
@@ -1,0 +1,254 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed class IsBetween
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMaximumIsNull_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? minimum = subject;
+				TimeSpan? maximum = null;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsNull_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? minimum = null;
+				TimeSpan? maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between <null> and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMaximumAreMaxValue_ShouldSucceed()
+			{
+				TimeSpan subject = TimeSpan.MaxValue;
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMinimumAreMinValue_ShouldSucceed()
+			{
+				TimeSpan subject = TimeSpan.MinValue;
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsBetweenMinimumAndMaximum_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = EarlierTime();
+				TimeSpan maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEarlierThanMinimum_ShouldFail()
+			{
+				TimeSpan subject = EarlierTime();
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsLaterThanMaximum_ShouldFail()
+			{
+				TimeSpan subject = LaterTime();
+				TimeSpan minimum = EarlierTime();
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMaximum_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = EarlierTime();
+				TimeSpan maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMinimum_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = subject;
+				TimeSpan maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeSpan subject = LaterTime(4);
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeSpan subject = EarlierTime(4);
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan? maximum = LaterTime(-4);
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? minimum = EarlierTime(-4);
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMaximumTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = LaterTime(3);
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMinimumTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = EarlierTime(3);
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotBetween.Tests.cs
@@ -1,0 +1,259 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed class IsNotBetween
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMaximumIsNull_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? minimum = subject;
+				TimeSpan? maximum = null;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and <null>,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMinimumIsNull_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? minimum = null;
+				TimeSpan? maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between <null> and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMaximumAreMaxValue_ShouldFail()
+			{
+				TimeSpan subject = TimeSpan.MaxValue;
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectAndMinimumAreMinValue_ShouldFail()
+			{
+				TimeSpan subject = TimeSpan.MinValue;
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotBetweenMinimumAndMaximum_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = EarlierTime();
+				TimeSpan maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEarlierThanMinimum_ShouldSucceed()
+			{
+				TimeSpan subject = EarlierTime();
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsLaterThanMaximum_ShouldSucceed()
+			{
+				TimeSpan subject = LaterTime();
+				TimeSpan minimum = EarlierTime();
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMaximum_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = EarlierTime();
+				TimeSpan maximum = subject;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsSameAsMinimum_ShouldFail()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = subject;
+				TimeSpan maximum = LaterTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class WithinTests
+		{
+			[Fact]
+			public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan maximum = LaterTime(2);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = EarlierTime(2);
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan? maximum = LaterTime(2);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan? minimum = EarlierTime(2);
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMaximumTolerance_ShouldFail()
+			{
+				TimeSpan subject = EarlierTime(3);
+				TimeSpan minimum = TimeSpan.MinValue;
+				TimeSpan maximum = CurrentTime();
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenValueIsWithinTheMinimumTolerance_ShouldFail()
+			{
+				TimeSpan subject = LaterTime(3);
+				TimeSpan minimum = CurrentTime();
+				TimeSpan maximum = TimeSpan.MaxValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum)
+						.Within(3.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsBetween.Tests.cs
@@ -1,0 +1,257 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsBetween
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenMaximumIsNull_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = subject;
+					TimeSpan? maximum = null;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and <null>,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumIsNull_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = null;
+					TimeSpan? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between <null> and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMaximumAreMaxValue_ShouldSucceed()
+				{
+					TimeSpan? subject = TimeSpan.MaxValue;
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan? maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMinimumAreMinValue_ShouldSucceed()
+				{
+					TimeSpan? subject = TimeSpan.MinValue;
+					TimeSpan? minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsBetweenMinimumAndMaximum_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime();
+					TimeSpan? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsEarlierThanMinimum_ShouldFail()
+				{
+					TimeSpan? subject = EarlierTime();
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsLaterThanMaximum_ShouldFail()
+				{
+					TimeSpan? subject = LaterTime();
+					TimeSpan? minimum = EarlierTime();
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMaximum_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime();
+					TimeSpan? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMinimum_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = subject;
+					TimeSpan? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class WithinTests
+			{
+				[Fact]
+				public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeSpan? subject = LaterTime(4);
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeSpan? subject = EarlierTime(4);
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = LaterTime(-4);
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime(-4);
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMaximumTolerance_ShouldSucceed()
+				{
+					TimeSpan? subject = LaterTime(3);
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMinimumTolerance_ShouldSucceed()
+				{
+					TimeSpan? subject = EarlierTime(3);
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotBetween.Tests.cs
@@ -1,0 +1,262 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatTimeSpan
+{
+	public sealed partial class Nullable
+	{
+		public sealed class IsNotBetween
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task WhenMaximumIsNull_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = subject;
+					TimeSpan? maximum = null;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and <null>,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenMinimumIsNull_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = null;
+					TimeSpan? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between <null> and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMaximumAreMaxValue_ShouldFail()
+				{
+					TimeSpan? subject = TimeSpan.MaxValue;
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectAndMinimumAreMinValue_ShouldFail()
+				{
+					TimeSpan? subject = TimeSpan.MinValue;
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsEarlierThanMinimum_ShouldSucceed()
+				{
+					TimeSpan? subject = EarlierTime();
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsLaterThanMaximum_ShouldSucceed()
+				{
+					TimeSpan? subject = LaterTime();
+					TimeSpan? minimum = EarlierTime();
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNotBetweenMinimumAndMaximum_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime();
+					TimeSpan? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMaximum_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime();
+					TimeSpan? maximum = subject;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsSameAsMinimum_ShouldFail()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = subject;
+					TimeSpan? maximum = LaterTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+
+			public sealed class WithinTests
+			{
+				[Fact]
+				public async Task WhenMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = LaterTime(2);
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime(2);
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableMaximumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = LaterTime(2);
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableMinimumValueIsOutsideTheTolerance_ShouldSucceed()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan? minimum = EarlierTime(2);
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMaximumTolerance_ShouldFail()
+				{
+					TimeSpan? subject = EarlierTime(3);
+					TimeSpan minimum = TimeSpan.MinValue;
+					TimeSpan? maximum = CurrentTime();
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenValueIsWithinTheMinimumTolerance_ShouldFail()
+				{
+					TimeSpan? subject = LaterTime(3);
+					TimeSpan? minimum = CurrentTime();
+					TimeSpan maximum = TimeSpan.MaxValue;
+
+					async Task Act()
+						=> await That(subject).IsNotBetween(minimum).And(maximum)
+							.Within(3.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)} ± 0:03,
+						              but it was {Formatter.Format(subject)}
+						              """);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds support for “between” assertions on `TimeSpan` (and nullable) with optional tolerance.

- Introduces `IsBetween` and `IsNotBetween` APIs and their constraint implementations  
- Adds comprehensive unit tests covering edge cases and tolerance behavior  
- Updates API surface expectations and documentation to reflect new methods

## Between

You can verify that the `TimeSpan` is between two values:

```csharp
TimeSpan subject = TimeSpan.FromSeconds(42);

await Expect.That(subject).IsBetween(TimeSpan.FromSeconds(40)).And(TimeSpan.FromSeconds(50));
```

You can also specify a tolerance:

```csharp
TimeSpan subject = TimeSpan.FromSeconds(42);

await Expect.That(subject)
	.IsBetween(43.Seconds())
    .And(45.Seconds())
	.Within(1.Seconds())
  .Because("it should expand the interval by 1 second");
```