### PR TITLE
fix: throw `ArgumentException` when expected is empty in `IsOneOf`

### DIFF
--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -103,7 +103,7 @@ internal class ExpectationNode : Node
 				result = _reason?.ApplyTo(result) ?? result;
 			}
 		}
-		catch (Exception e) when (_constraint is not null)
+		catch (Exception e) when (e is not ArgumentException && _constraint is not null)
 		{
 			throw new InvalidOperationException(
 					$"Error evaluating {Formatter.Format(_constraint.GetType())} constraint with value {Formatter.Format(value)}: {e.Message}",

--- a/Source/aweXpect/That/Chars/ThatChar.IsOneOf.cs
+++ b/Source/aweXpect/That/Chars/ThatChar.IsOneOf.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -70,7 +71,23 @@ public static partial class ThatChar
 		public ConstraintResult IsMetBy(char actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(value => actual.Equals(value)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (char? value in expected)
+			{
+				hasValues = true;
+				if (actual.Equals(value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/Chars/ThatNullableChar.IsOneOf.cs
+++ b/Source/aweXpect/That/Chars/ThatNullableChar.IsOneOf.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -70,7 +71,23 @@ public static partial class ThatNullableChar
 		public ConstraintResult IsMetBy(char? actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(value => actual.Equals(value)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (char? value in expected)
+			{
+				hasValues = true;
+				if (actual.Equals(value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatDateOnly.IsOneOf.cs
@@ -116,11 +116,23 @@ public static partial class ThatDateOnly
 			Actual = actual;
 			TimeSpan timeTolerance = tolerance.Tolerance ??
 			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-			Outcome = expected.Any(value =>
-				value != null && Math.Abs(actual.DayNumber - value.Value.DayNumber) <= (int)timeTolerance.TotalDays)
-				? Outcome.Success
-				: Outcome.Failure;
+			bool hasValues = false;
+			foreach (DateOnly? value in expected)
+			{
+				hasValues = true;
+				if (value != null && Math.Abs(actual.DayNumber - value.Value.DayNumber) <= (int)timeTolerance.TotalDays)
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
 
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/DateOnlys/ThatNullableDateOnly.IsOneOf.cs
@@ -122,11 +122,24 @@ public static partial class ThatNullableDateOnly
 			{
 				TimeSpan timeTolerance = tolerance.Tolerance ??
 				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-				Outcome = expected.Any(value =>
-					value != null &&
-					Math.Abs(actual.Value.DayNumber - value.Value.DayNumber) <= (int)timeTolerance.TotalDays)
-					? Outcome.Success
-					: Outcome.Failure;
+				bool hasValues = false;
+				foreach (DateOnly? value in expected)
+				{
+					hasValues = true;
+					if (value != null &&
+					    Math.Abs(actual.Value.DayNumber - value.Value.DayNumber) <= (int)timeTolerance.TotalDays)
+					{
+						Outcome = Outcome.Success;
+						return this;
+					}
+				}
+
+				if (!hasValues)
+				{
+					throw new ArgumentException("You have to provide at least one expected value!");
+				}
+
+				Outcome = Outcome.Failure;
 			}
 
 			return this;

--- a/Source/aweXpect/That/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.cs
@@ -115,13 +115,25 @@ public static partial class ThatDateTimeOffset
 			Actual = actual;
 			TimeSpan timeTolerance = tolerance.Tolerance ??
 			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-			Outcome = expected.Any(value =>
-				value != null &&
-				actual - value.Value <= timeTolerance &&
-				actual - value.Value >= timeTolerance.Negate())
-				? Outcome.Success
-				: Outcome.Failure;
+			bool hasValues = false;
+			foreach (DateTimeOffset? value in expected)
+			{
+				hasValues = true;
+				if (value != null &&
+				    actual - value.Value <= timeTolerance &&
+				    actual - value.Value >= timeTolerance.Negate())
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
 
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimeOffsets/ThatNullableDateTimeOffset.IsOneOf.cs
@@ -121,12 +121,25 @@ public static partial class ThatNullableDateTimeOffset
 			{
 				TimeSpan timeTolerance = tolerance.Tolerance ??
 				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-				Outcome = expected.Any(value =>
-					value != null &&
-					actual.Value - value.Value <= timeTolerance &&
-					actual.Value - value.Value >= timeTolerance.Negate())
-					? Outcome.Success
-					: Outcome.Failure;
+				bool hasValues = false;
+				foreach (DateTimeOffset? value in expected)
+				{
+					hasValues = true;
+					if (value != null &&
+					    actual - value.Value <= timeTolerance &&
+					    actual - value.Value >= timeTolerance.Negate())
+					{
+						Outcome = Outcome.Success;
+						return this;
+					}
+				}
+
+				if (!hasValues)
+				{
+					throw new ArgumentException("You have to provide at least one expected value!");
+				}
+
+				Outcome = Outcome.Failure;
 			}
 
 			return this;

--- a/Source/aweXpect/That/DateTimes/ThatDateTime.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimes/ThatDateTime.IsOneOf.cs
@@ -115,13 +115,25 @@ public static partial class ThatDateTime
 			Actual = actual;
 			TimeSpan timeTolerance = tolerance.Tolerance ??
 			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-			Outcome = expected.Any(value =>
-				value != null &&
-				actual - value.Value <= timeTolerance &&
-				actual - value.Value >= timeTolerance.Negate())
-				? Outcome.Success
-				: Outcome.Failure;
+			bool hasValues = false;
+			foreach (DateTime? value in expected)
+			{
+				hasValues = true;
+				if (value != null &&
+				    actual - value.Value <= timeTolerance &&
+				    actual - value.Value >= timeTolerance.Negate())
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
 
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsOneOf.cs
+++ b/Source/aweXpect/That/DateTimes/ThatNullableDateTime.IsOneOf.cs
@@ -121,12 +121,25 @@ public static partial class ThatNullableDateTime
 			{
 				TimeSpan timeTolerance = tolerance.Tolerance ??
 				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-				Outcome = expected.Any(value =>
-					value != null &&
-					actual.Value - value.Value <= timeTolerance &&
-					actual.Value - value.Value >= timeTolerance.Negate())
-					? Outcome.Success
-					: Outcome.Failure;
+				bool hasValues = false;
+				foreach (DateTime? value in expected)
+				{
+					hasValues = true;
+					if (value != null &&
+					    actual - value.Value <= timeTolerance &&
+					    actual - value.Value >= timeTolerance.Negate())
+					{
+						Outcome = Outcome.Success;
+						return this;
+					}
+				}
+
+				if (!hasValues)
+				{
+					throw new ArgumentException("You have to provide at least one expected value!");
+				}
+
+				Outcome = Outcome.Failure;
 			}
 
 			return this;

--- a/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
+++ b/Source/aweXpect/That/Numbers/ThatNumber.IsOneOf.cs
@@ -1,13 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
-#if !NET8_0_OR_GREATER
-using System;
-#endif
 
 namespace aweXpect;
 
@@ -218,7 +216,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -258,7 +272,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -298,7 +328,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -338,7 +384,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -373,8 +435,7 @@ public static partial class ThatNumber
 		this IThat<byte> source,
 		params byte?[] expected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -389,8 +450,7 @@ public static partial class ThatNumber
 		this IThat<byte> source,
 		IEnumerable<byte?> expected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -405,8 +465,7 @@ public static partial class ThatNumber
 		this IThat<byte> source,
 		IEnumerable<byte> expected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<byte>(it, grammars, expected, options)),
@@ -421,8 +480,7 @@ public static partial class ThatNumber
 		this IThat<sbyte> source,
 		params sbyte?[] expected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -437,8 +495,7 @@ public static partial class ThatNumber
 		this IThat<sbyte> source,
 		IEnumerable<sbyte?> expected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -453,8 +510,7 @@ public static partial class ThatNumber
 		this IThat<sbyte> source,
 		IEnumerable<sbyte> expected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<sbyte>(it, grammars, expected, options)),
@@ -469,8 +525,7 @@ public static partial class ThatNumber
 		this IThat<short> source,
 		params short?[] expected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -485,8 +540,7 @@ public static partial class ThatNumber
 		this IThat<short> source,
 		IEnumerable<short?> expected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -501,8 +555,7 @@ public static partial class ThatNumber
 		this IThat<short> source,
 		IEnumerable<short> expected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<short>(it, grammars, expected, options)),
@@ -517,8 +570,7 @@ public static partial class ThatNumber
 		this IThat<ushort> source,
 		params ushort?[] expected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -533,8 +585,7 @@ public static partial class ThatNumber
 		this IThat<ushort> source,
 		IEnumerable<ushort?> expected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -549,8 +600,7 @@ public static partial class ThatNumber
 		this IThat<ushort> source,
 		IEnumerable<ushort> expected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ushort>(it, grammars, expected, options)),
@@ -565,8 +615,7 @@ public static partial class ThatNumber
 		this IThat<int> source,
 		params int?[] expected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -581,8 +630,7 @@ public static partial class ThatNumber
 		this IThat<int> source,
 		IEnumerable<int?> expected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -597,8 +645,7 @@ public static partial class ThatNumber
 		this IThat<int> source,
 		IEnumerable<int> expected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<int>(it, grammars, expected, options)),
@@ -613,8 +660,7 @@ public static partial class ThatNumber
 		this IThat<uint> source,
 		params uint?[] expected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => a > e ? a - e : e - a);
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -629,8 +675,7 @@ public static partial class ThatNumber
 		this IThat<uint> source,
 		IEnumerable<uint?> expected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -645,8 +690,7 @@ public static partial class ThatNumber
 		this IThat<uint> source,
 		IEnumerable<uint> expected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<uint>(it, grammars, expected, options)),
@@ -661,8 +705,7 @@ public static partial class ThatNumber
 		this IThat<long> source,
 		params long?[] expected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -677,8 +720,7 @@ public static partial class ThatNumber
 		this IThat<long> source,
 		IEnumerable<long?> expected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -693,8 +735,7 @@ public static partial class ThatNumber
 		this IThat<long> source,
 		IEnumerable<long> expected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<long>(it, grammars, expected, options)),
@@ -709,8 +750,7 @@ public static partial class ThatNumber
 		this IThat<ulong> source,
 		params ulong?[] expected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -725,8 +765,7 @@ public static partial class ThatNumber
 		this IThat<ulong> source,
 		IEnumerable<ulong?> expected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -741,8 +780,7 @@ public static partial class ThatNumber
 		this IThat<ulong> source,
 		IEnumerable<ulong> expected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ulong>(it, grammars, expected, options)),
@@ -757,8 +795,7 @@ public static partial class ThatNumber
 		this IThat<float> source,
 		params float?[] expected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -773,8 +810,7 @@ public static partial class ThatNumber
 		this IThat<float> source,
 		IEnumerable<float?> expected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -789,8 +825,7 @@ public static partial class ThatNumber
 		this IThat<float> source,
 		IEnumerable<float> expected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<float>(it, grammars, expected, options)),
@@ -805,8 +840,7 @@ public static partial class ThatNumber
 		this IThat<double> source,
 		params double?[] expected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -821,8 +855,7 @@ public static partial class ThatNumber
 		this IThat<double> source,
 		IEnumerable<double?> expected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -837,8 +870,7 @@ public static partial class ThatNumber
 		this IThat<double> source,
 		IEnumerable<double> expected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<double>(it, grammars, expected, options)),
@@ -853,8 +885,7 @@ public static partial class ThatNumber
 		this IThat<decimal> source,
 		params decimal?[] expected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -869,8 +900,7 @@ public static partial class ThatNumber
 		this IThat<decimal> source,
 		IEnumerable<decimal?> expected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -885,8 +915,7 @@ public static partial class ThatNumber
 		this IThat<decimal> source,
 		IEnumerable<decimal> expected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<decimal>(it, grammars, expected, options)),
@@ -901,8 +930,7 @@ public static partial class ThatNumber
 		this IThat<byte?> source,
 		params byte?[] expected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -917,8 +945,7 @@ public static partial class ThatNumber
 		this IThat<byte?> source,
 		IEnumerable<byte?> expected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, expected, options)),
@@ -933,8 +960,7 @@ public static partial class ThatNumber
 		this IThat<byte?> source,
 		IEnumerable<byte> expected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<byte>(it, grammars, expected, options)),
