### PR TITLE
feat: replace `Expression` with `Func` for `memberSelector`

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/MemberAccessor.cs
+++ b/Source/aweXpect.Core/Core/MemberAccessor.cs
@@ -56,5 +56,29 @@ public class MemberAccessor<TSource, TTarget> : MemberAccessor
 		Func<TSource, TTarget> func, string name)
 		=> new(func, name);
 
+	/// <summary>
+	///     Creates a member accessor from the given <paramref name="func" />.
+	/// </summary>
+	public static MemberAccessor<TSource, TTarget> FromFuncAsMemberAccessor(
+		Func<TSource, TTarget> func, string name)
+		=> new(func, ExtractMemberPath(name));
+
+	private static string ExtractMemberPath(string name)
+	{
+		// Example: "x => x.Foo" would result in ".Foo"
+		int idx = name.IndexOf("=>", StringComparison.Ordinal);
+		if (idx > 0)
+		{
+			string? prefix = name.Substring(0, idx).Trim();
+			int idx2 = name.Substring(idx).IndexOf(prefix, StringComparison.Ordinal);
+			if (idx2 > 0)
+			{
+				name = name.Substring(idx + idx2 + prefix.Length).TrimStart();
+			}
+		}
+
+		return $"{name} ";
+	}
+
 	internal TTarget AccessMember(TSource value) => _accessor.Invoke(value);
 }

--- a/Source/aweXpect.Core/Core/MemberAccessor.cs
+++ b/Source/aweXpect.Core/Core/MemberAccessor.cs
@@ -61,23 +61,23 @@ public class MemberAccessor<TSource, TTarget> : MemberAccessor
 	/// </summary>
 	public static MemberAccessor<TSource, TTarget> FromFuncAsMemberAccessor(
 		Func<TSource, TTarget> func, string name)
-		=> new(func, ExtractMemberPath(name));
+		=> new(func, ExtractMemberPath(name.Trim()));
 
-	private static string ExtractMemberPath(string name)
+	private static string ExtractMemberPath(string expression)
 	{
 		// Example: "x => x.Foo" would result in ".Foo"
-		int idx = name.IndexOf("=>", StringComparison.Ordinal);
+		int idx = expression.IndexOf("=>", StringComparison.Ordinal);
 		if (idx > 0)
 		{
-			string? prefix = name.Substring(0, idx).Trim();
-			int idx2 = name.Substring(idx).IndexOf(prefix, StringComparison.Ordinal);
-			if (idx2 > 0)
+			string? prefix = expression.Substring(0, idx).Trim();
+			idx = expression.IndexOf(prefix, idx, StringComparison.Ordinal);
+			if (idx > 0)
 			{
-				name = name.Substring(idx + idx2 + prefix.Length).TrimStart();
+				expression = expression.Substring(idx + prefix.Length).TrimStart();
 			}
 		}
 
-		return $"{name} ";
+		return $"{expression} ";
 	}
 
 	internal TTarget AccessMember(TSource value) => _accessor.Invoke(value);

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Whose.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Whose.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Results;
 
