### PR TITLE
feat: support `null` in `WithParamName`

### DIFF
--- a/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithParamName.cs
+++ b/Source/aweXpect/That/Delegates/ThatDelegateThrows.WithParamName.cs
@@ -10,14 +10,25 @@ public static partial class ThatDelegateThrows
 	/// <summary>
 	///     Verifies that the actual <see cref="ArgumentException" /> has an <paramref name="expected" /> param name.
 	/// </summary>
+	/// <remarks>
+	///     If <paramref name="expected" /> is <see langword="null" />, does not verify anything.
+	/// </remarks>
 	public static AndOrResult<TException, ThatDelegateThrows<TException>> WithParamName<TException>(
 		this ThatDelegateThrows<TException> source,
-		string expected)
+		string? expected)
 		where TException : ArgumentException?
-		=> new(source.ExpectationBuilder.AddConstraint((it, grammars)
+	{
+		if (expected == null)
+		{
+			return new AndOrResult<TException, ThatDelegateThrows<TException>>(source.ExpectationBuilder, source);
+		}
+
+		return new AndOrResult<TException, ThatDelegateThrows<TException>>(
+			source.ExpectationBuilder.AddConstraint((it, grammars)
 				=> new ThatException.HasParamNameValueConstraint<TException>(
 					it,
 					grammars | ExpectationGrammars.Active | ExpectationGrammars.Nested,
 					expected)),
 			source);
+	}
 }

--- a/Source/aweXpect/That/Exceptions/ThatException.HasParamName.cs
+++ b/Source/aweXpect/That/Exceptions/ThatException.HasParamName.cs
@@ -11,18 +11,21 @@ public static partial class ThatException
 	/// <summary>
 	///     Verifies that the actual <see cref="ArgumentException" /> has an <paramref name="expected" /> param name.
 	/// </summary>
+	/// <remarks>
+	///     If <paramref name="expected" /> is <see langword="null" />, does not verify anything.
+	/// </remarks>
 	public static AndOrResult<TException, IThat<TException>> HasParamName<TException>(
 		this IThat<TException> source,
-		string expected)
+		string? expected)
 		where TException : ArgumentException?
-		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new HasParamNameValueConstraint<TException>(it, grammars, expected)),
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasParamNameValueConstraint<TException>(it, grammars, expected)),
 			source);
 
 	internal class HasParamNameValueConstraint<TArgumentException>(
 		string it,
 		ExpectationGrammars grammars,
-		string expected)
+		string? expected)
 		: ConstraintResult.WithNotNullValue<Exception?>(it, grammars),
 			IValueConstraint<Exception?>
 		where TArgumentException : ArgumentException?
@@ -30,7 +33,7 @@ public static partial class ThatException
 		public ConstraintResult IsMetBy(Exception? actual)
 		{
 			Actual = actual;
-			Outcome = actual is TArgumentException argumentException && argumentException.ParamName == expected
+			Outcome = actual is TArgumentException argumentException && (expected is null || argumentException.ParamName == expected)
 				? Outcome.Success
 				: Outcome.Failure;
 			return this;

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -280,7 +280,7 @@ namespace aweXpect
             where TException : System.Exception? { }
         public static aweXpect.Results.StringEqualityTypeResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithMessage<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string expected)
             where TException : System.Exception? { }
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string? expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.Results.AndOrResult<TException?, aweXpect.Delegates.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations)
             where TException : System.Exception? { }
@@ -669,7 +669,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInnerException(this aweXpect.Core.IThat<System.Exception?> source) { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInnerException(this aweXpect.Core.IThat<System.Exception?> source, System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasMessage(this aweXpect.Core.IThat<System.Exception?> source, string expected) { }
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasParamName<TException>(this aweXpect.Core.IThat<TException> source, string expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasParamName<TException>(this aweXpect.Core.IThat<TException> source, string? expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasRecursiveInnerExceptions(this aweXpect.Core.IThat<System.Exception?> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -131,7 +131,7 @@ namespace aweXpect
             where TException : System.Exception? { }
         public static aweXpect.Results.StringEqualityTypeResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithMessage<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string expected)
             where TException : System.Exception? { }
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Delegates.ThatDelegateThrows<TException>> WithParamName<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, string? expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.Results.AndOrResult<TException?, aweXpect.Delegates.ThatDelegateThrows<TException>> WithRecursiveInnerExceptions<TException>(this aweXpect.Delegates.ThatDelegateThrows<TException> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations)
             where TException : System.Exception? { }
@@ -454,7 +454,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInnerException(this aweXpect.Core.IThat<System.Exception?> source) { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasInnerException(this aweXpect.Core.IThat<System.Exception?> source, System.Action<aweXpect.Core.IThat<System.Exception?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasMessage(this aweXpect.Core.IThat<System.Exception?> source, string expected) { }
-        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasParamName<TException>(this aweXpect.Core.IThat<TException> source, string expected)
+        public static aweXpect.Results.AndOrResult<TException, aweXpect.Core.IThat<TException>> HasParamName<TException>(this aweXpect.Core.IThat<TException> source, string? expected)
             where TException : System.ArgumentException? { }
         public static aweXpect.Results.AndOrResult<System.Exception?, aweXpect.Core.IThat<System.Exception?>> HasRecursiveInnerExceptions(this aweXpect.Core.IThat<System.Exception?> source, System.Action<aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Exception>>> expectations) { }
     }

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.WithParamNameTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.Throws.WithParamNameTests.cs
@@ -8,6 +8,34 @@ public sealed partial class ThatDelegate
 		{
 			[Theory]
 			[AutoData]
+			public async Task WhenExpectedIsNull_AndParamNameIsEmpty_ShouldSucceed(string message)
+			{
+				ArgumentException exception = new(message);
+				void Delegate() => throw exception;
+
+				async Task Act()
+					=> await That(Delegate).Throws<ArgumentException>()
+						.WithParamName(null);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenExpectedIsNull_ShouldSucceed(string message)
+			{
+				ArgumentException exception = new(message, nameof(message));
+				void Delegate() => throw exception;
+
+				async Task Act()
+					=> await That(Delegate).Throws<ArgumentException>()
+						.WithParamName(null);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
 			public async Task WhenParamNameIsDifferent_ShouldFail(string message)
 			{
 				ArgumentException exception = new(message, nameof(message));

--- a/Tests/aweXpect.Tests/Exceptions/ThatException.HasParamName.Tests.cs
+++ b/Tests/aweXpect.Tests/Exceptions/ThatException.HasParamName.Tests.cs
@@ -8,6 +8,30 @@ public sealed partial class ThatException
 		{
 			[Theory]
 			[AutoData]
+			public async Task WhenExpectedIsNull_AndParamNameIsEmpty_ShouldSucceed(string message)
+			{
+				ArgumentException subject = new(message);
+
+				async Task Act()
+					=> await That(subject).HasParamName(null);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenExpectedIsNull_ShouldSucceed(string message)
+			{
+				ArgumentException subject = new(message, nameof(message));
+
+				async Task Act()
+					=> await That(subject).HasParamName(null);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
 			public async Task WhenParamNameIsDifferent_ShouldFail(string message)
 			{
 				ArgumentException subject = new(message, nameof(message));


### PR DESCRIPTION
This PR enhances the WithParamName and HasParamName APIs to accept a nullable expected parameter name, treating null as “do not verify”.