### PR TITLE
feat: add `IsParsableInto` for strings

### DIFF
--- a/Source/aweXpect/Results/IsParsableResult.cs
+++ b/Source/aweXpect/Results/IsParsableResult.cs
@@ -1,0 +1,34 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result for verifying that the subject is parsable into <typeparamref name="TType" />.
+/// </summary>
+public class IsParsableResult<TType>(
+	ExpectationBuilder expectationBuilder,
+	IThat<string?> subject,
+	IFormatProvider? formatProvider)
+	: AndOrResult<string?, IThat<string?>>(expectationBuilder, subject)
+	where TType : IParsable<TType>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     Gives access to the parsed value.
+	/// </summary>
+	public IThat<TType> Which
+		=> new ThatSubject<TType>(_expectationBuilder
+			.ForWhich<string, TType?>(d =>
+			{
+				if (TType.TryParse(d, formatProvider, out TType? result))
+				{
+					return result;
+				}
+
+				return default;
+			}, " which "));
+}
+#endif

--- a/Source/aweXpect/That/Strings/ThatString.IsParsableInto.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsParsableInto.cs
@@ -1,0 +1,119 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatString
+{
+	/// <summary>
+	///     Verifies that the subject is parsable into type <typeparamref name="TType" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional <paramref name="formatProvider" /> provides culture-specific formatting information.
+	/// </remarks>
+	public static IsParsableResult<TType> IsParsableInto<TType>(
+		this IThat<string?> source,
+		IFormatProvider? formatProvider = null)
+		where TType : IParsable<TType>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsParsableIntoConstraint<TType>(it, grammars, formatProvider)),
+			source,
+			formatProvider);
+
+	/// <summary>
+	///     Verifies that the subject is not parsable into type <typeparamref name="TType" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional <paramref name="formatProvider" /> provides culture-specific formatting information.
+	/// </remarks>
+	public static AndOrResult<string?, IThat<string?>> IsNotParsableInto<TType>(
+		this IThat<string?> source,
+		IFormatProvider? formatProvider = null)
+		where TType : IParsable<TType>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsParsableIntoConstraint<TType>(it, grammars, formatProvider).Invert()),
+			source);
+
+	private sealed class IsParsableIntoConstraint<TType> : ConstraintResult.WithValue<string?>,
+		IValueConstraint<string?>
+		where TType : IParsable<TType>
+	{
+		private readonly IFormatProvider? _formatProvider;
+		private readonly string _it;
+		private string? _exceptionMessage;
+
+		public IsParsableIntoConstraint(string it,
+			ExpectationGrammars grammars,
+			IFormatProvider? formatProvider) : base(grammars)
+		{
+			_it = it;
+			_formatProvider = formatProvider;
+			FurtherProcessingStrategy = FurtherProcessingStrategy.IgnoreResult;
+		}
+
+		public ConstraintResult IsMetBy(string? actual)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			try
+			{
+				_ = TType.Parse(actual, _formatProvider);
+				Outcome = Outcome.Success;
+			}
+			catch (Exception ex)
+			{
+				_exceptionMessage = char.ToLowerInvariant(ex.Message[0]) + ex.Message[1..^1];
+				Outcome = Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is parsable into ");
+			Formatter.Format(stringBuilder, typeof(TType));
+			if (_formatProvider is not null)
+			{
+				stringBuilder.Append(" using ");
+				Formatter.Format(stringBuilder, _formatProvider);
+			}
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is null)
+			{
+				stringBuilder.ItWasNull(_it);
+			}
+			else
+			{
+				stringBuilder.Append(_it).Append(" was not because ").Append(_exceptionMessage);
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not parsable into ");
+			Formatter.Format(stringBuilder, typeof(TType));
+			if (_formatProvider is not null)
+			{
+				stringBuilder.Append(" using ");
+				Formatter.Format(stringBuilder, _formatProvider);
+			}
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_it).Append(" was");
+	}
+}
+#endif

--- a/Source/aweXpect/That/Strings/ThatString.IsParsableInto.cs
+++ b/Source/aweXpect/That/Strings/ThatString.IsParsableInto.cs
@@ -13,7 +13,8 @@ public static partial class ThatString
 	///     Verifies that the subject is parsable into type <typeparamref name="TType" />.
 	/// </summary>
 	/// <remarks>
