### PR TITLE
fix: verify that the duration is not negative

### DIFF
--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Within.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Within.cs
@@ -10,6 +10,11 @@ public partial class ThatDelegateThrows<TException>
 	/// </summary>
 	public ThatDelegateThrows<TException> Within(TimeSpan duration)
 	{
+		if (duration < TimeSpan.Zero)
+		{
+			throw new ArgumentOutOfRangeException(nameof(duration), "The duration must not be negative.");
+		}
+
 		TimeSpanEqualityOptions options = new();
 		options.Within(duration);
 		_throwOptions.ExecutionTimeOptions = options;

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.Within.Tests.cs
@@ -42,6 +42,19 @@ public sealed partial class ThatDelegate
 				}
 
 				[Fact]
+				public async Task WhenDurationIsNegative_ShouldThrowArgumentOutOfRangeException()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).Throws<CustomException>().Within(-1.Milliseconds());
+
+					await That(Act).Throws<ArgumentOutOfRangeException>()
+						.WithParamName("duration").And
+						.WithMessage("The duration must not be negative").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenExactExceptionTypeIsThrownInTime_ShouldSucceed()
 				{
 					Exception exception = new CustomException();
@@ -146,12 +159,12 @@ public sealed partial class ThatDelegate
 					Action? subject = null;
 
 					async Task Act()
-						=> await That(subject!).Throws<CustomException>().Within(5.Seconds());
+						=> await That(subject!).Throws<CustomException>().Within(0.Seconds());
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             throws a ThatDelegate.CustomException within 0:05,
+						             throws a ThatDelegate.CustomException within 0:00,
 						             but it was <null>
 						             """);
 				}
@@ -208,6 +221,19 @@ public sealed partial class ThatDelegate
 						await That(action).Throws(typeof(CustomException)).Within(5.Seconds());
 
 					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenDurationIsNegative_ShouldThrowArgumentOutOfRangeException()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).Throws(typeof(CustomException)).Within(-1.Milliseconds());
+
+					await That(Act).Throws<ArgumentOutOfRangeException>()
+						.WithParamName("duration").And
+						.WithMessage("The duration must not be negative").AsPrefix();
 				}
 
 				[Fact]
@@ -315,12 +341,12 @@ public sealed partial class ThatDelegate
 					Action? subject = null;
 
 					async Task Act()
-						=> await That(subject!).Throws(typeof(CustomException)).Within(5.Seconds());
+						=> await That(subject!).Throws(typeof(CustomException)).Within(0.Seconds());
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             throws a ThatDelegate.CustomException within 0:05,
+						             throws a ThatDelegate.CustomException within 0:00,
 						             but it was <null>
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsExactly.Within.Tests.cs
@@ -42,6 +42,19 @@ public sealed partial class ThatDelegate
 				}
 
 				[Fact]
+				public async Task WhenDurationIsNegative_ShouldThrowArgumentOutOfRangeException()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).ThrowsExactly<CustomException>().Within(-1.Milliseconds());
+
+					await That(Act).Throws<ArgumentOutOfRangeException>()
+						.WithParamName("duration").And
+						.WithMessage("The duration must not be negative").AsPrefix();
+				}
+
+				[Fact]
 				public async Task WhenExactExceptionTypeIsThrownInTime_ShouldSucceed()
 				{
 					Exception exception = new CustomException();
@@ -152,12 +165,12 @@ public sealed partial class ThatDelegate
 					Action? subject = null;
 
 					async Task Act()
-						=> await That(subject!).ThrowsExactly<CustomException>().Within(5.Seconds());
+						=> await That(subject!).ThrowsExactly<CustomException>().Within(0.Seconds());
 
 					await That(Act).ThrowsExactly<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             throws exactly a ThatDelegate.CustomException within 0:05,
+						             throws exactly a ThatDelegate.CustomException within 0:00,
 						             but it was <null>
 						             """);
 				}
@@ -215,6 +228,19 @@ public sealed partial class ThatDelegate
 						await That(action).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
 
 					await That(result).IsSameAs(exception);
+				}
+
+				[Fact]
+				public async Task WhenDurationIsNegative_ShouldThrowArgumentOutOfRangeException()
+				{
+					Action? subject = null;
+
+					async Task Act()
+						=> await That(subject!).ThrowsExactly(typeof(CustomException)).Within(-1.Milliseconds());
+
+					await That(Act).Throws<ArgumentOutOfRangeException>()
+						.WithParamName("duration").And
+						.WithMessage("The duration must not be negative").AsPrefix();
 				}
 
 				[Fact]
@@ -328,12 +354,12 @@ public sealed partial class ThatDelegate
 					Action? subject = null;
 
 					async Task Act()
-						=> await That(subject!).ThrowsExactly(typeof(CustomException)).Within(5.Seconds());
+						=> await That(subject!).ThrowsExactly(typeof(CustomException)).Within(0.Seconds());
 
 					await That(Act).ThrowsExactly<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             throws exactly a ThatDelegate.CustomException within 0:05,
+						             throws exactly a ThatDelegate.CustomException within 0:00,
 						             but it was <null>
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.Within.Tests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.Within.Tests.cs
@@ -41,15 +41,16 @@ public sealed partial class ThatDelegate
 				}
 
 				[Fact]
-				public async Task WhenExceptionTypeIsThrownInTime_ShouldSucceed()
+				public async Task WhenDurationIsNegative_ShouldThrowArgumentOutOfRangeException()
 				{
-					Exception exception = new CustomException();
-					Action action = () => throw exception;
+					Action? subject = null;
 
-					async Task<Exception> Act()
-						=> await That(action).ThrowsException().Within(5.Seconds());
+					async Task Act()
+						=> await That(subject!).ThrowsException().Within(-1.Milliseconds());
 
-					await That(Act).DoesNotThrow();
+					await That(Act).Throws<ArgumentOutOfRangeException>()
+						.WithParamName("duration").And
+						.WithMessage("The duration must not be negative").AsPrefix();
 				}
 
 				[Fact]
@@ -71,6 +72,18 @@ public sealed partial class ThatDelegate
 						             throws an exception within 0:00.005,
 						             but it took *
 						             """).AsWildcard();
+				}
+
+				[Fact]
+				public async Task WhenExceptionTypeIsThrownInTime_ShouldSucceed()
+				{
+					Exception exception = new CustomException();
+					Action action = () => throw exception;
+
+					async Task<Exception> Act()
+						=> await That(action).ThrowsException().Within(5.Seconds());
+
+					await That(Act).DoesNotThrow();
 				}
 
 				[Fact]
@@ -114,12 +127,12 @@ public sealed partial class ThatDelegate
 					Action? subject = null;
 
 					async Task Act()
-						=> await That(subject!).ThrowsException().Within(5.Seconds());
+						=> await That(subject!).ThrowsException().Within(0.Seconds());
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             throws an exception within 0:05,
+						             throws an exception within 0:00,
 						             but it was <null>
 						             """);
 				}


### PR DESCRIPTION
Throw an `ArgumentOutOfRangeException` when using `.Within` with a negative range form #667 