### PR TITLE
fix: `Contains` for collections with duplicates in expected

### DIFF
--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.cs
@@ -161,12 +161,6 @@ public partial class CollectionMatchOptions(
 		{
 			foreach (KeyValuePair<int, (T Item, T Expected)> incorrectItem in incorrectItems)
 			{
-				if (equivalenceRelation.HasFlag(EquivalenceRelations.Contains) &&
-				    !expectedItems.Contains(incorrectItem.Value.Item))
-				{
-					continue;
-				}
-
 				yield return
 					$"contained item {Formatter.Format(incorrectItem.Value.Item)} at index {incorrectItem.Key} instead of {Formatter.Format(incorrectItem.Value.Expected)}";
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
@@ -190,11 +190,14 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -669,11 +672,14 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -1922,12 +1928,14 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
 					               did not contain any additional items and
 					               lacked 3 of 6 expected items:
 					                 "x",
 					                 "y",
 					                 "z"
-
+					             
 					             Collection:
 					             [
 					               "a",
@@ -2433,11 +2441,14 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionEnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionEnumerableTests.cs
@@ -190,11 +190,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -670,11 +673,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -1924,12 +1930,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
 					               did not contain any additional items and
 					               lacked 3 of 6 expected items:
 					                 "x",
 					                 "y",
 					                 "z"
-
+					             
 					             Collection:
 					             [
 					               "a",
@@ -2436,11 +2444,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionImmutableTests.cs
@@ -191,11 +191,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -671,11 +674,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -1925,12 +1931,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
 					               did not contain any additional items and
 					               lacked 3 of 6 expected items:
 					                 "x",
 					                 "y",
 					                 "z"
-
+					             
 					             Collection:
 					             [
 					               "a",
@@ -2437,11 +2445,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
@@ -143,6 +143,31 @@ public sealed partial class ThatEnumerable
 					             """);
 			}
 
+
+			[Fact]
+			public async Task WhenExpectedContainsDuplicateButMissingItems_ShouldFail()
+			{
+				int[] collection = [1, 2, 1, 3, 12, 2, 2,];
+
+				async Task Act()
+					=> await That(collection).Contains([1, 2, 1, 1, 2,]);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that collection
+					             contains collection [1, 2, 1, 1, 2,] in order,
+					             but it
+					               contained item 3 at index 3 instead of 1 and
+					               contained item 12 at index 4 instead of 2
+					             
+					             Collection:
+					             [1, 2, 1, 3, 12, 2, 2]
+					             
+					             Expected:
+					             [1, 2, 1, 1, 2]
+					             """);
+			}
+
 			[Fact]
 			public async Task WhenExpectedIsNull_ShouldFail()
 			{
@@ -189,11 +214,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -669,11 +697,14 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
-
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
+					             
 					             Collection:
 					             [
 					               "a",
@@ -1923,6 +1954,8 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
 					               did not contain any additional items and
 					               lacked 3 of 6 expected items:
 					                 "x",
@@ -2435,10 +2468,13 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 3 of 6 expected items:
-					               "x",
-					               "y",
-					               "z"
+					             but it
+					               contained item "d" at index 3 instead of "x" and
+					               contained item "e" at index 4 instead of "y" and
+					               lacked 3 of 6 expected items:
+					                 "x",
+					                 "y",
+					                 "z"
 
 					             Collection:
 					             [


### PR DESCRIPTION
Ensure that the following test succeeds:
```csharp
[Fact]
public async Task WhenExpectedContainsDuplicateButMissingItems_ShouldFail()
{
	int[] collection = [1, 2, 1, 3, 12, 2, 2,];

	async Task Act()
		=> await That(collection).Contains([1, 2, 1, 1, 2,]);

	await That(Act).Throws<XunitException>()
		.WithMessage("""
		             Expected that collection
		             contains collection [1, 2, 1, 1, 2,] in order,
		             but it
		               contained item 3 at index 3 instead of 1 and
		               contained item 12 at index 4 instead of 2

		             Collection:
		             [1, 2, 1, 3, 12, 2, 2]

		             Expected:
		             [1, 2, 1, 1, 2]
		             """);
}
```