### PR TITLE
refactor: use match object in `CollectionIndexOptions`

### DIFF
--- a/Source/aweXpect.Core/Options/CollectionIndexOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionIndexOptions.cs
@@ -20,7 +20,7 @@ public class CollectionIndexOptions
 	public void SetMatch(IMatch match)
 		=> Match = match;
 
-	private class AlwaysMatch : IMatchFromBeginning
+	private sealed class AlwaysMatch : IMatchFromBeginning
 	{
 		/// <inheritdoc cref="CollectionIndexOptions.IMatch.GetDescription()" />
 		public string GetDescription()

--- a/Source/aweXpect.Core/Options/CollectionIndexOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionIndexOptions.cs
@@ -7,89 +7,90 @@ namespace aweXpect.Options;
 /// </summary>
 public class CollectionIndexOptions
 {
-	private string _description = "";
-	private Func<int, int?, bool?> _isIndexMatch = (_, _) => true;
-	private bool _matchesOnlySingleIndex;
+	private static readonly IMatch DefaultMatch = new AlwaysMatch();
 
 	/// <summary>
-	///     Flag indicating if the expected index is checked from the end of the collection.
+	///     The object used to check if an index is a match.
 	/// </summary>
-	public bool FromEnd { get; private set; }
+	public IMatch Match { get; private set; } = DefaultMatch;
 
 	/// <summary>
-	///     Checks if the <paramref name="index" /> is in range.
+	///     Sets the object to verify the index match.
 	/// </summary>
-	/// <returns>
-	///     <see langword="true" />, if the <paramref name="index" /> is in range, <see langword="null" />,
-	///     if the <paramref name="index" /> is not in range, but could be in range for a larger index,
-	///     otherwise <see langword="false" /> when the <paramref name="index" /> is not in range
-	///     and will also not be in range for larger values.
-	/// </returns>
-	public bool? DoesIndexMatch(int index, int? count)
-		=> _isIndexMatch.Invoke(index, count);
+	public void SetMatch(IMatch match)
+		=> Match = match;
 
-	/// <summary>
-	///     Flag indicating, if only a single index is considered in range.
-	/// </summary>
-	public bool MatchesOnlySingleIndex()
-		=> _matchesOnlySingleIndex;
-
-	/// <summary>
-	///     Specifies, that the expected index is checked from the end of the collection.
-	/// </summary>
-	public void SetFromEnd() => FromEnd = true;
-
-	/// <summary>
-	///     Set the expected index to be <paramref name="index" />.
-	/// </summary>
-	public void SetIndex(int index)
+	private class AlwaysMatch : IMatchFromBeginning
 	{
-		if (index < 0)
-		{
-			throw new ArgumentOutOfRangeException(nameof(index), "The index must be greater than or equal to 0.");
-		}
+		/// <inheritdoc cref="CollectionIndexOptions.IMatch.GetDescription()" />
+		public string GetDescription()
+			=> "";
 
-		_isIndexMatch = (idx, count) =>
-		{
-			switch (FromEnd)
-			{
-				case true when
-					count is not null &&
-					count - idx - 1 == index:
-				case false when
-					idx == index:
-					return true;
-				default:
-					return null;
-			}
-		};
-		_matchesOnlySingleIndex = true;
-		_description = $" at index {index}";
+		/// <inheritdoc cref="CollectionIndexOptions.IMatch.OnlySingleIndex()" />
+		public bool OnlySingleIndex()
+			=> false;
+
+		/// <inheritdoc cref="CollectionIndexOptions.IMatchFromBeginning.MatchesIndex(int)" />
+		public bool? MatchesIndex(int index)
+			=> true;
+
+		/// <inheritdoc cref="CollectionIndexOptions.IMatchFromBeginning.FromEnd()" />
+		public IMatchFromEnd FromEnd()
+			=> throw new NotSupportedException("You have to specify a dedicated index condition first.");
 	}
 
 	/// <summary>
-	///     Set the checked index to be a match depending on the <paramref name="isIndexMatch" /> function.
-	///     <para />
-	///     The <paramref name="matchesOnlySingleIndex" /> parameter specifies, if only a single index could match the
-	///     function, or if it could match multiple indices.
+	///     Base interface for objects used to check if an index is a match.
 	/// </summary>
-	/// <remarks>
-	///     The <paramref name="isIndexMatch" /> receives two parameters,
-	///     the first being the index to check, the second the total number of items
-	///     and is expected to return <see langword="true" /> when the index matches,
-	///     <see langword="null" /> when the index does not match, but could match for larger values and otherwise
-	///     <see langword="false" />, when it does not match and will not match for larger values.
-	/// </remarks>
-	public void SetIndexMatch(Func<int, int?, bool?> isIndexMatch, bool matchesOnlySingleIndex, string description)
+	public interface IMatch
 	{
-		_isIndexMatch = isIndexMatch;
-		_matchesOnlySingleIndex = matchesOnlySingleIndex;
-		_description = description;
+		/// <summary>
+		///     Returns the description of the <see cref="CollectionIndexOptions.IMatch" />.
+		/// </summary>
+		string GetDescription();
+
+		/// <summary>
+		///     Flag indicating, if only a single index is considered a match.
+		/// </summary>
+		bool OnlySingleIndex();
 	}
 
 	/// <summary>
-	///     Returns the description of the <see cref="CollectionIndexOptions" />.
+	///     Checks if an index is a match from the beginning of the collection.
 	/// </summary>
-	public string GetDescription()
-		=> _description + (FromEnd ? " from end" : "");
+	public interface IMatchFromBeginning : IMatch
+	{
+		/// <summary>
+		///     Checks if the <paramref name="index" /> is a match.
+		/// </summary>
+		/// <returns>
+		///     <see langword="true" />, if the <paramref name="index" /> is in range, <see langword="null" />,
+		///     if the <paramref name="index" /> is not in range, but could be in range for a larger index,
+		///     otherwise <see langword="false" /> when the <paramref name="index" /> is not in range
+		///     and will also not be in range for larger values.
+		/// </returns>
+		bool? MatchesIndex(int index);
+
+		/// <summary>
+		///     Check the index match from the end of the collection.
+		/// </summary>
+		IMatchFromEnd FromEnd();
+	}
+
+	/// <summary>
+	///     Checks if an index is a match from the end of the collection.
+	/// </summary>
+	public interface IMatchFromEnd : IMatch
+	{
+		/// <summary>
+		///     Checks if the <paramref name="index" /> is a match from end with <paramref name="count" /> total items.
+		/// </summary>
+		/// <returns>
+		///     <see langword="true" />, if the <paramref name="index" /> is in range, <see langword="null" />,
+		///     if the <paramref name="index" /> is not in range, but could be in range for a larger index,
+		///     otherwise <see langword="false" /> when the <paramref name="index" /> is not in range
+		///     and will also not be in range for larger values.
+		/// </returns>
+		bool? MatchesIndex(int index, int? count);
+	}
 }

--- a/Source/aweXpect.Core/Results/HasItemResult.cs
+++ b/Source/aweXpect.Core/Results/HasItemResult.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Core;
+﻿using System;
+using aweXpect.Core;
 using aweXpect.Options;
 
 namespace aweXpect.Results;
@@ -7,23 +8,91 @@ namespace aweXpect.Results;
 ///     The result for verifying that a collection has a matching item at a given index.
 /// </summary>
 /// <remarks>
-///     <seealso cref="ExpectationResult{TType,TSelf}" />
+///     <seealso cref="AndOrResult{TType,TSelf}" />
 /// </remarks>
 public class HasItemResult<TCollection>(
 	ExpectationBuilder expectationBuilder,
 	IThat<TCollection> collection,
 	CollectionIndexOptions collectionIndexOptions)
-	: AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection)
+	: AndOrResult<TCollection, IThat<TCollection>>(expectationBuilder, collection),
+		IOptionsProvider<CollectionIndexOptions>
 {
 	private readonly IThat<TCollection> _collection = collection;
 	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <inheritdoc cref="IOptionsProvider{CollectionIndexOptions}.Options" />
+	CollectionIndexOptions IOptionsProvider<CollectionIndexOptions>.Options => collectionIndexOptions;
 
 	/// <summary>
 	///     …at the given <paramref name="index" />.
 	/// </summary>
 	public HasItemResultAtIndex<TCollection> AtIndex(int index)
 	{
-		collectionIndexOptions.SetIndex(index);
+		collectionIndexOptions.SetMatch(new HasItemResultAtIndexMatch(index));
 		return new HasItemResultAtIndex<TCollection>(_expectationBuilder, _collection, collectionIndexOptions);
+	}
+
+	private class HasItemResultAtIndexMatch : CollectionIndexOptions.IMatchFromBeginning
+	{
+		private readonly int _index;
+
+		public HasItemResultAtIndexMatch(int index)
+		{
+			if (index < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(index), "The index must be greater than or equal to 0.");
+			}
+
+			_index = index;
+		}
+
+		/// <inheritdoc cref="CollectionIndexOptions.IMatch.GetDescription()" />
+		public string GetDescription() => $" at index {_index}";
+
+		/// <inheritdoc cref="CollectionIndexOptions.IMatch.OnlySingleIndex()" />
+		public bool OnlySingleIndex() => true;
+
+		/// <inheritdoc cref="CollectionIndexOptions.IMatchFromBeginning.MatchesIndex(int)" />
+		public bool? MatchesIndex(int index)
+		{
+			if (index < _index)
+			{
+				return null;
+			}
+
+			return index == _index;
+		}
+
+		/// <inheritdoc cref="CollectionIndexOptions.IMatchFromBeginning.FromEnd()" />
+		public CollectionIndexOptions.IMatchFromEnd FromEnd() => new HasItemResultAtIndexMatchFromEnd(this);
+
+		private class HasItemResultAtIndexMatchFromEnd(HasItemResultAtIndexMatch inner)
+			: CollectionIndexOptions.IMatchFromEnd
+		{
+			/// <inheritdoc cref="CollectionIndexOptions.IMatch.GetDescription()" />
+			public string GetDescription()
+				=> inner.GetDescription() + " from end";
+
+			/// <inheritdoc cref="CollectionIndexOptions.IMatch.OnlySingleIndex()" />
+			public bool OnlySingleIndex()
+				=> inner.OnlySingleIndex();
+
+			/// <inheritdoc cref="CollectionIndexOptions.IMatchFromEnd.MatchesIndex(int, int?)" />
+			public bool? MatchesIndex(int index, int? count)
+			{
+				if (count is null)
+				{
+					return null;
+				}
+
+				int expected = count.Value - inner._index - 1;
+				if (index < expected)
+				{
+					return null;
+				}
+
+				return index == expected;
+			}
+		}
 	}
 }

