### PR TITLE
feat: add `IgnoringInterspersedItems` option for collections

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/Helpers/ExceptionHelpers.cs
+++ b/Source/aweXpect.Core/Core/Helpers/ExceptionHelpers.cs
@@ -11,4 +11,10 @@ internal static class ExceptionHelpers
 		Customize.aweXpect.TraceWriter.Value?.WriteException(exception);
 		return exception;
 	}
+	public static bool IsDefault<T>(this T value) where T : struct
+	{
+		bool isDefault = value.Equals(default(T));
+
+		return isDefault;
+	}
 }

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderCollectionMatcher.cs
@@ -57,7 +57,7 @@ public partial class CollectionMatchOptions
 
 			if (!_equivalenceRelations.HasFlag(EquivalenceRelations.IsContainedIn))
 			{
-				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelations));
+				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelations, false));
 			}
 			else if (_equivalenceRelations.HasFlag(EquivalenceRelations.IsContainedInProperly) && !_missingItems.Any())
 			{

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.AnyOrderIgnoreDuplicatesCollectionMatcher.cs
@@ -64,7 +64,7 @@ public partial class CollectionMatchOptions
 
 			if (!_equivalenceRelations.HasFlag(EquivalenceRelations.IsContainedIn))
 			{
-				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelations));
+				errors.AddRange(MissingItemsError(_totalExpectedCount, _missingItems, _equivalenceRelations, true));
 			}
 			else if (_equivalenceRelations.HasFlag(EquivalenceRelations.IsContainedInProperly) && !_missingItems.Any())
 			{

--- a/Source/aweXpect/Results/ObjectCollectionMatchResult.cs
+++ b/Source/aweXpect/Results/ObjectCollectionMatchResult.cs
@@ -52,4 +52,16 @@ public class ObjectCollectionMatchResult<TType, TThat, TElement, TSelf>(
 		collectionMatchOptions.IgnoringDuplicates();
 		return (TSelf)this;
 	}
+
+	/// <summary>
+	///     Ignores interspersed items in the actual collection.
+	/// </summary>
+	/// <remarks>
+	///     This option has no effect when <see cref="InAnyOrder()" /> is used.
+	/// </remarks>
+	public TSelf IgnoringInterspersedItems()
+	{
+		collectionMatchOptions.IgnoringInterspersedItems();
+		return (TSelf)this;
+	}
 }

--- a/Source/aweXpect/Results/StringCollectionMatchResult.cs
+++ b/Source/aweXpect/Results/StringCollectionMatchResult.cs
@@ -52,4 +52,16 @@ public class StringCollectionMatchResult<TType, TThat, TSelf>(
 		collectionMatchOptions.IgnoringDuplicates();
 		return (TSelf)this;
 	}
+
+	/// <summary>
+	///     Ignores interspersed items in the actual collection.
+	/// </summary>
+	/// <remarks>
+	///     This option has no effect when <see cref="InAnyOrder()" /> is used.
+	/// </remarks>
+	public TSelf IgnoringInterspersedItems()
+	{
+		collectionMatchOptions.IgnoringInterspersedItems();
+		return (TSelf)this;
+	}
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1246,6 +1246,7 @@ namespace aweXpect.Results
     {
         public ObjectCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions<TElement> options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
         public TSelf IgnoringDuplicates() { }
+        public TSelf IgnoringInterspersedItems() { }
         public TSelf InAnyOrder() { }
     }
     public class ObjectCollectionMatchWithToleranceResult<TType, TThat, TElement, TTolerance> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TElement>
@@ -1328,6 +1329,7 @@ namespace aweXpect.Results
     {
         public StringCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
         public TSelf IgnoringDuplicates() { }
+        public TSelf IgnoringInterspersedItems() { }
         public TSelf InAnyOrder() { }
     }
 }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -1229,6 +1229,7 @@ namespace aweXpect.Results
     {
         public ObjectCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.ObjectEqualityOptions<TElement> options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
         public TSelf IgnoringDuplicates() { }
+        public TSelf IgnoringInterspersedItems() { }
         public TSelf InAnyOrder() { }
     }
     public class ObjectCollectionMatchWithToleranceResult<TType, TThat, TElement, TTolerance> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TElement>