@@ -949,8 +975,7 @@ public static partial class ThatNumber
 		this IThat<sbyte?> source,
 		params sbyte?[] expected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -965,8 +990,7 @@ public static partial class ThatNumber
 		this IThat<sbyte?> source,
 		IEnumerable<sbyte?> expected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, expected, options)),
@@ -981,8 +1005,7 @@ public static partial class ThatNumber
 		this IThat<sbyte?> source,
 		IEnumerable<sbyte> expected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<sbyte>(it, grammars, expected, options)),
@@ -997,8 +1020,7 @@ public static partial class ThatNumber
 		this IThat<short?> source,
 		params short?[] expected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -1013,8 +1035,7 @@ public static partial class ThatNumber
 		this IThat<short?> source,
 		IEnumerable<short?> expected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, expected, options)),
@@ -1029,8 +1050,7 @@ public static partial class ThatNumber
 		this IThat<short?> source,
 		IEnumerable<short> expected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<short>(it, grammars, expected, options)),
@@ -1045,8 +1065,7 @@ public static partial class ThatNumber
 		this IThat<ushort?> source,
 		params ushort?[] expected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -1061,8 +1080,7 @@ public static partial class ThatNumber
 		this IThat<ushort?> source,
 		IEnumerable<ushort?> expected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, expected, options)),
@@ -1077,8 +1095,7 @@ public static partial class ThatNumber
 		this IThat<ushort?> source,
 		IEnumerable<ushort> expected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ushort>(it, grammars, expected, options)),
@@ -1093,8 +1110,7 @@ public static partial class ThatNumber
 		this IThat<int?> source,
 		params int?[] expected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -1109,8 +1125,7 @@ public static partial class ThatNumber
 		this IThat<int?> source,
 		IEnumerable<int?> expected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, expected, options)),
@@ -1125,8 +1140,7 @@ public static partial class ThatNumber
 		this IThat<int?> source,
 		IEnumerable<int> expected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<int>(it, grammars, expected, options)),
@@ -1141,8 +1155,7 @@ public static partial class ThatNumber
 		this IThat<uint?> source,
 		params uint?[] expected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -1157,8 +1170,7 @@ public static partial class ThatNumber
 		this IThat<uint?> source,
 		IEnumerable<uint?> expected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, expected, options)),
@@ -1173,8 +1185,7 @@ public static partial class ThatNumber
 		this IThat<uint?> source,
 		IEnumerable<uint> expected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<uint>(it, grammars, expected, options)),
@@ -1189,8 +1200,7 @@ public static partial class ThatNumber
 		this IThat<long?> source,
 		params long?[] expected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -1205,8 +1215,7 @@ public static partial class ThatNumber
 		this IThat<long?> source,
 		IEnumerable<long?> expected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, expected, options)),
@@ -1221,8 +1230,7 @@ public static partial class ThatNumber
 		this IThat<long?> source,
 		IEnumerable<long> expected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<long>(it, grammars, expected, options)),
@@ -1237,8 +1245,7 @@ public static partial class ThatNumber
 		this IThat<ulong?> source,
 		params ulong?[] expected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -1253,8 +1260,7 @@ public static partial class ThatNumber
 		this IThat<ulong?> source,
 		IEnumerable<ulong?> expected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, expected, options)),
@@ -1269,8 +1275,7 @@ public static partial class ThatNumber
 		this IThat<ulong?> source,
 		IEnumerable<ulong> expected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ulong>(it, grammars, expected, options)),
@@ -1285,8 +1290,7 @@ public static partial class ThatNumber
 		this IThat<float?> source,
 		params float?[] expected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -1301,8 +1305,7 @@ public static partial class ThatNumber
 		this IThat<float?> source,
 		IEnumerable<float?> expected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, expected, options)),
@@ -1317,8 +1320,7 @@ public static partial class ThatNumber
 		this IThat<float?> source,
 		IEnumerable<float> expected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<float>(it, grammars, expected, options)),
@@ -1333,8 +1335,7 @@ public static partial class ThatNumber
 		this IThat<double?> source,
 		params double?[] expected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -1349,8 +1350,7 @@ public static partial class ThatNumber
 		this IThat<double?> source,
 		IEnumerable<double?> expected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, expected, options)),
@@ -1365,8 +1365,7 @@ public static partial class ThatNumber
 		this IThat<double?> source,
 		IEnumerable<double> expected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<double>(it, grammars, expected, options)),
@@ -1381,8 +1380,7 @@ public static partial class ThatNumber
 		this IThat<decimal?> source,
 		params decimal?[] expected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -1397,8 +1395,7 @@ public static partial class ThatNumber
 		this IThat<decimal?> source,
 		IEnumerable<decimal?> expected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, expected, options)),
@@ -1413,8 +1410,7 @@ public static partial class ThatNumber
 		this IThat<decimal?> source,
 		IEnumerable<decimal> expected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<decimal>(it, grammars, expected, options)),
@@ -1429,8 +1425,7 @@ public static partial class ThatNumber
 		this IThat<byte> source,
 		params byte?[] unexpected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1445,8 +1440,7 @@ public static partial class ThatNumber
 		this IThat<byte> source,
 		IEnumerable<byte?> unexpected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1461,8 +1455,7 @@ public static partial class ThatNumber
 		this IThat<byte> source,
 		IEnumerable<byte> unexpected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NumberToleranceResult<byte, IThat<byte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<byte>(it, grammars, unexpected, options).Invert()),
@@ -1477,8 +1470,7 @@ public static partial class ThatNumber
 		this IThat<sbyte> source,
 		params sbyte?[] unexpected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -1493,8 +1485,7 @@ public static partial class ThatNumber
 		this IThat<sbyte> source,
 		IEnumerable<sbyte?> unexpected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -1509,8 +1500,7 @@ public static partial class ThatNumber
 		this IThat<sbyte> source,
 		IEnumerable<sbyte> unexpected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NumberToleranceResult<sbyte, IThat<sbyte>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -1525,8 +1515,7 @@ public static partial class ThatNumber
 		this IThat<short> source,
 		params short?[] unexpected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -1541,8 +1530,7 @@ public static partial class ThatNumber
 		this IThat<short> source,
 		IEnumerable<short?> unexpected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -1557,8 +1545,7 @@ public static partial class ThatNumber
 		this IThat<short> source,
 		IEnumerable<short> unexpected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NumberToleranceResult<short, IThat<short>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<short>(it, grammars, unexpected, options).Invert()),
@@ -1573,8 +1560,7 @@ public static partial class ThatNumber
 		this IThat<ushort> source,
 		params ushort?[] unexpected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -1589,8 +1575,7 @@ public static partial class ThatNumber
 		this IThat<ushort> source,
 		IEnumerable<ushort?> unexpected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -1605,8 +1590,7 @@ public static partial class ThatNumber
 		this IThat<ushort> source,
 		IEnumerable<ushort> unexpected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NumberToleranceResult<ushort, IThat<ushort>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ushort>(it, grammars, unexpected, options).Invert()),
@@ -1621,8 +1605,7 @@ public static partial class ThatNumber
 		this IThat<int> source,
 		params int?[] unexpected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -1637,8 +1620,7 @@ public static partial class ThatNumber
 		this IThat<int> source,
 		IEnumerable<int?> unexpected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -1653,8 +1635,7 @@ public static partial class ThatNumber
 		this IThat<int> source,
 		IEnumerable<int> unexpected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<int, IThat<int>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<int>(it, grammars, unexpected, options).Invert()),
@@ -1669,8 +1650,7 @@ public static partial class ThatNumber
 		this IThat<uint> source,
 		params uint?[] unexpected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -1685,8 +1665,7 @@ public static partial class ThatNumber
 		this IThat<uint> source,
 		IEnumerable<uint?> unexpected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -1701,8 +1680,7 @@ public static partial class ThatNumber
 		this IThat<uint> source,
 		IEnumerable<uint> unexpected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<uint, IThat<uint>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<uint>(it, grammars, unexpected, options).Invert()),
