### PR TITLE
chore: update aweXpect.Core to v2.15.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.19.1"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.15.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.15.1"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect.Core package from version 2.15.0 to 2.15.1 and adjusts the build scope configuration accordingly.

- Updates aweXpect.Core package version to 2.15.1
- Changes BuildScope from CoreOnly back to Default