### PR TITLE
feat: add `Within` option for `Throws`

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
@@ -18,7 +18,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<TException>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullWithinTimeoutConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsConstraint(it, grammars, typeof(TException), throwOptions))
 				.And(" "),
@@ -32,7 +32,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullWithinTimeoutConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsConstraint(it, grammars, exceptionType, throwOptions))
 				.And(" "),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
@@ -18,7 +18,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<TException>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsConstraint(it, grammars, typeof(TException), throwOptions))
 				.And(" "),
@@ -32,7 +32,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsConstraint(it, grammars, exceptionType, throwOptions))
 				.And(" "),
@@ -88,6 +88,12 @@ public abstract partial class ThatDelegate
 			else
 			{
 				stringBuilder.Append("throws ").Append(Formatter.Format(exceptionType).PrependAOrAn());
+			}
+
+			if (throwOptions.ExecutionTimeOptions is not null)
+			{
+				stringBuilder.Append(' ');
+				throwOptions.ExecutionTimeOptions.AppendTo(stringBuilder, "in ");
 			}
 		}
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
@@ -18,7 +18,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<TException>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars)
 					=> new ThrowsExactlyConstraint(it, grammars, typeof(TException), throwOptions))
@@ -33,7 +33,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsExactlyConstraint(it, grammars, exceptionType, throwOptions))
 				.And(" "),
@@ -85,6 +85,12 @@ public abstract partial class ThatDelegate
 			else
 			{
 				stringBuilder.Append("throws exactly ").Append(Formatter.Format(exceptionType).PrependAOrAn());
+			}
+
+			if (throwOptions.ExecutionTimeOptions is not null)
+			{
+				stringBuilder.Append(' ');
+				throwOptions.ExecutionTimeOptions.AppendTo(stringBuilder, "in ");
 			}
 		}
 

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
@@ -18,7 +18,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<TException>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullWithinTimeoutConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars)
 					=> new ThrowsExactlyConstraint(it, grammars, typeof(TException), throwOptions))
@@ -33,7 +33,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullWithinTimeoutConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsExactlyConstraint(it, grammars, exceptionType, throwOptions))
 				.And(" "),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsException.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsException.cs
@@ -12,7 +12,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullWithinTimeoutConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsConstraint(it, grammars, typeof(Exception), throwOptions))
 				.And(" "),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsException.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsException.cs
@@ -12,7 +12,7 @@ public abstract partial class ThatDelegate
 	{
 		ThrowsOption throwOptions = new();
 		return new ThatDelegateThrows<Exception>(ExpectationBuilder
-				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars))
+				.AddConstraint((it, grammars) => new DelegateIsNotNullConstraint(it, grammars, throwOptions))
 				.ForWhich<DelegateValue, Exception?>(d => d.Exception)
 				.AddConstraint((it, grammars) => new ThrowsConstraint(it, grammars, typeof(Exception), throwOptions))
 				.And(" "),

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.ExecutesIn.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithValue.ExecutesIn.cs
@@ -51,7 +51,10 @@ public abstract partial class ThatDelegate
 			}
 
 			public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
-				=> stringBuilder.Append("executes in ").Append(options);
+			{
+				stringBuilder.Append("executes ");
+				options.AppendTo(stringBuilder, "in ");
+			}
 
 			public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
 			{

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.ExecutesIn.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.WithoutValue.ExecutesIn.cs
@@ -51,7 +51,10 @@ public abstract partial class ThatDelegate
 			}
 
 			public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
-				=> stringBuilder.Append("executes in ").Append(options);
+			{
+				stringBuilder.Append("executes ");
+				options.AppendTo(stringBuilder, "in ");
+			}
 
 			public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
 			{

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.cs
@@ -5,6 +5,7 @@ using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Helpers;
 using aweXpect.Core.Sources;
+using aweXpect.Options;
 
 namespace aweXpect.Delegates;
 
@@ -34,13 +35,28 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 		return message;
 	}
 
