### PR TITLE
feat: make constructor of `ThatDelegateThrows` public

### DIFF
--- a/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.Throws.cs
@@ -124,7 +124,7 @@ public abstract partial class ThatDelegate
 
 		public override ConstraintResult Negate()
 		{
-			throwOptions.CheckThrow(!throwOptions.DoCheckThrow);
+			throwOptions.DoCheckThrow = !throwOptions.DoCheckThrow;
 			return this;
 		}
 	}

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.ThrowsExactly.cs
@@ -121,7 +121,7 @@ public abstract partial class ThatDelegate
 
 		public override ConstraintResult Negate()
 		{
-			throwOptions.CheckThrow(!throwOptions.DoCheckThrow);
+			throwOptions.DoCheckThrow = !throwOptions.DoCheckThrow;
 			return this;
 		}
 	}

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.cs
@@ -88,7 +88,7 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 			=> this;
 	}
 
-	internal class ThrowsOption
+	public class ThrowsOption
 	{
 		public bool DoCheckThrow { get; private set; } = true;
 		

--- a/Source/aweXpect.Core/Delegates/ThatDelegate.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegate.cs
@@ -35,11 +35,15 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 		return message;
 	}
 
-	private sealed class DelegateIsNotNullWithinTimeoutConstraint(string it, ExpectationGrammars grammars, ThrowsOption options)
+	private sealed class DelegateIsNotNullWithinTimeoutConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		ThrowsOption options)
 		: ConstraintResult(grammars),
 			IValueConstraint<DelegateValue>
 	{
 		private DelegateValue? _actual;
+
 		public ConstraintResult IsMetBy(DelegateValue value)
 		{
 			_actual = value;
@@ -55,7 +59,7 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 				Outcome = Outcome.Failure;
 				return this;
 			}
-			
+
 			Outcome = Outcome.Success;
 			return this;
 		}
@@ -88,12 +92,22 @@ public abstract partial class ThatDelegate(ExpectationBuilder expectationBuilder
 			=> this;
 	}
 
+	/// <summary>
+	///     Options on expectations if a delegate throws.
+	/// </summary>
 	public class ThrowsOption
 	{
-		public bool DoCheckThrow { get; private set; } = true;
-		
-		public TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
+		/// <summary>
+		///     Flag indicating if the delegate is expected to throw an exception.
+		/// </summary>
+		/// <remarks>
+		///     If set to <see langword="false" />, the delegate must not throw any exception.
+		/// </remarks>
+		public bool DoCheckThrow { get; set; } = true;
 
-		public void CheckThrow(bool doCheckThrow) => DoCheckThrow = doCheckThrow;
+		/// <summary>
+		///     Options on the execution time to allow specifying a timeout.
+		/// </summary>
+		public TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
 	}
 }

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.OnlyIf.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.OnlyIf.cs
@@ -8,7 +8,7 @@ public partial class ThatDelegateThrows<TException>
 	/// </summary>
 	public ThatDelegateThrows<TException?> OnlyIf(bool predicate)
 	{
-		ThrowOptions.CheckThrow(predicate);
+		ThrowOptions.DoCheckThrow = predicate;
 		return new ThatDelegateThrows<TException?>(ExpectationBuilder, ThrowOptions);
 	}
 }

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.OnlyIf.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.OnlyIf.cs
@@ -8,7 +8,7 @@ public partial class ThatDelegateThrows<TException>
 	/// </summary>
 	public ThatDelegateThrows<TException?> OnlyIf(bool predicate)
 	{
-		_throwOptions.CheckThrow(predicate);
-		return new ThatDelegateThrows<TException?>(ExpectationBuilder, _throwOptions);
+		ThrowOptions.CheckThrow(predicate);
+		return new ThatDelegateThrows<TException?>(ExpectationBuilder, ThrowOptions);
 	}
 }

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Within.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.Within.cs
@@ -17,7 +17,7 @@ public partial class ThatDelegateThrows<TException>
 
 		TimeSpanEqualityOptions options = new();
 		options.Within(duration);
-		_throwOptions.ExecutionTimeOptions = options;
+		ThrowOptions.ExecutionTimeOptions = options;
 		return this;
 	}
 }

--- a/Source/aweXpect.Core/Delegates/ThatDelegateThrows.cs
+++ b/Source/aweXpect.Core/Delegates/ThatDelegateThrows.cs
@@ -7,21 +7,19 @@ namespace aweXpect.Delegates;
 /// <summary>
 ///     An <see cref="ExpectationResult" /> when an exception was thrown.
 /// </summary>
