### PR TITLE
feat: add `Matching` and `MatchingExactly` option for `HasItem`

### DIFF
--- a/Docs/pages/docs/expectations/07-collections.md
+++ b/Docs/pages/docs/expectations/07-collections.md
@@ -500,6 +500,21 @@ await Expect.That(values).HasItem("2nd item").AtIndex(1).FromEnd(); // at the ze
 await Expect.That(values).HasItem(it => it.StartsWith("2nd")); // at any index
 ```
 
+You can also check that the item matches a specific type
+
+```csharp
+IEnumerable<INotification> values = //...
+
+// Verify that the item at index 1 is of type `UserCreatedNotification`
+await Expect.That(values).HasItem().Matching<UserCreatedNotification>().AtIndex(1);
+// Verify that an item of type `UserDeletedNotification` for user with ID 3 exists
+await Expect.That(values).HasItem().Matching<UserDeletedNotification>(x => x.UserId == 3);
+
+// Similar to the expectations above, but verify the type exactly:
+await Expect.That(values).HasItem().MatchingExactly<UserCreatedNotification>().AtIndex(1);
+await Expect.That(values).HasItem().MatchingExactly<UserDeletedNotification>(x => x.UserId == 3);
+```
+
 You can also use expectations on the individual items.
 
 ```csharp

