### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.19.1" />
-		<PackageVersion Include="aweXpect.Core" Version="2.15.2" />
+		<PackageVersion Include="aweXpect" Version="2.20.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.16.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect testing framework packages to their latest versions and reverts the build scope back to the default configuration.

- Update aweXpect from v2.19.1 to v2.20.0
- Update aweXpect.Core from v2.15.2 to v2.16.0
- Revert BuildScope from CoreOnly back to Default