### PR TITLE
fix: succeed for empty expected collection in `Contains`

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.cs
@@ -184,6 +184,11 @@ public partial class CollectionMatchOptions(
 	private static IEnumerable<string> MissingItemsError<T>(int total, List<T> missingItems,
 		EquivalenceRelations equivalenceRelation, bool ignoringDuplicates)
 	{
+		if (total == 0)
+		{
+			yield break;
+		}
+
 		bool hasMissingItems = missingItems.Any();
 		if (total == missingItems.Count)
 		{

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Contains.CollectionTests.cs
@@ -73,7 +73,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked all 3 expected items
-					             
+
 					             Collection:
 					             []
 
@@ -100,7 +100,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked all 10 expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -129,6 +129,18 @@ public sealed partial class ThatAsyncEnumerable
 					               110
 					             ]
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -184,7 +196,7 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
-					             
+
 					             Collection:
 					             [
 					               "a",
@@ -220,7 +232,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order,
 					             but it lacked all 6 expected items
-					             
+
 					             Collection:
 					             [
 					               "b",
@@ -544,7 +556,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
 					             but it lacked all 3 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -571,7 +583,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
 					             but it lacked all 2 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -598,7 +610,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
 					             but it lacked all 10 unique expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -630,6 +642,35 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringDuplicates();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int>? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!).IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in order ignoring duplicates,
+					             but it cannot compare to <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WithAdditionalAndMissingItems_ShouldFail()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c", "d", "e",]);
@@ -649,7 +690,7 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
-					             
+
 					             Collection:
 					             [
 					               "a",
@@ -685,7 +726,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in order ignoring duplicates,
 					             but it lacked all 5 unique expected items
-					             
+
 					             Collection:
 					             [
 					               "b",
@@ -966,7 +1007,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked all 3 expected items
-					             
+
 					             Collection:
 					             []
 
@@ -993,7 +1034,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order,
 					             but it lacked all 10 expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -1021,6 +1062,35 @@ public sealed partial class ThatAsyncEnumerable
 					               109,
 					               110
 					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).InAnyOrder();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int>? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!).InAnyOrder();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in any order,
+					             but it cannot compare to <null>
 					             """);
 			}
 
@@ -1379,7 +1449,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
 					             but it lacked all 3 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -1408,7 +1478,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
 					             but it lacked all 2 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -1435,7 +1505,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected in any order ignoring duplicates,
 					             but it lacked all 10 unique expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -1463,6 +1533,35 @@ public sealed partial class ThatAsyncEnumerable
 					               109,
 					               110
 					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Enumerable.Range(1, 11));
+				IEnumerable<int>? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!).InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in any order ignoring duplicates,
+					             but it cannot compare to <null>
 					             """);
 			}
 
@@ -1783,7 +1882,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 3 expected items
-					             
+
 					             Collection:
 					             []
 
@@ -1810,7 +1909,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order,
 					             but it lacked all 10 expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -1862,7 +1961,7 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
-					             
+
 					             Collection:
 					             [
 					               "a",
@@ -1900,7 +1999,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 6 expected items
-					             
+
 					             Collection:
 					             [
 					               "b",
@@ -2253,7 +2352,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 3 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -2282,7 +2381,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 2 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -2309,7 +2408,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates,
 					             but it lacked all 10 unique expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -2360,7 +2459,7 @@ public sealed partial class ThatAsyncEnumerable
 					                 "x",
 					                 "y",
 					                 "z"
-					             
+
 					             Collection:
 					             [
 					               "a",
@@ -2398,7 +2497,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 5 unique expected items
-					             
+
 					             Collection:
 					             [
 					               "b",
@@ -2805,7 +2904,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 3 expected items
-					             
+
 					             Collection:
 					             []
 
@@ -2832,7 +2931,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order,
 					             but it lacked all 10 expected items
-					             
+
 					             Collection:
 					             [
 					               1,
@@ -3268,7 +3367,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 3 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -3299,7 +3398,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it
 					               did not contain any additional items and
 					               lacked all 2 unique expected items
-					             
+
 					             Collection:
 					             []
 
@@ -3326,7 +3425,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in any order ignoring duplicates,
 					             but it lacked all 10 unique expected items
-					             
+
 					             Collection:
 					             [
 					               1,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Contains.CollectionTests.cs
@@ -130,7 +130,6 @@ public sealed partial class ThatEnumerable
 					             """);
 			}
 
-
 			[Fact]
 			public async Task WhenExpectedContainsDuplicateButMissingItems_ShouldFail()
 			{
@@ -153,6 +152,18 @@ public sealed partial class ThatEnumerable
 					             Expected:
 					             [1, 2, 1, 1, 2]
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -684,6 +695,35 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).IgnoringDuplicates();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int>? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!).IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in order ignoring duplicates,
+					             but it cannot compare to <null>
+					             """);
+			}
+
+			[Fact]
 			public async Task WithAdditionalAndMissingItems_ShouldFail()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c", "d", "e",]);
@@ -1105,6 +1145,35 @@ public sealed partial class ThatEnumerable
 					               109,
 					               110
 					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).InAnyOrder();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int>? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!).InAnyOrder();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in any order,
+					             but it cannot compare to <null>
 					             """);
 			}
 
@@ -1548,6 +1617,35 @@ public sealed partial class ThatEnumerable
 					               109,
 					               110
 					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldSucceed()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int> expected = [];
+
+				async Task Act()
+					=> await That(subject).Contains(expected).InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedIsNull_ShouldFail()
+			{
+				IEnumerable<int> subject = Enumerable.Range(1, 11);
+				IEnumerable<int>? expected = null;
+
+				async Task Act()
+					=> await That(subject).Contains(expected!).InAnyOrder().IgnoringDuplicates();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             contains collection expected in any order ignoring duplicates,
+					             but it cannot compare to <null>
 					             """);
 			}
 
@@ -4135,14 +4233,14 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring interspersed items,
 					             but it did not contain any additional items
-					             
+
 					             Collection:
 					             [
 					               "a",
 					               "b",
 					               "c"
 					             ]
-					             
+
 					             Expected:
 					             [
 					               "a",
@@ -4162,7 +4260,8 @@ public sealed partial class ThatEnumerable
 				string[] expected = ["a", "c",];
 
 				async Task Act()
-					=> await That(subject).Contains(expected).Properly().IgnoringDuplicates().IgnoringInterspersedItems();
+					=> await That(subject).Contains(expected).Properly().IgnoringDuplicates()
+						.IgnoringInterspersedItems();
 
 				await That(Act).DoesNotThrow();
 			}
@@ -4174,7 +4273,8 @@ public sealed partial class ThatEnumerable
 				string[] expected = ["b", "a",];
 
 				async Task Act()
-					=> await That(subject).Contains(expected).Properly().IgnoringInterspersedItems().IgnoringDuplicates();
+					=> await That(subject).Contains(expected).Properly().IgnoringInterspersedItems()
+						.IgnoringDuplicates();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -4204,21 +4304,22 @@ public sealed partial class ThatEnumerable
 				string[] expected = ["a", "b", "c",];
 
 				async Task Act()
-					=> await That(subject).Contains(expected).Properly().IgnoringDuplicates().IgnoringInterspersedItems();
+					=> await That(subject).Contains(expected).Properly().IgnoringDuplicates()
+						.IgnoringInterspersedItems();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
 					             contains collection expected and at least one additional item in order ignoring duplicates and interspersed items,
 					             but it did not contain any additional items
-					             
+
 					             Collection:
 					             [
 					               "a",
 					               "b",
 					               "c"
 					             ]
-					             
+
 					             Expected:
 					             [
 					               "a",


### PR DESCRIPTION
When checking that a collection contains an empty expected collection, it should succeed.