### PR TITLE
feat: add `HasItem` expectation for collections

### DIFF
--- a/Docs/pages/docs/expectations/07-collections.md
+++ b/Docs/pages/docs/expectations/07-collections.md
@@ -345,7 +345,7 @@ await Expect.That(["FOO", "BAR"]).EndsWith(["bar"]).IgnoringCase();
 
 ## Have
 
-Specifications that count the elements in a collection.
+Specifications that count the elements in a collection that satisfy specific conditions.
 
 ### All
 
@@ -486,6 +486,21 @@ await Expect.That(result).IsGreaterThan(41);
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
+
+## Have item at index
+
+You can verify that the collection contains an item that satisfies the expectation on a given index (or any index).
+
+```csharp
+IEnumerable<string> values = ["0th item", "1st item", "2nd item", "3rd item"];
+
+await Expect.That(values).HasItem("1st item").AtIndex(1);
+await Expect.That(values).HasItem(a => a.StartsWith("2nd")).AtAnyIndex();
+```
+
+*Note: The same expectation works also for `IAsyncEnumerable<T>`.*
+
 
 ## Dictionaries
 

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Options/CollectionIndexOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionIndexOptions.cs
@@ -1,0 +1,66 @@
+namespace aweXpect.Options;
+
+/// <summary>
+///     Options for limitations on a collection index.
+/// </summary>
+public class CollectionIndexOptions
+{
+	private int? _maximum;
+	private int? _minimum;
+
+	/// <summary>
+	///     Checks if the <paramref name="index" /> is in range.
+	/// </summary>
+	/// <returns>
+	///     <see langword="true" />, if the <paramref name="index" /> is in range, <see langword="null" />,
+	///     if the <paramref name="index" /> is not in range, but could be in range for a larger index,
+	///     otherwise <see langword="false" /> when the <paramref name="index" /> is not in range
+	///     and will also not be in range for larger values.
+	/// </returns>
+	public bool? IsIndexInRange(int index)
+	{
+		if (_maximum.HasValue && index > _maximum)
+		{
+			return false;
+		}
+
+		if ((_minimum is null || index >= _minimum) &&
+		    (_maximum is null || index <= _maximum))
+		{
+			return true;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	///     Flag indicating, if only a single index is considered in range.
+	/// </summary>
+	public bool HasOnlySingleIndex()
+		=> _maximum == _minimum && _minimum is not null;
+
+	/// <summary>
+	///     Set the checked index to be in range between <paramref name="minimum" /> and <paramref name="maximum" />.
+	/// </summary>
+	/// <remarks>When either parameter is set to <see langword="null" />, the corresponding range direction is unlimited.</remarks>
+	public void SetIndexRange(int? minimum, int? maximum)
+	{
+		_minimum = minimum;
+		_maximum = maximum;
+	}
+
+	/// <summary>
+	///     Returns the description of the <see cref="CollectionIndexOptions" />.
+	/// </summary>
+	public string GetDescription()
+	{
+		if (_minimum is null && _maximum is null)
+		{
+			return "";
+		}
+
+		return _minimum == _maximum
+			? $" at index {_minimum}"
+			: $" with index between {_minimum} and {_maximum}";
+	}
+}

--- a/Source/aweXpect.Core/Results/HasItemResult.cs
+++ b/Source/aweXpect.Core/Results/HasItemResult.cs
@@ -1,0 +1,34 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result for verifying that a collection has a matching item at a given index.
+/// </summary>
+/// <remarks>
+///     <seealso cref="ExpectationResult{TType,TSelf}" />
+/// </remarks>
+public class HasItemResult<TCollection>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TCollection> collection,
+	CollectionIndexOptions collectionIndexOptions)
+{
+	/// <summary>
+	///     …at any index.
+	/// </summary>
+	public AndOrResult<TCollection, IThat<TCollection>> AtAnyIndex()
+	{
+		collectionIndexOptions.SetIndexRange(null, null);
+		return new AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection);
+	}
+
+	/// <summary>
+	///     …at the given <paramref name="index" />.
+	/// </summary>
+	public AndOrResult<TCollection, IThat<TCollection>> AtIndex(int index)
+	{
+		collectionIndexOptions.SetIndexRange(index, index);
+		return new AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection);
+	}
+}

--- a/Source/aweXpect/Helpers/IMaterializedEnumerable.cs
+++ b/Source/aweXpect/Helpers/IMaterializedEnumerable.cs
@@ -1,10 +1,12 @@
 #if NET8_0_OR_GREATER
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace aweXpect.Helpers;
 
 internal interface IMaterializedEnumerable<out T> : ICountable
 {
 	IReadOnlyList<T> MaterializedItems { get; }
+	Task MaterializeItems(int minimumNumberOfItems);
 }
 #endif

