### PR TITLE
fix: ignore assemblies where `GetTypes()` throws an exception

### DIFF
--- a/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
+++ b/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
@@ -24,7 +24,7 @@ internal static class AweXpectInitialization
 		_ = State.Value;
 	}
 
-	internal static ITestFrameworkAdapter DetectFramework(IEnumerable<Type> types)
+	internal static ITestFrameworkAdapter? DetectFramework(IEnumerable<Type> types)
 	{
 		Type frameworkInterface = typeof(ITestFrameworkAdapter);
 		foreach (Type frameworkType in types
@@ -48,18 +48,33 @@ internal static class AweXpectInitialization
 			}
 		}
 
-		return new FallbackTestFramework();
+		return null;
 	}
 
 	private static InitializationState Initialize()
 	{
 		ExecuteCustomInitializers();
 
-		ITestFrameworkAdapter testFramework = DetectFramework(AppDomain.CurrentDomain.GetAssemblies()
-			.Where(assembly => Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
-				.All(excludedAssemblyPrefix => !assembly.FullName!.StartsWith(excludedAssemblyPrefix)))
-			.SelectMany(assembly => assembly.GetTypes().Where(x => !x.IsNestedPrivate)));
-		return new InitializationState(testFramework);
+		foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()
+			         .Where(assembly => Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
+				         .All(excludedAssemblyPrefix => !assembly.FullName!.StartsWith(excludedAssemblyPrefix))))
+		{
+			try
+			{
+				ITestFrameworkAdapter? testFrameworkAdapter = DetectFramework(
+					assembly.GetTypes().Where(x => !x.IsNestedPrivate));
+				if (testFrameworkAdapter is not null)
+				{
+					return new InitializationState(testFrameworkAdapter);
+				}
+			}
+			catch (ReflectionTypeLoadException)
+			{
+				// Ignore any ReflectionTypeLoadException and continue with the next assembly.
+			}
+		}
+
+		return new InitializationState(new FallbackTestFramework());
 	}
 
 	private static void ExecuteCustomInitializers()

--- a/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
+++ b/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
@@ -24,6 +24,13 @@ internal static class AweXpectInitialization
 		_ = State.Value;
 	}
 
+	/// <summary>
+	///     Detects a test framework adapter from the provided types.
+	/// </summary>
+	/// <returns>
+	///     An instance of <see cref="ITestFrameworkAdapter" /> if a matching framework is found;
+	///     otherwise <see langword="null" />.
+	/// </returns>
 	internal static ITestFrameworkAdapter? DetectFramework(IEnumerable<Type> types)
 	{
 		Type frameworkInterface = typeof(ITestFrameworkAdapter);
@@ -68,9 +75,11 @@ internal static class AweXpectInitialization
 					return new InitializationState(testFrameworkAdapter);
 				}
 			}
-			catch (ReflectionTypeLoadException)
+			catch (ReflectionTypeLoadException ex)
 			{
 				// Ignore any ReflectionTypeLoadException and continue with the next assembly.
+				Debug.WriteLine($"ReflectionTypeLoadException caught: {ex.Message}");
+				Debug.WriteLine(ex.StackTrace);
 			}
 		}
 

--- a/Tests/aweXpect.Core.Tests/Core/Initialization/AweXpectInitializationTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Initialization/AweXpectInitializationTests.cs
@@ -8,12 +8,11 @@ namespace aweXpect.Core.Tests.Core.Initialization;
 public sealed class AweXpectInitializationTests
 {
 	[Fact]
-	public async Task DetectFramework_WhenAllFrameworksAreNotAvailable_ShouldUseFallbackAdapter()
+	public async Task DetectFramework_WhenAllFrameworksAreNotAvailable_ShouldReturnNull()
 	{
-		ITestFrameworkAdapter result = AweXpectInitialization.DetectFramework([typeof(UnavailableFrameworkAdapter),]);
+		ITestFrameworkAdapter? result = AweXpectInitialization.DetectFramework([typeof(UnavailableFrameworkAdapter),]);
 
-		await That(result.IsAvailable).IsFalse();
-		await That(result.GetType().Name).IsEqualTo("FallbackTestFramework");
+		await That(result).IsNull();
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/TraceWriterTests.cs
+++ b/Tests/aweXpect.Core.Tests/TraceWriterTests.cs
@@ -107,10 +107,9 @@ public class TraceWriterTests
 			await That(callback).ExecutesWithin(500.Milliseconds());
 		}
 
-		await That(traceWriter.Messages).IsEqualTo([
-			"Checking expectation for callback delegate returning int 4 in 0:00",
-			"  Successfully verified that callback executes within 0:00.500",
-		]);
+		await That(traceWriter.Messages).HasCount(2);
+		await That(traceWriter.Messages[0]).IsEqualTo("Checking expectation for callback delegate returning int 4 in 0:00").AsPrefix();
+		await That(traceWriter.Messages[1]).IsEqualTo("  Successfully verified that callback executes within 0:00.500");
 	}
 
 	[Fact]


### PR DESCRIPTION
This PR modifies framework detection to skip assemblies that throw a `ReflectionTypeLoadException` and updates the fallback behavior to return `null` when no adapter is found.

Changed `DetectFramework` signature to return nullable and updated its fallback from a concrete adapter to null
Wrapped the assembly scanning loop in a try/catch to ignore `ReflectionTypeLoadException`
Updated the unit test to expect `null` instead of the fallback adapter