--- a/Source/aweXpect.Core/Results/HasItemResult.cs
+++ b/Source/aweXpect.Core/Results/HasItemResult.cs
@@ -32,7 +32,7 @@ public class HasItemResult<TCollection>(
 		return new HasItemResultAtIndex<TCollection>(_expectationBuilder, _collection, collectionIndexOptions);
 	}
 
-	private class HasItemResultAtIndexMatch : CollectionIndexOptions.IMatchFromBeginning
+	private sealed class HasItemResultAtIndexMatch : CollectionIndexOptions.IMatchFromBeginning
 	{
 		private readonly int _index;
 
@@ -66,7 +66,7 @@ public class HasItemResult<TCollection>(
 		/// <inheritdoc cref="CollectionIndexOptions.IMatchFromBeginning.FromEnd()" />
 		public CollectionIndexOptions.IMatchFromEnd FromEnd() => new HasItemResultAtIndexMatchFromEnd(this);
 
-		private class HasItemResultAtIndexMatchFromEnd(HasItemResultAtIndexMatch inner)
+		private sealed class HasItemResultAtIndexMatchFromEnd(HasItemResultAtIndexMatch inner)
 			: CollectionIndexOptions.IMatchFromEnd
 		{
 			/// <inheritdoc cref="CollectionIndexOptions.IMatch.GetDescription()" />

--- a/Source/aweXpect.Core/Results/HasItemResultAtIndex.cs
+++ b/Source/aweXpect.Core/Results/HasItemResultAtIndex.cs
@@ -20,7 +20,11 @@ public class HasItemResultAtIndex<TCollection>(
 	/// </summary>
 	public AndOrResult<TCollection, IThat<TCollection>> FromEnd()
 	{
-		collectionIndexOptions.SetFromEnd();
+		if (collectionIndexOptions.Match is CollectionIndexOptions.IMatchFromBeginning match)
+		{
+			collectionIndexOptions.SetMatch(match.FromEnd());
+		}
+
 		return this;
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -214,15 +214,21 @@ public static partial class ThatEnumerable
 			Outcome = Outcome.Failure;
 
 			int? count = null;
-			if (options.FromEnd)
+			if (options.Match is CollectionIndexOptions.IMatchFromEnd)
 			{
 				count = actual is ICollection<TItem> collection ? collection.Count : materialized.Count();
 			}
+
 			int index = -1;
 			foreach (TItem item in materialized)
 			{
 				index++;
-				bool? isIndexInRange = options.DoesIndexMatch(index, count);
+				bool? isIndexInRange = options.Match switch
+				{
+					CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(index),
+					CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(index, count),
+					_ => false
+				};
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -246,7 +252,7 @@ public static partial class ThatEnumerable
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.GetDescription());
+			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.Match.GetDescription());
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -256,15 +262,15 @@ public static partial class ThatEnumerable
 			}
 			else if (_hasIndex)
 			{
-				if (options.MatchesOnlySingleIndex())
+				if (options.Match.OnlySingleIndex())
 				{
 					stringBuilder.Append(it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);
-					stringBuilder.Append(options.GetDescription());
+					stringBuilder.Append(options.Match.GetDescription());
 				}
 				else
 				{
-					string optionDescription = options.GetDescription();
+					string optionDescription = options.Match.GetDescription();
 					if (string.IsNullOrEmpty(optionDescription))
 					{
 						optionDescription = " at any index";
@@ -275,13 +281,13 @@ public static partial class ThatEnumerable
 			}
 			else
 			{
-				stringBuilder.Append(it).Append(" did not contain any item").Append(options.GetDescription());
+				stringBuilder.Append(it).Append(" did not contain any item").Append(options.Match.GetDescription());
 			}
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append("does not have item ").Append(predicateDescription())
-				.Append(options.GetDescription());
+				.Append(options.Match.GetDescription());
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -323,15 +329,21 @@ public static partial class ThatEnumerable
 			Outcome = Outcome.Failure;
 
 			int? count = null;
-			if (options.FromEnd)
+			if (options.Match is CollectionIndexOptions.IMatchFromEnd)
 			{
 				count = actual is ICollection collection ? collection.Count : materialized.Cast<TItem>().Count();
 			}
+
 			int index = -1;
 			foreach (TItem item in materialized.Cast<TItem>())
 			{
 				index++;
-				bool? isIndexInRange = options.DoesIndexMatch(index, count);
+				bool? isIndexInRange = options.Match switch
+				{
+					CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(index),
+					CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(index, count),
+					_ => false
+				};
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -354,7 +366,7 @@ public static partial class ThatEnumerable
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.GetDescription());
+			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.Match.GetDescription());
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -364,15 +376,15 @@ public static partial class ThatEnumerable
 			}
 			else if (_actual is not null)
 			{
-				if (options.MatchesOnlySingleIndex())
+				if (options.Match.OnlySingleIndex())
 				{
 					stringBuilder.Append(it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);
-					stringBuilder.Append(options.GetDescription());
+					stringBuilder.Append(options.Match.GetDescription());
 				}
 				else
 				{
-					string optionDescription = options.GetDescription();
+					string optionDescription = options.Match.GetDescription();
 					if (string.IsNullOrEmpty(optionDescription))
 					{
 						optionDescription = " at any index";
@@ -383,13 +395,13 @@ public static partial class ThatEnumerable
 			}
 			else
 			{
-				stringBuilder.Append(it).Append(" did not contain any item").Append(options.GetDescription());
+				stringBuilder.Append(it).Append(" did not contain any item").Append(options.Match.GetDescription());
 			}
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append("does not have item ").Append(predicateDescription())
-				.Append(options.GetDescription());
+				.Append(options.Match.GetDescription());
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -199,6 +199,7 @@ public static partial class ThatEnumerable
 		private TItem? _actual;
 		private bool _hasIndex;
 
+#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 		public ConstraintResult IsMetBy(IEnumerable<TItem>? actual, IEvaluationContext context)
 		{
 			Actual = actual;
@@ -250,6 +251,7 @@ public static partial class ThatEnumerable
 
 			return this;
 		}
+#pragma warning restore S3776
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.Match.GetDescription());
@@ -315,6 +317,7 @@ public static partial class ThatEnumerable
 	{
 		private object? _actual;
 
+#pragma warning disable S3776 // Cognitive Complexity of methods should not be too high
 		public ConstraintResult IsMetBy(TEnumerable actual, IEvaluationContext context)
 		{
 			Actual = actual;
@@ -364,6 +367,7 @@ public static partial class ThatEnumerable
 
 			return this;
 		}
+#pragma warning restore S3776
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 			=> stringBuilder.Append("has item ").Append(predicateDescription()).Append(options.Match.GetDescription());

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItemThat.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItemThat.cs
@@ -93,15 +93,21 @@ public static partial class ThatEnumerable
 			Outcome = Outcome.Failure;
 
 			int? count = null;
-			if (_options.FromEnd)
+			if (_options.Match is CollectionIndexOptions.IMatchFromEnd)
 			{
 				count = actual is ICollection<TItem> collection ? collection.Count : materialized.Count();
 			}
+
 			int index = -1;
 			foreach (TItem item in materialized)
 			{
 				index++;
-				bool? isIndexInRange = _options.DoesIndexMatch(index, count);
+				bool? isIndexInRange = _options.Match switch
+				{
+					CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(index),
+					CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(index, count),
+					_ => false
+				};
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -129,7 +135,7 @@ public static partial class ThatEnumerable
 		{
 			stringBuilder.Append("has item that ");
 			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-			stringBuilder.Append(_options.GetDescription());
+			stringBuilder.Append(_options.Match.GetDescription());
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -140,15 +146,15 @@ public static partial class ThatEnumerable
 			}
 			else if (_hasIndex)
 			{
-				if (_options.MatchesOnlySingleIndex())
+				if (_options.Match.OnlySingleIndex())
 				{
 					stringBuilder.Append(_it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);
-					stringBuilder.Append(_options.GetDescription());
+					stringBuilder.Append(_options.Match.GetDescription());
 				}
 				else
 				{
-					string optionDescription = _options.GetDescription();
+					string optionDescription = _options.Match.GetDescription();
 					if (string.IsNullOrEmpty(optionDescription))
 					{
 						optionDescription = " at any index";
@@ -159,7 +165,7 @@ public static partial class ThatEnumerable
 			}
 			else
 			{
-				stringBuilder.Append(_it).Append(" did not contain any item").Append(_options.GetDescription());
+				stringBuilder.Append(_it).Append(" did not contain any item").Append(_options.Match.GetDescription());
 			}
 		}
 
@@ -167,7 +173,7 @@ public static partial class ThatEnumerable
 		{
 			stringBuilder.Append("does not have item that ");
 			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-			stringBuilder.Append(_options.GetDescription());
+			stringBuilder.Append(_options.Match.GetDescription());
 		}
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
@@ -224,15 +230,21 @@ public static partial class ThatEnumerable
 			Outcome = Outcome.Failure;
 
 			int? count = null;
-			if (_options.FromEnd)
+			if (_options.Match is CollectionIndexOptions.IMatchFromEnd)
 			{
 				count = actual is ICollection collection ? collection.Count : materialized.Cast<TItem>().Count();
 			}
+
 			int index = -1;
 			foreach (TItem item in materialized.Cast<TItem>())
 			{
 				index++;
-				bool? isIndexInRange = _options.DoesIndexMatch(index, count);
+				bool? isIndexInRange = _options.Match switch
+				{
+					CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(index),
+					CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(index, count),
+					_ => false
+				};
 				if (isIndexInRange != true)
 				{
 					if (isIndexInRange == false)
@@ -259,7 +271,7 @@ public static partial class ThatEnumerable
 		{
 			stringBuilder.Append("has item that ");
 			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-			stringBuilder.Append(_options.GetDescription());
+			stringBuilder.Append(_options.Match.GetDescription());
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -270,15 +282,15 @@ public static partial class ThatEnumerable
 			}
 			else if (_actual is not null)
 			{
-				if (_options.MatchesOnlySingleIndex())
+				if (_options.Match.OnlySingleIndex())
 				{
 					stringBuilder.Append(_it).Append(" had item ");
 					Formatter.Format(stringBuilder, _actual);
-					stringBuilder.Append(_options.GetDescription());
+					stringBuilder.Append(_options.Match.GetDescription());
 				}
 				else
 				{
-					string optionDescription = _options.GetDescription();
+					string optionDescription = _options.Match.GetDescription();
 					if (string.IsNullOrEmpty(optionDescription))
 					{
 						optionDescription = " at any index";
@@ -289,7 +301,7 @@ public static partial class ThatEnumerable
 			}
 			else
 			{
-				stringBuilder.Append(_it).Append(" did not contain any item").Append(_options.GetDescription());
+				stringBuilder.Append(_it).Append(" did not contain any item").Append(_options.Match.GetDescription());
 			}
 		}
 
@@ -297,7 +309,7 @@ public static partial class ThatEnumerable
 		{
 			stringBuilder.Append("does not have item that ");
 			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-			stringBuilder.Append(_options.GetDescription());
+			stringBuilder.Append(_options.Match.GetDescription());
 		}
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -753,13 +753,22 @@ namespace aweXpect.Options
     public class CollectionIndexOptions
     {
         public CollectionIndexOptions() { }
-        public bool FromEnd { get; }
-        public bool? DoesIndexMatch(int index, int? count) { }
-        public string GetDescription() { }
-        public bool MatchesOnlySingleIndex() { }
-        public void SetFromEnd() { }
-        public void SetIndex(int index) { }
-        public void SetIndexMatch(System.Func<int, int?, bool?> isIndexMatch, bool matchesOnlySingleIndex, string description) { }
+        public aweXpect.Options.CollectionIndexOptions.IMatch Match { get; }
+        public void SetMatch(aweXpect.Options.CollectionIndexOptions.IMatch match) { }
+        public interface IMatch
+        {
+            string GetDescription();
+            bool OnlySingleIndex();
+        }
+        public interface IMatchFromBeginning : aweXpect.Options.CollectionIndexOptions.IMatch
+        {
+            aweXpect.Options.CollectionIndexOptions.IMatchFromEnd FromEnd();
+            bool? MatchesIndex(int index);
+        }
+        public interface IMatchFromEnd : aweXpect.Options.CollectionIndexOptions.IMatch
+        {
+            bool? MatchesIndex(int index, int? count);
+        }
     }
     public class CollectionMatchOptions
     {
@@ -1095,7 +1104,7 @@ namespace aweXpect.Results
         public HasItemResultAtIndex(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
         public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> FromEnd() { }
     }
-    public class HasItemResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
+    public class HasItemResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>, aweXpect.Core.IOptionsProvider<aweXpect.Options.CollectionIndexOptions>
     {
         public HasItemResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
         public aweXpect.Results.HasItemResultAtIndex<TCollection> AtIndex(int index) { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -736,13 +736,22 @@ namespace aweXpect.Options
     public class CollectionIndexOptions
     {
         public CollectionIndexOptions() { }
-        public bool FromEnd { get; }
-        public bool? DoesIndexMatch(int index, int? count) { }
-        public string GetDescription() { }
-        public bool MatchesOnlySingleIndex() { }
-        public void SetFromEnd() { }
-        public void SetIndex(int index) { }
-        public void SetIndexMatch(System.Func<int, int?, bool?> isIndexMatch, bool matchesOnlySingleIndex, string description) { }
+        public aweXpect.Options.CollectionIndexOptions.IMatch Match { get; }
+        public void SetMatch(aweXpect.Options.CollectionIndexOptions.IMatch match) { }
+        public interface IMatch
+        {
+            string GetDescription();
+            bool OnlySingleIndex();
+        }
+        public interface IMatchFromBeginning : aweXpect.Options.CollectionIndexOptions.IMatch
+        {
+            aweXpect.Options.CollectionIndexOptions.IMatchFromEnd FromEnd();
+            bool? MatchesIndex(int index);
+        }
+        public interface IMatchFromEnd : aweXpect.Options.CollectionIndexOptions.IMatch
+        {
+            bool? MatchesIndex(int index, int? count);
+        }
     }
     public class CollectionMatchOptions
     {
@@ -1078,7 +1087,7 @@ namespace aweXpect.Results
         public HasItemResultAtIndex(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
         public aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>> FromEnd() { }
     }
-    public class HasItemResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
+    public class HasItemResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>, aweXpect.Core.IOptionsProvider<aweXpect.Options.CollectionIndexOptions>
     {
         public HasItemResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TCollection> collection, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
         public aweXpect.Results.HasItemResultAtIndex<TCollection> AtIndex(int index) { }

--- a/Tests/aweXpect.Core.Tests/Options/CollectionIndexOptionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Options/CollectionIndexOptionsTests.cs
@@ -1,0 +1,41 @@
+﻿using aweXpect.Options;
+
+namespace aweXpect.Core.Tests.Options;
+
+public class CollectionIndexOptionsTests
+{
+	[Fact]
+	public async Task DefaultMatch_FromEnd_ShouldThrowNotSupportedException()
+	{
+		CollectionIndexOptions sut = new();
+		CollectionIndexOptions.IMatchFromBeginning match = (CollectionIndexOptions.IMatchFromBeginning)sut.Match;
+
+		void Act()
+			=> _ = match.FromEnd();
+
+		await That(Act).Throws<NotSupportedException>()
+			.WithMessage("You have to specify a dedicated index condition first.");
+	}
+
+	[Fact]
+	public async Task DefaultMatch_ShouldHaveExpectedReturnValues()
+	{
+		CollectionIndexOptions sut = new();
+
+		await That(sut.Match.GetDescription()).IsEmpty();
+		await That(sut.Match.OnlySingleIndex()).IsFalse();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(1)]
+	[InlineData(3)]
+	[InlineData(-1)]
+	public async Task DefaultMatch_ShouldMatchAllIndices(int index)
+	{
+		CollectionIndexOptions sut = new();
+		CollectionIndexOptions.IMatchFromBeginning match = (CollectionIndexOptions.IMatchFromBeginning)sut.Match;
+
+		await That(match.MatchesIndex(index)).IsTrue();
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
@@ -137,6 +137,25 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2, 3, 4);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c",]);
@@ -319,6 +338,25 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             has item 42 at index 0 from end,
 					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2, 3, 4);
+
+				async Task Act()
+					=> await That(subject).HasItem(2).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 2 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
 					             """);
 			}
 
@@ -723,6 +761,29 @@ public sealed partial class ThatAsyncEnumerable
 					=> await That(subject).HasItem("bAr").Using(new IgnoreCaseForVocalsComparer()).AtIndex(1);
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IAsyncEnumerable<string?> subject = ToAsyncEnumerable(["foo", "bar", "baz",]);
+
+				async Task Act()
+					=> await That(subject).HasItem("foo").WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item equal to "foo" with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz"
+					             ]
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItemThat.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItemThat.Tests.cs
@@ -123,6 +123,25 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2, 3, 4);
+
+				async Task Act()
+					=> await That(subject).HasItemThat(it => it.IsEqualTo(3)).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item that is equal to 3 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c",]);
@@ -146,7 +165,7 @@ public sealed partial class ThatAsyncEnumerable
 					             """);
 			}
 		}
-		
+
 		public sealed class FromEndTests
 		{
 			[Theory]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
@@ -39,10 +39,7 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
 			{
-				IEnumerable subject = new[]
-				{
-					0, 1, 2
-				};
+				IEnumerable subject = new []{0, 1, 2,};
 
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(2);
@@ -61,10 +58,7 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
 			{
-				IEnumerable subject = new[]
-				{
-					0, 1, 2
-				};
+				IEnumerable subject = new []{0, 1, 2,};
 
 				async Task Act()
 					=> await That(subject).HasItem(_ => true).AtIndex(2);
@@ -75,10 +69,7 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
 			{
-				IEnumerable subject = new[]
-				{
-					0, 1, 2
-				};
+				IEnumerable subject = new []{0, 1, 2,};
 
 				async Task Act()
 					=> await That(subject).HasItem(_ => true).AtIndex(3);
@@ -265,10 +256,7 @@ public sealed partial class ThatEnumerable
 			[AutoData]
 			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
 			{
-				IEnumerable subject = new[]
-				{
-					0, 1, expected
-				};
+				IEnumerable subject = new []{0, 1, expected,};
 
 				async Task Act()
 					=> await That(subject).HasItem(expected).AtIndex(3);

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
@@ -39,7 +39,10 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
 			{
-				IEnumerable subject = new []{0, 1, 2,};
+				IEnumerable subject = new[]
+				{
+					0, 1, 2
+				};
 
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(2);
@@ -58,7 +61,10 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
 			{
-				IEnumerable subject = new []{0, 1, 2,};
+				IEnumerable subject = new[]
+				{
+					0, 1, 2
+				};
 
 				async Task Act()
 					=> await That(subject).HasItem(_ => true).AtIndex(2);
@@ -69,7 +75,10 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
 			{
-				IEnumerable subject = new []{0, 1, 2,};
+				IEnumerable subject = new[]
+				{
+					0, 1, 2
+				};
 
 				async Task Act()
 					=> await That(subject).HasItem(_ => true).AtIndex(3);
@@ -137,6 +146,31 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IEnumerable subject = ToEnumerable([0, 1, 2, 3, 4,]);
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				IEnumerable subject = ToEnumerable(["a", "b", "c",]);
@@ -144,7 +178,7 @@ public sealed partial class ThatEnumerable
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
 						.HasItem(_ => false)
-						;
+				;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -161,7 +195,7 @@ public sealed partial class ThatEnumerable
 					             """);
 			}
 		}
-		
+
 		public sealed class EnumerableItemTests
 		{
 			[Fact]
@@ -231,7 +265,10 @@ public sealed partial class ThatEnumerable
 			[AutoData]
 			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
 			{
-				IEnumerable subject = new []{0, 1, expected,};
+				IEnumerable subject = new[]
+				{
+					0, 1, expected
+				};
 
 				async Task Act()
 					=> await That(subject).HasItem(expected).AtIndex(3);
@@ -302,13 +339,38 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IEnumerable subject = ToEnumerable([0, 1, 2, 3, 4,]);
+
+				async Task Act()
+					=> await That(subject).HasItem(2).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 2 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [
+					               0,
+					               1,
+					               2,
+					               3,
+					               4
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				IEnumerable subject = ToEnumerable(["a", "b", "c",]);
 
 				async Task Act()
 					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
-						;
+				;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
@@ -82,6 +82,25 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				ImmutableArray<int> subject = [0, 1, 2, 3, 4,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				ImmutableArray<string> subject = ["a", "b", "c",];
@@ -89,7 +108,7 @@ public sealed partial class ThatEnumerable
 				async Task Act()
 					=> await That(subject).HasItem(_ => false).AtIndex(0).And.HasItem(_ => false).AtIndex(1).And
 						.HasItem(_ => false)
-						;
+				;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -179,13 +198,32 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				ImmutableArray<int> subject = [0, 1, 2, 3, 4,];
+
+				async Task Act()
+					=> await That(subject).HasItem(2).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 2 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				ImmutableArray<string?> subject = ["a", "b", "c",];
 
 				async Task Act()
 					=> await That(subject).HasItem("d").AtIndex(0).And.HasItem("e").AtIndex(1).And.HasItem("f")
-						;
+				;
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
@@ -141,6 +141,25 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IEnumerable<int> subject = [0, 1, 2, 3, 4,];
+
+				async Task Act()
+					=> await That(subject).HasItem(_ => true).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item _ => true with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
@@ -320,6 +339,25 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             has item 42 at index 0,
 					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IEnumerable<int> subject = [0, 1, 2, 3, 4,];
+
+				async Task Act()
+					=> await That(subject).HasItem(2).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item 2 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
 					             """);
 			}
 
@@ -727,6 +765,29 @@ public sealed partial class ThatEnumerable
 					=> await That(subject).HasItem("bAr").Using(new IgnoreCaseForVocalsComparer()).AtIndex(1);
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IEnumerable<string> subject = ["foo", "bar", "baz",];
+
+				async Task Act()
+					=> await That(subject).HasItem("foo").WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item equal to "foo" with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [
+					               "foo",
+					               "bar",
+					               "baz"
+					             ]
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.ImmutableTests.cs
@@ -80,6 +80,25 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				ImmutableArray<int> subject = [0, 1, 2, 3, 4,];
+
+				async Task Act()
+					=> await That(subject).HasItemThat(it => it.IsEqualTo(2)).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item that is equal to 2 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				ImmutableArray<string> subject = ["a", "b", "c",];

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.Tests.cs
@@ -139,6 +139,25 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
+			public async Task WithInvalidMatch_ShouldNotMatch()
+			{
+				IEnumerable<int> subject = [0, 1, 2, 3, 4,];
+
+				async Task Act()
+					=> await That(subject).HasItemThat(it => it.IsEqualTo(2)).WithInvalidMatch();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has item that is equal to 2 with invalid match,
+					             but it did not contain any item with invalid match
+
+					             Collection:
+					             [0, 1, 2, 3, 4]
+					             """);
+			}
+
+			[Fact]
 			public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
 			{
 				IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);

--- a/Tests/aweXpect.Tests/TestHelpers/HasItemResultExtensions.cs
+++ b/Tests/aweXpect.Tests/TestHelpers/HasItemResultExtensions.cs
@@ -1,0 +1,22 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Tests;
+
+public static class HasItemResultExtensions
+{
+	public static AndOrResult<TCollection, IThat<TCollection>> WithInvalidMatch<TCollection>(
+		this HasItemResult<TCollection> hasItemResult)
+	{
+		(hasItemResult as IOptionsProvider<CollectionIndexOptions>).Options.SetMatch(new InvalidMatch());
+		return hasItemResult;
+	}
+
+	private class InvalidMatch : CollectionIndexOptions.IMatch
+	{
+		public string GetDescription() => " with invalid match";
+
+		public bool OnlySingleIndex() => false;
+	}
+}


### PR DESCRIPTION
This PR refactors `CollectionIndexOptions` to use a match object pattern instead of method-based configuration. The refactoring replaces multiple method calls and internal state management with a hierarchical interface design that separates matching logic from the configuration object.

- Replaces method-based configuration (`SetIndex`, `SetFromEnd`, etc.) with an interface-based match object pattern
- Introduces three interfaces: `IMatch`, `IMatchFromBeginning`, and `IMatchFromEnd` to handle different matching scenarios
- Updates all collection assertion implementations to use the new match object API