@@ -1311,6 +1312,7 @@ namespace aweXpect.Results
     {
         public StringCollectionMatchResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue, aweXpect.Options.StringEqualityOptions options, aweXpect.Options.CollectionMatchOptions collectionMatchOptions) { }
         public TSelf IgnoringDuplicates() { }
+        public TSelf IgnoringInterspersedItems() { }
         public TSelf InAnyOrder() { }
     }
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -747,6 +747,7 @@ namespace aweXpect.Options
             where T : T2 { }
         public string GetExpectation(string expectedExpression, aweXpect.Core.ExpectationGrammars grammars) { }
         public void IgnoringDuplicates() { }
+        public void IgnoringInterspersedItems() { }
         public void InAnyOrder() { }
         public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelations equivalenceRelation) { }
         [System.Flags]

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -730,6 +730,7 @@ namespace aweXpect.Options
             where T : T2 { }
         public string GetExpectation(string expectedExpression, aweXpect.Core.ExpectationGrammars grammars) { }
         public void IgnoringDuplicates() { }
+        public void IgnoringInterspersedItems() { }
         public void InAnyOrder() { }
         public void SetEquivalenceRelation(aweXpect.Options.CollectionMatchOptions.EquivalenceRelations equivalenceRelation) { }
         [System.Flags]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
@@ -72,11 +72,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -102,18 +99,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -232,10 +219,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
-
+					             but it lacked all 6 expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -558,11 +543,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -588,10 +570,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -617,18 +597,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -714,10 +684,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
-
+					             but it lacked all 5 unique expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -997,11 +965,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1027,18 +992,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1423,11 +1378,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1455,10 +1407,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1484,18 +1434,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1842,11 +1782,8 @@ public sealed partial class ThatAsyncEnumerable
 					             contains collection expected and at least one additional item in order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1872,18 +1809,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1970,10 +1897,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
-
+					             but it
+					               did not contain any additional items and
+					               lacked all 6 expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -2325,11 +2252,8 @@ public sealed partial class ThatAsyncEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -2357,10 +2281,8 @@ public sealed partial class ThatAsyncEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
-
+					               lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -2386,18 +2308,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -2483,10 +2395,10 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
-
+					             but it
+					               did not contain any additional items and
+					               lacked all 5 unique expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -2892,11 +2804,8 @@ public sealed partial class ThatAsyncEnumerable
 					             contains collection expected and at least one additional item in any order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -2922,18 +2831,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -3368,11 +3267,8 @@ public sealed partial class ThatAsyncEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -3402,10 +3298,8 @@ public sealed partial class ThatAsyncEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