-public partial class ThatDelegateThrows<TException>
-	: ExpectationResult<TException, ThatDelegateThrows<TException>>, IThatDelegateThrows<TException>
+public partial class ThatDelegateThrows<TException>(
+	ExpectationBuilder expectationBuilder,
+	ThatDelegate.ThrowsOption throwOptions)
+	: ExpectationResult<TException, ThatDelegateThrows<TException>>(expectationBuilder), IThatDelegateThrows<TException>
 	where TException : Exception?
 {
-	private readonly ThatDelegate.ThrowsOption _throwOptions;
-
-	internal ThatDelegateThrows(ExpectationBuilder expectationBuilder, ThatDelegate.ThrowsOption throwOptions)
-		: base(expectationBuilder)
-	{
-		ExpectationBuilder = expectationBuilder;
-		_throwOptions = throwOptions;
-	}
+	/// <summary>
+	///     The throw options.
+	/// </summary>
+	public ThatDelegate.ThrowsOption ThrowOptions { get; } = throwOptions;
 
 	/// <summary>
 	///     The expectation builder.
 	/// </summary>
-	public ExpectationBuilder ExpectationBuilder { get; }
+	public ExpectationBuilder ExpectationBuilder { get; } = expectationBuilder;
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -463,9 +463,8 @@ namespace aweXpect.Delegates
         public class ThrowsOption
         {
             public ThrowsOption() { }
-            public bool DoCheckThrow { get; }
+            public bool DoCheckThrow { get; set; }
             public aweXpect.Options.TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
-            public void CheckThrow(bool doCheckThrow) { }
         }
         public sealed class WithValue<T> : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>
         {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -460,6 +460,13 @@ namespace aweXpect.Delegates
         public aweXpect.Delegates.ThatDelegateThrows<TException> ThrowsExactly<TException>()
             where TException : System.Exception { }
         public aweXpect.Delegates.ThatDelegateThrows<System.Exception> ThrowsException() { }
+        public class ThrowsOption
+        {
+            public ThrowsOption() { }
+            public bool DoCheckThrow { get; }
+            public aweXpect.Options.TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
+            public void CheckThrow(bool doCheckThrow) { }
+        }
         public sealed class WithValue<T> : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>
         {
             public WithValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
@@ -488,7 +495,9 @@ namespace aweXpect.Delegates
     public class ThatDelegateThrows<TException> : aweXpect.Results.ExpectationResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>>, aweXpect.Core.IExpectThat<TException>, aweXpect.Core.IThatDelegateThrows<TException>, aweXpect.Core.IThat<TException>
         where TException : System.Exception?
     {
+        public ThatDelegateThrows(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Delegates.ThatDelegate.ThrowsOption throwOptions) { }
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public aweXpect.Delegates.ThatDelegate.ThrowsOption ThrowOptions { get; }
         public aweXpect.Core.IThat<TException> Which { get; }
         public aweXpect.Delegates.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Func<TException, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -463,9 +463,8 @@ namespace aweXpect.Delegates
         public class ThrowsOption
         {
             public ThrowsOption() { }
-            public bool DoCheckThrow { get; }
+            public bool DoCheckThrow { get; set; }
             public aweXpect.Options.TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
-            public void CheckThrow(bool doCheckThrow) { }
         }
         public sealed class WithValue<T> : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>
         {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -460,6 +460,13 @@ namespace aweXpect.Delegates
         public aweXpect.Delegates.ThatDelegateThrows<TException> ThrowsExactly<TException>()
             where TException : System.Exception { }
         public aweXpect.Delegates.ThatDelegateThrows<System.Exception> ThrowsException() { }
+        public class ThrowsOption
+        {
+            public ThrowsOption() { }
+            public bool DoCheckThrow { get; }
+            public aweXpect.Options.TimeSpanEqualityOptions? ExecutionTimeOptions { get; set; }
+            public void CheckThrow(bool doCheckThrow) { }
+        }
         public sealed class WithValue<T> : aweXpect.Delegates.ThatDelegate, aweXpect.Core.IExpectThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>, aweXpect.Core.IThat<aweXpect.Delegates.ThatDelegate.WithValue<T>>
         {
             public WithValue(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
@@ -488,7 +495,9 @@ namespace aweXpect.Delegates
     public class ThatDelegateThrows<TException> : aweXpect.Results.ExpectationResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>>, aweXpect.Core.IExpectThat<TException>, aweXpect.Core.IThatDelegateThrows<TException>, aweXpect.Core.IThat<TException>
         where TException : System.Exception?
     {
+        public ThatDelegateThrows(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Delegates.ThatDelegate.ThrowsOption throwOptions) { }
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
+        public aweXpect.Delegates.ThatDelegate.ThrowsOption ThrowOptions { get; }
         public aweXpect.Core.IThat<TException> Which { get; }
         public aweXpect.Delegates.ThatDelegateThrows<TException?> OnlyIf(bool predicate) { }
         public aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> Whose<TMember>(System.Func<TException, TMember?> memberSelector, System.Action<aweXpect.Core.IThat<TMember?>> expectations, [System.Runtime.CompilerServices.CallerArgumentExpression("memberSelector")] string doNotPopulateThisValue = "") { }


### PR DESCRIPTION
This makes it extensible for custom expectations.