### PR TITLE
feat: avoid the need to specify `AtAnyIndex` for `HasItem` and `HasItemThat`

### DIFF
--- a/Docs/pages/docs/expectations/07-collections.md
+++ b/Docs/pages/docs/expectations/07-collections.md
@@ -496,7 +496,7 @@ You can verify that the collection contains an item that satisfies the expectati
 IEnumerable<string> values = ["0th item", "1st item", "2nd item", "3rd item"];
 
 await Expect.That(values).HasItem("1st item").AtIndex(1);
-await Expect.That(values).HasItem(it => it.StartsWith("2nd")).AtAnyIndex();
+await Expect.That(values).HasItem(it => it.StartsWith("2nd")); // at any index
 ```
 
 You can also use expectations on the individual items.
@@ -505,7 +505,7 @@ You can also use expectations on the individual items.
 IEnumerable<string> values = ["0th item", "1st item", "2nd item", "3rd item"];
 
 await Expect.That(values).HasItemThat(it => it.IsEqualTo("1st item")).AtIndex(1);
-await Expect.That(values).HasItemThat(it => it.StartsWith("2nd").And.EndsWith("item")).AtAnyIndex();
+await Expect.That(values).HasItemThat(it => it.StartsWith("2nd").And.EndsWith("item")); // at any index
 ```
 
 *Note: The same expectation works also for `IAsyncEnumerable<T>`.*

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Results/HasItemResult.cs
+++ b/Source/aweXpect.Core/Results/HasItemResult.cs
@@ -13,22 +13,14 @@ public class HasItemResult<TCollection>(
 	ExpectationBuilder expectationBuilder,
 	IThat<TCollection> collection,
 	CollectionIndexOptions collectionIndexOptions)
