### PR TITLE
feat: add `IsNotBetween` for numbers

### DIFF
--- a/Source/aweXpect/That/Numbers/ThatNumber.IsBetween.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsBetween.cs
@@ -12,7 +12,7 @@ public static partial class ThatNumber
 {
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Verifies that the subject is between <paramref name="minimum" />…
+	///     Verifies that the subject is between the <paramref name="minimum" />…
 	/// </summary>
 	public static BetweenResult<AndOrResult<TNumber, IThat<TNumber>>, TNumber?> IsBetween<TNumber>(
 		this IThat<TNumber> source, TNumber? minimum)
@@ -31,6 +31,28 @@ public static partial class ThatNumber
 		=> new(maximum => new AndOrResult<TNumber?, IThat<TNumber?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsInRangeConstraint<TNumber>(it, grammars, minimum, maximum)),
+			source));
+	
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<TNumber, IThat<TNumber>>, TNumber?> IsNotBetween<TNumber>(
+		this IThat<TNumber> source, TNumber? minimum)
+		where TNumber : struct, INumber<TNumber>
+		=> new(maximum => new AndOrResult<TNumber, IThat<TNumber>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsInRangeConstraint<TNumber>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<TNumber?, IThat<TNumber?>>, TNumber?> IsNotBetween<TNumber>(
+		this IThat<TNumber?> source, TNumber? minimum)
+		where TNumber : struct, INumber<TNumber>
+		=> new(maximum => new AndOrResult<TNumber?, IThat<TNumber?>>(
+			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new NullableIsInRangeConstraint<TNumber>(it, grammars, minimum, maximum).Invert()),
 			source));
 
 	private sealed class IsInRangeConstraint<TNumber> : ConstraintResult.WithValue<TNumber>,