--- a/Source/aweXpect/Results/HasItemWithConditionResult.cs
+++ b/Source/aweXpect/Results/HasItemWithConditionResult.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Options;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result for verifying that a collection has an item…
+/// </summary>
+/// <remarks>
+///     <seealso cref="ExpectationResult{TType,TSelf}" />
+/// </remarks>
+public class HasItemWithConditionResult<TCollection, TItem>
+	: HasItemResult<TCollection?>,
+		IOptionsProvider<PredicateOptions<TItem>>
+{
+	private readonly CollectionIndexOptions _collectionIndexOptions;
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly PredicateOptions<TItem> _options;
+	private readonly IThat<TCollection?> _subject;
+
+	internal HasItemWithConditionResult(ExpectationBuilder expectationBuilder,
+		IThat<TCollection?> subject,
+		CollectionIndexOptions collectionIndexOptions,
+		PredicateOptions<TItem> options)
+		: base(expectationBuilder, subject, collectionIndexOptions)
+	{
+		_expectationBuilder = expectationBuilder;
+		_subject = subject;
+		_collectionIndexOptions = collectionIndexOptions;
+		_options = options;
+	}
+
+	/// <inheritdoc cref="IOptionsProvider{TOptions}.Options" />
+	PredicateOptions<TItem> IOptionsProvider<PredicateOptions<TItem>>.Options => _options;
+
+	/// <summary>
+	///     …that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public HasItemWithConditionResult<TCollection, TItem> Matching(Func<TItem, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		predicate.ThrowIfNull();
+		_options.SetPredicate(predicate,
+			$"matching {doNotPopulateThisValue}");
+		return this;
+	}
+
+	/// <summary>
+	///     …of type <typeparamref name="T" />.
+	/// </summary>
+	public HasItemWithConditionResult<TCollection, T> Matching<T>()
+	{
+		_options.SetPredicate(item => item is T,
+			$"of type {Formatter.Format(typeof(T))}");
+		return Cast<T>();
+	}
+
+	/// <summary>
+	///     …of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public HasItemWithConditionResult<TCollection, T> Matching<T>(Func<T, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		predicate.ThrowIfNull();
+		_options.SetPredicate(item => item is T typed && predicate(typed),
+			$"of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
+		return Cast<T>();
+	}
+
+	/// <summary>
+	///     …of type <typeparamref name="T" />.
+	/// </summary>
+	public HasItemWithConditionResult<TCollection, T> MatchingExactly<T>()
+	{
+		_options.SetPredicate(item => item is T && item.GetType() == typeof(T),
+			$"exactly of type {Formatter.Format(typeof(T))}");
+		return Cast<T>();
+	}
+
+	/// <summary>
+	///     …of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public HasItemWithConditionResult<TCollection, T> MatchingExactly<T>(Func<T, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+	{
+		predicate.ThrowIfNull();
+		_options.SetPredicate(item => item is T typed && item.GetType() == typeof(T) && predicate(typed),
+			$"exactly of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
+		return Cast<T>();
+	}
+
+	private HasItemWithConditionResult<TCollection, T> Cast<T>()
+		=> new(_expectationBuilder, _subject, _collectionIndexOptions, new PredicateOptions<T>());
+}

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItem.cs
@@ -18,6 +18,26 @@ namespace aweXpect;
 public static partial class ThatAsyncEnumerable
 {
 	/// <summary>
+	///     Verifies that the collection has an item…
+	/// </summary>
+	public static HasItemWithConditionResult<IAsyncEnumerable<TItem>?, TItem> HasItem<TItem>(
+		this IThat<IAsyncEnumerable<TItem>?> source)
+	{
+		CollectionIndexOptions indexOptions = new();
+		PredicateOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemWithConditionResult<IAsyncEnumerable<TItem>?, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars,
+					x => options.Matches(x),
+					options.GetDescription,
+					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+
+	/// <summary>
 	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
 	/// </summary>
 	public static HasItemResult<IAsyncEnumerable<TItem>?> HasItem<TItem>(

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -20,6 +20,26 @@ namespace aweXpect;
 public static partial class ThatEnumerable
 {
 	/// <summary>
+	///     Verifies that the collection has an item…
+	/// </summary>
+	public static HasItemWithConditionResult<IEnumerable<TItem>, TItem> HasItem<TItem>(
+		this IThat<IEnumerable<TItem>?> source)
+	{
+		CollectionIndexOptions indexOptions = new();
+		PredicateOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemWithConditionResult<IEnumerable<TItem>, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars,
+					x => options.Matches(x),
+					options.GetDescription,
+					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+
+	/// <summary>
 	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
 	/// </summary>
 	public static HasItemResult<IEnumerable<TItem>?> HasItem<TItem>(
@@ -72,6 +92,23 @@ public static partial class ThatEnumerable
 					a => options.AreConsideredEqual(a, expected),
 					() => options.GetExpectation(expected, grammars),
 					indexOptions)),
+			source,
+			indexOptions,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the collection has an item…
+	/// </summary>
+	public static HasItemWithConditionResult<IEnumerable, object?> HasItem(
+		this IThat<IEnumerable?> source)
+	{
+		CollectionIndexOptions indexOptions = new();
+		PredicateOptions<object?> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemWithConditionResult<IEnumerable, object?>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemForEnumerableConstraint<IEnumerable, object?>(expectationBuilder, it, grammars, x => options.Matches(x), options.GetDescription, indexOptions)),
 			source,
 			indexOptions,
 			options);
@@ -137,6 +174,25 @@ public static partial class ThatEnumerable
 					indexOptions)),
 			source,
 			indexOptions);
+	}
+#endif
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that the collection has an item…
+	/// </summary>
+	public static HasItemWithConditionResult<ImmutableArray<TItem>, TItem> HasItem<TItem>(
+		this IThat<ImmutableArray<TItem>> source)
+	{
+		CollectionIndexOptions indexOptions = new();
+		PredicateOptions<TItem> options = new();
+		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
+		return new HasItemWithConditionResult<ImmutableArray<TItem>, TItem>(
+			expectationBuilder.AddConstraint((it, grammars)
+				=> new HasItemForEnumerableConstraint<ImmutableArray<TItem>, TItem>(expectationBuilder, it, grammars, x => options.Matches(x), options.GetDescription, indexOptions)),
+			source,
+			indexOptions,
+			options);
 	}
 #endif
 

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -89,6 +89,7 @@ namespace aweXpect
         public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Generic.IAsyncEnumerable<string?>?> HasItem(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> source, string? expected) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IAsyncEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, TItem expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IAsyncEnumerable<TItem>?> HasItemThat<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