@@ -1717,8 +1695,7 @@ public static partial class ThatNumber
 		this IThat<long> source,
 		params long?[] unexpected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -1733,8 +1710,7 @@ public static partial class ThatNumber
 		this IThat<long> source,
 		IEnumerable<long?> unexpected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -1749,8 +1725,7 @@ public static partial class ThatNumber
 		this IThat<long> source,
 		IEnumerable<long> unexpected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<long, IThat<long>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<long>(it, grammars, unexpected, options).Invert()),
@@ -1765,8 +1740,7 @@ public static partial class ThatNumber
 		this IThat<ulong> source,
 		params ulong?[] unexpected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -1781,8 +1755,7 @@ public static partial class ThatNumber
 		this IThat<ulong> source,
 		IEnumerable<ulong?> unexpected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -1797,8 +1770,7 @@ public static partial class ThatNumber
 		this IThat<ulong> source,
 		IEnumerable<ulong> unexpected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NumberToleranceResult<ulong, IThat<ulong>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<ulong>(it, grammars, unexpected, options).Invert()),
@@ -1813,8 +1785,7 @@ public static partial class ThatNumber
 		this IThat<float> source,
 		params float?[] unexpected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -1829,8 +1800,7 @@ public static partial class ThatNumber
 		this IThat<float> source,
 		IEnumerable<float?> unexpected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -1845,8 +1815,7 @@ public static partial class ThatNumber
 		this IThat<float> source,
 		IEnumerable<float> unexpected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<float, IThat<float>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<float>(it, grammars, unexpected, options).Invert()),
@@ -1861,8 +1830,7 @@ public static partial class ThatNumber
 		this IThat<double> source,
 		params double?[] unexpected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -1877,8 +1845,7 @@ public static partial class ThatNumber
 		this IThat<double> source,
 		IEnumerable<double?> unexpected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -1893,8 +1860,7 @@ public static partial class ThatNumber
 		this IThat<double> source,
 		IEnumerable<double> unexpected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NumberToleranceResult<double, IThat<double>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<double>(it, grammars, unexpected, options).Invert()),
@@ -1909,8 +1875,7 @@ public static partial class ThatNumber
 		this IThat<decimal> source,
 		params decimal?[] unexpected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -1925,8 +1890,7 @@ public static partial class ThatNumber
 		this IThat<decimal> source,
 		IEnumerable<decimal?> unexpected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -1941,8 +1905,7 @@ public static partial class ThatNumber
 		this IThat<decimal> source,
 		IEnumerable<decimal> unexpected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NumberToleranceResult<decimal, IThat<decimal>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new IsOneOfConstraint<decimal>(it, grammars, unexpected, options).Invert()),
@@ -1957,8 +1920,7 @@ public static partial class ThatNumber
 		this IThat<byte?> source,
 		params byte?[] unexpected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1973,8 +1935,7 @@ public static partial class ThatNumber
 		this IThat<byte?> source,
 		IEnumerable<byte?> unexpected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<byte>(it, grammars, unexpected, options).Invert()),
@@ -1989,8 +1950,7 @@ public static partial class ThatNumber
 		this IThat<byte?> source,
 		IEnumerable<byte> unexpected)
 	{
-		NumberTolerance<byte> options = new(
-			(a, e) => (byte)Math.Abs(a - e));
+		NumberTolerance<byte> options = new((a, e) => (byte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<byte, IThat<byte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<byte>(it, grammars, unexpected, options).Invert()),
@@ -2005,8 +1965,7 @@ public static partial class ThatNumber
 		this IThat<sbyte?> source,
 		params sbyte?[] unexpected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -2021,8 +1980,7 @@ public static partial class ThatNumber
 		this IThat<sbyte?> source,
 		IEnumerable<sbyte?> unexpected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -2037,8 +1995,7 @@ public static partial class ThatNumber
 		this IThat<sbyte?> source,
 		IEnumerable<sbyte> unexpected)
 	{
-		NumberTolerance<sbyte> options = new(
-			(a, e) => (sbyte)Math.Abs(a - e));
+		NumberTolerance<sbyte> options = new((a, e) => (sbyte)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<sbyte, IThat<sbyte?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<sbyte>(it, grammars, unexpected, options).Invert()),
@@ -2053,8 +2010,7 @@ public static partial class ThatNumber
 		this IThat<short?> source,
 		params short?[] unexpected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -2069,8 +2025,7 @@ public static partial class ThatNumber
 		this IThat<short?> source,
 		IEnumerable<short?> unexpected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<short>(it, grammars, unexpected, options).Invert()),
@@ -2085,8 +2040,7 @@ public static partial class ThatNumber
 		this IThat<short?> source,
 		IEnumerable<short> unexpected)
 	{
-		NumberTolerance<short> options = new(
-			(a, e) => (short)Math.Abs(a - e));
+		NumberTolerance<short> options = new((a, e) => (short)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<short, IThat<short?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<short>(it, grammars, unexpected, options).Invert()),
@@ -2101,8 +2055,7 @@ public static partial class ThatNumber
 		this IThat<ushort?> source,
 		params ushort?[] unexpected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -2117,8 +2070,7 @@ public static partial class ThatNumber
 		this IThat<ushort?> source,
 		IEnumerable<ushort?> unexpected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ushort>(it, grammars, unexpected, options).Invert()),
@@ -2133,8 +2085,7 @@ public static partial class ThatNumber
 		this IThat<ushort?> source,
 		IEnumerable<ushort> unexpected)
 	{
-		NumberTolerance<ushort> options = new(
-			(a, e) => (ushort)Math.Abs(a - e));
+		NumberTolerance<ushort> options = new((a, e) => (ushort)Math.Abs(a - e));
 		return new NullableNumberToleranceResult<ushort, IThat<ushort?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ushort>(it, grammars, unexpected, options).Invert()),
@@ -2149,8 +2100,7 @@ public static partial class ThatNumber
 		this IThat<int?> source,
 		params int?[] unexpected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -2165,8 +2115,7 @@ public static partial class ThatNumber
 		this IThat<int?> source,
 		IEnumerable<int?> unexpected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<int>(it, grammars, unexpected, options).Invert()),
@@ -2181,8 +2130,7 @@ public static partial class ThatNumber
 		this IThat<int?> source,
 		IEnumerable<int> unexpected)
 	{
-		NumberTolerance<int> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<int> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<int, IThat<int?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<int>(it, grammars, unexpected, options).Invert()),
@@ -2197,8 +2145,7 @@ public static partial class ThatNumber
 		this IThat<uint?> source,
 		params uint?[] unexpected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -2213,8 +2160,7 @@ public static partial class ThatNumber
 		this IThat<uint?> source,
 		IEnumerable<uint?> unexpected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<uint>(it, grammars, unexpected, options).Invert()),
@@ -2229,8 +2175,7 @@ public static partial class ThatNumber
 		this IThat<uint?> source,
 		IEnumerable<uint> unexpected)
 	{
-		NumberTolerance<uint> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<uint> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<uint, IThat<uint?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<uint>(it, grammars, unexpected, options).Invert()),
@@ -2245,8 +2190,7 @@ public static partial class ThatNumber
 		this IThat<long?> source,
 		params long?[] unexpected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -2261,8 +2205,7 @@ public static partial class ThatNumber
 		this IThat<long?> source,
 		IEnumerable<long?> unexpected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<long>(it, grammars, unexpected, options).Invert()),
@@ -2277,8 +2220,7 @@ public static partial class ThatNumber
 		this IThat<long?> source,
 		IEnumerable<long> unexpected)
 	{
-		NumberTolerance<long> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<long> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<long, IThat<long?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<long>(it, grammars, unexpected, options).Invert()),
@@ -2293,8 +2235,7 @@ public static partial class ThatNumber
 		this IThat<ulong?> source,
 		params ulong?[] unexpected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -2309,8 +2250,7 @@ public static partial class ThatNumber
 		this IThat<ulong?> source,
 		IEnumerable<ulong?> unexpected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<ulong>(it, grammars, unexpected, options).Invert()),
@@ -2325,8 +2265,7 @@ public static partial class ThatNumber
 		this IThat<ulong?> source,
 		IEnumerable<ulong> unexpected)
 	{
-		NumberTolerance<ulong> options = new(
-			(a, e) => (a > e ? a - e : e - a));
+		NumberTolerance<ulong> options = new((a, e) => a > e ? a - e : e - a);
 		return new NullableNumberToleranceResult<ulong, IThat<ulong?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<ulong>(it, grammars, unexpected, options).Invert()),
@@ -2341,8 +2280,7 @@ public static partial class ThatNumber
 		this IThat<float?> source,
 		params float?[] unexpected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -2357,8 +2295,7 @@ public static partial class ThatNumber
 		this IThat<float?> source,
 		IEnumerable<float?> unexpected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<float>(it, grammars, unexpected, options).Invert()),