+	: AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection)
 {
-	/// <summary>
-	///     …at any index.
-	/// </summary>
-	public AndOrResult<TCollection, IThat<TCollection>> AtAnyIndex()
-	{
-		collectionIndexOptions.SetIndexRange(null, null);
-		return new AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection);
-	}
-
 	/// <summary>
 	///     …at the given <paramref name="index" />.
 	/// </summary>
 	public AndOrResult<TCollection, IThat<TCollection>> AtIndex(int index)
 	{
 		collectionIndexOptions.SetIndexRange(index, index);
-		return new AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection);
+		return this;
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
@@ -108,7 +108,7 @@ public static partial class ThatAsyncEnumerable
 			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
 			{
 				index++;
-				bool? isIndexInRange = options.IsIndexInRange(index);
+				bool? isIndexInRange = options.DoesIndexMatch(index);
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -142,7 +142,7 @@ public static partial class ThatAsyncEnumerable
 			}
 			else if (_hasIndex)
 			{
-				if (options.HasOnlySingleIndex())
+				if (options.MatchesOnlySingleIndex())
 				{
 					stringBuilder.Append(it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItemThat.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItemThat.cs
@@ -75,7 +75,7 @@ public static partial class ThatAsyncEnumerable
 			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
 			{
 				index++;
-				bool? isIndexInRange = _options.IsIndexInRange(index);
+				bool? isIndexInRange = _options.DoesIndexMatch(index);
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -114,7 +114,7 @@ public static partial class ThatAsyncEnumerable
 			}
 			else if (_hasIndex)
 			{
-				if (_options.HasOnlySingleIndex())
+				if (_options.MatchesOnlySingleIndex())
 				{
 					stringBuilder.Append(_it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -217,7 +217,7 @@ public static partial class ThatEnumerable
 			foreach (TItem item in materialized)
 			{
 				index++;
-				bool? isIndexInRange = options.IsIndexInRange(index);
+				bool? isIndexInRange = options.DoesIndexMatch(index);
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -251,7 +251,7 @@ public static partial class ThatEnumerable
 			}
 			else if (_hasIndex)
 			{
-				if (options.HasOnlySingleIndex())
+				if (options.MatchesOnlySingleIndex())
 				{
 					stringBuilder.Append(it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);
@@ -321,7 +321,7 @@ public static partial class ThatEnumerable
 			foreach (TItem item in materialized.Cast<TItem>())
 			{
 				index++;
-				bool? isIndexInRange = options.IsIndexInRange(index);
+				bool? isIndexInRange = options.DoesIndexMatch(index);
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -354,7 +354,7 @@ public static partial class ThatEnumerable
 			}
 			else if (_actual is not null)
 			{
-				if (options.HasOnlySingleIndex())
+				if (options.MatchesOnlySingleIndex())
 				{
 					stringBuilder.Append(it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItemThat.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItemThat.cs
@@ -96,7 +96,7 @@ public static partial class ThatEnumerable
 			foreach (TItem item in materialized)
 			{
 				index++;
-				bool? isIndexInRange = _options.IsIndexInRange(index);
+				bool? isIndexInRange = _options.DoesIndexMatch(index);
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -135,7 +135,7 @@ public static partial class ThatEnumerable
 			}
 			else if (_hasIndex)
 			{
-				if (_options.HasOnlySingleIndex())
+				if (_options.MatchesOnlySingleIndex())
 				{
 					stringBuilder.Append(_it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);
@@ -222,7 +222,7 @@ public static partial class ThatEnumerable
 			foreach (TItem item in materialized.Cast<TItem>())
 			{
 				index++;
-				bool? isIndexInRange = _options.IsIndexInRange(index);
+				bool? isIndexInRange = _options.DoesIndexMatch(index);
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -260,7 +260,7 @@ public static partial class ThatEnumerable
 			}
 			else if (_actual is not null)
 			{
-				if (_options.HasOnlySingleIndex())
+				if (_options.MatchesOnlySingleIndex())
 				{
 					stringBuilder.Append(_it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -753,9 +753,10 @@ namespace aweXpect.Options
     public class CollectionIndexOptions
     {
         public CollectionIndexOptions() { }
+        public bool? DoesIndexMatch(int index) { }
         public string GetDescription() { }
-        public bool HasOnlySingleIndex() { }
-        public bool? IsIndexInRange(int index) { }
+        public bool MatchesOnlySingleIndex() { }
+        public void SetIndexMatch(System.Func<int, bool?> isIndexMatch, bool matchesOnlySingleIndex, string description) { }
         public void SetIndexRange(int? minimum, int? maximum) { }
     }
     public class CollectionMatchOptions

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -1087,10 +1087,9 @@ namespace aweXpect.Results
         public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public TSelf WithTimeout(System.TimeSpan timeout) { }
     }
-    public class HasItemResult<TCollection>
+    public class HasItemResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
     {
         public HasItemResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
-        public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtAnyIndex() { }
         public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtIndex(int index) { }
     }
     public class NullableNumberToleranceResult<TType, TThat> : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, aweXpect.Results.NullableNumberToleranceResult<TType, TThat>>

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -736,9 +736,10 @@ namespace aweXpect.Options
     public class CollectionIndexOptions
     {
         public CollectionIndexOptions() { }
+        public bool? DoesIndexMatch(int index) { }
         public string GetDescription() { }
-        public bool HasOnlySingleIndex() { }
-        public bool? IsIndexInRange(int index) { }
+        public bool MatchesOnlySingleIndex() { }
+        public void SetIndexMatch(System.Func<int, bool?> isIndexMatch, bool matchesOnlySingleIndex, string description) { }
         public void SetIndexRange(int? minimum, int? maximum) { }
     }
     public class CollectionMatchOptions

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -1070,10 +1070,9 @@ namespace aweXpect.Results
         public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken) { }
         public TSelf WithTimeout(System.TimeSpan timeout) { }
     }
-    public class HasItemResult<TCollection>
+    public class HasItemResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
     {
         public HasItemResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
-        public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtAnyIndex() { }
         public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> AtIndex(int index) { }
     }
     public class NullableNumberToleranceResult<TType, TThat> : aweXpect.Results.NullableNumberToleranceResult<TType, TThat, aweXpect.Results.NullableNumberToleranceResult<TType, TThat>>

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex()
+					=> await That(subject).HasItem(_ => true)
 						.And.HasItem(_ => true).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -31,7 +31,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItem(a => a == 5).AtAnyIndex();
+					=> await That(subject).HasItem(a => a == 5);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -91,7 +91,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -110,7 +110,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -144,7 +144,7 @@ public sealed partial class ThatAsyncEnumerable
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
 						.HasItem(_ => false)
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -170,7 +170,7 @@ public sealed partial class ThatAsyncEnumerable
 				ThrowWhenIteratingTwiceAsyncEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).HasItem(1).AtAnyIndex()
+					=> await That(subject).HasItem(1)
 						.And.HasItem(1).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -182,7 +182,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItem(5).AtAnyIndex();
+					=> await That(subject).HasItem(5);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -243,7 +243,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).AtAnyIndex();
+					=> await That(subject).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -263,7 +263,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).AtAnyIndex();
+					=> await That(subject).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -297,7 +297,7 @@ public sealed partial class ThatAsyncEnumerable
 
 				async Task Act()
 					=> await That(subject).HasItem(4).AtIndex(0).And.HasItem(5).AtIndex(1).And.HasItem(6)
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -614,7 +614,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<string?> subject = ToAsyncEnumerable(Array.Empty<string>());
 
 				async Task Act()
-					=> await That(subject).HasItem("foo").AtAnyIndex();
+					=> await That(subject).HasItem("foo");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -633,7 +633,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<string>? subject = null;
 
 				async Task Act()
-					=> await That(subject!).HasItem("foo").AtAnyIndex();
+					=> await That(subject!).HasItem("foo");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -700,7 +700,7 @@ public sealed partial class ThatAsyncEnumerable
 
 				async Task Act()
 					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -728,7 +728,7 @@ public sealed partial class ThatAsyncEnumerable
 				MyClass expected = new(5);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).DoesNotThrow();
 			}
@@ -741,7 +741,7 @@ public sealed partial class ThatAsyncEnumerable
 				MyClass expected = new(4);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -808,7 +808,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers(20);
 
 				async Task Act()
-					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -839,7 +839,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers(20);
 
 				async Task Act()
-					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer());
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItemThat.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItemThat.Tests.cs
@@ -17,7 +17,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsEqualTo(5)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsEqualTo(5));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -77,7 +77,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(Array.Empty<int>());
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -96,7 +96,7 @@ public sealed partial class ThatAsyncEnumerable
 				IAsyncEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = new ThrowWhenIteratingTwiceEnumerable();
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex()
+					=> await That(subject).HasItem(_ => true)
 						.And.HasItem(_ => true).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -31,7 +31,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItem(a => 5.Equals(a)).AtAnyIndex();
+					=> await That(subject).HasItem(a => 5.Equals(a));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -91,7 +91,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = Array.Empty<int>();
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -110,7 +110,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable? subject = null;
 
 				async Task Act()
-					=> await That(subject!).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject!).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -144,7 +144,7 @@ public sealed partial class ThatEnumerable
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
 						.HasItem(_ => false)
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -170,7 +170,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = new ThrowWhenIteratingTwiceEnumerable();
 
 				async Task Act()
-					=> await That(subject).HasItem(1).AtAnyIndex()
+					=> await That(subject).HasItem(1)
 						.And.HasItem(1).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -182,7 +182,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItem(5).AtAnyIndex();
+					=> await That(subject).HasItem(5);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -254,7 +254,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = Array.Empty<int>();
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).AtAnyIndex();
+					=> await That(subject).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -274,7 +274,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable? subject = null;
 
 				async Task Act()
-					=> await That(subject!).HasItem(expected).AtAnyIndex();
+					=> await That(subject!).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -308,7 +308,7 @@ public sealed partial class ThatEnumerable
 
 				async Task Act()
 					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -335,7 +335,7 @@ public sealed partial class ThatEnumerable
 				MyClass expected = new(5);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).DoesNotThrow();
 			}
@@ -347,7 +347,7 @@ public sealed partial class ThatEnumerable
 				MyClass expected = new(4);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -414,7 +414,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = Factory.GetFibonacciNumbers(20);
 
 				async Task Act()
-					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -445,7 +445,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable subject = Factory.GetFibonacciNumbers(20);
 
 				async Task Act()
-					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer());
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
@@ -68,7 +68,7 @@ public sealed partial class ThatEnumerable
 				ImmutableArray<int> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -89,7 +89,7 @@ public sealed partial class ThatEnumerable
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
 						.HasItem(_ => false)
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -165,7 +165,7 @@ public sealed partial class ThatEnumerable
 				ImmutableArray<int> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).AtAnyIndex();