@@ -11,10 +11,11 @@ public partial class ThatDelegateThrows<TException>
 	///     Verifies the <paramref name="expectations" /> on the member selected by the <paramref name="memberSelector" />.
 	/// </summary>
 	public AndOrResult<TException, ThatDelegateThrows<TException>> Whose<TMember>(
-		Expression<Func<TException, TMember?>> memberSelector,
-		Action<IThat<TMember?>> expectations)
+		Func<TException, TMember?> memberSelector,
+		Action<IThat<TMember?>> expectations,
+		[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
 		=> new(ExpectationBuilder.ForMember(
-					MemberAccessor<TException, TMember?>.FromExpression(memberSelector),
+					MemberAccessor<TException, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
 					(member, expectation) => expectation.Append("whose ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			this);

--- a/Source/aweXpect.Core/Results/AndOrWhichResult.cs
+++ b/Source/aweXpect.Core/Results/AndOrWhichResult.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 
 namespace aweXpect.Results;
@@ -38,11 +38,12 @@ public class AndOrWhichResult<TType, TThat, TSelf>(
 	/// </summary>
 	public AdditionalAndOrWhichResult
 		Which<TMember>(
-			Expression<Func<TType, TMember?>> memberSelector,
-			Action<IThat<TMember?>> expectations)
+			Func<TType, TMember?> memberSelector,
+			Action<IThat<TMember?>> expectations,
+			[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
 		=> new(
 			_expectationBuilder
-				.ForMember(MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
+				.ForMember(MemberAccessor<TType, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
 					(member, stringBuilder) => stringBuilder.Append(" which ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			_returnValue);
@@ -67,14 +68,15 @@ public class AndOrWhichResult<TType, TThat, TSelf>(
 		/// </summary>
 		public AdditionalAndOrWhichResult
 			AndWhich<TMember>(
-				Expression<Func<TType, TMember?>> memberSelector,
-				Action<IThat<TMember?>> expectations)
+				Func<TType, TMember?> memberSelector,
+				Action<IThat<TMember?>> expectations,
+				[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
 		{
 			_expectationBuilder.And(" and");
 			return new AdditionalAndOrWhichResult(
 				_expectationBuilder
 					.ForMember(
-						MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
+						MemberAccessor<TType, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
 						(member, stringBuilder) => stringBuilder.Append(" which ").Append(member))
 					.AddExpectations(e
 						=> expectations(new ThatSubject<TMember?>(e))),

--- a/Source/aweXpect.Core/Results/AndOrWhoseResult.cs
+++ b/Source/aweXpect.Core/Results/AndOrWhoseResult.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 
 namespace aweXpect.Results;
@@ -38,11 +38,12 @@ public class AndOrWhoseResult<TType, TThat, TSelf>(
 	/// </summary>
 	public AdditionalAndOrWhoseResult
 		Whose<TMember>(
-			Expression<Func<TType, TMember?>> memberSelector,
-			Action<IThat<TMember?>> expectations)
+			Func<TType, TMember?> memberSelector,
+			Action<IThat<TMember?>> expectations,
+			[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
 		=> new(
 			_expectationBuilder
-				.ForMember(MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
+				.ForMember(MemberAccessor<TType, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
 					(member, stringBuilder) => stringBuilder.Append(" whose ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			_returnValue);
@@ -67,14 +68,15 @@ public class AndOrWhoseResult<TType, TThat, TSelf>(
 		/// </summary>
 		public AdditionalAndOrWhoseResult
 			AndWhose<TMember>(
-				Expression<Func<TType, TMember?>> memberSelector,
-				Action<IThat<TMember?>> expectations)
+				Func<TType, TMember?> memberSelector,
+				Action<IThat<TMember?>> expectations,
+				[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
 		{
 			_expectationBuilder.And(" and");
 			return new AdditionalAndOrWhoseResult(
 				_expectationBuilder
 					.ForMember(
-						MemberAccessor<TType, TMember?>.FromExpression(memberSelector),
+						MemberAccessor<TType, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
 						(member, stringBuilder) => stringBuilder.Append(" whose ").Append(member))
 					.AddExpectations(e
 						=> expectations(new ThatSubject<TMember?>(e))),

--- a/Source/aweXpect/That/ThatGeneric.For.cs
+++ b/Source/aweXpect/That/ThatGeneric.For.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Results;
@@ -13,13 +13,14 @@ public static partial class ThatGeneric
 	/// </summary>
 	public static AndOrResult<T, IThat<T>> For<T, TMember>(
 		this IThat<T> source,
-		Expression<Func<T, TMember?>> memberSelector,
-		Action<IThat<TMember?>> expectations)
+		Func<T, TMember?> memberSelector,
+		Action<IThat<TMember?>> expectations,
+		[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
 	{
 		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
 		expectationBuilder
 			.ForMember(
-				MemberAccessor<T, TMember?>.FromExpression(memberSelector),
+				MemberAccessor<T, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
 				(member, stringBuilder) => stringBuilder.Append("for ").Append(member))
 			.AddExpectations(e => expectations(new ThatSubject<TMember?>(e)));
 		return new AndOrResult<T, IThat<T>>(expectationBuilder, source);

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -678,7 +678,7 @@ namespace aweXpect
         public static aweXpect.Results.RepeatedCheckResult<T, aweXpect.Core.IThat<T>> CompliesWith<T>(this aweXpect.Core.IThat<T> source, System.Action<aweXpect.Core.IThat<T>> expectations) { }
         public static aweXpect.Results.RepeatedCheckResult<T, aweXpect.Core.IThat<T>> DoesNotComplyWith<T>(this aweXpect.Core.IThat<T> source, System.Action<aweXpect.Core.IThat<T>> expectations) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> DoesNotSatisfy<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> For<T, TMember>(this aweXpect.Core.IThat<T> source, System.Linq.Expressions.Expression<System.Func<T, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> For<T, TMember>(this aweXpect.Core.IThat<T> source, System.Func<T, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.RepeatedCheckResult<T, aweXpect.Core.IThat<T>> Satisfies<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatGuid

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -463,7 +463,7 @@ namespace aweXpect
         public static aweXpect.Results.RepeatedCheckResult<T, aweXpect.Core.IThat<T>> CompliesWith<T>(this aweXpect.Core.IThat<T> source, System.Action<aweXpect.Core.IThat<T>> expectations) { }
         public static aweXpect.Results.RepeatedCheckResult<T, aweXpect.Core.IThat<T>> DoesNotComplyWith<T>(this aweXpect.Core.IThat<T> source, System.Action<aweXpect.Core.IThat<T>> expectations) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> DoesNotSatisfy<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> For<T, TMember>(this aweXpect.Core.IThat<T> source, System.Linq.Expressions.Expression<System.Func<T, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> For<T, TMember>(this aweXpect.Core.IThat<T> source, System.Func<T, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.RepeatedCheckResult<T, aweXpect.Core.IThat<T>> Satisfies<T>(this aweXpect.Core.IThat<T> source, System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public static class ThatGuid

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -250,6 +250,7 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
         public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFunc(System.Func<TSource, TTarget> func, string name) { }
+        public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFuncAsMemberAccessor(System.Func<TSource, TTarget> func, string name) { }
     }
     public class ResultContext
     {
@@ -490,7 +491,7 @@ namespace aweXpect.Delegates
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
         public aweXpect.Core.IThat<TException> Which { get; }
         public aweXpect.Delegates.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
-        public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Linq.Expressions.Expression<System.Func<TException, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Func<TException, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner<TInnerException>()
@@ -918,11 +919,11 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>
     {
         public AndOrWhichResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult Which<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult Which<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public class AdditionalAndOrWhichResult : aweXpect.Results.AndOrResult<TType, TThat, TSelf>
         {
             public AdditionalAndOrWhichResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-            public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult AndWhich<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+            public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult AndWhich<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         }
     }
     public class AndOrWhoseResult<TType, TThat> : aweXpect.Results.AndOrWhoseResult<TType, TThat, aweXpect.Results.AndOrWhoseResult<TType, TThat>>
@@ -933,11 +934,11 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>
     {
         public AndOrWhoseResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult Whose<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult Whose<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public class AdditionalAndOrWhoseResult : aweXpect.Results.AndOrResult<TType, TThat, TSelf>
         {
             public AdditionalAndOrWhoseResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-            public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult AndWhose<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+            public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult AndWhose<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         }
     }
     public class AndResult<TThat> : aweXpect.Results.ExpectationResult

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -250,6 +250,7 @@ namespace aweXpect.Core
     {
         public static aweXpect.Core.MemberAccessor<TSource, TTarget?> FromExpression(System.Linq.Expressions.Expression<System.Func<TSource, TTarget?>> expression) { }
         public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFunc(System.Func<TSource, TTarget> func, string name) { }
+        public static aweXpect.Core.MemberAccessor<TSource, TTarget> FromFuncAsMemberAccessor(System.Func<TSource, TTarget> func, string name) { }
     }
     public class ResultContext
     {
@@ -490,7 +491,7 @@ namespace aweXpect.Delegates
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
         public aweXpect.Core.IThat<TException> Which { get; }
         public aweXpect.Delegates.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
-        public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Linq.Expressions.Expression<System.Func<TException, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Func<TException, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner(System.Type innerExceptionType, System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInner<TInnerException>()
@@ -901,11 +902,11 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>
     {
         public AndOrWhichResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult Which<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult Which<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public class AdditionalAndOrWhichResult : aweXpect.Results.AndOrResult<TType, TThat, TSelf>
         {
             public AdditionalAndOrWhichResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-            public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult AndWhich<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+            public aweXpect.Results.AndOrWhichResult<TType, TThat, TSelf>.AdditionalAndOrWhichResult AndWhich<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         }
     }
     public class AndOrWhoseResult<TType, TThat> : aweXpect.Results.AndOrWhoseResult<TType, TThat, aweXpect.Results.AndOrWhoseResult<TType, TThat>>
@@ -916,11 +917,11 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>
     {
         public AndOrWhoseResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-        public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult Whose<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+        public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult Whose<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         public class AdditionalAndOrWhoseResult : aweXpect.Results.AndOrResult<TType, TThat, TSelf>
         {
             public AdditionalAndOrWhoseResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TThat returnValue) { }
-            public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult AndWhose<TMember>(System.Linq.Expressions.Expression<System.Func<TType, TMember?>> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations) { }
+            public aweXpect.Results.AndOrWhoseResult<TType, TThat, TSelf>.AdditionalAndOrWhoseResult AndWhose<TMember>(System.Func<TType, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }
         }
     }
     public class AndResult<TThat> : aweXpect.Results.ExpectationResult

--- a/Tests/aweXpect.Core.Tests/Core/MemberAccessorTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/MemberAccessorTests.cs
@@ -1,0 +1,39 @@
+﻿namespace aweXpect.Core.Tests.Core;
+
+public sealed class MemberAccessorTests
+{
+	[Fact]
+	public async Task FromExpression_ShouldGetMemberPath()
+	{
+		MemberAccessor<string, int> subject = MemberAccessor<string, int>
+			.FromExpression(x => x.Length);
+
+		await That(subject.ToString()).IsEqualTo(".Length ");
+	}
+
+	[Theory]
+	[InlineData("Foo")]
+	[InlineData("  x => x.Foo")]
+	[InlineData("x => x.Foo  ")]
+	public async Task FromFunc_ShouldKeepNameUnchanged(string expression)
+	{
+		MemberAccessor<string, int> subject = MemberAccessor<string, int>
+			.FromFunc(x => x.Length, expression);
+
+		await That(subject.ToString()).IsEqualTo(expression);
+	}
+
+	[Theory]
+	[InlineData("Foo", "Foo ")]
+	[InlineData("x => x.Foo", ".Foo ")]
+	[InlineData("  x => x.Foo", ".Foo ")]
+	[InlineData("x => x.Foo  ", ".Foo ")]
+	[InlineData("itIs => itIs.Foo  ", ".Foo ")]
+	public async Task FromFuncAsMemberAccessor_ShouldTryToExtractMemberAccessor(string expression, string expected)
+	{
+		MemberAccessor<string, int> subject = MemberAccessor<string, int>
+			.FromFuncAsMemberAccessor(x => x.Length, expression);
+
+		await That(subject.ToString()).IsEqualTo(expected);
+	}
+}


### PR DESCRIPTION
The `memberSelector` in `For`/`Which`/`Whose` now accepts a `Func<T, TMember?>` instead of `Expression<Func<T, TMember?>>` which allows more use cases to be met.