@@ -2373,8 +2310,7 @@ public static partial class ThatNumber
 		this IThat<float?> source,
 		IEnumerable<float> unexpected)
 	{
-		NumberTolerance<float> options = new(
-			(a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<float> options = new((a, e) => float.IsNaN(a) || float.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<float, IThat<float?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<float>(it, grammars, unexpected, options).Invert()),
@@ -2389,8 +2325,7 @@ public static partial class ThatNumber
 		this IThat<double?> source,
 		params double?[] unexpected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -2405,8 +2340,7 @@ public static partial class ThatNumber
 		this IThat<double?> source,
 		IEnumerable<double?> unexpected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<double>(it, grammars, unexpected, options).Invert()),
@@ -2421,8 +2355,7 @@ public static partial class ThatNumber
 		this IThat<double?> source,
 		IEnumerable<double> unexpected)
 	{
-		NumberTolerance<double> options = new(
-			(a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
+		NumberTolerance<double> options = new((a, e) => double.IsNaN(a) || double.IsNaN(e) ? null : Math.Abs(a - e));
 		return new NullableNumberToleranceResult<double, IThat<double?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<double>(it, grammars, unexpected, options).Invert()),
@@ -2437,8 +2370,7 @@ public static partial class ThatNumber
 		this IThat<decimal?> source,
 		params decimal?[] unexpected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -2453,8 +2385,7 @@ public static partial class ThatNumber
 		this IThat<decimal?> source,
 		IEnumerable<decimal?> unexpected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraintWithNullable<decimal>(it, grammars, unexpected, options).Invert()),
@@ -2469,8 +2400,7 @@ public static partial class ThatNumber
 		this IThat<decimal?> source,
 		IEnumerable<decimal> unexpected)
 	{
-		NumberTolerance<decimal> options = new(
-			(a, e) => Math.Abs(a - e));
+		NumberTolerance<decimal> options = new((a, e) => Math.Abs(a - e));
 		return new NullableNumberToleranceResult<decimal, IThat<decimal?>>(
 			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
 				new NullableIsOneOfConstraint<decimal>(it, grammars, unexpected, options).Invert()),
@@ -2490,7 +2420,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -2530,7 +2476,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -2570,7 +2532,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 
@@ -2610,7 +2588,23 @@ public static partial class ThatNumber
 		public ConstraintResult IsMetBy(TNumber? actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(e => options.IsWithinTolerance(actual, e)) ? Outcome.Success : Outcome.Failure;
+			bool hasValues = false;
+			foreach (TNumber? value in expected)
+			{
+				hasValues = true;
+				if (options.IsWithinTolerance(actual, value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatNullableTimeOnly.IsOneOf.cs
@@ -27,7 +27,7 @@ public static partial class ThatNullableTimeOnly
 			source,
 			tolerance);
 	}
-	
+
 	/// <summary>
 	///     Verifies that the subject is one of the <paramref name="expected" /> values.
 	/// </summary>
@@ -42,7 +42,7 @@ public static partial class ThatNullableTimeOnly
 			source,
 			tolerance);
 	}
-	
+
 	/// <summary>
 	///     Verifies that the subject is one of the <paramref name="expected" /> values.
 	/// </summary>
@@ -122,11 +122,24 @@ public static partial class ThatNullableTimeOnly
 			{
 				TimeSpan timeTolerance = tolerance.Tolerance ??
 				                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-				Outcome = expected.Any(value =>
-					value != null &&
-					Math.Abs(actual.Value.Ticks - value.Value.Ticks) <= timeTolerance.Ticks)
-					? Outcome.Success
-					: Outcome.Failure;
+				bool hasValues = false;
+				foreach (TimeOnly? value in expected)
+				{
+					hasValues = true;
+					if (value != null &&
+					    Math.Abs(actual.Value.Ticks - value.Value.Ticks) <= timeTolerance.Ticks)
+					{
+						Outcome = Outcome.Success;
+						return this;
+					}
+				}
+
+				if (!hasValues)
+				{
+					throw new ArgumentException("You have to provide at least one expected value!");
+				}
+
+				Outcome = Outcome.Failure;
 			}
 
 			return this;

--- a/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeOnlys/ThatTimeOnly.IsOneOf.cs
@@ -27,7 +27,7 @@ public static partial class ThatTimeOnly
 			source,
 			tolerance);
 	}
-	
+
 	/// <summary>
 	///     Verifies that the subject is one of the <paramref name="expected" /> values.
 	/// </summary>
@@ -42,7 +42,7 @@ public static partial class ThatTimeOnly
 			source,
 			tolerance);
 	}
-	
+
 	/// <summary>
 	///     Verifies that the subject is one of the <paramref name="expected" /> values.
 	/// </summary>
@@ -116,11 +116,24 @@ public static partial class ThatTimeOnly
 			Actual = actual;
 			TimeSpan timeTolerance = tolerance.Tolerance ??
 			                         Customize.aweXpect.Settings().DefaultTimeComparisonTolerance.Get();
-			Outcome = expected.Any(value =>
-				value != null &&
-				Math.Abs(actual.Ticks - value.Value.Ticks) <= timeTolerance.Ticks)
-				? Outcome.Success
-				: Outcome.Failure;
+			bool hasValues = false;
+			foreach (TimeOnly? value in expected)
+			{
+				hasValues = true;
+				if (value != null &&
+				    Math.Abs(actual.Ticks - value.Value.Ticks) <= timeTolerance.Ticks)
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 
 			return this;
 		}

--- a/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatNullableTimeSpan.IsOneOf.cs
@@ -118,11 +118,24 @@ public static partial class ThatNullableTimeSpan
 			}
 			else
 			{
-				Outcome = expected.Any(value =>
-					value != null &&
-					IsWithinTolerance(tolerance.Tolerance, actual.Value - value.Value))
-					? Outcome.Success
-					: Outcome.Failure;
+				bool hasValues = false;
+				foreach (TimeSpan? value in expected)
+				{
+					hasValues = true;
+					if (value != null &&
+					    IsWithinTolerance(tolerance.Tolerance, actual.Value - value.Value))
+					{
+						Outcome = Outcome.Success;
+						return this;
+					}
+				}
+
+				if (!hasValues)
+				{
+					throw new ArgumentException("You have to provide at least one expected value!");
+				}
+
+				Outcome = Outcome.Failure;
 			}
 
 			return this;

--- a/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsOneOf.cs
+++ b/Source/aweXpect/That/TimeSpans/ThatTimeSpan.IsOneOf.cs
@@ -112,11 +112,24 @@ public static partial class ThatTimeSpan
 		public ConstraintResult IsMetBy(TimeSpan actual)
 		{
 			Actual = actual;
-			Outcome = expected.Any(value =>
-				value != null &&
-				IsWithinTolerance(tolerance.Tolerance, actual - value.Value))
-				? Outcome.Success
-				: Outcome.Failure;
+			bool hasValues = false;
+			foreach (TimeSpan? value in expected)
+			{
+				hasValues = true;
+				if (value != null &&
+				    IsWithinTolerance(tolerance.Tolerance, actual - value.Value))
+				{
+					Outcome = Outcome.Success;
+					return this;
+				}
+			}
+
+			if (!hasValues)
+			{
+				throw new ArgumentException("You have to provide at least one expected value!");
+			}
+
+			Outcome = Outcome.Failure;
 
 			return this;
 		}