+					=> await That(subject).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -185,7 +185,7 @@ public sealed partial class ThatEnumerable
 
 				async Task Act()
 					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -212,7 +212,7 @@ public sealed partial class ThatEnumerable
 				MyClass expected = new(5);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).DoesNotThrow();
 			}
@@ -224,7 +224,7 @@ public sealed partial class ThatEnumerable
 				MyClass expected = new(4);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -291,7 +291,7 @@ public sealed partial class ThatEnumerable
 				ImmutableArray<int> subject = [..Factory.GetFibonacciNumbers(20),];
 
 				async Task Act()
-					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -322,7 +322,7 @@ public sealed partial class ThatEnumerable
 				ImmutableArray<int> subject = [..Factory.GetFibonacciNumbers(20),];
 
 				async Task Act()
-					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer());
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
@@ -18,7 +18,7 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex()
+					=> await That(subject).HasItem(_ => true)
 						.And.HasItem(_ => true).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -30,7 +30,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItem(a => a == 5).AtAnyIndex();
+					=> await That(subject).HasItem(a => a == 5);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -95,7 +95,7 @@ public sealed partial class ThatEnumerable
 				List<int> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -114,7 +114,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasItem(_ => true).AtAnyIndex();
+					=> await That(subject).HasItem(_ => true);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -148,7 +148,7 @@ public sealed partial class ThatEnumerable
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
 						.HasItem(_ => false)
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -174,7 +174,7 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).HasItem(1).AtAnyIndex()
+					=> await That(subject).HasItem(1)
 						.And.HasItem(1).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -186,7 +186,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItem(5).AtAnyIndex();