--- a/Source/aweXpect/Results/HasItemObjectResult.cs
+++ b/Source/aweXpect/Results/HasItemObjectResult.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using aweXpect.Core;
+using aweXpect.Equivalency;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result for verifying that a collection has a specific item at a given index.
+/// </summary>
+/// <remarks>
+///     <seealso cref="HasItemResult{TCollection}" />
+/// </remarks>
+public class HasItemObjectResult<TCollection, TItem>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TCollection> collection,
+	CollectionIndexOptions collectionIndexOptions,
+	ObjectEqualityOptions<TItem> options)
+	: HasItemObjectResult<TCollection, TItem,
+		HasItemObjectResult<TCollection, TItem>>(
+		expectationBuilder,
+		collection,
+		collectionIndexOptions,
+		options);
+
+
+/// <summary>
+///     The result for verifying that a collection has a specific item at a given index.
+/// </summary>
+/// <remarks>
+///     <seealso cref="HasItemResult{TCollection}" />
+/// </remarks>
+public class HasItemObjectResult<TCollection, TItem, TSelf>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TCollection> collection,
+	CollectionIndexOptions collectionIndexOptions,
+	ObjectEqualityOptions<TItem> options)
+	: HasItemResult<TCollection>(expectationBuilder, collection, collectionIndexOptions)
+	where TSelf : HasItemObjectResult<TCollection, TItem, TSelf>
+{
+	/// <summary>
+	///     Use equivalency to compare objects.
+	/// </summary>
+	public TSelf Equivalent(Func<EquivalencyOptions, EquivalencyOptions>? optionsCallback = null)
+	{
+		options.Equivalent(EquivalencyOptionsExtensions.FromCallback(optionsCallback));
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Uses the provided <paramref name="comparer" /> for comparing <see langword="object" />s.
+	/// </summary>
+	public TSelf Using(IEqualityComparer<object> comparer)
+	{
+		options.Using(comparer);
+		return (TSelf)this;
+	}
+}

--- a/Source/aweXpect/That/Collections/CollectionHelpers.cs
+++ b/Source/aweXpect/That/Collections/CollectionHelpers.cs
@@ -2,7 +2,9 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using aweXpect.Core;
+using aweXpect.Customization;
 using aweXpect.Helpers;
 
 namespace aweXpect;
@@ -101,13 +103,15 @@ internal static class CollectionHelpers
 	}
 
 #if NET8_0_OR_GREATER
-	internal static ExpectationBuilder AddCollectionContext<TItem>(this ExpectationBuilder expectationBuilder,
+	internal static async Task<ExpectationBuilder> AddCollectionContext<TItem>(this ExpectationBuilder expectationBuilder,
 		IMaterializedEnumerable<TItem>? value, bool isIncomplete = false)
 	{
 		if (value is null)
 		{
 			return expectationBuilder;
 		}
+
+		await value.MaterializeItems(Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get());
 
 		return expectationBuilder.UpdateContexts(contexts
 			=>

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.EndsWith.cs
@@ -266,7 +266,7 @@ public static partial class ThatAsyncEnumerable
 				if (_index + _offset < 0)
 				{
 					Outcome = Outcome.Failure;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
+					await _expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 					return this;
 				}
 
@@ -276,8 +276,7 @@ public static partial class ThatAsyncEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>,
-						true);
+					await _expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
@@ -84,7 +84,6 @@ public static partial class ThatAsyncEnumerable
 			_hasIndex = false;
 			Outcome = Outcome.Failure;
 
-			List<TItem> items = [];
 			int index = -1;
 			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
 			{

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
@@ -1,0 +1,166 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect;
+
+public static partial class ThatAsyncEnumerable
+{
+	/// <summary>
+	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
+	/// </summary>
+	public static HasItemResult<IAsyncEnumerable<TItem>?> HasItem<TItem>(
+		this IThat<IAsyncEnumerable<TItem>?> source, Func<TItem, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemResult<IAsyncEnumerable<TItem>?>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars, predicate,
+					() => doNotPopulateThisValue, indexOptions)),
+			source,
+			indexOptions);
+	}
+
+	/// <summary>
+	///     Verifies that the collection has the <paramref name="expected" /> item…
+	/// </summary>
+	public static HasItemObjectResult<IAsyncEnumerable<TItem>?, TItem> HasItem<TItem>(
+		this IThat<IAsyncEnumerable<TItem>?> source, TItem expected)
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		ObjectEqualityOptions<TItem> options = new();
+		return new HasItemObjectResult<IAsyncEnumerable<TItem>?, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars,
+					a => options.AreConsideredEqual(a, expected),
+					() => $"{Formatter.Format(expected)}{options}",
+					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+
+	private sealed class HasItemConstraint<TItem>(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		ExpectationGrammars grammars,
+		Func<TItem, bool> predicate,
+		Func<string> predicateDescription,
+		CollectionIndexOptions options)
+		: ConstraintResult.WithValue<IAsyncEnumerable<TItem>?>(grammars),
+			IAsyncContextConstraint<IAsyncEnumerable<TItem>?>
+	{
+		private TItem? _actual;
+		private bool _hasIndex;
+
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TItem>? actual, IEvaluationContext context,
+			CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			IAsyncEnumerable<TItem> materialized =
+				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
+			await expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
+			_hasIndex = false;
+			Outcome = Outcome.Failure;
+
+			List<TItem> items = [];
+			int index = -1;
+			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
+			{
+				index++;
+				bool? isIndexInRange = options.IsIndexInRange(index);
+				if (isIndexInRange != true)
+				{
+					if (isIndexInRange == false)
+					{
+						break;
+					}
+
+					continue;
+				}
+
+				_hasIndex = true;
+				_actual = item;
+				Outcome = predicate(item) ? Outcome.Success : Outcome.Failure;
+				if (Outcome == Outcome.Success)
+				{
+					break;
+				}
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.GetDescription());
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else if (_hasIndex)
+			{
+				if (options.HasOnlySingleIndex())
+				{
+					stringBuilder.Append(it).Append(" had item ");
+					Formatter.Format(stringBuilder, _actual);
+					stringBuilder.Append(options.GetDescription());
+				}
+				else
+				{
+					string optionDescription = options.GetDescription();
+					if (string.IsNullOrEmpty(optionDescription))
+					{
+						optionDescription = " at any index";
+					}
+
+					stringBuilder.Append(it).Append(" did not match").Append(optionDescription);
+				}
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did not contain any item").Append(options.GetDescription());
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have item ").Append(predicateDescription())
+				.Append(options.GetDescription());
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (_actual is null)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasSingle.cs
@@ -87,7 +87,7 @@ public static partial class ThatAsyncEnumerable
 			Outcome = _count == 1 ? Outcome.Success : Outcome.Failure;
 			if (_count > 1)
 			{
-				expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
+				await expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
 			}
 
 			return this;

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.StartsWith.cs
@@ -259,8 +259,7 @@ public static partial class ThatAsyncEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>,
-						true);
+					await _expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -273,7 +272,7 @@ public static partial class ThatAsyncEnumerable
 				}
 			}
 