-	private sealed class DelegateIsNotNullConstraint(string it, ExpectationGrammars grammars)
+	private sealed class DelegateIsNotNullConstraint(string it, ExpectationGrammars grammars, ThrowsOption options)
 		: ConstraintResult(grammars),
 			IValueConstraint<DelegateValue>
 	{
+		private DelegateValue? _actual;
 		public ConstraintResult IsMetBy(DelegateValue value)
 		{
-			Outcome = value.IsNull ? Outcome.Failure : Outcome.Success;
+			_actual = value;
+			if (value.IsNull)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			if (options.ExecutionTimeOptions is not null &&
+			    !options.ExecutionTimeOptions.IsWithinLimit(value.Duration))
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+			
+			Outcome = Outcome.Success;
 			return this;
 		}
 
@@ -50,7 +66,17 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 		}
 
 		public override void AppendResult(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.ItWasNull(it);
+		{
+			if (_actual?.IsNull != false)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else if (options.ExecutionTimeOptions is not null)
+			{
+				stringBuilder.Append(it).Append(" took ");
+				options.ExecutionTimeOptions.AppendFailureResult(stringBuilder, _actual.Duration);
+			}
+		}
 
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 		{
@@ -65,6 +91,8 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 	internal class ThrowsOption
 	{
 		public bool DoCheckThrow { get; private set; } = true;
+		
+		public TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
 
 		public void CheckThrow(bool doCheckThrow) => DoCheckThrow = doCheckThrow;
 	}

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.cs
@@ -35,7 +35,7 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 		return message;
 	}
 
-	private sealed class DelegateIsNotNullConstraint(string it, ExpectationGrammars grammars, ThrowsOption options)
+	private sealed class DelegateIsNotNullWithinTimeoutConstraint(string it, ExpectationGrammars grammars, ThrowsOption options)
 		: ConstraintResult(grammars),
 			IValueConstraint<DelegateValue>
 	{

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Which.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Which.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.Linq.Expressions;
-using aweXpect.Core;
-using aweXpect.Core.Sources;
-using aweXpect.Results;
+﻿using aweXpect.Core;
 
 namespace aweXpect.Delegates;
 
 public partial class ThatDelegateThrows<TException>
 {
-
 	/// <summary>
 	///     Further expectations on the <typeparamref name="TException" />
 	/// </summary>
 	public IThat<TException> Which
 		=> new ThatSubject<TException>(ExpectationBuilder.And(" which "));
-	
 }

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Whose.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Whose.cs
@@ -13,9 +13,11 @@ public partial class ThatDelegateThrows<TException>
 	public AndOrResult<TException, ThatDelegateThrows<TException>> Whose<TMember>(
 		Func<TException, TMember?> memberSelector,
 		Action<IThat<TMember?>> expectations,
-		[CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "")
+		[CallerArgumentExpression("memberSelector")]
+		string doNotPopulateThisValue = "")
 		=> new(ExpectationBuilder.ForMember(
-					MemberAccessor<TException, TMember?>.FromFuncAsMemberAccessor(memberSelector, doNotPopulateThisValue),
+					MemberAccessor<TException, TMember?>.FromFuncAsMemberAccessor(memberSelector,
+						doNotPopulateThisValue),
 					(member, expectation) => expectation.Append("whose ").Append(member))
 				.AddExpectations(e => expectations(new ThatSubject<TMember?>(e))),
 			this);

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Within.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Within.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using aweXpect.Options;
+
+namespace aweXpect.Delegates;
+
+public partial class ThatDelegateThrows<TException>
+{
+	/// <summary>
+	///     Verifies that the delegate throws within the given <paramref name="duration" />.
+	/// </summary>
+	public ThatDelegateThrows<TException> Within(TimeSpan duration)
+	{
+		TimeSpanEqualityOptions options = new();
+		options.Within(duration);
+		_throwOptions.ExecutionTimeOptions = options;
+		return this;
+	}
+}

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -500,6 +500,7 @@ namespace aweXpect.Delegates
             where TInnerException : System.Exception { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInnerException() { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInnerException(System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
+        public aweXpect.Delegates.ThatDelegateThrows<TException> Within(System.TimeSpan duration) { }
     }
 }
 namespace aweXpect.Equivalency
@@ -846,12 +847,13 @@ namespace aweXpect.Options
     {
         public TimeSpanEqualityOptions() { }
         public void AppendFailureResult(System.Text.StringBuilder stringBuilder, System.TimeSpan actual) { }
+        public void AppendTo(System.Text.StringBuilder stringBuilder, string prefix) { }
         public void Approximately(System.TimeSpan expected, System.TimeSpan tolerance) { }
         public void AtLeast(System.TimeSpan minimum) { }
         public void AtMost(System.TimeSpan maximum) { }
         public void Between(System.TimeSpan minimum, System.TimeSpan maximum) { }
         public bool IsWithinLimit(System.TimeSpan? actual) { }
-        public override string ToString() { }
+        public void Within(System.TimeSpan duration) { }
     }
     public class TimeTolerance
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -500,6 +500,7 @@ namespace aweXpect.Delegates
             where TInnerException : System.Exception { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInnerException() { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithInnerException(System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
+        public aweXpect.Delegates.ThatDelegateThrows<TException> Within(System.TimeSpan duration) { }
     }
 }
 namespace aweXpect.Equivalency
@@ -829,12 +830,13 @@ namespace aweXpect.Options
     {
         public TimeSpanEqualityOptions() { }
         public void AppendFailureResult(System.Text.StringBuilder stringBuilder, System.TimeSpan actual) { }
+        public void AppendTo(System.Text.StringBuilder stringBuilder, string prefix) { }
         public void Approximately(System.TimeSpan expected, System.TimeSpan tolerance) { }
         public void AtLeast(System.TimeSpan minimum) { }
         public void AtMost(System.TimeSpan maximum) { }
         public void Between(System.TimeSpan minimum, System.TimeSpan maximum) { }
         public bool IsWithinLimit(System.TimeSpan? actual) { }
-        public override string ToString() { }
+        public void Within(System.TimeSpan duration) { }
     }
     public class TimeTolerance
     {

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Within.Tests.cs
@@ -1,0 +1,349 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class Throws
+	{
+		public sealed class Within
+		{
+			public sealed class GenericTests
+			{
+				[Fact]
+				public async Task ShouldSupportChainedConstraints()
+				{
+					Action action = () => { };
+
+					async Task Act()
+						=> await That(action).Throws<ArgumentException>().Within(5.Seconds()).WithMessage("foo");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an ArgumentException within 0:05 with Message equal to "foo",
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenAwaited_ShouldReturnThrownException(string value)
+				{
+					Exception exception = new CustomException
+					{
+						Value = value
+					};
+					Action action = () => throw exception;
+
+					CustomException result =
+						await That(action).Throws<CustomException>().Within(5.Seconds());
+
+					await That(result.Value).IsEqualTo(value);
+					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownInTime_ShouldSucceed()
+				{
+					Exception exception = new CustomException();
+					Action action = () => throw exception;
+
+					async Task<CustomException> Act()
+						=> await That(action).Throws<CustomException>().Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownTooLate_ShouldFail()
+				{
+					Exception exception = new CustomException();
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+						throw exception;
+					};
+
+					async Task<CustomException> Act()
+						=> await That(action).Throws<CustomException>().Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws a ThatDelegate.CustomException within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownAndExecutionTimeIsTooLarge_ShouldFail()
+				{
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).Throws<Exception>().Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownInTime_ShouldFail()
+				{
+					Action action = () => { };
+
+					async Task<Exception> Act()
+						=> await That(action).Throws<Exception>().Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:05,
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new OtherException(message);
+					Action action = () => throw exception;
+
+					async Task<CustomException> Act()
+						=> await That(action).Throws<CustomException>().Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws a ThatDelegate.CustomException within 0:05,
+						              but it did throw a ThatDelegate.OtherException:
+						                {message}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubCustomExceptionIsThrown_ShouldSucceed()
+				{
+					Exception exception = new SubCustomException();
+					Action action = () => throw exception;
+
+					async Task<CustomException> Act()
+						=> await That(action).Throws<CustomException>().Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).Throws<CustomException>().Within(5.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             throws a ThatDelegate.CustomException within 0:05,
+						             but it was <null>
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenSupertypeExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new CustomException(message);
+					Action action = () => throw exception;
+
+					async Task<SubCustomException> Act()
+						=> await That(action).Throws<SubCustomException>().Within(6.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws a ThatDelegate.SubCustomException within 0:06,
+						              but it did throw a ThatDelegate.CustomException:
+						                {message}
+						              """);
+				}
+			}
+
+			public sealed class TypeTests
+			{
+				[Fact]
+				public async Task ShouldSupportChainedConstraints()
+				{
+					Action action = () => { };
+
+					async Task Act()
+						=> await That(action).Throws(typeof(ArgumentException)).Within(5.Seconds()).WithMessage("foo");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an ArgumentException within 0:05 with Message equal to "foo",
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenAwaited_ShouldReturnThrownException(string value)
+				{
+					Exception exception = new CustomException
+					{
+						Value = value
+					};
+					Action action = () => throw exception;
+
+					Exception result =
+						await That(action).Throws(typeof(CustomException)).Within(5.Seconds());
+
+					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownInTime_ShouldSucceed()
+				{
+					Exception exception = new CustomException();
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownTooLate_ShouldFail()
+				{
+					Exception exception = new CustomException();
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+						throw exception;
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(CustomException)).Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws a ThatDelegate.CustomException within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownAndExecutionTimeIsTooLarge_ShouldFail()
+				{
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(Exception)).Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownInTime_ShouldFail()
+				{
+					Action action = () => { };
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(Exception)).Within(5.Seconds()).Because("it should");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:05, because it should,
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new OtherException(message);
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws a ThatDelegate.CustomException within 0:05,
+						              but it did throw a ThatDelegate.OtherException:
+						                {message}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubCustomExceptionIsThrown_ShouldSucceed()
+				{
+					Exception exception = new SubCustomException();
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).Throws(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             throws a ThatDelegate.CustomException within 0:05,
+						             but it was <null>
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenSupertypeExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new CustomException(message);
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).Throws(typeof(SubCustomException)).Within(6.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws a ThatDelegate.SubCustomException within 0:06,
+						              but it did throw a ThatDelegate.CustomException:
+						                {message}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Within.Tests.cs
@@ -1,0 +1,362 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ThrowsExactly
+	{
+		public sealed class Within
+		{
+			public sealed class GenericTests
+			{
+				[Fact]
+				public async Task ShouldSupportChainedConstraints()
+				{
+					Action action = () => { };
+
+					async Task Act()
+						=> await That(action).ThrowsExactly<ArgumentException>().Within(5.Seconds()).WithMessage("foo");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly an ArgumentException within 0:05 with Message equal to "foo",
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenAwaited_ShouldReturnThrownException(string value)
+				{
+					Exception exception = new CustomException
+					{
+						Value = value
+					};
+					Action action = () => throw exception;
+
+					CustomException result =
+						await That(action).ThrowsExactly<CustomException>().Within(5.Seconds());
+
+					await That(result.Value).IsEqualTo(value);
+					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownInTime_ShouldSucceed()
+				{
+					Exception exception = new CustomException();
+					Action action = () => throw exception;
+
+					async Task<CustomException> Act()
+						=> await That(action).ThrowsExactly<CustomException>().Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownTooLate_ShouldFail()
+				{
+					Exception exception = new CustomException();
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+						throw exception;
+					};
+
+					async Task<CustomException> Act()
+						=> await That(action).ThrowsExactly<CustomException>().Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly a ThatDelegate.CustomException within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownAndExecutionTimeIsTooLarge_ShouldFail()
+				{
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly<Exception>().Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly an Exception within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownInTime_ShouldFail()
+				{
+					Action action = () => { };
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly<Exception>().Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly an Exception within 0:05,
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new OtherException(message);
+					Action action = () => throw exception;
+
+					async Task<CustomException> Act()
+						=> await That(action).ThrowsExactly<CustomException>().Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws exactly a ThatDelegate.CustomException within 0:05,
+						              but it did throw a ThatDelegate.OtherException:
+						                {message}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubCustomExceptionIsThrown_ShouldFail()
+				{
+					Exception exception = new SubCustomException();
+					Action action = () => throw exception;
+
+					async Task<CustomException> Act()
+						=> await That(action).ThrowsExactly<CustomException>().Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly a ThatDelegate.CustomException within 0:05,
+						             but it did throw a ThatDelegate.SubCustomException:
+						               WhenSubCustomExceptionIsThrown_ShouldFail
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).ThrowsExactly<CustomException>().Within(5.Seconds());
+
+					await That(Act).ThrowsExactly<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             throws exactly a ThatDelegate.CustomException within 0:05,
+						             but it was <null>
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenSupertypeExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new CustomException(message);
+					Action action = () => throw exception;
+
+					async Task<SubCustomException> Act()
+						=> await That(action).ThrowsExactly<SubCustomException>().Within(6.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws exactly a ThatDelegate.SubCustomException within 0:06,
+						              but it did throw a ThatDelegate.CustomException:
+						                {message}
+						              """);
+				}
+			}
+
+			public sealed class TypeTests
+			{
+				[Fact]
+				public async Task ShouldSupportChainedConstraints()
+				{
+					Action action = () => { };
+
+					async Task Act()
+						=> await That(action).ThrowsExactly(typeof(ArgumentException)).Within(5.Seconds())
+							.WithMessage("foo");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly an ArgumentException within 0:05 with Message equal to "foo",
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenAwaited_ShouldReturnThrownException(string value)
+				{
+					Exception exception = new CustomException
+					{
+						Value = value
+					};
+					Action action = () => throw exception;
+
+					Exception result =
+						await That(action).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
+
+					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownInTime_ShouldSucceed()
+				{
+					Exception exception = new CustomException();
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenExactExceptionTypeIsThrownTooLate_ShouldFail()
+				{
+					Exception exception = new CustomException();
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+						throw exception;
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(CustomException)).Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly a ThatDelegate.CustomException within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownAndExecutionTimeIsTooLarge_ShouldFail()
+				{
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(Exception)).Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly an Exception within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownInTime_ShouldFail()
+				{
+					Action action = () => { };
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(Exception)).Within(5.Seconds()).Because("it should");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly an Exception within 0:05, because it should,
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenOtherExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new OtherException(message);
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws exactly a ThatDelegate.CustomException within 0:05,
+						              but it did throw a ThatDelegate.OtherException:
+						                {message}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubCustomExceptionIsThrown_ShouldFail()
+				{
+					Exception exception = new SubCustomException();
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws exactly a ThatDelegate.CustomException within 0:05,
+						             but it did throw a ThatDelegate.SubCustomException:
+						               WhenSubCustomExceptionIsThrown_ShouldFail
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
+
+					await That(Act).ThrowsExactly<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             throws exactly a ThatDelegate.CustomException within 0:05,
+						             but it was <null>
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenSupertypeExceptionIsThrown_ShouldFail(string message)
+				{
+					Exception exception = new CustomException(message);
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsExactly(typeof(SubCustomException)).Within(6.Seconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage($"""
+						              Expected that action
+						              throws exactly a ThatDelegate.SubCustomException within 0:06,
+						              but it did throw a ThatDelegate.CustomException:
+						                {message}
+						              """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.Within.Tests.cs
@@ -1,0 +1,129 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatDelegate
+{
+	public sealed partial class ThrowsException
+	{
+		public sealed class Within
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task ShouldSupportChainedConstraints()
+				{
+					Action action = () => { };
+
+					async Task Act()
+						=> await That(action).ThrowsException().Within(5.Seconds()).WithMessage("foo");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:05 with Message equal to "foo",
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Theory]
+				[AutoData]
+				public async Task WhenAwaited_ShouldReturnThrownException(string value)
+				{
+					Exception exception = new CustomException
+					{
+						Value = value
+					};
+					Action action = () => throw exception;
+
+					Exception result =
+						await That(action).ThrowsException().Within(5.Seconds());
+
+					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenExceptionTypeIsThrownInTime_ShouldSucceed()
+				{
+					Exception exception = new CustomException();
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsException().Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenExceptionIsThrownTooLate_ShouldFail()
+				{
+					Exception exception = new CustomException();
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+						throw exception;
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsException().Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownAndExecutionTimeIsTooLarge_ShouldFail()
+				{
+					Action action = () =>
+					{
+						Task.Delay(50.Milliseconds()).Wait();
+					};
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsException().Within(5.Milliseconds());
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:00.005,
+						             but it took *
+						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenNoExceptionIsThrownInTime_ShouldFail()
+				{
+					Action action = () => { };
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsException().Within(5.Seconds()).Because("it should");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that action
+						             throws an exception within 0:05, because it should,
+						             but it did not throw any exception
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_ShouldFail()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).ThrowsException().Within(5.Seconds());
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             throws an exception within 0:05,
+						             but it was <null>
+						             """);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
When checking that a delegate throws an exception, add the option to additionally specify a timeout in which the delegate must complete.

- *Fixes #666*