### PR TITLE
feat!: remove unnecessary `And` from delegate `DoesNotThrow`

### DIFF
--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrow.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrow.cs
@@ -18,8 +18,7 @@ public abstract partial class ThatDelegate
 		/// </summary>
 		public DelegateWithValueResult<T> DoesNotThrow()
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowConstraint(it, grammars, typeof(Exception))),
-				this);
+					new DoesNotThrowConstraint(it, grammars, typeof(Exception))));
 
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
@@ -27,16 +26,14 @@ public abstract partial class ThatDelegate
 		public DelegateWithValueResult<T> DoesNotThrow<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowConstraint(it, grammars, typeof(TException))),
-				this);
+					new DoesNotThrowConstraint(it, grammars, typeof(TException))));
 
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
 		public DelegateWithValueResult<T> DoesNotThrow(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowConstraint(it, grammars, exceptionType)),
-				this);
+					new DoesNotThrowConstraint(it, grammars, exceptionType)));
 
 		private sealed class DoesNotThrowConstraint(
 			string it,

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrowExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.DoesNotThrowExactly.cs
@@ -19,16 +19,14 @@ public abstract partial class ThatDelegate
 		public DelegateWithValueResult<T> DoesNotThrowExactly<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowExactlyConstraint(it, grammars, typeof(TException))),
-				this);
+					new DoesNotThrowExactlyConstraint(it, grammars, typeof(TException))));
 
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
 		public DelegateWithValueResult<T> DoesNotThrowExactly(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowExactlyConstraint(it, grammars, exceptionType)),
-				this);
+					new DoesNotThrowExactlyConstraint(it, grammars, exceptionType)));
 
 		private sealed class DoesNotThrowExactlyConstraint(
 			string it,

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrow.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrow.cs
@@ -16,27 +16,24 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw any exception.
 		/// </summary>
-		public AndResult<WithoutValue> DoesNotThrow()
+		public ExpectationResult DoesNotThrow()
 			=> new(ExpectationBuilder.AddConstraint((it, grammars)
-					=> new DoesNotThrowConstraint(it, grammars, typeof(Exception))),
-				this);
+					=> new DoesNotThrowConstraint(it, grammars, typeof(Exception))));
 
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
 		/// </summary>
-		public AndResult<WithoutValue> DoesNotThrow<TException>()
+		public ExpectationResult DoesNotThrow<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowConstraint(it, grammars, typeof(TException))),
-				this);
+					new DoesNotThrowConstraint(it, grammars, typeof(TException))));
 
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
-		public AndResult<WithoutValue> DoesNotThrow(Type exceptionType)
+		public ExpectationResult DoesNotThrow(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowConstraint(it, grammars, exceptionType)),
-				this);
+					new DoesNotThrowConstraint(it, grammars, exceptionType)));
 
 		private sealed class DoesNotThrowConstraint(string it, ExpectationGrammars grammars, Type exceptionType)
 			: ConstraintResult(grammars),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrowExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.DoesNotThrowExactly.cs
@@ -16,19 +16,17 @@ public abstract partial class ThatDelegate
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <typeparamref name="TException" />.
 		/// </summary>
-		public AndResult<WithoutValue> DoesNotThrowExactly<TException>()
+		public ExpectationResult DoesNotThrowExactly<TException>()
 			where TException : Exception
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowExactlyConstraint(it, grammars, typeof(TException))),
-				this);
+					new DoesNotThrowExactlyConstraint(it, grammars, typeof(TException))));
 
 		/// <summary>
 		///     Verifies that the delegate does not throw an exception of type <paramref name="exceptionType" />.
 		/// </summary>
-		public AndResult<WithoutValue> DoesNotThrowExactly(Type exceptionType)
+		public ExpectationResult DoesNotThrowExactly(Type exceptionType)
 			=> new(ExpectationBuilder.AddConstraint((it, grammars) =>
-					new DoesNotThrowExactlyConstraint(it, grammars, exceptionType)),
-				this);
+					new DoesNotThrowExactlyConstraint(it, grammars, exceptionType)));
 
 		private sealed class DoesNotThrowExactlyConstraint(string it, ExpectationGrammars grammars, Type exceptionType)
 			: ConstraintResult(grammars),