@@ -393,6 +415,249 @@ public static partial class ThatNumber
 		=> new(maximum => new AndOrResult<decimal?, IThat<decimal?>>(source.Get().ExpectationBuilder
 				.AddConstraint((it, grammars) =>
 					new NullableIsInRangeConstraint<decimal>(it, grammars, minimum, maximum)),
+			source));
+
+	
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<byte, IThat<byte>>, byte?> IsNotBetween(
+		this IThat<byte> source,
+		byte? minimum)
+		=> new(maximum => new AndOrResult<byte, IThat<byte>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<byte>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<sbyte, IThat<sbyte>>, sbyte?> IsNotBetween(
+		this IThat<sbyte> source,
+		sbyte? minimum)
+		=> new(maximum => new AndOrResult<sbyte, IThat<sbyte>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<sbyte>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<short, IThat<short>>, short?> IsNotBetween(
+		this IThat<short> source,
+		short? minimum)
+		=> new(maximum => new AndOrResult<short, IThat<short>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<short>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<ushort, IThat<ushort>>, ushort?> IsNotBetween(
+		this IThat<ushort> source,
+		ushort? minimum)
+		=> new(maximum => new AndOrResult<ushort, IThat<ushort>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<ushort>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<int, IThat<int>>, int?> IsNotBetween(
+		this IThat<int> source,
+		int? minimum)
+		=> new(maximum => new AndOrResult<int, IThat<int>>(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=>
+				new IsInRangeConstraint<int>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<uint, IThat<uint>>, uint?> IsNotBetween(
+		this IThat<uint> source,
+		uint? minimum)
+		=> new(maximum => new AndOrResult<uint, IThat<uint>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<uint>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<long, IThat<long>>, long?> IsNotBetween(
+		this IThat<long> source,
+		long? minimum)
+		=> new(maximum => new AndOrResult<long, IThat<long>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<long>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<ulong, IThat<ulong>>, ulong?> IsNotBetween(
+		this IThat<ulong> source,
+		ulong? minimum)
+		=> new(maximum => new AndOrResult<ulong, IThat<ulong>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<ulong>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<float, IThat<float>>, float?> IsNotBetween(
+		this IThat<float> source,
+		float? minimum)
+		=> new(maximum => new AndOrResult<float, IThat<float>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<float>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<double, IThat<double>>, double?> IsNotBetween(
+		this IThat<double> source,
+		double? minimum)
+		=> new(maximum => new AndOrResult<double, IThat<double>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<double>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<decimal, IThat<decimal>>, decimal?> IsNotBetween(
+		this IThat<decimal> source,
+		decimal? minimum)
+		=> new(maximum => new AndOrResult<decimal, IThat<decimal>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new IsInRangeConstraint<decimal>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<byte?, IThat<byte?>>, byte?> IsNotBetween(
+		this IThat<byte?> source,
+		byte? minimum)
+		=> new(maximum => new AndOrResult<byte?, IThat<byte?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<byte>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<sbyte?, IThat<sbyte?>>, sbyte?> IsNotBetween(
+		this IThat<sbyte?> source,
+		sbyte? minimum)
+		=> new(maximum => new AndOrResult<sbyte?, IThat<sbyte?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<sbyte>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<short?, IThat<short?>>, short?> IsNotBetween(
+		this IThat<short?> source,
+		short? minimum)
+		=> new(maximum => new AndOrResult<short?, IThat<short?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<short>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<ushort?, IThat<ushort?>>, ushort?> IsNotBetween(
+		this IThat<ushort?> source,
+		ushort? minimum)
+		=> new(maximum => new AndOrResult<ushort?, IThat<ushort?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<ushort>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<int?, IThat<int?>>, int?> IsNotBetween(
+		this IThat<int?> source,
+		int? minimum)
+		=> new(maximum => new AndOrResult<int?, IThat<int?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<int>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<uint?, IThat<uint?>>, uint?> IsNotBetween(
+		this IThat<uint?> source,
+		uint? minimum)
+		=> new(maximum => new AndOrResult<uint?, IThat<uint?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<uint>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<long?, IThat<long?>>, long?> IsNotBetween(
+		this IThat<long?> source,
+		long? minimum)
+		=> new(maximum => new AndOrResult<long?, IThat<long?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<long>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<ulong?, IThat<ulong?>>, ulong?> IsNotBetween(
+		this IThat<ulong?> source,
+		ulong? minimum)
+		=> new(maximum => new AndOrResult<ulong?, IThat<ulong?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<ulong>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<float?, IThat<float?>>, float?> IsNotBetween(
+		this IThat<float?> source,
+		float? minimum)
+		=> new(maximum => new AndOrResult<float?, IThat<float?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<float>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<double?, IThat<double?>>, double?> IsNotBetween(
+		this IThat<double?> source,
+		double? minimum)
+		=> new(maximum => new AndOrResult<double?, IThat<double?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<double>(it, grammars, minimum, maximum).Invert()),
+			source));
+
+	/// <summary>
+	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
+	/// </summary>
+	public static BetweenResult<AndOrResult<decimal?, IThat<decimal?>>, decimal?> IsNotBetween(
+		this IThat<decimal?> source,
+		decimal? minimum)
+		=> new(maximum => new AndOrResult<decimal?, IThat<decimal?>>(source.Get().ExpectationBuilder
+				.AddConstraint((it, grammars) =>
+					new NullableIsInRangeConstraint<decimal>(it, grammars, minimum, maximum).Invert()),
 			source));
 
 	private sealed class IsInRangeConstraint<TNumber> : ConstraintResult.WithValue<TNumber>,

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsBetween.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsBetween.cs
@@ -417,7 +417,6 @@ public static partial class ThatNumber
 					new NullableIsInRangeConstraint<decimal>(it, grammars, minimum, maximum)),
 			source));
 
-	
 	/// <summary>
 	///     Verifies that the subject is not in the range between the <paramref name="minimum" />…
 	/// </summary>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -724,6 +724,10 @@ namespace aweXpect
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>> IsNegative<TNumber>(this aweXpect.Core.IThat<TNumber?> source)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<TNumber, aweXpect.Core.IThat<TNumber>>, TNumber?> IsNotBetween<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? minimum)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<TNumber?, aweXpect.Core.IThat<TNumber?>>, TNumber?> IsNotBetween<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? minimum)
+            where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.NumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber>> IsNotEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber> source, TNumber? unexpected)
             where TNumber :  struct, System.Numerics.INumber<TNumber> { }
         public static aweXpect.Results.NullableNumberToleranceResult<TNumber, aweXpect.Core.IThat<TNumber?>> IsNotEqualTo<TNumber>(this aweXpect.Core.IThat<TNumber?> source, TNumber? unexpected)

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -652,6 +652,28 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>> IsNegative(this aweXpect.Core.IThat<sbyte?> source) { }
         public static aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>> IsNegative(this aweXpect.Core.IThat<short> source) { }
         public static aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>> IsNegative(this aweXpect.Core.IThat<short?> source) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<byte, aweXpect.Core.IThat<byte>>, byte?> IsNotBetween(this aweXpect.Core.IThat<byte> source, byte? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<byte?, aweXpect.Core.IThat<byte?>>, byte?> IsNotBetween(this aweXpect.Core.IThat<byte?> source, byte? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<decimal, aweXpect.Core.IThat<decimal>>, decimal?> IsNotBetween(this aweXpect.Core.IThat<decimal> source, decimal? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<decimal?, aweXpect.Core.IThat<decimal?>>, decimal?> IsNotBetween(this aweXpect.Core.IThat<decimal?> source, decimal? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<double, aweXpect.Core.IThat<double>>, double?> IsNotBetween(this aweXpect.Core.IThat<double> source, double? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<double?, aweXpect.Core.IThat<double?>>, double?> IsNotBetween(this aweXpect.Core.IThat<double?> source, double? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<float, aweXpect.Core.IThat<float>>, float?> IsNotBetween(this aweXpect.Core.IThat<float> source, float? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<float?, aweXpect.Core.IThat<float?>>, float?> IsNotBetween(this aweXpect.Core.IThat<float?> source, float? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<int, aweXpect.Core.IThat<int>>, int?> IsNotBetween(this aweXpect.Core.IThat<int> source, int? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<int?, aweXpect.Core.IThat<int?>>, int?> IsNotBetween(this aweXpect.Core.IThat<int?> source, int? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<long, aweXpect.Core.IThat<long>>, long?> IsNotBetween(this aweXpect.Core.IThat<long> source, long? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<long?, aweXpect.Core.IThat<long?>>, long?> IsNotBetween(this aweXpect.Core.IThat<long?> source, long? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<sbyte, aweXpect.Core.IThat<sbyte>>, sbyte?> IsNotBetween(this aweXpect.Core.IThat<sbyte> source, sbyte? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<sbyte?, aweXpect.Core.IThat<sbyte?>>, sbyte?> IsNotBetween(this aweXpect.Core.IThat<sbyte?> source, sbyte? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<short, aweXpect.Core.IThat<short>>, short?> IsNotBetween(this aweXpect.Core.IThat<short> source, short? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<short?, aweXpect.Core.IThat<short?>>, short?> IsNotBetween(this aweXpect.Core.IThat<short?> source, short? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<uint, aweXpect.Core.IThat<uint>>, uint?> IsNotBetween(this aweXpect.Core.IThat<uint> source, uint? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<uint?, aweXpect.Core.IThat<uint?>>, uint?> IsNotBetween(this aweXpect.Core.IThat<uint?> source, uint? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<ulong, aweXpect.Core.IThat<ulong>>, ulong?> IsNotBetween(this aweXpect.Core.IThat<ulong> source, ulong? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<ulong?, aweXpect.Core.IThat<ulong?>>, ulong?> IsNotBetween(this aweXpect.Core.IThat<ulong?> source, ulong? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<ushort, aweXpect.Core.IThat<ushort>>, ushort?> IsNotBetween(this aweXpect.Core.IThat<ushort> source, ushort? minimum) { }
+        public static aweXpect.Results.BetweenResult<aweXpect.Results.AndOrResult<ushort?, aweXpect.Core.IThat<ushort?>>, ushort?> IsNotBetween(this aweXpect.Core.IThat<ushort?> source, ushort? minimum) { }
         public static aweXpect.Results.NumberToleranceResult<byte, aweXpect.Core.IThat<byte>> IsNotEqualTo(this aweXpect.Core.IThat<byte> source, byte? unexpected) { }
         public static aweXpect.Results.NullableNumberToleranceResult<byte, aweXpect.Core.IThat<byte?>> IsNotEqualTo(this aweXpect.Core.IThat<byte?> source, byte? unexpected) { }
         public static aweXpect.Results.NumberToleranceResult<decimal, aweXpect.Core.IThat<decimal>> IsNotEqualTo(this aweXpect.Core.IThat<decimal> source, decimal? unexpected) { }

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotBetween.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotBetween.Tests.cs
@@ -1,0 +1,1268 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatNumber
+{
+	public sealed class IsNotBetween
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData(null, (byte)1)]
+			[InlineData((byte)1, null)]
+			public async Task ForByte_WhenMinimumOrMaximumIsNull_ShouldSucceed(byte? minimum, byte? maximum)
+			{
+				byte subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((byte)2, (byte)1, (byte)3)]
+			[InlineData((byte)2, (byte)2, (byte)4)]
+			[InlineData((byte)2, (byte)1, (byte)2)]
+			public async Task ForByte_WhenValueIsInRangeExpected_ShouldFail(byte subject,
+				byte? minimum, byte? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((byte)2, (byte)0, (byte)1)]
+			[InlineData((byte)0, (byte)1, (byte)2)]
+			public async Task ForByte_WhenValueIsOutsideTheRange_ShouldSucceed(byte subject,
+				byte? minimum, byte? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, 1.1)]
+			[InlineData(1.1, null)]
+			public async Task ForDecimal_WhenMinimumOrMaximumIsNull_ShouldSucceed(double? minimumValue,
+				double? maximumValue)
+			{
+				decimal subject = 2;
+				decimal? minimum = minimumValue is null ? null : new decimal(minimumValue.Value);
+				decimal? maximum = maximumValue is null ? null : new decimal(maximumValue.Value);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2.0, 1.0, 3.0)]
+			[InlineData(2.0, 2.0, 4.0)]
+			[InlineData(2.0, 1.0, 2.0)]
+			public async Task ForDecimal_WhenValueIsInRangeExpected_ShouldFail(
+				double subjectValue, double expectedMinimum, double expectedMaximum)
+			{
+				decimal subject = new(subjectValue);
+				decimal? minimum = new(expectedMinimum);
+				decimal? maximum = new(expectedMaximum);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(2.0, 0.0, 1.9)]
+			[InlineData(0.0, 0.1, 2.0)]
+			public async Task ForDecimal_WhenValueIsOutsideTheRange_ShouldSucceed(
+				double subjectValue, double minimumValue, double maximumValue)
+			{
+				decimal subject = new(subjectValue);
+				decimal minimum = new(minimumValue);
+				decimal maximum = new(maximumValue);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, 1.1)]
+			[InlineData(1.1, null)]
+			public async Task ForDouble_WhenMinimumOrMaximumIsNull_ShouldSucceed(double? minimum, double? maximum)
+			{
+				double subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2.0, 1.0, 3.0)]
+			[InlineData(2.0, 2.0, 4.0)]
+			[InlineData(2.0, 1.0, 2.0)]
+			public async Task ForDouble_WhenValueIsInRangeExpected_ShouldFail(
+				double subject, double minimum, double maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(2.0, 0.0, 1.9)]
+			[InlineData(0.0, 0.1, 2.0)]
+			public async Task ForDouble_WhenValueIsOutsideTheRange_ShouldSucceed(
+				double subject, double minimum, double maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, 1.0F)]
+			[InlineData(1.0F, null)]
+			public async Task ForFloat_WhenMinimumOrMaximumIsNull_ShouldSucceed(float? minimum, float? maximum)
+			{
+				float subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((float)2.0, (float)1.0, (float)3.0)]
+			[InlineData((float)2.0, (float)2.0, (float)4.0)]
+			[InlineData((float)2.0, (float)1.0, (float)2.0)]
+			public async Task ForFloat_WhenValueIsInRangeExpected_ShouldFail(
+				float subject, float minimum, float maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((float)2.0, (float)0.0, (float)1.9)]
+			[InlineData((float)0.0, (float)0.1, (float)2.0)]
+			public async Task ForFloat_WhenValueIsOutsideTheRange_ShouldSucceed(
+				float subject, float minimum, float maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ForInt_WhenMaximumIsSmallerThanMinimum_ShouldThrowArgumentOutOfRangeException()
+			{
+				int subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(2).And(1);
+
+				await That(Act).Throws<ArgumentOutOfRangeException>()
+					.WithParamName("maximum").And
+					.WithMessage("The maximum must be greater than or equal to the minimum.").AsPrefix();
+			}
+
+			[Theory]
+			[InlineData(null, 1)]
+			[InlineData(1, null)]
+			public async Task ForInt_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				int? minimum, int? maximum)
+			{
+				int subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2, 1, 3)]
+			[InlineData(2, 2, 4)]
+			[InlineData(2, 1, 2)]
+			public async Task ForInt_WhenValueIsInRangeExpected_ShouldFail(int subject,
+				int? minimum, int maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(2, 0, 1)]
+			[InlineData(0, 1, 2)]
+			public async Task ForInt_WhenValueIsOutsideTheRange_ShouldSucceed(int subject,
+				int? minimum, int maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(null, 1)]
+			[InlineData(1, null)]
+			public async Task ForInt128_WhenMinimumOrMaximumIsNull_ShouldSucceed(int? minimumValue, int? maximumValue)
+			{
+				Int128 subject = 2;
+				Int128? minimum = minimumValue;
+				Int128? maximum = maximumValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1, 3)]
+			[InlineData(2, 2, 4)]
+			[InlineData(2, 1, 2)]
+			public async Task ForInt128_WhenValueIsInRangeExpected_ShouldFail(
+				int subjectValue, int minimumValue, int maximumValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? minimum = minimumValue;
+				Int128? maximum = maximumValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 0, 1)]
+			[InlineData(0, 1, 2)]
+			public async Task ForInt128_WhenValueIsOutsideTheRange_ShouldSucceed(
+				int subjectValue, int minimumValue, int maximumValue)
+			{
+				Int128 subject = subjectValue;
+				Int128? minimum = minimumValue;
+				Int128? maximum = maximumValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+			[Theory]
+			[InlineData(null, (long)1)]
+			[InlineData((long)1, null)]
+			public async Task ForLong_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				long? minimum, long? maximum)
+			{
+				long subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((long)2, (long)1, (long)3)]
+			[InlineData((long)2, (long)2, (long)4)]
+			[InlineData((long)2, (long)1, (long)2)]
+			public async Task ForLong_WhenValueIsInRangeExpected_ShouldFail(long subject,
+				long? minimum, long maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((long)2, (long)0, (long)1)]
+			[InlineData((long)0, (long)1, (long)2)]
+			public async Task ForLong_WhenValueIsOutsideTheRange_ShouldSucceed(long subject,
+				long? minimum, long maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((byte)2, (byte)1, (byte)3)]
+			[InlineData((byte)2, (byte)2, (byte)4)]
+			[InlineData((byte)2, (byte)1, (byte)2)]
+			public async Task ForNullableByte_WhenValueIsInRangeExpected_ShouldFail(
+				byte? subject, byte? minimum, byte? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableByte_WhenValueIsNull_ShouldSucceed()
+			{
+				byte? subject = null;
+				byte minimum = 1;
+				byte maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((byte)2, (byte)0, (byte)1)]
+			[InlineData((byte)0, (byte)1, (byte)2)]
+			public async Task ForNullableByte_WhenValueIsOutsideTheRange_ShouldSucceed(
+				byte? subject, byte? minimum, byte? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, 1.1)]
+			[InlineData(1.1, null)]
+			public async Task ForNullableDecimal_WhenMinimumOrMaximumIsNull_ShouldSucceed(double? minimumValue,
+				double? maximumValue)
+			{
+				decimal subject = 2;
+				decimal? minimum = minimumValue == null ? null : new decimal(minimumValue.Value);
+				decimal? maximum = maximumValue == null ? null : new decimal(maximumValue.Value);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2.0, 1.0, 3.0)]
+			[InlineData(2.0, 2.0, 4.0)]
+			[InlineData(2.0, 1.0, 2.0)]
+			public async Task ForNullableDecimal_WhenValueIsInRangeExpected_ShouldFail(
+				double? subjectValue, double? minimumValue, double? maximumValue)
+			{
+				decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
+				decimal? minimum = minimumValue == null ? null : new decimal(minimumValue.Value);
+				decimal? maximum = maximumValue == null ? null : new decimal(maximumValue.Value);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(2.0, 0.0, 1.9)]
+			[InlineData(0.0, 0.1, 2.0)]
+			public async Task ForNullableDecimal_WhenValueIsOutsideTheRange_ShouldSucceed(
+				double? subjectValue, double? minimumValue, double? maximumValue)
+			{
+				decimal? subject = subjectValue == null ? null : new decimal(subjectValue.Value);
+				decimal? minimum = minimumValue == null ? null : new decimal(minimumValue.Value);
+				decimal? maximum = maximumValue == null ? null : new decimal(maximumValue.Value);
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, 1.1)]
+			[InlineData(1.1, null)]
+			public async Task ForNullableDouble_WhenMinimumOrMaximumIsNull_ShouldSucceed(double? minimum,
+				double? maximum)
+			{
+				double subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2.0, 1.0, 3.0)]
+			[InlineData(2.0, 2.0, 4.0)]
+			[InlineData(2.0, 1.0, 2.0)]
+			public async Task ForNullableDouble_WhenValueIsInRangeExpected_ShouldFail(
+				double? subject, double? minimum, double? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(2.0, 0.0, 1.9)]
+			[InlineData(0.0, 0.1, 2.0)]
+			public async Task ForNullableDouble_WhenValueIsOutsideTheRange_ShouldSucceed(
+				double? subject, double? minimum, double? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, 1.1F)]
+			[InlineData(1.1F, null)]
+			public async Task ForNullableFloat_WhenMinimumOrMaximumIsNull_ShouldSucceed(float? minimum, float? maximum)
+			{
+				float subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((float)2.0, (float)1.0, (float)3.0)]
+			[InlineData((float)2.0, (float)2.0, (float)4.0)]
+			[InlineData((float)2.0, (float)1.0, (float)2.0)]
+			public async Task ForNullableFloat_WhenValueIsInRangeExpected_ShouldFail(
+				float? subject, float? minimum, float? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((float)2.0, (float)0.0, (float)1.9)]
+			[InlineData((float)0.0, (float)0.1, (float)2.0)]
+			public async Task ForNullableFloat_WhenValueIsOutsideTheRange_ShouldSucceed(
+				float? subject, float? minimum, float? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenMaximumIsSmallerThanMinimum_ShouldThrowArgumentOutOfRangeException()
+			{
+				int? subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(2).And(1);
+
+				await That(Act).Throws<ArgumentOutOfRangeException>()
+					.WithParamName("maximum").And
+					.WithMessage("The maximum must be greater than or equal to the minimum.").AsPrefix();
+			}
+
+			[Theory]
+			[InlineData(null, 1)]
+			[InlineData(1, null)]
+			public async Task ForNullableInt_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				int? minimum, int? maximum)
+			{
+				int? subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2, 1, 3)]
+			[InlineData(2, 2, 4)]
+			[InlineData(2, 1, 2)]
+			public async Task ForNullableInt_WhenValueIsInRangeExpected_ShouldFail(
+				int? subject, int? minimum, int? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenValueIsNull_ShouldSucceed()
+			{
+				int? subject = null;
+				int minimum = 1;
+				int maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2, 0, 1)]
+			[InlineData(0, 1, 2)]
+			public async Task ForNullableInt_WhenValueIsOutsideTheRange_ShouldSucceed(
+				int? subject, int? minimum, int? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(null, 1)]
+			[InlineData(1, null)]
+			public async Task ForNullableInt128_WhenMinimumOrMaximumIsNull_ShouldSucceed(int? minimumValue,
+				int? maximumValue)
+			{
+				Int128? subject = 2;
+				Int128? minimum = minimumValue;
+				Int128? maximum = maximumValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 1, 3)]
+			[InlineData(2, 2, 4)]
+			[InlineData(2, 1, 2)]
+			public async Task ForNullableInt128_WhenValueIsInRangeExpected_ShouldFail(
+				int? subjectValue, int? minimumValue, int? maximumValue)
+			{
+				Int128? subject = subjectValue;
+				Int128? minimum = minimumValue;
+				Int128? maximum = maximumValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {Formatter.Format(minimum)} and {Formatter.Format(maximum)},
+					              but it was {Formatter.Format(subject)}
+					              """);
+			}
+#endif
+
+#if NET8_0_OR_GREATER
+			[Theory]
+			[InlineData(2, 0, 1)]
+			[InlineData(0, 1, 2)]
+			public async Task ForNullableInt128_WhenValueIsOutsideTheRange_ShouldSucceed(
+				int? subjectValue, int? minimumValue, int? maximumValue)
+			{
+				Int128? subject = subjectValue;
+				Int128? minimum = minimumValue;
+				Int128? maximum = maximumValue;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+			[Theory]
+			[InlineData(null, (long)1)]
+			[InlineData((long)1, null)]
+			public async Task ForNullableLong_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				long? minimum, long? maximum)
+			{
+				long? subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((long)2, (long)1, (long)3)]
+			[InlineData((long)2, (long)2, (long)4)]
+			[InlineData((long)2, (long)1, (long)2)]
+			public async Task ForNullableLong_WhenValueIsInRangeExpected_ShouldFail(
+				long? subject, long? minimum, long? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableLong_WhenValueIsNull_ShouldSucceed()
+			{
+				long? subject = null;
+				long minimum = 1;
+				long maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((long)2, (long)0, (long)1)]
+			[InlineData((long)0, (long)1, (long)2)]
+			public async Task ForNullableLong_WhenValueIsOutsideTheRange_ShouldSucceed(
+				long? subject, long? minimum, long? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((sbyte)2, (sbyte)1, (sbyte)3)]
+			[InlineData((sbyte)2, (sbyte)2, (sbyte)4)]
+			[InlineData((sbyte)2, (sbyte)1, (sbyte)2)]
+			public async Task ForNullableSbyte_WhenValueIsInRangeExpected_ShouldFail(
+				sbyte? subject, sbyte? minimum, sbyte? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableSbyte_WhenValueIsNull_ShouldSucceed()
+			{
+				sbyte? subject = null;
+				sbyte minimum = 1;
+				sbyte maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((sbyte)2, (sbyte)0, (sbyte)1)]
+			[InlineData((sbyte)0, (sbyte)1, (sbyte)2)]
+			public async Task ForNullableSbyte_WhenValueIsOutsideTheRange_ShouldSucceed(
+				sbyte? subject, sbyte? minimum, sbyte? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((short)2, (short)1, (short)3)]
+			[InlineData((short)2, (short)2, (short)4)]
+			[InlineData((short)2, (short)1, (short)2)]
+			public async Task ForNullableShort_WhenValueIsInRangeExpected_ShouldFail(
+				short? subject, short? minimum, short? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableShort_WhenValueIsNull_ShouldSucceed()
+			{
+				short? subject = null;
+				short minimum = 1;
+				short maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((short)2, (short)0, (short)1)]
+			[InlineData((short)0, (short)1, (short)2)]
+			public async Task ForNullableShort_WhenValueIsOutsideTheRange_ShouldSucceed(
+				short? subject, short? minimum, short? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((uint)2, (uint)1, (uint)3)]
+			[InlineData((uint)2, (uint)2, (uint)4)]
+			[InlineData((uint)2, (uint)1, (uint)2)]
+			public async Task ForNullableUint_WhenValueIsInRangeExpected_ShouldFail(
+				uint? subject, uint? minimum, uint maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableUint_WhenValueIsNull_ShouldSucceed()
+			{
+				uint? subject = null;
+				uint minimum = 1;
+				uint maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((uint)2, (uint)0, (uint)1)]
+			[InlineData((uint)0, (uint)1, (uint)2)]
+			public async Task ForNullableUint_WhenValueIsOutsideTheRange_ShouldSucceed(
+				uint? subject, uint? minimum, uint maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((ulong)2, (ulong)1, (ulong)3)]
+			[InlineData((ulong)2, (ulong)2, (ulong)4)]
+			[InlineData((ulong)2, (ulong)1, (ulong)2)]
+			public async Task ForNullableUlong_WhenValueIsInRangeExpected_ShouldFail(
+				ulong? subject, ulong? minimum, ulong? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableUlong_WhenValueIsNull_ShouldSucceed()
+			{
+				ulong? subject = null;
+				ulong minimum = 1;
+				ulong maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((ulong)2, (ulong)0, (ulong)1)]
+			[InlineData((ulong)0, (ulong)1, (ulong)2)]
+			public async Task ForNullableUlong_WhenValueIsOutsideTheRange_ShouldSucceed(
+				ulong? subject, ulong? minimum, ulong? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((ushort)2, (ushort)1, (ushort)3)]
+			[InlineData((ushort)2, (ushort)2, (ushort)4)]
+			[InlineData((ushort)2, (ushort)1, (ushort)2)]
+			public async Task ForNullableUshort_WhenValueIsInRangeExpected_ShouldFail(
+				ushort? subject, ushort? minimum, ushort? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task ForNullableUshort_WhenValueIsNull_ShouldSucceed()
+			{
+				ushort? subject = null;
+				ushort minimum = 1;
+				ushort maximum = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((ushort)2, (ushort)0, (ushort)1)]
+			[InlineData((ushort)0, (ushort)1, (ushort)2)]
+			public async Task ForNullableUshort_WhenValueIsOutsideTheRange_ShouldSucceed(
+				ushort? subject, ushort? minimum, ushort? maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, (sbyte)1)]
+			[InlineData((sbyte)1, null)]
+			public async Task ForSbyte_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				sbyte? minimum, sbyte? maximum)
+			{
+				sbyte subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((sbyte)2, (sbyte)1, (sbyte)3)]
+			[InlineData((sbyte)2, (sbyte)2, (sbyte)4)]
+			[InlineData((sbyte)2, (sbyte)1, (sbyte)2)]
+			public async Task ForSbyte_WhenValueIsInRangeExpected_ShouldFail(sbyte subject,
+				sbyte? minimum, sbyte maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((sbyte)2, (sbyte)0, (sbyte)1)]
+			[InlineData((sbyte)0, (sbyte)1, (sbyte)2)]
+			public async Task ForSbyte_WhenValueIsOutsideTheRange_ShouldSucceed(sbyte subject,
+				sbyte? minimum, sbyte maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, (short)1)]
+			[InlineData((short)1, null)]
+			public async Task ForShort_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				short? minimum, short? maximum)
+			{
+				short subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((short)2, (short)1, (short)3)]
+			[InlineData((short)2, (short)2, (short)4)]
+			[InlineData((short)2, (short)1, (short)2)]
+			public async Task ForShort_WhenValueIsInRangeExpected_ShouldFail(short subject,
+				short? minimum, short maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((short)2, (short)0, (short)1)]
+			[InlineData((short)0, (short)1, (short)2)]
+			public async Task ForShort_WhenValueIsOutsideTheRange_ShouldSucceed(short subject,
+				short? minimum, short maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, (uint)1)]
+			[InlineData((uint)1, null)]
+			public async Task ForUint_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				uint? minimum, uint? maximum)
+			{
+				uint subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((uint)2, (uint)1, (uint)3)]
+			[InlineData((uint)2, (uint)2, (uint)4)]
+			[InlineData((uint)2, (uint)1, (uint)2)]
+			public async Task ForUint_WhenValueIsInRangeExpected_ShouldFail(uint subject,
+				uint? minimum, uint maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((uint)2, (uint)0, (uint)1)]
+			[InlineData((uint)0, (uint)1, (uint)2)]
+			public async Task ForUint_WhenValueIsOutsideTheRange_ShouldSucceed(uint subject,
+				uint? minimum, uint maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, (ulong)1)]
+			[InlineData((ulong)1, null)]
+			public async Task ForUlong_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				ulong? minimum, ulong? maximum)
+			{
+				ulong subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((ulong)2, (ulong)1, (ulong)3)]
+			[InlineData((ulong)2, (ulong)2, (ulong)4)]
+			[InlineData((ulong)2, (ulong)1, (ulong)2)]
+			public async Task ForUlong_WhenValueIsInRangeExpected_ShouldFail(ulong subject,
+				ulong? minimum, ulong maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((ulong)2, (ulong)0, (ulong)1)]
+			[InlineData((ulong)0, (ulong)1, (ulong)2)]
+			public async Task ForUlong_WhenValueIsOutsideTheRange_ShouldSucceed(ulong subject,
+				ulong? minimum, ulong maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(null, (ushort)1)]
+			[InlineData((ushort)1, null)]
+			public async Task ForUshort_WhenMinimumOrMaximumIsNull_ShouldSucceed(
+				ushort? minimum, ushort? maximum)
+			{
+				ushort subject = 2;
+
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData((ushort)2, (ushort)1, (ushort)3)]
+			[InlineData((ushort)2, (ushort)2, (ushort)4)]
+			[InlineData((ushort)2, (ushort)1, (ushort)2)]
+			public async Task ForUshort_WhenValueIsInRangeExpected_ShouldFail(
+				ushort subject,
+				ushort? minimum, ushort maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData((ushort)2, (ushort)0, (ushort)1)]
+			[InlineData((ushort)0, (ushort)1, (ushort)2)]
+			public async Task ForUshort_WhenValueIsOutsideTheRange_ShouldSucceed(ushort subject,
+				ushort? minimum, ushort maximum)
+			{
+				async Task Act()
+					=> await That(subject).IsNotBetween(minimum).And(maximum);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData(null, 1)]
+			[InlineData(1, null)]
+			public async Task ForInt_WhenMinimumOrMaximumIsNull_ShouldFail(
+				int? minimum, int? maximum)
+			{
+				int subject = 2;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsNotBetween(minimum).And(maximum));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+
+			[Theory]
+			[InlineData(2, 1, 3)]
+			[InlineData(2, 2, 4)]
+			[InlineData(2, 1, 2)]
+			public async Task ForInt_WhenValueIsInRangeExpected_ShouldSucceed(int subject,
+				int? minimum, int maximum)
+			{
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsNotBetween(minimum).And(maximum));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2, 0, 1)]
+			[InlineData(0, 1, 2)]
+			public async Task ForInt_WhenValueIsOutsideTheRange_ShouldFail(int subject,
+				int? minimum, int maximum)
+			{
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsNotBetween(minimum).And(maximum));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+			[Theory]
+			[InlineData(null, 1)]
+			[InlineData(1, null)]
+			public async Task ForNullableInt_WhenMinimumIsNull_ShouldFail(
+				int? minimum, int? maximum)
+			{
+				int subject = 2;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsNotBetween(minimum).And(maximum));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+
+
+			[Theory]
+			[InlineData(2, 1, 3)]
+			[InlineData(2, 2, 4)]
+			[InlineData(2, 1, 2)]
+			public async Task ForNullableInt_WhenValueIsInRangeExpected_ShouldSucceed(int? subject,
+				int? minimum, int maximum)
+			{
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsNotBetween(minimum).And(maximum));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(2, 0, 1)]
+			[InlineData(0, 1, 2)]
+			public async Task ForNullableInt_WhenValueIsOutsideTheRange_ShouldFail(int? subject,
+				int? minimum, int maximum)
+			{
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.IsNotBetween(minimum).And(maximum));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is between {ValueFormatters.Format(Formatter, minimum)} and {ValueFormatters.Format(Formatter, maximum)},
+					              but it was {ValueFormatters.Format(Formatter, subject)}
+					              """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds “IsNotBetween” assertion methods to the aweXpect API so callers can verify a value is outside a given range.

- Introduces `IsNotBetween` overloads for each built-in numeric type