+					=> await That(subject).HasItem(5);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -261,7 +261,7 @@ public sealed partial class ThatEnumerable
 				List<int> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).AtAnyIndex();
+					=> await That(subject).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -281,7 +281,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).AtAnyIndex();
+					=> await That(subject).HasItem(expected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -315,7 +315,7 @@ public sealed partial class ThatEnumerable
 
 				async Task Act()
 					=> await That(subject).HasItem(4).AtIndex(0).And.HasItem(5).AtIndex(1).And.HasItem(6)
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -635,7 +635,7 @@ public sealed partial class ThatEnumerable
 				List<string?> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItem("foo").AtAnyIndex();
+					=> await That(subject).HasItem("foo");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -654,7 +654,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<string>? subject = null;
 
 				async Task Act()
-					=> await That(subject!).HasItem("foo").AtAnyIndex();
+					=> await That(subject!).HasItem("foo");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -721,7 +721,7 @@ public sealed partial class ThatEnumerable
 
 				async Task Act()
 					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
-						.AtAnyIndex();
+						;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -748,7 +748,7 @@ public sealed partial class ThatEnumerable
 				MyClass expected = new(5);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).DoesNotThrow();
 			}
@@ -760,7 +760,7 @@ public sealed partial class ThatEnumerable
 				MyClass expected = new(4);
 
 				async Task Act()
-					=> await That(subject).HasItem(expected).Equivalent().AtAnyIndex();
+					=> await That(subject).HasItem(expected).Equivalent();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -827,7 +827,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers(20);
 
 				async Task Act()
-					=> await That(subject).HasItem(1).Using(new AllDifferentComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(1).Using(new AllDifferentComparer());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -858,7 +858,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers(20);
 
 				async Task Act()
-					=> await That(subject).HasItem(4).Using(new AllEqualComparer()).AtAnyIndex();
+					=> await That(subject).HasItem(4).Using(new AllEqualComparer());
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.ImmutableTests.cs
@@ -66,7 +66,7 @@ public sealed partial class ThatEnumerable
 				ImmutableArray<int> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.Tests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatEnumerable
 				ThrowWhenIteratingTwiceEnumerable subject = new();
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(int.MinValue)).AtAnyIndex()
+					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(int.MinValue))
 						.And.HasItemThat(it => it.IsNotEqualTo(int.MinValue)).AtIndex(0);
 
 				await That(Act).DoesNotThrow();
@@ -28,7 +28,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int> subject = Factory.GetFibonacciNumbers();
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsEqualTo(5)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsEqualTo(5));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -93,7 +93,7 @@ public sealed partial class ThatEnumerable
 				List<int> subject = [];
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -112,7 +112,7 @@ public sealed partial class ThatEnumerable
 				IEnumerable<int>? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0)).AtAnyIndex();
+					=> await That(subject).HasItemThat(it => it.IsNotEqualTo(0));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""


### PR DESCRIPTION
This PR simplifies the collection item verification API by removing the need to explicitly call `.AtAnyIndex()` after `HasItem()` or `HasItemThat()` methods. The change makes the API more intuitive by defaulting to checking items at any index while still allowing specific index checks with `.AtIndex(index)`.

- Refactored `HasItemResult<TCollection>` to inherit from `AndOrResult` and removed the `AtAnyIndex()` method
- Updated all test cases to remove `.AtAnyIndex()` calls, making them more concise
- Updated API documentation and usage examples to reflect the simplified syntax