### PR TITLE
fix: throw `InvalidOperationException` when using async void delegates

### DIFF
--- a/Source/aweXpect.Core/Expect.cs
+++ b/Source/aweXpect.Core/Expect.cs
@@ -55,7 +55,7 @@ public static class Expect
 		[CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "")
 		=> new(new ExpectationBuilder<DelegateValue>(
 			// ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-			new DelegateSource(@delegate is null ? null : _ => @delegate()), doNotPopulateThisValue));
+			new DelegateSource(@delegate), doNotPopulateThisValue));
 
 	/// <summary>
 	///     Specify expectations for the current <see cref="Action{CancellationToken}" /> <paramref name="delegate" />.

--- a/Tests/aweXpect.Internal.Tests/ThatTests/DelegateTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/DelegateTests.cs
@@ -5,6 +5,64 @@ namespace aweXpect.Internal.Tests.ThatTests;
 
 public sealed class DelegateTests
 {
+	[Fact]
+	public async Task ForAsyncVoidAction_WhenVerifyingDoesNotThrow_ShouldThrowInvalidOperationException()
+	{
+		Task incompleteTask = new TaskCompletionSource<bool>().Task;
+		// ReSharper disable once AsyncVoidLambda
+		Action @delegate = async () => await incompleteTask;
+
+		async Task Act()
+			=> await That(@delegate).DoesNotThrow();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("Cannot use aweXpect on an async void method: Use Func<Task> instead.");
+	}
+
+	[Fact]
+	public async Task
+		ForAsyncVoidAction_WithCancellationToken_WhenVerifyingDoesNotThrow_ShouldThrowInvalidOperationException()
+	{
+		Task incompleteTask = new TaskCompletionSource<bool>().Task;
+		// ReSharper disable once AsyncVoidLambda
+		Action<CancellationToken> @delegate = async _ => await incompleteTask;
+
+		async Task Act()
+			=> await That(@delegate).DoesNotThrow();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("Cannot use aweXpect on an async void method: Use Func<CancellationToken, Task> instead.");
+	}
+
+	[Fact]
+	public async Task ForAsyncVoidAction_WhenVerifyingDoesThrow_ShouldThrowInvalidOperationException()
+	{
+		Task incompleteTask = new TaskCompletionSource<bool>().Task;
+		// ReSharper disable once AsyncVoidLambda
+		Action @delegate = async () => await incompleteTask;
+
+		async Task Act()
+			=> await That(@delegate).ThrowsException();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("Cannot use aweXpect on an async void method: Use Func<Task> instead.");
+	}
+
+	[Fact]
+	public async Task
+		ForAsyncVoidAction_WithCancellationToken_WhenVerifyingDoesThrow_ShouldThrowInvalidOperationException()
+	{
+		Task incompleteTask = new TaskCompletionSource<bool>().Task;
+		// ReSharper disable once AsyncVoidLambda
+		Action<CancellationToken> @delegate = async _ => await incompleteTask;
+
+		async Task Act()
+			=> await That(@delegate).ThrowsException();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("Cannot use aweXpect on an async void method: Use Func<CancellationToken, Task> instead.");
+	}
+
 	[Theory]
 	[AutoData]
 	public async Task ShouldReturnValue_FuncTaskValue(int value)


### PR DESCRIPTION
This pull request ensures that using aweXpect on async void delegates now throws an `InvalidOperationException` to prevent silent failures when awaiting outcomes.