--- a/Source/aweXpect.Core/Results/DelegateWithValueResult.cs
+++ b/Source/aweXpect.Core/Results/DelegateWithValueResult.cs
@@ -10,8 +10,8 @@ namespace aweXpect.Results;
 /// <summary>
 ///     Result for a delegate with a value that does not throw.
 /// </summary>
-public class DelegateWithValueResult<T>(ExpectationBuilder expectationBuilder, ThatDelegate.WithValue<T> returnValue)
-	: AndResult<T, ThatDelegate.WithValue<T>>(expectationBuilder, returnValue)
+public class DelegateWithValueResult<T>(ExpectationBuilder expectationBuilder)
+	: ExpectationResult<T>(expectationBuilder)
 {
 	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
 

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -475,12 +475,12 @@ namespace aweXpect.Delegates
         public sealed class WithoutValue : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithoutValue>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithoutValue>
         {
             public WithoutValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow() { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow(System.Type exceptionType) { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow<TException>()
+            public aweXpect.Results.ExpectationResult DoesNotThrow() { }
+            public aweXpect.Results.ExpectationResult DoesNotThrow(System.Type exceptionType) { }
+            public aweXpect.Results.ExpectationResult DoesNotThrow<TException>()
                 where TException : System.Exception { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly(System.Type exceptionType) { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly<TException>()
+            public aweXpect.Results.ExpectationResult DoesNotThrowExactly(System.Type exceptionType) { }
+            public aweXpect.Results.ExpectationResult DoesNotThrowExactly<TException>()
                 where TException : System.Exception { }
             public aweXpect.Results.ExecutesInResult<aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue>> ExecutesIn() { }
         }
@@ -999,9 +999,9 @@ namespace aweXpect.Results
         public TTarget Once() { }
         public TTarget Twice() { }
     }
-    public class DelegateWithValueResult<T> : aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>>
+    public class DelegateWithValueResult<T> : aweXpect.Results.ExpectationResult<T>
     {
-        public DelegateWithValueResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Delegates.ThatDelegate.WithValue<T> returnValue) { }
+        public DelegateWithValueResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Core.IThat<T> AndWhoseResult { get; }
     }
     public class ExecutesInResult<TResult>

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -475,12 +475,12 @@ namespace aweXpect.Delegates
         public sealed class WithoutValue : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithoutValue>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithoutValue>
         {
             public WithoutValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow() { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow(System.Type exceptionType) { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrow<TException>()
+            public aweXpect.Results.ExpectationResult DoesNotThrow() { }
+            public aweXpect.Results.ExpectationResult DoesNotThrow(System.Type exceptionType) { }
+            public aweXpect.Results.ExpectationResult DoesNotThrow<TException>()
                 where TException : System.Exception { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly(System.Type exceptionType) { }
-            public aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue> DoesNotThrowExactly<TException>()
+            public aweXpect.Results.ExpectationResult DoesNotThrowExactly(System.Type exceptionType) { }
+            public aweXpect.Results.ExpectationResult DoesNotThrowExactly<TException>()
                 where TException : System.Exception { }
             public aweXpect.Results.ExecutesInResult<aweXpect.Results.AndResult<aweXpect.Delegates.ThatDelegate.WithoutValue>> ExecutesIn() { }
         }
@@ -982,9 +982,9 @@ namespace aweXpect.Results
         public TTarget Once() { }
         public TTarget Twice() { }
     }
-    public class DelegateWithValueResult<T> : aweXpect.Results.AndResult<T, aweXpect.Delegates.ThatDelegate.WithValue<T>>
+    public class DelegateWithValueResult<T> : aweXpect.Results.ExpectationResult<T>
     {
-        public DelegateWithValueResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Delegates.ThatDelegate.WithValue<T> returnValue) { }
+        public DelegateWithValueResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Core.IThat<T> AndWhoseResult { get; }
     }
     public class ExecutesInResult<TResult>


### PR DESCRIPTION
When it has a value, you can access it with `AndWhoseResult` (see #660), otherwise you cannot chain the expectation anymore.

- *fixes #664*