### PR TITLE
chore: update aweXpect.Core to v2.15.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.19.1"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.15.1"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.15.2"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect.Core package to version 2.15.2 and re-enables the full build scope by changing from CoreOnly to Default, which aligns with the typical workflow after package updates are completed.

- Updates aweXpect.Core package reference from version 2.15.1 to 2.15.2
- Changes BuildScope from CoreOnly back to Default to enable full build pipeline