### PR TITLE
fix: support failed `Task<T>`

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResult.ExceptionConstraintResult.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResult.ExceptionConstraintResult.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core.Helpers;
+
+namespace aweXpect.Core.Constraints;
+
+/// <summary>
+///     The result of the check if an expectation is met.
+/// </summary>
+public abstract partial class ConstraintResult
+{
+	/// <summary>
+	///     A failed <see cref="ConstraintResult" /> due to an <see cref="Exception" />.
+	/// </summary>
+	internal class ExceptionConstraintResult : ConstraintResult
+	{
+		private readonly Exception _exception;
+		private readonly ConstraintResult _inner;
+
+		/// <summary>
+		///     A failed <see cref="ConstraintResult" /> due to a thrown <paramref name="exception" />.
+		/// </summary>
+		public ExceptionConstraintResult(
+			ConstraintResult inner,
+			Exception exception,
+			ExpectationBuilder expectationBuilder)
+			: base(inner.Grammars)
+		{
+			_inner = inner;
+			_exception = exception;
+			FurtherProcessingStrategy = inner.FurtherProcessingStrategy;
+			expectationBuilder.UpdateContexts(c => c.Add(new ResultContext("Exception", exception.ToString())));
+		}
+
+		public override Outcome Outcome
+		{
+			get => Outcome.Failure;
+			protected set => _inner.Outcome = value;
+		}
+
+		/// <inheritdoc cref="ConstraintResult.AppendExpectation(StringBuilder, string?)" />
+		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> _inner.AppendExpectation(stringBuilder, indentation);
+
+		/// <inheritdoc cref="ConstraintResult.AppendResult(StringBuilder, string?)" />
+		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder
+				.Append("it did throw ");
+
+			Type? exceptionType = _exception.GetType();
+			if (exceptionType == typeof(Exception))
+			{
+				stringBuilder.Append("an exception");
+			}
+			else
+			{
+				stringBuilder.Append(Formatter.Format(exceptionType).PrependAOrAn());
+			}
+		}
+
+		/// <inheritdoc cref="ConstraintResult.TryGetValue{TValue}(out TValue)" />
+		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value)
+			where TValue : default
+			=> _inner.TryGetValue(out value);
+
+		/// <inheritdoc cref="ConstraintResult.Negate()" />
+		public override ConstraintResult Negate()
+			=> _inner.Negate();
+	}
+}

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.IsFalse.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.IsFalse.Tests.cs
@@ -18,6 +18,26 @@ public sealed partial class ThatBool
 			}
 
 			[Fact]
+			public async Task WhenTaskFails_ShouldFailWithExceptionMessage()
+			{
+				Task<bool> subject = Task.FromException<bool>(
+					new NotSupportedException("When Task throws an exception"));
+
+				async Task Act()
+					=> await That(subject).IsFalse().Because("the exception should be logged");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is False, because the exception should be logged,
+					             but it did throw a NotSupportedException
+
+					             Exception:
+					             System.NotSupportedException: When Task throws an exception
+					             """).AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenTrue_ShouldFail()
 			{
 				bool subject = true;

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.IsTrue.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.IsTrue.Tests.cs
@@ -39,6 +39,26 @@ public sealed partial class ThatBool
 			}
 
 			[Fact]
+			public async Task WhenTaskFails_ShouldFailWithExceptionMessage()
+			{
+				Task<bool> subject = Task.FromException<bool>(
+					new NotSupportedException("When Task throws an exception"));
+
+				async Task Act()
+					=> await That(subject).IsTrue().Because("the exception should be logged");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is True, because the exception should be logged,
+					             but it did throw a NotSupportedException
+
+					             Exception:
+					             System.NotSupportedException: When Task throws an exception
+					             """).AsPrefix();
+			}
+
+			[Fact]
 			public async Task WhenTrue_ShouldSucceed()
 			{
 				bool subject = true;

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsFalse.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsFalse.Tests.cs
@@ -19,6 +19,26 @@ public sealed partial class ThatBool
 					await That(Act).DoesNotThrow();
 				}
 
+				[Fact]
+				public async Task WhenTaskFails_ShouldFailWithExceptionMessage()
+				{
+					Task<bool?> subject = Task.FromException<bool?>(
+						new NotSupportedException("When Task throws an exception"));
+
+					async Task Act()
+						=> await That(subject).IsFalse().Because("the exception should be logged");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is False, because the exception should be logged,
+						             but it did throw a NotSupportedException
+
+						             Exception:
+						             System.NotSupportedException: When Task throws an exception
+						             """).AsPrefix();
+				}
+
 				[Theory]
 				[InlineData(true)]
 				[InlineData(null)]

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotEqualTo.Tests.cs
@@ -18,11 +18,11 @@ public sealed partial class ThatBool
 						=> await That(subject).IsNotEqualTo(unexpected);
 
 					await That(Act).Throws<XunitException>()
-						.WithMessage($"""
-						              Expected that subject
-						              is not <null>,
-						              but it was <null>
-						              """);
+						.WithMessage("""
+						             Expected that subject
+						             is not <null>,
+						             but it was <null>
+						             """);
 				}
 
 				[Theory]

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotFalse.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotFalse.Tests.cs
@@ -24,6 +24,26 @@ public sealed partial class ThatBool
 						             """);
 				}
 
+				[Fact]
+				public async Task WhenTaskFails_ShouldFailWithExceptionMessage()
+				{
+					Task<bool?> subject = Task.FromException<bool?>(
+						new NotSupportedException("When Task throws an exception"));
+
+					async Task Act()
+						=> await That(subject).IsNotFalse().Because("the exception should be logged");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not False, because the exception should be logged,
+						             but it did throw a NotSupportedException
+
+						             Exception:
+						             System.NotSupportedException: When Task throws an exception
+						             """).AsPrefix();
+				}
+
 				[Theory]
 				[InlineData(true)]
 				[InlineData(null)]

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotTrue.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsNotTrue.Tests.cs
@@ -20,6 +20,26 @@ public sealed partial class ThatBool
 				}
 
 				[Fact]
+				public async Task WhenTaskFails_ShouldFailWithExceptionMessage()
+				{
+					Task<bool?> subject = Task.FromException<bool?>(
+						new NotSupportedException("When Task throws an exception"));
+
+					async Task Act()
+						=> await That(subject).IsNotTrue().Because("the exception should be logged");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is not True, because the exception should be logged,
+						             but it did throw a NotSupportedException
+
+						             Exception:
+						             System.NotSupportedException: When Task throws an exception
+						             """).AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenTrue_ShouldFail()
 				{
 					bool? subject = true;

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsTrue.Tests.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.Nullable.IsTrue.Tests.cs
@@ -25,6 +25,26 @@ public sealed partial class ThatBool
 				}
 
 				[Fact]
+				public async Task WhenTaskFails_ShouldFailWithExceptionMessage()
+				{
+					Task<bool?> subject = Task.FromException<bool?>(
+						new NotSupportedException("When Task throws an exception"));
+
+					async Task Act()
+						=> await That(subject).IsTrue().Because("the exception should be logged");
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             is True, because the exception should be logged,
+						             but it did throw a NotSupportedException
+
+						             Exception:
+						             System.NotSupportedException: When Task throws an exception
+						             """).AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenTrue_ShouldSucceed()
 				{
 					bool? subject = true;


### PR DESCRIPTION
Handle the case when a `Task<T>` is evaluated that throws an exception: Keep the original expectation but include the exception details in the result.