-			_expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
+			await _expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 			Outcome = Outcome.Failure;
 			return this;
 		}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
@@ -249,7 +249,7 @@ public static partial class ThatAsyncEnumerable
 				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
-					_expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>, true);
+					await _expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
 					return this;
 				}
 			}
@@ -257,13 +257,13 @@ public static partial class ThatAsyncEnumerable
 			if (cancellationToken.IsCancellationRequested)
 			{
 				Outcome = Outcome.Undecided;
-				_expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>, true);
+				await _expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>, true);
 				return this;
 			}
 
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
-			_expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
+			await _expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
 			return this;
 		}
 
@@ -363,13 +363,12 @@ public static partial class ThatAsyncEnumerable
 				{
 					_failure ??= TooManyDeviationsError();
 					Outcome = Outcome.Failure;
-					expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>,
-						true);
+					await expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 					return this;
 				}
 			}
 
-			expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
+			await expectationBuilder.AddCollectionContext(materializedEnumerable as IMaterializedEnumerable<TItem>);
 			if (matcher.VerifyComplete(It, options, maximumNumber, out _failure))
 			{
 				_failure ??= TooManyDeviationsError();
@@ -452,7 +451,7 @@ public static partial class ThatAsyncEnumerable
 
 			IAsyncEnumerable<TItem> materialized = context
 				.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
-			expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
+			await expectationBuilder.AddCollectionContext(materialized as IMaterializedEnumerable<TItem>);
 
 			TMember previous = default!;
 			int index = 0;

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -1,0 +1,353 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.EvaluationContext;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+#if NET8_0_OR_GREATER
+using System.Collections.Immutable;
+#endif
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect;
+
+public static partial class ThatEnumerable
+{
+	/// <summary>
+	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
+	/// </summary>
+	public static HasItemResult<IEnumerable<TItem>?> HasItem<TItem>(
+		this IThat<IEnumerable<TItem>?> source, Func<TItem, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemResult<IEnumerable<TItem>?>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars, predicate,
+					() => doNotPopulateThisValue, indexOptions)),
+			source,
+			indexOptions);
+	}
+
+	/// <summary>
+	///     Verifies that the collection has the <paramref name="expected" /> item…
+	/// </summary>
+	public static HasItemObjectResult<IEnumerable<TItem>?, TItem> HasItem<TItem>(
+		this IThat<IEnumerable<TItem>?> source, TItem expected)
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		ObjectEqualityOptions<TItem> options = new();
+		return new HasItemObjectResult<IEnumerable<TItem>?, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars,
+					a => options.AreConsideredEqual(a, expected),
+					() => $"{Formatter.Format(expected)}{options}",
+					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
+	/// </summary>
+	public static HasItemResult<IEnumerable> HasItem(
+		this IThat<IEnumerable> source, Func<object?, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemResult<IEnumerable>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemForEnumerableConstraint<IEnumerable, object?>(
+					expectationBuilder, it, grammars,
+					predicate, () => doNotPopulateThisValue,
+					indexOptions)),
+			source,
+			indexOptions);
+	}
+
+	/// <summary>
+	///     Verifies that the collection has the <paramref name="expected" /> item…
+	/// </summary>
+	public static HasItemObjectResult<IEnumerable, object?> HasItem(
+		this IThat<IEnumerable> source, object? expected)
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		ObjectEqualityOptions<object?> options = new();
+		return new HasItemObjectResult<IEnumerable, object?>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemForEnumerableConstraint<IEnumerable, object?>(
+					expectationBuilder, it, grammars,
+					a => options.AreConsideredEqual(a, expected),
+					() => $"{Formatter.Format(expected)}{options}",
+					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
+	/// </summary>
+	public static HasItemResult<ImmutableArray<TItem>> HasItem<TItem>(
+		this IThat<ImmutableArray<TItem>> source, Func<TItem, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemResult<ImmutableArray<TItem>>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemForEnumerableConstraint<ImmutableArray<TItem>, TItem>(
+					expectationBuilder, it, grammars,
+					predicate, () => doNotPopulateThisValue,
+					indexOptions)),
+			source,
+			indexOptions);
+	}
+#endif
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the collection has the <paramref name="expected" /> item…
+	/// </summary>
+	public static HasItemObjectResult<ImmutableArray<TItem>, TItem> HasItem<TItem>(
+		this IThat<ImmutableArray<TItem>> source, TItem expected)
+	{
+		CollectionIndexOptions indexOptions = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		ObjectEqualityOptions<TItem> options = new();
+		return new HasItemObjectResult<ImmutableArray<TItem>, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemForEnumerableConstraint<ImmutableArray<TItem>, TItem>(
+					expectationBuilder, it, grammars,
+					a => options.AreConsideredEqual(a, expected),
+					() => $"{Formatter.Format(expected)}{options}",
+					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+#endif
+
+	private sealed class HasItemConstraint<TItem>(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		ExpectationGrammars grammars,
+		Func<TItem, bool> predicate,
+		Func<string> predicateDescription,
+		CollectionIndexOptions options)
+		: ConstraintResult.WithValue<IEnumerable<TItem>?>(grammars),
+			IContextConstraint<IEnumerable<TItem>?>
+	{
+		private TItem? _actual;
+		private bool _hasIndex;
+
+		public ConstraintResult IsMetBy(IEnumerable<TItem>? actual, IEvaluationContext context)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			IEnumerable<TItem> materialized = context.UseMaterializedEnumerable<TItem, IEnumerable<TItem>>(actual);
+			expectationBuilder.AddCollectionContext(materialized);
+			_hasIndex = false;
+			Outcome = Outcome.Failure;
+
+			int index = -1;
+			foreach (TItem item in materialized)
+			{
+				index++;
+				bool? isIndexInRange = options.IsIndexInRange(index);
+				if (isIndexInRange != true)
+				{
+					if (isIndexInRange == false)
+					{
+						break;
+					}
+
+					continue;
+				}
+
+				_hasIndex = true;
+				_actual = item;
+				Outcome = predicate(item) ? Outcome.Success : Outcome.Failure;
+				if (Outcome == Outcome.Success)
+				{
+					break;
+				}
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.GetDescription());
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else if (_hasIndex)
+			{
+				if (options.HasOnlySingleIndex())
+				{
+					stringBuilder.Append(it).Append(" had item ");
+					Formatter.Format(stringBuilder, _actual);
+					stringBuilder.Append(options.GetDescription());
+				}
+				else
+				{
+					string optionDescription = options.GetDescription();
+					if (string.IsNullOrEmpty(optionDescription))
+					{
+						optionDescription = " at any index";
+					}
+
+					stringBuilder.Append(it).Append(" did not match").Append(optionDescription);
+				}
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did not contain any item").Append(options.GetDescription());
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have item ").Append(predicateDescription())
+				.Append(options.GetDescription());
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (_actual is null)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+
+	private sealed class HasItemForEnumerableConstraint<TEnumerable, TItem>(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		ExpectationGrammars grammars,
+		Func<TItem, bool> predicate,
+		Func<string> predicateDescription,
+		CollectionIndexOptions options)
+		: ConstraintResult.WithValue<TEnumerable>(grammars),
+			IContextConstraint<TEnumerable>
+		where TEnumerable : IEnumerable?
+	{
+		private object? _actual;
+
+		public ConstraintResult IsMetBy(TEnumerable actual, IEvaluationContext context)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			IEnumerable materialized = context.UseMaterializedEnumerable(actual);
+			expectationBuilder.AddCollectionContext(materialized);
+			Outcome = Outcome.Failure;
+
+			int index = -1;
+			foreach (TItem item in materialized.Cast<TItem>())
+			{
+				index++;
+				bool? isIndexInRange = options.IsIndexInRange(index);
+				if (isIndexInRange != true)
+				{
+					if (isIndexInRange == false)
+					{
+						break;
+					}
+
+					continue;
+				}
+
+				_actual = item;
+				Outcome = predicate(item) ? Outcome.Success : Outcome.Failure;
+				if (Outcome == Outcome.Success)
+				{
+					break;
+				}
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.GetDescription());
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else if (_actual is not null)
+			{
+				if (options.HasOnlySingleIndex())
+				{
+					stringBuilder.Append(it).Append(" had item ");
+					Formatter.Format(stringBuilder, _actual);
+					stringBuilder.Append(options.GetDescription());
+				}
+				else
+				{
+					string optionDescription = options.GetDescription();
+					if (string.IsNullOrEmpty(optionDescription))
+					{
+						optionDescription = " at any index";
+					}
+
+					stringBuilder.Append(it).Append(" did not match").Append(optionDescription);
+				}
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did not contain any item").Append(options.GetDescription());
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have item ").Append(predicateDescription())
+				.Append(options.GetDescription());
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (_actual is null)
+			{
+				stringBuilder.ItWasNull(it);
+			}
+			else
+			{
+				stringBuilder.Append(it).Append(" did");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -88,6 +88,8 @@ namespace aweXpect
         public static aweXpect.ThatAsyncEnumerable.Elements<TItem> Exactly<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject, int expected) { }
+        public static aweXpect.Results.HasItemObjectResult<System.Collections.Generic.IAsyncEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, TItem expected) { }
+        public static aweXpect.Results.HasItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>, TItem>.Async HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringCollectionBeContainedInResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> IsContainedIn(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.ObjectCollectionBeContainedInResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> IsContainedIn<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Collections.Generic.IEnumerable<TItem> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
@@ -479,6 +481,12 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Immutable.ImmutableArray<TItem>, aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject, int expected) { }
+        public static aweXpect.Results.HasItemObjectResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, object? expected) { }
+        public static aweXpect.Results.HasItemResult<System.Collections.IEnumerable> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.HasItemObjectResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, TItem expected) { }
+        public static aweXpect.Results.HasItemObjectResult<System.Collections.Immutable.ImmutableArray<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source, TItem expected) { }
+        public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.HasItemResult<System.Collections.Immutable.ImmutableArray<TItem>> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.SingleItemResult<System.Collections.IEnumerable, object?> HasSingle(this aweXpect.Core.IThat<System.Collections.IEnumerable> source) { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Immutable.ImmutableArray<TItem>, TItem> HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source) { }
@@ -1229,6 +1237,17 @@ namespace aweXpect.Results
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
+    }
+    public class HasItemObjectResult<TCollection, TItem> : aweXpect.Results.HasItemObjectResult<TCollection, TItem, aweXpect.Results.HasItemObjectResult<TCollection, TItem>>
+    {
+        public HasItemObjectResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions, aweXpect.Options.ObjectEqualityOptions<TItem> options) { }
+    }
+    public class HasItemObjectResult<TCollection, TItem, TSelf> : aweXpect.Results.HasItemResult<TCollection>
+        where TSelf : aweXpect.Results.HasItemObjectResult<TCollection, TItem, TSelf>
+    {
+        public HasItemObjectResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions, aweXpect.Options.ObjectEqualityOptions<TItem> options) { }
+        public TSelf Equivalent(System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? optionsCallback = null) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -291,6 +291,10 @@ namespace aweXpect
         public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject, int expected) { }