--- a/Tests/aweXpect.Tests/Chars/ThatChar.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Chars/ThatChar.IsNotOneOf.Tests.cs
@@ -10,6 +10,19 @@ public sealed partial class ThatChar
 	{
 		public sealed class Tests
 		{
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				char subject = 'a';
+				char[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
 			[Theory]
 			[InlineData('a')]
 			[InlineData('X')]
@@ -17,12 +30,25 @@ public sealed partial class ThatChar
 			[InlineData('\t')]
 			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(char subject)
 			{
-				IEnumerable<char?> expected = [null,];
+				IEnumerable<char?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				char subject = 'a';
+				char?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
 			}
 
 			[Theory]
@@ -31,7 +57,7 @@ public sealed partial class ThatChar
 			public async Task WhenSubjectIsContained_ShouldFail(char subject,
 				params char[] otherValues)
 			{
-				IEnumerable<char> expected = [..otherValues, subject,];
+				IEnumerable<char> expected = [..otherValues, subject];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);

--- a/Tests/aweXpect.Tests/Chars/ThatChar.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Chars/ThatChar.IsOneOf.Tests.cs
@@ -10,6 +10,19 @@ public sealed partial class ThatChar
 	{
 		public sealed class Tests
 		{
+			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				char subject = 'a';
+				char[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
 			[Theory]
 			[InlineData('a')]
 			[InlineData('X')]
@@ -17,7 +30,7 @@ public sealed partial class ThatChar
 			[InlineData('\t')]
 			public async Task WhenExpectedOnlyContainsNull_ShouldFail(char subject)
 			{
-				IEnumerable<char?> expected = [null,];
+				IEnumerable<char?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -30,13 +43,26 @@ public sealed partial class ThatChar
 					              """);
 			}
 
+			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				char subject = 'a';
+				char?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
 			[Theory]
 			[InlineData('a')]
 			[InlineData('B', 'b', 'A')]
 			public async Task WhenSubjectIsContained_ShouldSucceed(char subject,
 				params char[] otherValues)
 			{
-				IEnumerable<char> expected = [..otherValues, subject,];
+				IEnumerable<char> expected = [..otherValues, subject];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);

--- a/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsNotOneOf.Tests.cs
@@ -12,6 +12,19 @@ public sealed partial class ThatChar
 		{
 			public sealed class Tests
 			{
+				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					char? subject = 'a';
+					char[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
 				[Theory]
 				[InlineData('a')]
 				[InlineData('X')]
@@ -19,12 +32,25 @@ public sealed partial class ThatChar
 				[InlineData('\t')]
 				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed(char subject)
 				{
-					IEnumerable<char?> expected = [null,];
+					IEnumerable<char?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
 
 					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					char? subject = 'a';
+					char?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
 				}
 
 				[Theory]
@@ -33,7 +59,7 @@ public sealed partial class ThatChar
 				public async Task WhenSubjectIsContained_ShouldFail(char subject,
 					params char[] otherValues)
 				{
-					IEnumerable<char> expected = [..otherValues, subject,];
+					IEnumerable<char> expected = [..otherValues, subject];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -61,7 +87,7 @@ public sealed partial class ThatChar
 				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 				{
 					char? subject = null;
-					IEnumerable<char?> expected = ['a', null,];
+					IEnumerable<char?> expected = ['a', null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);

--- a/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Chars/ThatChar.Nullable.IsOneOf.Tests.cs
@@ -12,6 +12,19 @@ public sealed partial class ThatChar
 		{
 			public sealed class Tests
 			{
+				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					char? subject = 'a';
+					char[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
 				[Theory]
 				[InlineData('a')]
 				[InlineData('X')]
@@ -19,7 +32,7 @@ public sealed partial class ThatChar
 				[InlineData('\t')]
 				public async Task WhenExpectedOnlyContainsNull_ShouldFail(char? subject)
 				{
-					IEnumerable<char?> expected = [null,];
+					IEnumerable<char?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -32,13 +45,26 @@ public sealed partial class ThatChar
 						              """);
 				}
 
+				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					char? subject = 'a';
+					char?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
 				[Theory]
 				[InlineData('a')]
 				[InlineData('B', 'b', 'A')]
 				public async Task WhenSubjectIsContained_ShouldSucceed(char? subject,
 					params char[] otherValues)
 				{
-					char?[] expected = [..otherValues, subject,];
+					char?[] expected = [..otherValues, subject];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -66,7 +92,7 @@ public sealed partial class ThatChar
 				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 				{
 					char? subject = null;
-					IEnumerable<char?> expected = ['a', null,];
+					IEnumerable<char?> expected = ['a', null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsNotOneOf.Tests.cs
@@ -12,10 +12,23 @@ public sealed partial class ThatDateOnly
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 			{
 				DateOnly subject = CurrentTime();
-				IEnumerable<DateOnly?> expected = [null,];
+				IEnumerable<DateOnly?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -24,10 +37,23 @@ public sealed partial class ThatDateOnly
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldFail()
 			{
 				DateOnly subject = CurrentTime();
-				IEnumerable<DateOnly> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<DateOnly> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -44,7 +70,7 @@ public sealed partial class ThatDateOnly
 			public async Task WhenSubjectIsDifferent_ShouldSucceed()
 			{
 				DateOnly subject = CurrentTime();
-				DateOnly[] expected = [LaterTime(), EarlierTime(),];
+				DateOnly[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -61,7 +87,7 @@ public sealed partial class ThatDateOnly
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				DateOnly subject = EarlierTime(actualDifference);
-				DateOnly[] expected = [CurrentTime(), LaterTime(),];
+				DateOnly[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.IsOneOf.Tests.cs
@@ -12,10 +12,23 @@ public sealed partial class ThatDateOnly
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 			{
 				DateOnly subject = CurrentTime();
-				IEnumerable<DateOnly?> expected = [null,];
+				IEnumerable<DateOnly?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -29,10 +42,23 @@ public sealed partial class ThatDateOnly
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateOnly subject = CurrentTime();
+				DateOnly?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldSucceed()
 			{
 				DateOnly subject = CurrentTime();
-				IEnumerable<DateOnly> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<DateOnly> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -44,7 +70,7 @@ public sealed partial class ThatDateOnly
 			public async Task WhenSubjectIsDifferent_ShouldFail()
 			{
 				DateOnly subject = CurrentTime();
-				DateOnly[] expected = [LaterTime(), EarlierTime(),];
+				DateOnly[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -66,7 +92,7 @@ public sealed partial class ThatDateOnly
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				DateOnly subject = EarlierTime(actualDifference);
-				DateOnly[] expected = [CurrentTime(), LaterTime(),];
+				DateOnly[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsNotOneOf.Tests.cs
@@ -14,10 +14,23 @@ public sealed partial class ThatDateOnly
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 				{
 					DateOnly? subject = CurrentTime();
-					IEnumerable<DateOnly?> expected = [null,];
+					IEnumerable<DateOnly?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -26,10 +39,23 @@ public sealed partial class ThatDateOnly
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldFail()
 				{
 					DateOnly? subject = CurrentTime();
-					IEnumerable<DateOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<DateOnly?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -46,7 +72,7 @@ public sealed partial class ThatDateOnly
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					DateOnly? subject = CurrentTime();
-					DateOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					DateOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -69,7 +95,7 @@ public sealed partial class ThatDateOnly
 				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 				{
 					DateOnly? subject = null;
-					IEnumerable<DateOnly?> expected = [CurrentTime(), null,];
+					IEnumerable<DateOnly?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -91,7 +117,7 @@ public sealed partial class ThatDateOnly
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					DateOnly? subject = EarlierTime(actualDifference);
-					DateOnly?[] expected = [CurrentTime(), LaterTime(),];
+					DateOnly?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateOnlys/ThatDateOnly.Nullable.IsOneOf.Tests.cs
@@ -14,10 +14,23 @@ public sealed partial class ThatDateOnly
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 				{
 					DateOnly? subject = CurrentTime();
-					IEnumerable<DateOnly?> expected = [null,];
+					IEnumerable<DateOnly?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -31,10 +44,23 @@ public sealed partial class ThatDateOnly
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateOnly? subject = CurrentTime();
+					DateOnly?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldSucceed()
 				{
 					DateOnly? subject = CurrentTime();
-					IEnumerable<DateOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<DateOnly?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -46,7 +72,7 @@ public sealed partial class ThatDateOnly
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					DateOnly? subject = CurrentTime();
-					DateOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					DateOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -63,7 +89,7 @@ public sealed partial class ThatDateOnly
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					DateOnly? subject = null;
-					IEnumerable<DateOnly?> expected = [CurrentTime(), LaterTime(),];
+					IEnumerable<DateOnly?> expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -80,7 +106,7 @@ public sealed partial class ThatDateOnly
 				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 				{
 					DateOnly? subject = null;
-					IEnumerable<DateOnly?> expected = [CurrentTime(), null,];
+					IEnumerable<DateOnly?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -97,7 +123,7 @@ public sealed partial class ThatDateOnly
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					DateOnly? subject = EarlierTime(actualDifference);
-					DateOnly?[] expected = [CurrentTime(), LaterTime(),];
+					DateOnly?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsNotOneOf.Tests.cs
@@ -11,10 +11,23 @@ public sealed partial class ThatDateTimeOffset
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTimeOffset subject = CurrentTime();
+				DateTimeOffset[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 			{
 				DateTimeOffset subject = CurrentTime();
-				IEnumerable<DateTimeOffset?> expected = [null,];
+				IEnumerable<DateTimeOffset?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -23,10 +36,23 @@ public sealed partial class ThatDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTimeOffset subject = CurrentTime();
+				DateTimeOffset?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldFail()
 			{
 				DateTimeOffset subject = CurrentTime();
-				IEnumerable<DateTimeOffset> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<DateTimeOffset> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -43,7 +69,7 @@ public sealed partial class ThatDateTimeOffset
 			public async Task WhenSubjectIsDifferent_ShouldSucceed()
 			{
 				DateTimeOffset subject = CurrentTime();
-				DateTimeOffset[] expected = [LaterTime(), EarlierTime(),];
+				DateTimeOffset[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -60,7 +86,7 @@ public sealed partial class ThatDateTimeOffset
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				DateTimeOffset subject = EarlierTime(actualDifference);
-				DateTimeOffset[] expected = [CurrentTime(), LaterTime(),];
+				DateTimeOffset[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.IsOneOf.Tests.cs
@@ -11,10 +11,23 @@ public sealed partial class ThatDateTimeOffset
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTimeOffset subject = CurrentTime();
+				DateTimeOffset[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 			{
 				DateTimeOffset subject = CurrentTime();
-				IEnumerable<DateTimeOffset?> expected = [null,];
+				IEnumerable<DateTimeOffset?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -28,10 +41,23 @@ public sealed partial class ThatDateTimeOffset
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTimeOffset subject = CurrentTime();
+				DateTimeOffset?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldSucceed()
 			{
 				DateTimeOffset subject = CurrentTime();
-				IEnumerable<DateTimeOffset> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<DateTimeOffset> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -43,7 +69,7 @@ public sealed partial class ThatDateTimeOffset
 			public async Task WhenSubjectIsDifferent_ShouldFail()
 			{
 				DateTimeOffset subject = CurrentTime();
-				DateTimeOffset[] expected = [LaterTime(), EarlierTime(),];
+				DateTimeOffset[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -65,7 +91,7 @@ public sealed partial class ThatDateTimeOffset
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				DateTimeOffset subject = EarlierTime(actualDifference);
-				DateTimeOffset[] expected = [CurrentTime(), LaterTime(),];
+				DateTimeOffset[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsNotOneOf.Tests.cs
@@ -13,10 +13,23 @@ public sealed partial class ThatDateTimeOffset
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					DateTimeOffset[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 				{
 					DateTimeOffset? subject = CurrentTime();
-					IEnumerable<DateTimeOffset?> expected = [null,];
+					IEnumerable<DateTimeOffset?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -25,10 +38,23 @@ public sealed partial class ThatDateTimeOffset
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					DateTimeOffset?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldFail()
 				{
 					DateTimeOffset? subject = CurrentTime();
-					IEnumerable<DateTimeOffset?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<DateTimeOffset?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -45,7 +71,7 @@ public sealed partial class ThatDateTimeOffset
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					DateTimeOffset? subject = CurrentTime();
-					DateTimeOffset[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					DateTimeOffset[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -68,7 +94,7 @@ public sealed partial class ThatDateTimeOffset
 				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 				{
 					DateTimeOffset? subject = null;
-					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), null,];
+					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -90,7 +116,7 @@ public sealed partial class ThatDateTimeOffset
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					DateTimeOffset? subject = EarlierTime(actualDifference);
-					DateTimeOffset?[] expected = [CurrentTime(), LaterTime(),];
+					DateTimeOffset?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimeOffsets/ThatDateTimeOffset.Nullable.IsOneOf.Tests.cs
@@ -13,10 +13,23 @@ public sealed partial class ThatDateTimeOffset
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					DateTimeOffset[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 				{
 					DateTimeOffset? subject = CurrentTime();
-					IEnumerable<DateTimeOffset?> expected = [null,];
+					IEnumerable<DateTimeOffset?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -30,10 +43,23 @@ public sealed partial class ThatDateTimeOffset
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTimeOffset? subject = CurrentTime();
+					DateTimeOffset?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldSucceed()
 				{
 					DateTimeOffset? subject = CurrentTime();
-					IEnumerable<DateTimeOffset?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<DateTimeOffset?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -45,7 +71,7 @@ public sealed partial class ThatDateTimeOffset
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					DateTimeOffset? subject = CurrentTime();
-					DateTimeOffset[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					DateTimeOffset[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -62,7 +88,7 @@ public sealed partial class ThatDateTimeOffset
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					DateTimeOffset? subject = null;
-					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), LaterTime(),];
+					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -79,7 +105,7 @@ public sealed partial class ThatDateTimeOffset
 				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 				{
 					DateTimeOffset? subject = null;
-					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), null,];
+					IEnumerable<DateTimeOffset?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -96,7 +122,7 @@ public sealed partial class ThatDateTimeOffset
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					DateTimeOffset? subject = EarlierTime(actualDifference);
-					DateTimeOffset?[] expected = [CurrentTime(), LaterTime(),];
+					DateTimeOffset?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsNotOneOf.Tests.cs
@@ -11,10 +11,23 @@ public sealed partial class ThatDateTime
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTime subject = CurrentTime();
+				DateTime[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 			{
 				DateTime subject = CurrentTime();
-				IEnumerable<DateTime?> expected = [null,];
+				IEnumerable<DateTime?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -23,10 +36,23 @@ public sealed partial class ThatDateTime
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTime subject = CurrentTime();
+				DateTime?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldFail()
 			{
 				DateTime subject = CurrentTime();
-				IEnumerable<DateTime> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<DateTime> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -43,7 +69,7 @@ public sealed partial class ThatDateTime
 			public async Task WhenSubjectIsDifferent_ShouldSucceed()
 			{
 				DateTime subject = CurrentTime();
-				DateTime[] expected = [LaterTime(), EarlierTime(),];
+				DateTime[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -60,7 +86,7 @@ public sealed partial class ThatDateTime
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				DateTime subject = EarlierTime(actualDifference);
-				DateTime[] expected = [CurrentTime(), LaterTime(),];
+				DateTime[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.IsOneOf.Tests.cs
@@ -11,10 +11,23 @@ public sealed partial class ThatDateTime
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTime subject = CurrentTime();
+				DateTime[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 			{
 				DateTime subject = CurrentTime();
-				IEnumerable<DateTime?> expected = [null,];
+				IEnumerable<DateTime?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -28,10 +41,23 @@ public sealed partial class ThatDateTime
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				DateTime subject = CurrentTime();
+				DateTime?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldSucceed()
 			{
 				DateTime subject = CurrentTime();
-				IEnumerable<DateTime> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<DateTime> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -43,7 +69,7 @@ public sealed partial class ThatDateTime
 			public async Task WhenSubjectIsDifferent_ShouldFail()
 			{
 				DateTime subject = CurrentTime();
-				DateTime[] expected = [LaterTime(), EarlierTime(),];
+				DateTime[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -65,7 +91,7 @@ public sealed partial class ThatDateTime
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				DateTime subject = EarlierTime(actualDifference);
-				DateTime[] expected = [CurrentTime(), LaterTime(),];
+				DateTime[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsNotOneOf.Tests.cs
@@ -13,10 +13,23 @@ public sealed partial class ThatDateTime
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTime? subject = CurrentTime();
+					DateTime[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 				{
 					DateTime? subject = CurrentTime();
-					IEnumerable<DateTime?> expected = [null,];
+					IEnumerable<DateTime?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -25,10 +38,23 @@ public sealed partial class ThatDateTime
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTime? subject = CurrentTime();
+					DateTime?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					IEnumerable<DateTime?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<DateTime?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -45,7 +71,7 @@ public sealed partial class ThatDateTime
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					DateTime[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -68,7 +94,7 @@ public sealed partial class ThatDateTime
 				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 				{
 					DateTime? subject = null;
-					IEnumerable<DateTime?> expected = [CurrentTime(), null,];
+					IEnumerable<DateTime?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -90,7 +116,7 @@ public sealed partial class ThatDateTime
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					DateTime? subject = EarlierTime(actualDifference);
-					DateTime?[] expected = [CurrentTime(), LaterTime(),];
+					DateTime?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/DateTimes/ThatDateTime.Nullable.IsOneOf.Tests.cs
@@ -13,10 +13,23 @@ public sealed partial class ThatDateTime
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTime? subject = CurrentTime();
+					DateTime[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					IEnumerable<DateTime?> expected = [null,];
+					IEnumerable<DateTime?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -30,10 +43,23 @@ public sealed partial class ThatDateTime
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					DateTime? subject = CurrentTime();
+					DateTime?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldSucceed()
 				{
 					DateTime? subject = CurrentTime();
-					IEnumerable<DateTime?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<DateTime?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -45,7 +71,7 @@ public sealed partial class ThatDateTime
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					DateTime? subject = CurrentTime();
-					DateTime[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					DateTime[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -62,7 +88,7 @@ public sealed partial class ThatDateTime
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					DateTime? subject = null;
-					IEnumerable<DateTime?> expected = [CurrentTime(), LaterTime(),];
+					IEnumerable<DateTime?> expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -79,7 +105,7 @@ public sealed partial class ThatDateTime
 				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 				{
 					DateTime? subject = null;
-					IEnumerable<DateTime?> expected = [CurrentTime(), null,];
+					IEnumerable<DateTime?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -96,7 +122,7 @@ public sealed partial class ThatDateTime
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					DateTime? subject = EarlierTime(actualDifference);
-					DateTime?[] expected = [CurrentTime(), LaterTime(),];
+					DateTime?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsNotOneOf.Tests.cs
@@ -15,7 +15,7 @@ public sealed partial class ThatNumber
 			public async Task ForByte_ShouldSupportEnumerable()
 			{
 				byte subject = 2;
-				IEnumerable<byte> unexpected = [1, 2, 3,];
+				IEnumerable<byte> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -73,7 +73,7 @@ public sealed partial class ThatNumber
 			public async Task ForDecimal_ShouldSupportEnumerable()
 			{
 				decimal subject = 2;
-				IEnumerable<decimal> unexpected = [1, 2, 3,];
+				IEnumerable<decimal> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -140,7 +140,7 @@ public sealed partial class ThatNumber
 			public async Task ForDouble_ShouldSupportEnumerable()
 			{
 				double subject = 2;
-				IEnumerable<double> unexpected = [1, 2, 3,];
+				IEnumerable<double> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -157,7 +157,7 @@ public sealed partial class ThatNumber
 			public async Task ForDouble_WhenSubjectAndExpectedAreNaN_ShouldFail()
 			{
 				double subject = double.NaN;
-				double[] expected = [double.NaN,];
+				double[] expected = [double.NaN];
 
 				async Task Act() => await That(subject).IsNotOneOf(expected);
 
@@ -240,7 +240,7 @@ public sealed partial class ThatNumber
 			public async Task ForFloat_ShouldSupportEnumerable()
 			{
 				float subject = 2;
-				IEnumerable<float> unexpected = [1, 2, 3,];
+				IEnumerable<float> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -257,7 +257,7 @@ public sealed partial class ThatNumber
 			public async Task ForFloat_WhenSubjectAndExpectedAreNaN_ShouldFail()
 			{
 				float subject = float.NaN;
-				float[] expected = [float.NaN,];
+				float[] expected = [float.NaN];
 
 				async Task Act() => await That(subject).IsNotOneOf(expected);
 
@@ -324,7 +324,7 @@ public sealed partial class ThatNumber
 			public async Task ForInt_ShouldSupportEnumerable()
 			{
 				int subject = 2;
-				IEnumerable<int> unexpected = [1, 2, 3,];
+				IEnumerable<int> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -335,6 +335,32 @@ public sealed partial class ThatNumber
 					             is not one of [1, 2, 3],
 					             but it was 2
 					             """);
+			}
+
+			[Fact]
+			public async Task ForInt_WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int subject = 1;
+				int[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
+			public async Task ForInt_WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int subject = 1;
+				int?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
 			}
 
 			[Theory]
@@ -382,7 +408,7 @@ public sealed partial class ThatNumber
 			public async Task ForLong_ShouldSupportEnumerable()
 			{
 				long subject = 2;
-				IEnumerable<long> unexpected = [1, 2, 3,];
+				IEnumerable<long> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -456,7 +482,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableByte_ShouldSupportEnumerable()
 			{
 				byte? subject = 2;
-				IEnumerable<byte?> unexpected = [1, 2, 3,];
+				IEnumerable<byte?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -514,7 +540,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableDecimal_ShouldSupportEnumerable()
 			{
 				decimal? subject = 2;
-				IEnumerable<decimal?> unexpected = [1, 2, 3,];
+				IEnumerable<decimal?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -585,7 +611,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableDouble_ShouldSupportEnumerable()
 			{
 				double? subject = 2;
-				IEnumerable<double?> unexpected = [1, 2, 3,];
+				IEnumerable<double?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -642,7 +668,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableFloat_ShouldSupportEnumerable()
 			{
 				float? subject = 2;
-				IEnumerable<float?> unexpected = [1, 2, 3,];
+				IEnumerable<float?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -699,7 +725,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableInt_ShouldSupportEnumerable()
 			{
 				int? subject = 2;
-				IEnumerable<int?> unexpected = [1, 2, 3,];
+				IEnumerable<int?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -710,6 +736,32 @@ public sealed partial class ThatNumber
 					             is not one of [1, 2, 3],
 					             but it was 2
 					             """);
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int? subject = 1;
+				int[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int? subject = 1;
+				int?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
 			}
 
 			[Theory]
@@ -757,7 +809,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableLong_ShouldSupportEnumerable()
 			{
 				long? subject = 2;
-				IEnumerable<long?> unexpected = [1, 2, 3,];
+				IEnumerable<long?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -815,7 +867,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableSbyte_ShouldSupportEnumerable()
 			{
 				sbyte? subject = 2;
-				IEnumerable<sbyte?> unexpected = [1, 2, 3,];
+				IEnumerable<sbyte?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -873,7 +925,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableShort_ShouldSupportEnumerable()
 			{
 				short? subject = 2;
-				IEnumerable<short?> unexpected = [1, 2, 3,];
+				IEnumerable<short?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -931,7 +983,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableUint_ShouldSupportEnumerable()
 			{
 				uint? subject = 2;
-				IEnumerable<uint?> unexpected = [1, 2, 3,];
+				IEnumerable<uint?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -989,7 +1041,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableUlong_ShouldSupportEnumerable()
 			{
 				ulong? subject = 2;
-				IEnumerable<ulong?> unexpected = [1, 2, 3,];
+				IEnumerable<ulong?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1047,7 +1099,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableUshort_ShouldSupportEnumerable()
 			{
 				ushort? subject = 2;
-				IEnumerable<ushort?> unexpected = [1, 2, 3,];
+				IEnumerable<ushort?> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1105,7 +1157,7 @@ public sealed partial class ThatNumber
 			public async Task ForSbyte_ShouldSupportEnumerable()
 			{
 				sbyte subject = 2;
-				IEnumerable<sbyte> unexpected = [1, 2, 3,];
+				IEnumerable<sbyte> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1163,7 +1215,7 @@ public sealed partial class ThatNumber
 			public async Task ForShort_ShouldSupportEnumerable()
 			{
 				short subject = 2;
-				IEnumerable<short> unexpected = [1, 2, 3,];
+				IEnumerable<short> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1221,7 +1273,7 @@ public sealed partial class ThatNumber
 			public async Task ForUint_ShouldSupportEnumerable()
 			{
 				uint subject = 2;
-				IEnumerable<uint> unexpected = [1, 2, 3,];
+				IEnumerable<uint> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1279,7 +1331,7 @@ public sealed partial class ThatNumber
 			public async Task ForUlong_ShouldSupportEnumerable()
 			{
 				ulong subject = 2;
-				IEnumerable<ulong> unexpected = [1, 2, 3,];
+				IEnumerable<ulong> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1337,7 +1389,7 @@ public sealed partial class ThatNumber
 			public async Task ForUshort_ShouldSupportEnumerable()
 			{
 				ushort subject = 2;
-				IEnumerable<ushort> unexpected = [1, 2, 3,];
+				IEnumerable<ushort> unexpected = [1, 2, 3];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(unexpected);
@@ -1396,7 +1448,7 @@ public sealed partial class ThatNumber
 			public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 			{
 				int? subject = null;
-				IEnumerable<int?> expected = [1, null,];
+				IEnumerable<int?> expected = [1, null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);

--- a/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/Numbers/ThatNumber.IsOneOf.Tests.cs
@@ -15,7 +15,7 @@ public sealed partial class ThatNumber
 			public async Task ForByte_ShouldSupportEnumerable()
 			{
 				byte subject = 1;
-				IEnumerable<byte> expected = [2, 3,];
+				IEnumerable<byte> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -60,7 +60,7 @@ public sealed partial class ThatNumber
 			public async Task ForDecimal_ShouldSupportEnumerable()
 			{
 				decimal subject = 1;
-				IEnumerable<decimal> expected = [2, 3,];
+				IEnumerable<decimal> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -115,7 +115,7 @@ public sealed partial class ThatNumber
 			public async Task ForDouble_ShouldSupportEnumerable()
 			{
 				double subject = 1.1;
-				IEnumerable<double> expected = [2.1, 3.1,];
+				IEnumerable<double> expected = [2.1, 3.1];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -198,7 +198,7 @@ public sealed partial class ThatNumber
 			public async Task ForFloat_ShouldSupportEnumerable()
 			{
 				float subject = 1.1F;
-				IEnumerable<float> expected = [2.1F, 3.1F,];
+				IEnumerable<float> expected = [2.1F, 3.1F];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -270,7 +270,7 @@ public sealed partial class ThatNumber
 			public async Task ForInt_ShouldSupportEnumerable()
 			{
 				int subject = 1;
-				IEnumerable<int> expected = [2, 3,];
+				IEnumerable<int> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -281,6 +281,32 @@ public sealed partial class ThatNumber
 					             is one of [2, 3],
 					             but it was 1
 					             """);
+			}
+
+			[Fact]
+			public async Task ForInt_WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int subject = 1;
+				int[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
+			public async Task ForInt_WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int subject = 1;
+				int?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
 			}
 
 			[Theory]
@@ -315,7 +341,7 @@ public sealed partial class ThatNumber
 			public async Task ForLong_ShouldSupportEnumerable()
 			{
 				long subject = 1;
-				IEnumerable<long> expected = [2, 3,];
+				IEnumerable<long> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -370,7 +396,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableByte_ShouldSupportEnumerable()
 			{
 				byte? subject = 1;
-				IEnumerable<byte?> expected = [2, 3,];
+				IEnumerable<byte?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -433,7 +459,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableDecimal_ShouldSupportEnumerable()
 			{
 				decimal? subject = 1;
-				IEnumerable<decimal?> expected = [2, 3,];
+				IEnumerable<decimal?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -492,7 +518,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableDouble_ShouldSupportEnumerable()
 			{
 				double? subject = 1;
-				IEnumerable<double?> expected = [2, 3,];
+				IEnumerable<double?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -537,7 +563,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableFloat_ShouldSupportEnumerable()
 			{
 				float? subject = 1;
-				IEnumerable<float?> expected = [2, 3,];
+				IEnumerable<float?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -582,7 +608,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableInt_ShouldSupportEnumerable()
 			{
 				int? subject = 1;
-				IEnumerable<int?> expected = [2, 3,];
+				IEnumerable<int?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -593,6 +619,32 @@ public sealed partial class ThatNumber
 					             is one of [2, 3],
 					             but it was 1
 					             """);
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int? subject = 1;
+				int[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
+			public async Task ForNullableInt_WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				int? subject = 1;
+				int?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
 			}
 
 			[Theory]
@@ -645,7 +697,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableLong_ShouldSupportEnumerable()
 			{
 				long? subject = 1;
-				IEnumerable<long?> expected = [2, 3,];
+				IEnumerable<long?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -708,7 +760,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableSbyte_ShouldSupportEnumerable()
 			{
 				sbyte? subject = 1;
-				IEnumerable<sbyte?> expected = [2, 3,];
+				IEnumerable<sbyte?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -771,7 +823,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableShort_ShouldSupportEnumerable()
 			{
 				short? subject = 1;
-				IEnumerable<short?> expected = [2, 3,];
+				IEnumerable<short?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -834,7 +886,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableUint_ShouldSupportEnumerable()
 			{
 				uint? subject = 1;
-				IEnumerable<uint?> expected = [2, 3,];
+				IEnumerable<uint?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -897,7 +949,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableUlong_ShouldSupportEnumerable()
 			{
 				ulong? subject = 1;
-				IEnumerable<ulong?> expected = [2, 3,];
+				IEnumerable<ulong?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -960,7 +1012,7 @@ public sealed partial class ThatNumber
 			public async Task ForNullableUshort_ShouldSupportEnumerable()
 			{
 				ushort? subject = 1;
-				IEnumerable<ushort?> expected = [2, 3,];
+				IEnumerable<ushort?> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -1023,7 +1075,7 @@ public sealed partial class ThatNumber
 			public async Task ForSbyte_ShouldSupportEnumerable()
 			{
 				sbyte subject = 1;
-				IEnumerable<sbyte> expected = [2, 3,];
+				IEnumerable<sbyte> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -1068,7 +1120,7 @@ public sealed partial class ThatNumber
 			public async Task ForShort_ShouldSupportEnumerable()
 			{
 				short subject = 1;
-				IEnumerable<short> expected = [2, 3,];
+				IEnumerable<short> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -1113,7 +1165,7 @@ public sealed partial class ThatNumber
 			public async Task ForUint_ShouldSupportEnumerable()
 			{
 				uint subject = 1;
-				IEnumerable<uint> expected = [2, 3,];
+				IEnumerable<uint> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -1158,7 +1210,7 @@ public sealed partial class ThatNumber
 			public async Task ForUlong_ShouldSupportEnumerable()
 			{
 				ulong subject = 1;
-				IEnumerable<ulong> expected = [2, 3,];
+				IEnumerable<ulong> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -1203,7 +1255,7 @@ public sealed partial class ThatNumber
 			public async Task ForUshort_ShouldSupportEnumerable()
 			{
 				ushort subject = 1;
-				IEnumerable<ushort> expected = [2, 3,];
+				IEnumerable<ushort> expected = [2, 3];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -1248,7 +1300,7 @@ public sealed partial class ThatNumber
 			public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 			{
 				int? subject = null;
-				IEnumerable<int?> expected = [1, null,];
+				IEnumerable<int?> expected = [1, null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsNotOneOf.Tests.cs
@@ -12,10 +12,23 @@ public sealed partial class ThatTimeOnly
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 			{
 				TimeOnly subject = CurrentTime();
-				IEnumerable<TimeOnly?> expected = [null,];
+				IEnumerable<TimeOnly?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -24,10 +37,23 @@ public sealed partial class ThatTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldFail()
 			{
 				TimeOnly subject = CurrentTime();
-				IEnumerable<TimeOnly> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<TimeOnly> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -44,7 +70,7 @@ public sealed partial class ThatTimeOnly
 			public async Task WhenSubjectIsDifferent_ShouldSucceed()
 			{
 				TimeOnly subject = CurrentTime();
-				TimeOnly[] expected = [LaterTime(), EarlierTime(),];
+				TimeOnly[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -61,7 +87,7 @@ public sealed partial class ThatTimeOnly
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				TimeOnly subject = EarlierTime(actualDifference);
-				TimeOnly[] expected = [CurrentTime(), LaterTime(),];
+				TimeOnly[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.IsOneOf.Tests.cs
@@ -12,10 +12,23 @@ public sealed partial class ThatTimeOnly
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 			{
 				TimeOnly subject = CurrentTime();
-				IEnumerable<TimeOnly?> expected = [null,];
+				IEnumerable<TimeOnly?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -29,10 +42,23 @@ public sealed partial class ThatTimeOnly
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeOnly subject = CurrentTime();
+				TimeOnly?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldSucceed()
 			{
 				TimeOnly subject = CurrentTime();
-				IEnumerable<TimeOnly> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<TimeOnly> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -44,7 +70,7 @@ public sealed partial class ThatTimeOnly
 			public async Task WhenSubjectIsDifferent_ShouldFail()
 			{
 				TimeOnly subject = CurrentTime();
-				TimeOnly[] expected = [LaterTime(), EarlierTime(),];
+				TimeOnly[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -66,7 +92,7 @@ public sealed partial class ThatTimeOnly
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				TimeOnly subject = EarlierTime(actualDifference);
-				TimeOnly[] expected = [CurrentTime(), LaterTime(),];
+				TimeOnly[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsNotOneOf.Tests.cs
@@ -14,10 +14,23 @@ public sealed partial class ThatTimeOnly
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 				{
 					TimeOnly? subject = CurrentTime();
-					IEnumerable<TimeOnly?> expected = [null,];
+					IEnumerable<TimeOnly?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -26,10 +39,23 @@ public sealed partial class ThatTimeOnly
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldFail()
 				{
 					TimeOnly? subject = CurrentTime();
-					IEnumerable<TimeOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<TimeOnly?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -46,7 +72,7 @@ public sealed partial class ThatTimeOnly
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					TimeOnly? subject = CurrentTime();
-					TimeOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					TimeOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -69,7 +95,7 @@ public sealed partial class ThatTimeOnly
 				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 				{
 					TimeOnly? subject = null;
-					IEnumerable<TimeOnly?> expected = [CurrentTime(), null,];
+					IEnumerable<TimeOnly?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -91,7 +117,7 @@ public sealed partial class ThatTimeOnly
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					TimeOnly? subject = EarlierTime(actualDifference);
-					TimeOnly?[] expected = [CurrentTime(), LaterTime(),];
+					TimeOnly?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeOnlys/ThatTimeOnly.Nullable.IsOneOf.Tests.cs
@@ -14,10 +14,23 @@ public sealed partial class ThatTimeOnly
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 				{
 					TimeOnly? subject = CurrentTime();
-					IEnumerable<TimeOnly?> expected = [null,];
+					IEnumerable<TimeOnly?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -31,10 +44,23 @@ public sealed partial class ThatTimeOnly
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeOnly? subject = CurrentTime();
+					TimeOnly?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldSucceed()
 				{
 					TimeOnly? subject = CurrentTime();
-					IEnumerable<TimeOnly?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<TimeOnly?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -46,7 +72,7 @@ public sealed partial class ThatTimeOnly
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					TimeOnly? subject = CurrentTime();
-					TimeOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					TimeOnly[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -63,7 +89,7 @@ public sealed partial class ThatTimeOnly
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					TimeOnly? subject = null;
-					IEnumerable<TimeOnly?> expected = [CurrentTime(), LaterTime(),];
+					IEnumerable<TimeOnly?> expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -80,7 +106,7 @@ public sealed partial class ThatTimeOnly
 				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 				{
 					TimeOnly? subject = null;
-					IEnumerable<TimeOnly?> expected = [CurrentTime(), null,];
+					IEnumerable<TimeOnly?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -97,7 +123,7 @@ public sealed partial class ThatTimeOnly
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					TimeOnly? subject = EarlierTime(actualDifference);
-					TimeOnly?[] expected = [CurrentTime(), LaterTime(),];
+					TimeOnly?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsNotOneOf.Tests.cs
@@ -11,10 +11,23 @@ public sealed partial class ThatTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 			{
 				TimeSpan subject = CurrentTime();
-				IEnumerable<TimeSpan?> expected = [null,];
+				IEnumerable<TimeSpan?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -23,10 +36,23 @@ public sealed partial class ThatTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsNotOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldFail()
 			{
 				TimeSpan subject = CurrentTime();
-				IEnumerable<TimeSpan> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<TimeSpan> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -43,7 +69,7 @@ public sealed partial class ThatTimeSpan
 			public async Task WhenSubjectIsDifferent_ShouldSucceed()
 			{
 				TimeSpan subject = CurrentTime();
-				TimeSpan[] expected = [LaterTime(), EarlierTime(),];
+				TimeSpan[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected);
@@ -60,7 +86,7 @@ public sealed partial class ThatTimeSpan
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				TimeSpan subject = EarlierTime(actualDifference);
-				TimeSpan[] expected = [CurrentTime(), LaterTime(),];
+				TimeSpan[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.IsOneOf.Tests.cs
@@ -11,10 +11,23 @@ public sealed partial class ThatTimeSpan
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 			{
 				TimeSpan subject = CurrentTime();
-				IEnumerable<TimeSpan?> expected = [null,];
+				IEnumerable<TimeSpan?> expected = [null];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -28,10 +41,23 @@ public sealed partial class ThatTimeSpan
 			}
 
 			[Fact]
+			public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+			{
+				TimeSpan subject = CurrentTime();
+				TimeSpan?[] expected = [];
+
+				async Task Act()
+					=> await That(subject).IsOneOf(expected);
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("You have to provide at least one expected value!");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsContained_ShouldSucceed()
 			{
 				TimeSpan subject = CurrentTime();
-				IEnumerable<TimeSpan> expected = [LaterTime(), subject, EarlierTime(),];
+				IEnumerable<TimeSpan> expected = [LaterTime(), subject, EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -43,7 +69,7 @@ public sealed partial class ThatTimeSpan
 			public async Task WhenSubjectIsDifferent_ShouldFail()
 			{
 				TimeSpan subject = CurrentTime();
-				TimeSpan[] expected = [LaterTime(), EarlierTime(),];
+				TimeSpan[] expected = [LaterTime(), EarlierTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected);
@@ -65,7 +91,7 @@ public sealed partial class ThatTimeSpan
 				int actualDifference, int tolerance, bool expectToThrow)
 			{
 				TimeSpan subject = EarlierTime(actualDifference);
-				TimeSpan[] expected = [CurrentTime(), LaterTime(),];
+				TimeSpan[] expected = [CurrentTime(), LaterTime()];
 
 				async Task Act()
 					=> await That(subject).IsOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsNotOneOf.Tests.cs
@@ -13,10 +13,23 @@ public sealed partial class ThatTimeSpan
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldSucceed()
 				{
 					TimeSpan? subject = CurrentTime();
-					IEnumerable<TimeSpan?> expected = [null,];
+					IEnumerable<TimeSpan?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -25,10 +38,23 @@ public sealed partial class ThatTimeSpan
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsNotOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldFail()
 				{
 					TimeSpan? subject = CurrentTime();
-					IEnumerable<TimeSpan?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<TimeSpan?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -45,7 +71,7 @@ public sealed partial class ThatTimeSpan
 				public async Task WhenSubjectIsDifferent_ShouldSucceed()
 				{
 					TimeSpan? subject = CurrentTime();
-					TimeSpan[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					TimeSpan[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -68,7 +94,7 @@ public sealed partial class ThatTimeSpan
 				public async Task WhenSubjectIsNullAndUnexpectedContainsNull_ShouldFail()
 				{
 					TimeSpan? subject = null;
-					IEnumerable<TimeSpan?> expected = [CurrentTime(), null,];
+					IEnumerable<TimeSpan?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected);
@@ -90,7 +116,7 @@ public sealed partial class ThatTimeSpan
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					TimeSpan? subject = EarlierTime(actualDifference);
-					TimeSpan?[] expected = [CurrentTime(), LaterTime(),];
+					TimeSpan?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsNotOneOf(expected)

--- a/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsOneOf.Tests.cs
+++ b/Tests/aweXpect.Tests/TimeSpans/ThatTimeSpan.Nullable.IsOneOf.Tests.cs
@@ -13,10 +13,23 @@ public sealed partial class ThatTimeSpan
 			public sealed class Tests
 			{
 				[Fact]
+				public async Task WhenExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenExpectedOnlyContainsNull_ShouldFail()
 				{
 					TimeSpan? subject = CurrentTime();
-					IEnumerable<TimeSpan?> expected = [null,];
+					IEnumerable<TimeSpan?> expected = [null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -30,10 +43,23 @@ public sealed partial class ThatTimeSpan
 				}
 
 				[Fact]
+				public async Task WhenNullableExpectedIsEmpty_ShouldThrowArgumentException()
+				{
+					TimeSpan? subject = CurrentTime();
+					TimeSpan?[] expected = [];
+
+					async Task Act()
+						=> await That(subject).IsOneOf(expected);
+
+					await That(Act).Throws<ArgumentException>()
+						.WithMessage("You have to provide at least one expected value!");
+				}
+
+				[Fact]
 				public async Task WhenSubjectIsContained_ShouldSucceed()
 				{
 					TimeSpan? subject = CurrentTime();
-					IEnumerable<TimeSpan?> expected = [LaterTime(), subject, EarlierTime(),];
+					IEnumerable<TimeSpan?> expected = [LaterTime(), subject, EarlierTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -45,7 +71,7 @@ public sealed partial class ThatTimeSpan
 				public async Task WhenSubjectIsDifferent_ShouldFail()
 				{
 					TimeSpan? subject = CurrentTime();
-					TimeSpan[] expected = [LaterTime()!.Value, EarlierTime()!.Value,];
+					TimeSpan[] expected = [LaterTime()!.Value, EarlierTime()!.Value];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -62,7 +88,7 @@ public sealed partial class ThatTimeSpan
 				public async Task WhenSubjectIsNull_ShouldFail()
 				{
 					TimeSpan? subject = null;
-					IEnumerable<TimeSpan?> expected = [CurrentTime(), LaterTime(),];
+					IEnumerable<TimeSpan?> expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -79,7 +105,7 @@ public sealed partial class ThatTimeSpan
 				public async Task WhenSubjectIsNullAndExpectedContainsNull_ShouldSucceed()
 				{
 					TimeSpan? subject = null;
-					IEnumerable<TimeSpan?> expected = [CurrentTime(), null,];
+					IEnumerable<TimeSpan?> expected = [CurrentTime(), null];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected);
@@ -96,7 +122,7 @@ public sealed partial class ThatTimeSpan
 					int actualDifference, int tolerance, bool expectToThrow)
 				{
 					TimeSpan? subject = EarlierTime(actualDifference);
-					TimeSpan?[] expected = [CurrentTime(), LaterTime(),];
+					TimeSpan?[] expected = [CurrentTime(), LaterTime()];
 
 					async Task Act()
 						=> await That(subject).IsOneOf(expected)


### PR DESCRIPTION
When providing an empty collection as expected values to `IsOneOf` throw an `ArgumentException` instead of a normal failure exception to make it easier to detect incorrectly set-up tests.

- *Implements part of #643*