@@ -483,10 +484,13 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Immutable.ImmutableArray<TItem>, aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject, int expected) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable?> source) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Generic.IEnumerable<string?>?> HasItem(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, string? expected) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, object? expected) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Immutable.ImmutableArray<string?>> HasItem(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>> source, string? expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.IEnumerable> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Immutable.ImmutableArray<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, TItem expected) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Immutable.ImmutableArray<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source, TItem expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -1249,6 +1253,14 @@ namespace aweXpect.Results
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
+    }
+    public class HasItemWithConditionResult<TCollection, TItem> : aweXpect.Results.HasItemResult<TCollection?>, aweXpect.Core.IOptionsProvider<aweXpect.Options.PredicateOptions<TItem>>
+    {
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, TItem> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>() { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>() { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public class IsParsableResult<TType> : aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>>
         where TType : System.IParsable<TType>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -291,9 +291,11 @@ namespace aweXpect
         public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject, int expected) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable?> source) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Generic.IEnumerable<string?>?> HasItem(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, string? expected) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, object? expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.IEnumerable> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, TItem expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItemThat<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
@@ -1220,6 +1222,14 @@ namespace aweXpect.Results
         {
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
+    }
+    public class HasItemWithConditionResult<TCollection, TItem> : aweXpect.Results.HasItemResult<TCollection?>, aweXpect.Core.IOptionsProvider<aweXpect.Options.PredicateOptions<TItem>>
+    {
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, TItem> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>() { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>() { }
+        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>
     {

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Matching.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Matching.Tests.cs
@@ -1,0 +1,668 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatAsyncEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed class Matching
+		{
+			public sealed class PredicateTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IAsyncEnumerable<int> subject = Factory.GetAsyncFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(a => a == 5);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					int[] subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => false at index 2,
+						              but it had item 2 at index 2
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					int[] subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					List<int> subject =
+					[
+						0,
+						1,
+						2,
+					];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					List<int> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IAsyncEnumerable<int>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IAsyncEnumerable<int>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2, 3, 4);
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [0, 1, 2, 3, 4]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+				{
+					IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c",]);
+
+					async Task Act()
+						=> await That(subject)
+							.HasItem().Matching(_ => false).AtIndex(0).And
+							.HasItem().Matching(_ => false).AtIndex(1).And
+							.HasItem().Matching(_ => false)
+					;
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => false at index 0 and has item matching _ => false at index 1 and has item matching _ => false,
+						             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+						             Collection:
+						             [
+						               "a",
+						               "b",
+						               "c"
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericPredicateTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(a => a.Value == 5);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => false at index 2,
+						             but it had item MyClass {
+						               StringValue = "",
+						               Value = 2
+						             } at index 2
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true at index 3,
+						             but it did not contain any item at index 3
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable(Array.Empty<MyClass>());
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type uint matching _ => true,
+						             but it did not match at any index
+
+						             Collection:
+						             [1, 2, 3]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IAsyncEnumerable<MyBaseClass> subject =
+						ToAsyncEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyClass matching _ => true,
+						             but it did not match at any index
+
+						             Collection:
+						             [
+						               MyBaseClass {
+						                 Value = 0
+						               },
+						               MyBaseClass {
+						                 Value = 1
+						               },
+						               MyBaseClass {
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyBaseClass> subject =
+						ToAsyncEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyClass at index 2,
+						             but it had item MyBaseClass {
+						               Value = 2
+						             } at index 2
+
+						             Collection:
+						             [
+						               MyBaseClass {
+						                 Value = 0
+						               },
+						               MyBaseClass {
+						                 Value = 1
+						               },
+						               MyBaseClass {
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass at index 3,
+						             but it did not contain any item at index 3
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable(Array.Empty<MyClass>());
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type uint,
+						             but it did not match at any index
+
+						             Collection:
+						             [1, 2, 3]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IAsyncEnumerable<MyBaseClass> subject =
+						ToAsyncEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyClass,
+						             but it did not match at any index
+
+						             Collection:
+						             [
+						               MyBaseClass {
+						                 Value = 0
+						               },
+						               MyBaseClass {
+						                 Value = 1
+						               },
+						               MyBaseClass {
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.MatchingExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.MatchingExactly.Tests.cs
@@ -1,0 +1,549 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatAsyncEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed class MatchingExactly
+		{
+			public sealed class GenericPredicateTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(a => a.Value == 5);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => false at index 2,
+						             but it had item MyClass {
+						               StringValue = "",
+						               Value = 2
+						             } at index 2
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => true at index 3,
+						             but it did not contain any item at index 3
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable(Array.Empty<MyClass>());
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => true,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => true at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type uint matching _ => true,
+						             but it did not match at any index
+
+						             Collection:
+						             [1, 2, 3]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true,
+						             but it did not match at any index
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IAsyncEnumerable<MyBaseClass> subject =
+						ToAsyncEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => true,
+						             but it did not match at any index
+
+						             Collection:
+						             [
+						               MyBaseClass {
+						                 Value = 0
+						               },
+						               MyBaseClass {
+						                 Value = 1
+						               },
+						               MyBaseClass {
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IAsyncEnumerable<MyClass> subject = Factory.GetAsyncFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass at index 2,
+						             but it had item MyClass {
+						               StringValue = "",
+						               Value = 2
+						             } at index 2
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass at index 3,
+						             but it did not contain any item at index 3
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject = ToAsyncEnumerable(Array.Empty<MyClass>());
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type uint,
+						             but it did not match at any index
+
+						             Collection:
+						             [1, 2, 3]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass,
+						             but it did not match at any index
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IAsyncEnumerable<MyBaseClass> subject =
+						ToAsyncEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass,
+						             but it did not match at any index
+
+						             Collection:
+						             [
+						               MyBaseClass {
+						                 Value = 0
+						               },
+						               MyBaseClass {
+						                 Value = 1
+						               },
+						               MyBaseClass {
+						                 Value = 2
+						               }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IAsyncEnumerable<MyClass> subject =
+						ToAsyncEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItem.Tests.cs
@@ -9,7 +9,7 @@ namespace aweXpect.Tests;
 
 public sealed partial class ThatAsyncEnumerable
 {
-	public sealed class HasItem
+	public sealed partial class HasItem
 	{
 		public sealed class PredicateTests
 		{
@@ -67,7 +67,7 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
 
@@ -237,7 +237,7 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
 
@@ -656,7 +656,7 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				IAsyncEnumerable<string> subject = ToAsyncEnumerable(["a", "b", "c",]);
 
@@ -974,7 +974,7 @@ public sealed partial class ThatAsyncEnumerable
 
 			[Theory]
 			[AutoData]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail(int expected)
 			{
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(expected, 3, 4);
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItemThat.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.HasItemThat.Tests.cs
@@ -53,7 +53,7 @@ public sealed partial class ThatAsyncEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(0, 1, 2);
 
@@ -202,7 +202,7 @@ public sealed partial class ThatAsyncEnumerable
 
 			[Theory]
 			[AutoData]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail(int expected)
 			{
 				IAsyncEnumerable<int> subject = ToAsyncEnumerable(expected, 3, 4);
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.EnumerableTests.cs
@@ -67,7 +67,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				IEnumerable subject = new []{0, 1, 2,};
 
@@ -254,7 +254,7 @@ public sealed partial class ThatEnumerable
 
 			[Theory]
 			[AutoData]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail(int expected)
 			{
 				IEnumerable subject = new []{0, 1, expected,};
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.ImmutableTests.cs
@@ -44,7 +44,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				ImmutableArray<int> subject = [0, 1, 2,];
 
@@ -159,7 +159,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				ImmutableArray<int> subject = [0, 1, 2,];
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Matching.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Matching.EnumerableTests.cs
@@ -1,0 +1,471 @@
+﻿using System.Collections;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed partial class Matching
+		{
+			public sealed class EnumerablePredicateTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = new[]
+					{
+						0, 1, 2,
+					};
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => false at index 2,
+						              but it had item 2 at index 2
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = new[]
+					{
+						0, 1, 2,
+					};
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable subject = new[]
+					{
+						0, 1, 2,
+					};
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable subject = Array.Empty<int>();
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable subject = new[]
+					{
+						0, 1, 2, 3, 4,
+					};
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [0, 1, 2, 3, 4]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+				{
+					IEnumerable subject = new[]
+					{
+						"a", "b", "c",
+					};
+
+					async Task Act()
+						=> await That(subject)
+							.HasItem().Matching(_ => false).AtIndex(0).And
+							.HasItem().Matching(_ => false).AtIndex(1).And
+							.HasItem().Matching(_ => false)
+					;
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => false at index 0 and has item matching _ => false at index 1 and has item matching _ => false,
+						             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+						             Collection:
+						             [
+						               "a",
+						               "b",
+						               "c"
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class EnumerableGenericPredicateTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item of type MyBaseClass matching _ => false at index 2,
+						               but it had item MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyBaseClass matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable subject = Array.Empty<MyClass>();
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type uint matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class EnumerableGenericTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item of type MyClass at index 2,
+						               but it had item MyBaseClass {
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyBaseClass at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable subject = Array.Empty<MyClass>();
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type uint,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Matching.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Matching.ImmutableTests.cs
@@ -1,0 +1,461 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Immutable;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed partial class Matching
+		{
+			public sealed class ImmutablePredicateTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<int> subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => false at index 2,
+						              but it had item 2 at index 2
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<int> subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					ImmutableArray<int> subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					ImmutableArray<int> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					ImmutableArray<int> subject = [0, 1, 2, 3, 4,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [0, 1, 2, 3, 4]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+				{
+					ImmutableArray<string> subject = ["a", "b", "c",];
+
+					async Task Act()
+						=> await That(subject)
+							.HasItem().Matching(_ => false).AtIndex(0).And
+							.HasItem().Matching(_ => false).AtIndex(1).And
+							.HasItem().Matching(_ => false)
+					;
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => false at index 0 and has item matching _ => false at index 1 and has item matching _ => false,
+						             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+						             Collection:
+						             [
+						               "a",
+						               "b",
+						               "c"
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class ImmutableGenericPredicateTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item of type MyBaseClass matching _ => false at index 2,
+						               but it had item MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyBaseClass matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					ImmutableArray<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type uint matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					ImmutableArray<MyBaseClass> subject =
+						[..ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class ImmutableGenericTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyBaseClass> subject =
+						[..ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item of type MyClass at index 2,
+						               but it had item MyBaseClass {
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyBaseClass at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					ImmutableArray<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type uint,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					ImmutableArray<MyBaseClass> subject =
+						[..ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Matching.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Matching.Tests.cs
@@ -1,0 +1,602 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed partial class Matching
+		{
+			public sealed class PredicateTests
+			{
+				[Fact]
+				public async Task DoesNotEnumerateTwice()
+				{
+					ThrowWhenIteratingTwiceEnumerable subject = new();
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true)
+							.And.HasItem().Matching(_ => true).AtIndex(0);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<int> subject = Factory.GetFibonacciNumbers();
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(a => a == 5);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					int[] subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => false at index 2,
+						              but it had item 2 at index 2
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					int[] subject = [0, 1, 2,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					List<int> subject =
+					[
+						0,
+						1,
+						2,
+					];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					List<int> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IEnumerable<int>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IEnumerable<int>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable<int> subject = [0, 1, 2, 3, 4,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [0, 1, 2, 3, 4]
+						             """);
+				}
+
+				[Fact]
+				public async Task WithMultipleFailures_ShouldIncludeCollectionOnlyOnce()
+				{
+					IEnumerable<string> subject = ToEnumerable(["a", "b", "c",]);
+
+					async Task Act()
+						=> await That(subject)
+							.HasItem().Matching(_ => false).AtIndex(0).And
+							.HasItem().Matching(_ => false).AtIndex(1).And
+							.HasItem().Matching(_ => false)
+					;
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item matching _ => false at index 0 and has item matching _ => false at index 1 and has item matching _ => false,
+						             but it had item "a" at index 0 and it had item "b" at index 1 and it did not match at any index
+
+						             Collection:
+						             [
+						               "a",
+						               "b",
+						               "c"
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericPredicateTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(a => a.Value == 5);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item of type MyBaseClass matching _ => false at index 2,
+						               but it had item MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyBaseClass matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type uint matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item of type MyClass at index 2,
+						               but it had item MyBaseClass {
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyBaseClass at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type uint,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item of type MyClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().Matching<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.MatchingExactly.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.MatchingExactly.EnumerableTests.cs
@@ -1,0 +1,355 @@
+﻿using System.Collections;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed partial class MatchingExactly
+		{
+			public sealed class EnumerableGenericPredicateTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item exactly of type MyBaseClass matching _ => false at index 2,
+						               but it had item MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable subject = Array.Empty<MyClass>();
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<int>(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type uint matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class EnumerableGenericTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item exactly of type MyClass at index 2,
+						               but it had item MyBaseClass {
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable subject = Array.Empty<MyClass>();
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<int>(1, 2, 3);
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type uint,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.MatchingExactly.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.MatchingExactly.ImmutableTests.cs
@@ -1,0 +1,362 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Immutable;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed partial class MatchingExactly
+		{
+			public sealed class ImmutableGenericPredicateTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item exactly of type MyBaseClass matching _ => false at index 2,
+						               but it had item MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					ImmutableArray<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type uint matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject =
+						[..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					ImmutableArray<MyBaseClass> subject =
+						[..ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class ImmutableGenericTests
+			{
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyBaseClass> subject =
+						[..ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item exactly of type MyClass at index 2,
+						               but it had item MyBaseClass {
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					ImmutableArray<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type uint,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					ImmutableArray<MyClass> subject =
+						[..ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					ImmutableArray<MyBaseClass> subject =
+						[..ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					ImmutableArray<MyClass> subject = [..ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x)),];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.MatchingExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.MatchingExactly.Tests.cs
@@ -1,0 +1,441 @@
+﻿using System.Collections.Generic;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class HasItem
+	{
+		public sealed partial class MatchingExactly
+		{
+			public sealed class GenericPredicateTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(a => a.Value == 5);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => false).AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item exactly of type MyClass matching _ => false at index 2,
+						               but it had item MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true).AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass matching _ => true at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true).AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type uint matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>(_ => true);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass matching _ => true,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>(_ => true).WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass matching _ => true with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericTests
+			{
+				[Fact]
+				public async Task DoesNotMaterializeEnumerable()
+				{
+					IEnumerable<MyClass> subject = Factory.GetFibonacciNumbers<MyClass>(x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsDifferentItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($$"""
+						               Expected that subject
+						               has item exactly of type MyClass at index 2,
+						               but it had item MyBaseClass {
+						                 Value = 2
+						               } at index 2
+
+						               Collection:
+						               {{Formatter.Format(subject, FormattingOptions.MultipleLines)}}
+						               """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsExpectedItemAtGivenIndex_ShouldSucceed()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>().AtIndex(2);
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>().AtIndex(3);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass at index 3,
+						              but it did not contain any item at index 3
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenEnumerableIsEmpty_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = [];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass,
+						             but it did not contain any item
+
+						             Collection:
+						             []
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithAnyIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNull_WithFixedIndex_ShouldFail()
+				{
+					IEnumerable<MyClass>? subject = null;
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>().AtIndex(0);
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass at index 0,
+						             but it was <null>
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenTypeDoesNotMatch_ShouldFail()
+				{
+					IEnumerable<int> subject = [1, 2, 3,];
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<uint>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type uint,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSubtype_ShouldFail()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyBaseClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WhenTypeIsSupertype_ShouldFail()
+				{
+					IEnumerable<MyBaseClass> subject = ToEnumerable<MyBaseClass>([0, 1, 2,], x => new MyBaseClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyClass>();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage($"""
+						              Expected that subject
+						              has item exactly of type MyClass,
+						              but it did not match at any index
+
+						              Collection:
+						              {Formatter.Format(subject, FormattingOptions.MultipleLines)}
+						              """);
+				}
+
+				[Fact]
+				public async Task WithInvalidMatch_ShouldNotMatch()
+				{
+					IEnumerable<MyClass> subject = ToEnumerable<MyClass>([0, 1, 2, 3, 4,], x => new MyClass(x));
+
+					async Task Act()
+						=> await That(subject).HasItem().MatchingExactly<MyBaseClass>().WithInvalidMatch();
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             has item exactly of type MyBaseClass with invalid match,
+						             but it did not contain any item with invalid match
+
+						             Collection:
+						             [
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 0
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 1
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 2
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 3
+						               },
+						               MyClass {
+						                 StringValue = "",
+						                 Value = 4
+						               }
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItem.Tests.cs
@@ -66,7 +66,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				List<int> subject =
 				[
@@ -250,7 +250,7 @@ public sealed partial class ThatEnumerable
 
 			[Theory]
 			[AutoData]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail(int expected)
 			{
 				List<int> subject =
 				[
@@ -660,7 +660,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				List<string> subject = ["a", "b", "c",];
 
@@ -988,7 +988,7 @@ public sealed partial class ThatEnumerable
 
 			[Theory]
 			[AutoData]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail(int expected)
 			{
 				IEnumerable<int> subject = new[]
 				{

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.ImmutableTests.cs
@@ -42,7 +42,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				ImmutableArray<int> subject = [0, 1, 2,];
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasItemThat.Tests.cs
@@ -64,7 +64,7 @@ public sealed partial class ThatEnumerable
 			}
 
 			[Fact]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed()
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail()
 			{
 				List<int> subject =
 				[
@@ -230,7 +230,7 @@ public sealed partial class ThatEnumerable
 
 			[Theory]
 			[AutoData]
-			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldSucceed(int expected)
+			public async Task WhenEnumerableContainsNoItemAtGivenIndex_ShouldFail(int expected)
 			{
 				IEnumerable<int> subject = [expected, 3, 4,];
 


### PR DESCRIPTION
This PR adds `Matching` and `MatchingExactly` methods to the `HasItem` expectation, enabling type-based filtering when verifying collection items. The new functionality allows checking for items of specific types with optional predicate conditions, with `Matching` supporting inheritance and `MatchingExactly` requiring exact type matches.

Key changes:
- Introduces `HasItemWithConditionResult` class providing fluent type-matching methods
- Adds overloaded `HasItem()` methods returning the new result type for different collection types

---

You can now also check that the item matches a specific type

```csharp
IEnumerable<INotification> values = //...

// Verify that the item at index 1 is of type `UserCreatedNotification`
await Expect.That(values).HasItem().Matching<UserCreatedNotification>().AtIndex(1);
// Verify that an item of type `UserDeletedNotification` for user with ID 3 exists
await Expect.That(values).HasItem().Matching<UserDeletedNotification>(x => x.UserId == 3);

// Similar to the expectations above, but verify the type exactly:
await Expect.That(values).HasItem().MatchingExactly<UserCreatedNotification>().AtIndex(1);
await Expect.That(values).HasItem().MatchingExactly<UserDeletedNotification>(x => x.UserId == 3);
```

---

- *Fixes #650*