+        public static aweXpect.Results.HasItemObjectResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, object? expected) { }
+        public static aweXpect.Results.HasItemResult<System.Collections.IEnumerable> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.HasItemObjectResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, TItem expected) { }
+        public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.SingleItemResult<System.Collections.IEnumerable, object?> HasSingle(this aweXpect.Core.IThat<System.Collections.IEnumerable> source) { }
         public static aweXpect.Results.SingleItemResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasSingle<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringCollectionBeContainedInResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> IsContainedIn(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, System.Collections.Generic.IEnumerable<string?> expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") { }
@@ -1212,6 +1216,17 @@ namespace aweXpect.Results
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
+    }
+    public class HasItemObjectResult<TCollection, TItem> : aweXpect.Results.HasItemObjectResult<TCollection, TItem, aweXpect.Results.HasItemObjectResult<TCollection, TItem>>
+    {
+        public HasItemObjectResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions, aweXpect.Options.ObjectEqualityOptions<TItem> options) { }
+    }
+    public class HasItemObjectResult<TCollection, TItem, TSelf> : aweXpect.Results.HasItemResult<TCollection>
+        where TSelf : aweXpect.Results.HasItemObjectResult<TCollection, TItem, TSelf>
+    {
+        public HasItemObjectResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions, aweXpect.Options.ObjectEqualityOptions<TItem> options) { }
+        public TSelf Equivalent(System.Func<aweXpect.Equivalency.EquivalencyOptions, aweXpect.Equivalency.EquivalencyOptions>? optionsCallback = null) { }
+        public TSelf Using(System.Collections.Generic.IEqualityComparer<object> comparer) { }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>
     {

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -750,6 +750,14 @@ namespace aweXpect.Formatting
 }
 namespace aweXpect.Options
 {
+    public class CollectionIndexOptions
+    {
+        public CollectionIndexOptions() { }
+        public string GetDescription() { }
+        public bool HasOnlySingleIndex() { }
+        public bool? IsIndexInRange(int index) { }
+        public void SetIndexRange(int? minimum, int? maximum) { }
+    }
     public class CollectionMatchOptions
     {
         public CollectionMatchOptions(aweXpect.Options.CollectionMatchOptions.EquivalenceRelations equivalenceRelations = 1) { }
@@ -1078,6 +1086,12 @@ namespace aweXpect.Results
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }
         public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public TSelf WithTimeout(System.TimeSpan timeout) { }
+    }
+    public class HasItemResult<TCollection>
+    {
+        public HasItemResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
+        public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtAnyIndex() { }
+        public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtIndex(int index) { }
     }
     public class NullableNumberToleranceResult<TType, TThat> : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, aweXpect.Results.NullableNumberToleranceResult<TType, TThat>>
         where TType :  struct, System.Numerics.INumber<TType>

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -733,6 +733,14 @@ namespace aweXpect.Formatting
 }
 namespace aweXpect.Options
 {
+    public class CollectionIndexOptions
+    {
+        public CollectionIndexOptions() { }
+        public string GetDescription() { }
+        public bool HasOnlySingleIndex() { }
+        public bool? IsIndexInRange(int index) { }
+        public void SetIndexRange(int? minimum, int? maximum) { }
+    }
     public class CollectionMatchOptions
     {
         public CollectionMatchOptions(aweXpect.Options.CollectionMatchOptions.EquivalenceRelations equivalenceRelations = 1) { }
@@ -1061,6 +1069,12 @@ namespace aweXpect.Results
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }
         public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public TSelf WithTimeout(System.TimeSpan timeout) { }
+    }
+    public class HasItemResult<TCollection>
+    {
+        public HasItemResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
+        public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtAnyIndex() { }
+        public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtIndex(int index) { }
     }
     public class NullableNumberToleranceResult<TType, TThat> : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, aweXpect.Results.NullableNumberToleranceResult<TType, TThat>>
         where TType :  struct, System.IComparable<TType>

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotHaveCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.DoesNotHaveCount.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.EndsWith.Tests.cs
@@ -66,7 +66,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained 2 at index 3 instead of 1
 
 					             Collection:
-					             [0, 0, 1, 2, 3, (… and maybe others)]
+					             [0, 0, 1, 2, 3]
 					             """);
 			}
 
@@ -152,8 +152,7 @@ public sealed partial class ThatAsyncEnumerable
 					             [
 					               "foo",
 					               "bar",
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtLeastTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtLeastTests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtMostTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.AtMostTests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 
@@ -72,12 +72,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.BetweenTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.BetweenTests.cs
@@ -30,7 +30,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, (… and maybe others)]
 					             """);
 			}
 
@@ -79,16 +79,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 7
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               4,
-					               5,
-					               6,
-					               7,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3, 4, 5, 6, 7]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.EqualToTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.EqualToTests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 
@@ -80,12 +80,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.LessThanTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.LessThanTests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 
@@ -50,12 +50,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -85,11 +80,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 2
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.MoreThanTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.MoreThanTests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasCount.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but could not verify, because it was already cancelled
 
 					             Collection:
-					             [0, 1, 2, 3, 4, 5, (… and maybe others)]
+					             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, (… and maybe others)]
 					             """);
 			}
 
@@ -80,12 +80,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
@@ -1,0 +1,445 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatAsyncEnumerable
+{
+	public sealed class HasItem
+	{
+		public sealed class PredicateTests
+		{
+			[Fact]
+			public async Task DoesNotEnumerateTwice()
+			{
+				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex()
+						.And.HasItem(_ => true).AtIndex(0);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasItem(a => a == 5).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => false at index 2,
+					             but it had item 2 at index 2
+
+					             Collection:
+					             [0, 1, 2]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true at index 3,
+					             but it did not contain any item at index 3
+
+					             Collection:
+					             [0, 1, 2]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it did not contain any item
+
+					             Collection:
+					             []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true at index 0,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c",]);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
+						.HasItem(_ => false)
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => false at index 0 and has item _ => false at index 1 and has item _ => false,
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class ItemTests
+		{
+			[Fact]
+			public async Task DoesNotEnumerateTwice()
+			{
+				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
+
+				async Task Act()
+					=> await That(subject).HasItem(1).AtAnyIndex()
+						.And.HasItem(1).AtIndex(0);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasItem(5).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2, 3, 4, 5);
+
+				async Task Act()
+					=> await That(subject).HasItem(3).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 3 at index 2,
+					             but it had item 2 at index 2
+
+					             Collection:
+					             [0, 1, 2, 3, 4, 5]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2, 3, 4, 5);
+
+				async Task Act()
+					=> await That(subject).HasItem(2).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
+
+				async Task Act()
+					=> await That(subject).HasItem(5).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 5 at index 3,
+					             but it did not contain any item at index 3
+
+					             Collection:
+					             [0, 1, 2]
+					             """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableIsEmpty_ShouldFail(int expected)
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected},
+					              but it did not contain any item
+
+					              Collection:
+					              []
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+			{
+				int expected = 42;
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 42,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+			{
+				int expected = 42;
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtIndex(0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 42 at index 0,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c",]);
+
+				async Task Act()
+					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item "d" at index 0 and has item "e" at index 1 and has item "f",
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class EquivalentTests
+		{
+			[Fact]
+			public async Task WhenEquivalentItemIsFound_ShouldSucceed()
+			{
+				IAsyncEnumerable<MyClass> subject =
+					ToAsyncEnumerable(Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x)).ToArray());
+				MyClass expected = new(5);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEquivalentItemIsNotFound_ShouldFail()
+			{
+				IAsyncEnumerable<MyClass> subject =
+					ToAsyncEnumerable(Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x)).ToArray());
+				MyClass expected = new(4);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item MyClass {
+					               StringValue = "",
+					               Value = 4
+					             } equivalent,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 5
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 8
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 13
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 21
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 34
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 55
+					               },
+					               …
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class UsingTests
+		{
+			[Fact]
+			public async Task WithAllDifferentComparer_ShouldFail()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers(20);
+
+				async Task Act()
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 1 using AllDifferentComparer,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithAllEqualComparer_ShouldSucceed()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers(20);
+
+				async Task Act()
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasSingle.Tests.cs
@@ -36,10 +36,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained more than one item
 
 					             Collection:
-					             [
-					               1,
-					               2
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -107,7 +104,14 @@ public sealed partial class ThatAsyncEnumerable
 					               1,
 					               1,
 					               2,
-					               3
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
 					             ]
 					             """);
 			}
@@ -137,11 +141,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained more than one item
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -443,10 +443,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained more than one item
 
 					             Collection:
-					             [
-					               1,
-					               2
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.IsEqualTo.Tests.cs
@@ -38,7 +38,7 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               (… and maybe others)
+					               …
 					             ]
 
 					             Expected:
@@ -602,7 +602,7 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               (… and maybe others)
+					               …
 					             ]
 
 					             Expected:
@@ -1077,7 +1077,7 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               (… and maybe others)
+					               …
 					             ]
 
 					             Expected:
@@ -1604,7 +1604,7 @@ public sealed partial class ThatAsyncEnumerable
 					               8,
 					               9,
 					               10,
-					               (… and maybe others)
+					               …
 					             ]
 
 					             Expected:

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.StartsWith.Tests.cs
@@ -77,11 +77,7 @@ public sealed partial class ThatAsyncEnumerable
 					             but it contained 2 at index 1 instead of 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -166,7 +162,7 @@ public sealed partial class ThatAsyncEnumerable
 					             [
 					               "foo",
 					               "bar",
-					               (… and maybe others)
+					               "baz"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
@@ -1,0 +1,453 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed class EnumerablePredicateTests
+		{
+			[Fact]
+			public async Task DoesNotEnumerateTwice()
+			{
+				IEnumerable subject = new ThrowWhenIteratingTwiceEnumerable();
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex()
+						.And.HasItem(_ => true).AtIndex(0);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IEnumerable subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasItem(a => 5.Equals(a)).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+			{
+				IEnumerable subject = new []{0, 1, 2,};
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item _ => false at index 2,
+					              but it had item 2 at index 2
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+			{
+				IEnumerable subject = new []{0, 1, 2,};
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			{
+				IEnumerable subject = new []{0, 1, 2,};
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item _ => true at index 3,
+					              but it did not contain any item at index 3
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				IEnumerable subject = Array.Empty<int>();
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it did not contain any item
+
+					             Collection:
+					             []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+			{
+				IEnumerable? subject = null;
+
+				async Task Act()
+					=> await That(subject!).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+			{
+				IEnumerable? subject = null;
+
+				async Task Act()
+					=> await That(subject!).HasItem(_ => true).AtIndex(0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true at index 0,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				IEnumerable subject = ToEnumerable(["a", "b", "c",]);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
+						.HasItem(_ => false)
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => false at index 0 and has item _ => false at index 1 and has item _ => false,
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+		
+		public sealed class EnumerableItemTests
+		{
+			[Fact]
+			public async Task DoesNotEnumerateTwice()
+			{
+				IEnumerable subject = new ThrowWhenIteratingTwiceEnumerable();
+
+				async Task Act()
+					=> await That(subject).HasItem(1).AtAnyIndex()
+						.And.HasItem(1).AtIndex(0);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IEnumerable subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasItem(5).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed(
+				List<int> values, int expected)
+			{
+				values.Add(0);
+				values.Add(1);
+				values.Insert(2, expected);
+				IEnumerable subject = values;
+
+				async Task Act()
+					=> await That(subject).HasItem(expected - 1).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected - 1} at index 2,
+					              but it had item {expected} at index 2
+
+					              Collection:
+					              {Formatter.Format(values)}
+					              """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed(
+				List<int> values, int expected)
+			{
+				values.Add(0);
+				values.Add(1);
+				values.Insert(2, expected);
+				IEnumerable subject = values;
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			{
+				IEnumerable subject = new []{0, 1, expected,};
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected} at index 3,
+					              but it did not contain any item at index 3
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableIsEmpty_ShouldFail(int expected)
+			{
+				IEnumerable subject = Array.Empty<int>();
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected},
+					              but it did not contain any item
+
+					              Collection:
+					              []
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+			{
+				int expected = 42;
+				IEnumerable? subject = null;
+
+				async Task Act()
+					=> await That(subject!).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 42,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+			{
+				int expected = 42;
+				IEnumerable? subject = null;
+
+				async Task Act()
+					=> await That(subject!).HasItem(expected).AtIndex(0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 42 at index 0,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				IEnumerable subject = ToEnumerable(["a", "b", "c",]);
+
+				async Task Act()
+					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item "d" at index 0 and has item "e" at index 1 and has item "f",
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class EnumerableEquivalentTests
+		{
+			[Fact]
+			public async Task WhenEquivalentItemIsFound_ShouldSucceed()
+			{
+				IEnumerable subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x));
+				MyClass expected = new(5);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEquivalentItemIsNotFound_ShouldFail()
+			{
+				IEnumerable subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x));
+				MyClass expected = new(4);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item MyClass {
+					               StringValue = "",
+					               Value = 4
+					             } equivalent,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 5
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 8
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 13
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 21
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 34
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 55
+					               },
+					               …
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class EnumerableUsingTests
+		{
+			[Fact]
+			public async Task WithAllDifferentComparer_ShouldFail()
+			{
+				IEnumerable subject = Factory.GetFibonacciNumbers(20);
+
+				async Task Act()
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 1 using AllDifferentComparer,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithAllEqualComparer_ShouldSucceed()
+			{
+				IEnumerable subject = Factory.GetFibonacciNumbers(20);
+
+				async Task Act()
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
@@ -1,0 +1,331 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Immutable;
+using System.Linq;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed class ImmutablePredicateTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [0, 1, 2,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item _ => false at index 2,
+					              but it had item 2 at index 2
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [0, 1, 2,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [0, 1, 2,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item _ => true at index 3,
+					              but it did not contain any item at index 3
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				ImmutableArray<int> subject = [];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it did not contain any item
+
+					             Collection:
+					             []
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				ImmutableArray<string> subject = ["a", "b", "c",];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
+						.HasItem(_ => false)
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => false at index 0 and has item _ => false at index 1 and has item _ => false,
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class ImmutableItemTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [0, 1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).HasItem(3).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 3 at index 2,
+					             but it had item 2 at index 2
+
+					             Collection:
+					             [0, 1, 2, 3, 4, 5]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [0, 1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).HasItem(2).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [0, 1, 2,];
+
+				async Task Act()
+					=> await That(subject).HasItem(2).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 2 at index 3,
+					             but it did not contain any item at index 3
+
+					             Collection:
+					             [0, 1, 2]
+					             """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableIsEmpty_ShouldFail(int expected)
+			{
+				ImmutableArray<int> subject = [];
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected},
+					              but it did not contain any item
+
+					              Collection:
+					              []
+					              """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				ImmutableArray<string> subject = ["a", "b", "c",];
+
+				async Task Act()
+					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item "d" at index 0 and has item "e" at index 1 and has item "f",
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class ImmutableEquivalentTests
+		{
+			[Fact]
+			public async Task WhenEquivalentItemIsFound_ShouldSucceed()
+			{
+				ImmutableArray<MyClass> subject = [..Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x)),];
+				MyClass expected = new(5);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEquivalentItemIsNotFound_ShouldFail()
+			{
+				ImmutableArray<MyClass> subject = [..Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x)),];
+				MyClass expected = new(4);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item MyClass {
+					               StringValue = "",
+					               Value = 4
+					             } equivalent,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 5
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 8
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 13
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 21
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 34
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 55
+					               },
+					               …
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class ImmutableUsingTests
+		{
+			[Fact]
+			public async Task WithAllDifferentComparer_ShouldFail()
+			{
+				ImmutableArray<int> subject = [..Factory.GetFibonacciNumbers(20),];
+
+				async Task Act()
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 1 using AllDifferentComparer,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithAllEqualComparer_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [..Factory.GetFibonacciNumbers(20),];
+
+				async Task Act()
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
@@ -1,0 +1,460 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed class PredicateTests
+		{
+			[Fact]
+			public async Task DoesNotEnumerateTwice()
+			{
+				ThrowWhenIteratingTwiceEnumerable subject = new();
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex()
+						.And.HasItem(_ => true).AtIndex(0);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasItem(a => a == 5).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+			{
+				int[] subject = [0, 1, 2,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item _ => false at index 2,
+					              but it had item 2 at index 2
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+			{
+				int[] subject = [0, 1, 2,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			{
+				List<int> subject =
+				[
+					0,
+					1,
+					2,
+				];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item _ => true at index 3,
+					              but it did not contain any item at index 3
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEnumerableIsEmpty_ShouldFail()
+			{
+				List<int> subject = [];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it did not contain any item
+
+					             Collection:
+					             []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).AtIndex(0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true at index 0,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
+						.HasItem(_ => false)
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => false at index 0 and has item _ => false at index 1 and has item _ => false,
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+		
+		public sealed class ItemTests
+		{
+			[Fact]
+			public async Task DoesNotEnumerateTwice()
+			{
+				ThrowWhenIteratingTwiceEnumerable subject = new();
+
+				async Task Act()
+					=> await That(subject).HasItem(1).AtAnyIndex()
+						.And.HasItem(1).AtIndex(0);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task DoesNotMaterializeEnumerable()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+				async Task Act()
+					=> await That(subject).HasItem(5).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed(
+				List<int> subject, int expected)
+			{
+				subject.Add(0);
+				subject.Add(1);
+				subject.Insert(2, expected);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected - 1).AtIndex(2);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected - 1} at index 2,
+					              but it had item {expected} at index 2
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed(
+				List<int> subject, int expected)
+			{
+				subject.Add(0);
+				subject.Add(1);
+				subject.Insert(2, expected);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtIndex(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			{
+				List<int> subject =
+				[
+					0,
+					1,
+					expected,
+				];
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtIndex(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected} at index 3,
+					              but it did not contain any item at index 3
+
+					              Collection:
+					              {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Theory]
+			[AutoData]
+			public async Task WhenEnumerableIsEmpty_ShouldFail(int expected)
+			{
+				List<int> subject = [];
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has item {expected},
+					              but it did not contain any item
+
+					              Collection:
+					              []
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+			{
+				int expected = 42;
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 42,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+			{
+				int expected = 42;
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).AtIndex(0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 42 at index 0,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+			{
+				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+
+				async Task Act()
+					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
+						.AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item "d" at index 0 and has item "e" at index 1 and has item "f",
+					             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class EquivalentTests
+		{
+			[Fact]
+			public async Task WhenEquivalentItemIsFound_ShouldSucceed()
+			{
+				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x));
+				MyClass expected = new(5);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEquivalentItemIsNotFound_ShouldFail()
+			{
+				IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers(20).Select(x => new MyClass(x));
+				MyClass expected = new(4);
+
+				async Task Act()
+					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item MyClass {
+					               StringValue = "",
+					               Value = 4
+					             } equivalent,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 1
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 2
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 3
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 5
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 8
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 13
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 21
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 34
+					               },
+					               MyClass {
+					                 StringValue = "",
+					                 Value = 55
+					               },
+					               …
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class UsingTests
+		{
+			[Fact]
+			public async Task WithAllDifferentComparer_ShouldFail()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers(20);
+
+				async Task Act()
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 1 using AllDifferentComparer,
+					             but it did not match at any index
+
+					             Collection:
+					             [
+					               1,
+					               1,
+					               2,
+					               3,
+					               5,
+					               8,
+					               13,
+					               21,
+					               34,
+					               55,
+					               …
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WithAllEqualComparer_ShouldSucceed()
+			{
+				IEnumerable<int> subject = Factory.GetFibonacciNumbers(20);
+
+				async Task Act()
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Have item at index

You can verify that the collection contains an item that satisfies the expectation on a given index (or any index).

```csharp
IEnumerable<string> values = ["0th item", "1st item", "2nd item", "3rd item"];

await Expect.That(values).HasItem("1st item").AtIndex(1);
await Expect.That(values).HasItem(a => a.StartsWith("2nd")).AtAnyIndex();
```

*Note: The same expectation works also for `IAsyncEnumerable<T>`.*