-
+					               lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -3431,18 +3325,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.Tests.cs
@@ -106,11 +106,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -147,18 +144,8 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -683,11 +670,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -713,10 +697,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -753,18 +735,8 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1173,11 +1145,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1214,18 +1183,8 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1713,11 +1672,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1745,10 +1701,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1785,18 +1739,8 @@ public sealed partial class ThatAsyncEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionEnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionEnumerableTests.cs
@@ -72,11 +72,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -102,18 +99,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -232,10 +219,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
-
+					             but it lacked all 6 expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -559,11 +544,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -589,10 +571,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -618,18 +598,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -715,10 +685,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
-
+					             but it lacked all 5 unique expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -998,11 +966,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1028,18 +993,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1425,11 +1380,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1457,10 +1409,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1486,18 +1436,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1844,11 +1784,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1874,18 +1811,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1972,10 +1899,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
-
+					             but it
+					               did not contain any additional items and
+					               lacked all 6 expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -2328,11 +2255,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -2360,10 +2284,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
-
+					               lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -2389,18 +2311,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -2486,10 +2398,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
-
+					             but it
+					               did not contain any additional items and
+					               lacked all 5 unique expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -2895,11 +2807,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -2925,18 +2834,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -3372,11 +3271,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -3406,10 +3302,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
-
+					               lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -3435,18 +3329,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionImmutableTests.cs
@@ -73,11 +73,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -103,18 +100,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -233,10 +220,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
-
+					             but it lacked all 6 expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -560,11 +545,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -590,10 +572,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -619,18 +599,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -716,10 +686,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
-
+					             but it lacked all 5 unique expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -999,11 +967,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1029,18 +994,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1426,11 +1381,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1458,10 +1410,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1487,18 +1437,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1845,11 +1785,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1875,18 +1812,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1973,10 +1900,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
-
+					             but it
+					               did not contain any additional items and
+					               lacked all 6 expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -2329,11 +2256,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -2361,10 +2285,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
-
+					               lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -2390,18 +2312,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -2487,10 +2399,10 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
-
+					             but it
+					               did not contain any additional items and
+					               lacked all 5 unique expected items
+					             
 					             Collection:
 					             [
 					               "b",
@@ -2896,11 +2808,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -2926,18 +2835,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -3373,11 +3272,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
-
+					               lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -3407,10 +3303,8 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
-
+					               lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -3436,18 +3330,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
-
+					             but it lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -3890,8 +3774,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage($$"""
 					               Expected that subject
 					               contains collection [regex,] in order as regex,
-					               but it lacked 1 of 1 expected items: "{{regex}}"
-
+					               but it lacked all 1 expected items
+					               
 					               Collection:
 					               [
 					                 "foo",
@@ -3920,8 +3804,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains collection [wildcard,] in order as wildcard,
-					              but it lacked 1 of 1 expected items: "{wildcard}"
-
+					              but it lacked all 1 expected items
+					              
 					              Collection:
 					              [
 					                "foo",
@@ -3950,8 +3834,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains collection [match,] in order,
-					              but it lacked 1 of 1 expected items: "{match}"
-
+					              but it lacked all 1 expected items
+					              
 					              Collection:
 					              [
 					                "foo",
@@ -3980,8 +3864,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage($"""
 					              Expected that subject
 					              contains collection [match,] in order ignoring case,
-					              but it lacked 1 of 1 expected items: "{match}"
-
+					              but it lacked all 1 expected items
+					              
 					              Collection:
 					              [
 					                "foo",

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
@@ -71,10 +71,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
+					             but it lacked all 3 expected items
 
 					             Collection:
 					             []
@@ -101,17 +98,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 expected items
 
 					             Collection:
 					             [
@@ -159,10 +146,10 @@ public sealed partial class ThatEnumerable
 					             but it
 					               contained item 3 at index 3 instead of 1 and
 					               contained item 12 at index 4 instead of 2
-					             
+
 					             Collection:
 					             [1, 2, 1, 3, 12, 2, 2]
-					             
+
 					             Expected:
 					             [1, 2, 1, 1, 2]
 					             """);
@@ -221,7 +208,7 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
-					             
+
 					             Collection:
 					             [
 					               "a",
@@ -256,9 +243,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
+					             but it lacked all 6 expected items
 
 					             Collection:
 					             [
@@ -441,6 +426,36 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithItemsInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["c", "a",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in order,
+					             but it lacked 1 of 2 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+
+					             Expected:
+					             [
+					               "c",
+					               "a"
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMissingItem_ShouldFail()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
@@ -506,7 +521,6 @@ public sealed partial class ThatEnumerable
 					             ]
 					             """);
 			}
-
 
 			[Fact]
 			public async Task WithSameCollection_ShouldSucceed()
@@ -583,10 +597,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
+					             but it lacked all 3 unique expected items
 
 					             Collection:
 					             []
@@ -613,9 +624,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
+					             but it lacked all 2 unique expected items
 
 					             Collection:
 					             []
@@ -642,17 +651,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 unique expected items
 
 					             Collection:
 					             [
@@ -704,7 +703,7 @@ public sealed partial class ThatEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
-					             
+
 					             Collection:
 					             [
 					               "a",
@@ -739,9 +738,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
+					             but it lacked all 5 unique expected items
 
 					             Collection:
 					             [
@@ -878,6 +875,36 @@ public sealed partial class ThatEnumerable
 					=> await That(subject).Contains(expected).IgnoringDuplicates();
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithItemsInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["c", "a",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in order ignoring duplicates,
+					             but it lacked 1 of 2 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+
+					             Expected:
+					             [
+					               "c",
+					               "a"
+					             ]
+					             """);
 			}
 
 			[Fact]
@@ -1022,10 +1049,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
+					             but it lacked all 3 expected items
 
 					             Collection:
 					             []
@@ -1052,17 +1076,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 expected items
 
 					             Collection:
 					             [
@@ -1449,10 +1463,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
+					             but it lacked all 3 unique expected items
 
 					             Collection:
 					             []
@@ -1481,9 +1492,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
+					             but it lacked all 2 unique expected items
 
 					             Collection:
 					             []
@@ -1510,17 +1519,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 unique expected items
 
 					             Collection:
 					             [
@@ -1868,10 +1867,7 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
+					               lacked all 3 expected items
 
 					             Collection:
 					             []
@@ -1898,17 +1894,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 expected items
 
 					             Collection:
 					             [
@@ -1996,9 +1982,9 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
-					             but it lacked 2 of 6 expected items:
-					               "a",
-					               "e"
+					             but it
+					               did not contain any additional items and
+					               lacked all 6 expected items
 
 					             Collection:
 					             [
@@ -2352,10 +2338,7 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
+					               lacked all 3 unique expected items
 
 					             Collection:
 					             []
@@ -2384,9 +2367,7 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
+					               lacked all 2 unique expected items
 
 					             Collection:
 					             []
@@ -2413,17 +2394,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 unique expected items
 
 					             Collection:
 					             [
@@ -2510,9 +2481,9 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
-					             but it lacked 2 of 5 expected items:
-					               "a",
-					               "e"
+					             but it
+					               did not contain any additional items and
+					               lacked all 5 unique expected items
 
 					             Collection:
 					             [
@@ -2919,10 +2890,7 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
+					               lacked all 3 expected items
 
 					             Collection:
 					             []
@@ -2949,17 +2917,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 expected items
 
 					             Collection:
 					             [
@@ -3396,10 +3354,7 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 3 of 3 expected items:
-					                 "a",
-					                 "b",
-					                 "c"
+					               lacked all 3 unique expected items
 
 					             Collection:
 					             []
@@ -3430,9 +3385,7 @@ public sealed partial class ThatEnumerable
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it
 					               did not contain any additional items and
-					               lacked 2 of 2 expected items:
-					                 "a",
-					                 "b"
+					               lacked all 2 unique expected items
 
 					             Collection:
 					             []
@@ -3459,17 +3412,7 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
-					             but it lacked 10 of 10 expected items:
-					               101,
-					               102,
-					               103,
-					               104,
-					               105,
-					               106,
-					               107,
-					               108,
-					               109,
-					               110
+					             but it lacked all 10 unique expected items
 
 					             Collection:
 					             [
@@ -3910,23 +3853,23 @@ public sealed partial class ThatEnumerable
 					=> await That(subject).Contains([regex,]).AsRegex();
 
 				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
-					.WithMessage($$"""
-					               Expected that subject
-					               contains collection [regex,] in order as regex,
-					               but it lacked 1 of 1 expected items: "{{regex}}"
+					.WithMessage("""
+					             Expected that subject
+					             contains collection [regex,] in order as regex,
+					             but it lacked all 1 expected items
 
-					               Collection:
-					               [
-					                 "foo",
-					                 "bar",
-					                 "baz"
-					               ]
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz"
+					             ]
 
-					               Expected:
-					               [
-					                 "[g-h]{1}[o]*"
-					               ]
-					               """);
+					             Expected:
+					             [
+					               "[g-h]{1}[o]*"
+					             ]
+					             """);
 			}
 
 			[Theory]
@@ -3940,23 +3883,23 @@ public sealed partial class ThatEnumerable
 					=> await That(subject).Contains([wildcard,]).AsWildcard();
 
 				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
-					.WithMessage($"""
-					              Expected that subject
-					              contains collection [wildcard,] in order as wildcard,
-					              but it lacked 1 of 1 expected items: "{wildcard}"
+					.WithMessage("""
+					             Expected that subject
+					             contains collection [wildcard,] in order as wildcard,
+					             but it lacked all 1 expected items
 
-					              Collection:
-					              [
-					                "foo",
-					                "bar",
-					                "baz"
-					              ]
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz"
+					             ]
 
-					              Expected:
-					              [
-					                "f??o"
-					              ]
-					              """);
+					             Expected:
+					             [
+					               "f??o"
+					             ]
+					             """);
 			}
 
 			[Theory]
@@ -3970,23 +3913,23 @@ public sealed partial class ThatEnumerable
 					=> await That(subject).Contains([match,]).AsWildcard().Exactly();
 
 				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
-					.WithMessage($"""
-					              Expected that subject
-					              contains collection [match,] in order,
-					              but it lacked 1 of 1 expected items: "{match}"
+					.WithMessage("""
+					             Expected that subject
+					             contains collection [match,] in order,
+					             but it lacked all 1 expected items
 
-					              Collection:
-					              [
-					                "foo",
-					                "bar",
-					                "baz"
-					              ]
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz"
+					             ]
 
-					              Expected:
-					              [
-					                "*oo"
-					              ]
-					              """);
+					             Expected:
+					             [
+					               "*oo"
+					             ]
+					             """);
 			}
 
 			[Theory]
@@ -4000,23 +3943,289 @@ public sealed partial class ThatEnumerable
 					=> await That(subject).Contains([match,]).IgnoringCase();
 
 				await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
-					.WithMessage($"""
-					              Expected that subject
-					              contains collection [match,] in order ignoring case,
-					              but it lacked 1 of 1 expected items: "{match}"
+					.WithMessage("""
+					             Expected that subject
+					             contains collection [match,] in order ignoring case,
+					             but it lacked all 1 expected items
 
-					              Collection:
-					              [
-					                "foo",
-					                "bar",
-					                "baz"
-					              ]
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz"
+					             ]
 
-					              Expected:
-					              [
-					                "goo"
-					              ]
-					              """);
+					             Expected:
+					             [
+					               "goo"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class InSameOrderIgnoringInterspersedItemsTests
+		{
+			[Fact]
+			public async Task WithInterspersedItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringInterspersedItems();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithInterspersedItemsInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["b", "a",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringInterspersedItems();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in order ignoring interspersed items,
+					             but it lacked 1 of 2 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+
+					             Expected:
+					             [
+					               "b",
+					               "a"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "b", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringInterspersedItems();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class InSameOrderIgnoringDuplicatesAndInterspersedItemsTests
+		{
+			[Fact]
+			public async Task WithInterspersedItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringDuplicates().IgnoringInterspersedItems();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithInterspersedItemsInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["b", "a",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringInterspersedItems().IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in order ignoring duplicates and interspersed items,
+					             but it lacked 1 of 2 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+
+					             Expected:
+					             [
+					               "b",
+					               "a"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithSameCollection_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "b", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringDuplicates().IgnoringInterspersedItems();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class ProperlyInSameOrderIgnoringInterspersedItemsTests
+		{
+			[Fact]
+			public async Task WithInterspersedItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Properly().IgnoringInterspersedItems();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithInterspersedItemsInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["b", "a",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Properly().IgnoringInterspersedItems();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected and at least one additional item in order ignoring interspersed items,
+					             but it lacked 1 of 2 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+
+					             Expected:
+					             [
+					               "b",
+					               "a"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithSameCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "b", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Properly().IgnoringInterspersedItems();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected and at least one additional item in order ignoring interspersed items,
+					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             
+					             Expected:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class ProperlyInSameOrderIgnoringDuplicatesAndInterspersedItemsTests
+		{
+			[Fact]
+			public async Task WithInterspersedItems_ShouldSucceed()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Properly().IgnoringDuplicates().IgnoringInterspersedItems();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithInterspersedItemsInDifferentOrder_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["b", "a",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Properly().IgnoringInterspersedItems().IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected and at least one additional item in order ignoring duplicates and interspersed items,
+					             but it lacked 1 of 2 expected items: "a"
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+
+					             Expected:
+					             [
+					               "b",
+					               "a"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithSameCollection_ShouldFail()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+				string[] expected = ["a", "b", "c",];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).Properly().IgnoringDuplicates().IgnoringInterspersedItems();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected and at least one additional item in order ignoring duplicates and interspersed items,
+					             but it did not contain any additional items
+					             
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             
+					             Expected:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.EnumerableTests.cs
@@ -107,11 +107,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -148,18 +145,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -685,11 +672,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -715,10 +699,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -755,18 +737,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1163,11 +1135,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1204,18 +1173,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1673,11 +1632,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1705,10 +1661,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1745,18 +1699,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.ImmutableTests.cs
@@ -108,11 +108,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -149,18 +146,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -686,11 +673,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -716,10 +700,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -756,18 +738,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1164,11 +1136,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1205,18 +1174,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1674,11 +1633,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1706,10 +1662,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1746,18 +1700,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
@@ -106,11 +106,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -147,18 +144,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -684,11 +671,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -714,10 +698,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -754,18 +736,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1162,11 +1134,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 expected items
+					             
 					             Collection:
 					             []
 
@@ -1203,18 +1172,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 expected items
+					             
 					             Collection:
 					             [
 					               1,
@@ -1672,11 +1631,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 3 of 3 expected items:
-					               "a",
-					               "b",
-					               "c"
-
+					             but it lacked all 3 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1704,10 +1660,8 @@ public sealed partial class ThatEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             matches collection expected in any order ignoring duplicates,
-					             but it lacked 2 of 2 expected items:
-					               "a",
-					               "b"
-
+					             but it lacked all 2 unique expected items
+					             
 					             Collection:
 					             []
 
@@ -1744,18 +1698,8 @@ public sealed partial class ThatEnumerable
 					               contained item 8 at index 7 that was not expected and
 					               contained item 9 at index 8 that was not expected and
 					               contained item 10 at index 9 that was not expected and
-					               lacked 10 of 10 expected items:
-					                 101,
-					                 102,
-					                 103,
-					                 104,
-					                 105,
-					                 106,
-					                 107,
-					                 108,
-					                 109,
-					                 110
-
+					               lacked all 10 unique expected items
+					             
 					             Collection:
 					             [
 					               1,


### PR DESCRIPTION
This PR introduces a new `IgnoringInterspersedItems` option for collection matchers, allowing expected items to be matched in order while skipping any extra items between them. Key changes include:  
- API extensions to expose `IgnoringInterspersedItems()` on expectation/result builders.  
- Core logic updates in `CollectionMatchOptions` and various `CollectionMatcher` implementations to honor interspersed-item skipping.  
- Extensive updates to existing tests to adjust error messages when all expected items are missing.

---

- *Fixes #645*