-	///     The optional <paramref name="formatProvider" /> provides culture-specific formatting information.
+	///     The optional parameter <paramref name="formatProvider" /> provides culture-specific formatting information
+	///     in the call to <see cref="IParsable{TType}.Parse(string, IFormatProvider)" />.
 	/// </remarks>
 	public static IsParsableResult<TType> IsParsableInto<TType>(
 		this IThat<string?> source,
@@ -28,7 +29,8 @@ public static partial class ThatString
 	///     Verifies that the subject is not parsable into type <typeparamref name="TType" />.
 	/// </summary>
 	/// <remarks>
-	///     The optional <paramref name="formatProvider" /> provides culture-specific formatting information.
+	///     The optional parameter <paramref name="formatProvider" /> provides culture-specific formatting information
+	///     in the call to <see cref="IParsable{TType}.Parse(string, IFormatProvider)" />.
 	/// </remarks>
 	public static AndOrResult<string?, IThat<string?>> IsNotParsableInto<TType>(
 		this IThat<string?> source,
@@ -71,7 +73,15 @@ public static partial class ThatString
 			}
 			catch (Exception ex)
 			{
-				_exceptionMessage = char.ToLowerInvariant(ex.Message[0]) + ex.Message[1..^1];
+				if (string.IsNullOrEmpty(ex.Message) || ex.Message.Length < 2)
+				{
+					_exceptionMessage = "an unknown error occurred";
+				}
+				else
+				{
+					_exceptionMessage = char.ToLowerInvariant(ex.Message[0]) + ex.Message[1..^1];
+				}
+
 				Outcome = Outcome.Failure;
 			}
 

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1118,12 +1118,16 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsNotOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsNotOneOf(this aweXpect.Core.IThat<string?> source, params string?[] unexpected) { }
+        public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNotParsableInto<TType>(this aweXpect.Core.IThat<string?> source, System.IFormatProvider? formatProvider = null)
+            where TType : System.IParsable<TType> { }
         public static aweXpect.Results.AndOrResult<string, aweXpect.Core.IThat<string?>> IsNotUpperCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNull(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNullOrEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsNullOrWhiteSpace(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
+        public static aweXpect.Results.IsParsableResult<TType> IsParsableInto<TType>(this aweXpect.Core.IThat<string?> source, System.IFormatProvider? formatProvider = null)
+            where TType : System.IParsable<TType> { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsUpperCased(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
     }
@@ -1245,6 +1249,12 @@ namespace aweXpect.Results
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
+    }
+    public class IsParsableResult<TType> : aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>>
+        where TType : System.IParsable<TType>
+    {
+        public IsParsableResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<string?> subject, System.IFormatProvider? formatProvider) { }
+        public aweXpect.Core.IThat<TType> Which { get; }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>
     {

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsNotParsableInto.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsNotParsableInto.Tests.cs
@@ -1,0 +1,70 @@
+﻿#if NET8_0_OR_GREATER
+using System.Globalization;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatString
+{
+	public class IsNotParsableInto
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNull_ShouldSucceed()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringIsNotParsable_ShouldSucceed()
+			{
+				string subject = "abc";
+
+				async Task Act()
+					=> await That(subject).IsNotParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenStringIsParsable_ShouldFail()
+			{
+				string subject = "42";
+
+				async Task Act()
+					=> await That(subject).IsNotParsableInto<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not parsable into int,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_ShouldBeUsed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject).IsNotParsableInto<decimal>(formatProvider);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not parsable into decimal using {cultureName},
+					              but it was
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsParsableInto.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsParsableInto.Tests.cs
@@ -1,0 +1,147 @@
+﻿#if NET8_0_OR_GREATER
+using System.Globalization;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatString
+{
+	public class IsParsableInto
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<int>().Because("null should fail");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is parsable into int, because null should fail,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringIsNotParsable_ShouldFail()
+			{
+				string subject = "abc";
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is parsable into int,
+					             but it was not because the input string 'abc' was not in a correct format
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringIsParsable_ShouldSucceed()
+			{
+				string subject = "42";
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("12.34", "de-AT")]
+			[InlineData("12.34,0", "en-US")]
+			public async Task WithFormatProvider_WhenFormatDoesNotMatch_ShouldFail(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<decimal>(formatProvider);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is parsable into decimal using {cultureName},
+					              but it was not because the input string '{subject}' was not in a correct format
+					              """);
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_WhenFormatMatches_ShouldSucceed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<decimal>(formatProvider);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WhichTests
+		{
+			[Fact]
+			public async Task WhenNull_ShouldFail()
+			{
+				string? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<int>().Which.IsGreaterThan(2).And.IsLessThan(3);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is parsable into int which is greater than 2 and is less than 3,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringIsNotParsable_ShouldFail()
+			{
+				string subject = "abc";
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<TimeSpan>().Which.IsLessThan(10.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is parsable into TimeSpan which is less than 0:10,
+					             but it was not because string 'abc' was not recognized as a valid TimeSpan
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStringIsParsable_ShouldSucceed()
+			{
+				string subject = "42";
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<int>().Which.IsBetween(41).And(43);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_ShouldBeUsed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject).IsParsableInto<decimal>(formatProvider).Which.IsEqualTo(12.34M);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsParsableInto.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsParsableInto.Tests.cs
@@ -53,19 +53,19 @@ public sealed partial class ThatString
 			}
 
 			[Theory]
-			[InlineData("12.34", "de-AT")]
-			[InlineData("12.34,0", "en-US")]
+			[InlineData("-12.34", "de-AT")]
+			[InlineData("-12,34", "en-US")]
 			public async Task WithFormatProvider_WhenFormatDoesNotMatch_ShouldFail(string subject, string cultureName)
 			{
 				IFormatProvider formatProvider = new CultureInfo(cultureName);
 
 				async Task Act()
-					=> await That(subject).IsParsableInto<decimal>(formatProvider);
+					=> await That(subject).IsParsableInto<uint>(formatProvider);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              is parsable into decimal using {cultureName},
+					              is parsable into uint using {cultureName},
 					              but it was not because the input string '{subject}' was not in a correct format
 					              """);
 			}


### PR DESCRIPTION
This PR adds `IsParsableInto` functionality for strings, allowing verification that a string can be parsed into a specific type using the .NET 8+ `IParsable<T>` interface.

- Introduces `IsParsableInto<TType>` and `IsNotParsableInto<TType>` extension methods for string assertions
- Adds support for culture-specific parsing via optional `IFormatProvider` parameter
- Provides fluent API support through `Which` property for chaining additional assertions on the parsed value