### PR TITLE
fix: include because-reason when verifying that an exception is thrown

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -79,7 +79,16 @@ internal class AndNode : Node
 
 	/// <inheritdoc />
 	public override void SetReason(BecauseReason becauseReason)
-		=> Current.SetReason(becauseReason);
+	{
+		if (_nodes.Any() && Current is ExpectationNode expectationNode && expectationNode.IsEmpty())
+		{
+			_nodes.Last().Item2.SetReason(becauseReason);
+		}
+		else
+		{
+			Current.SetReason(becauseReason);
+		}
+	}
 
 	/// <inheritdoc />
 	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -73,7 +73,16 @@ internal class OrNode : Node
 
 	/// <inheritdoc />
 	public override void SetReason(BecauseReason becauseReason)
-		=> Current.SetReason(becauseReason);
+	{
+		if (_nodes.Any() && Current is ExpectationNode expectationNode && expectationNode.IsEmpty())
+		{
+			_nodes.Last().Item2.SetReason(becauseReason);
+		}
+		else
+		{
+			Current.SetReason(becauseReason);
+		}
+	}
 
 	/// <inheritdoc />
 	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.Tests.cs
@@ -51,12 +51,12 @@ public sealed partial class ThatDelegate
 				Action action = () => { };
 
 				async Task<Exception> Act()
-					=> await That(action).ThrowsException();
+					=> await That(action).ThrowsException().Because("it should throw");
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that action
-					             throws an exception,
+					             throws an exception, because it should throw,
 					             but it did not throw any exception
 					             """);
 			}


### PR DESCRIPTION
When an "And" node (or an "Or" node) has an empty node, this node is ignored during evaluation, but the because reason is applied to it.
In this case, the because reason should instead be applied to the latest previous node.

- *Fixes #654*