### PR TITLE
fix: `HasItem` without parameters does not make sense

### DIFF
--- a/Source/aweXpect/Results/HasItemWithConditionResult.cs
+++ b/Source/aweXpect/Results/HasItemWithConditionResult.cs
@@ -13,19 +13,17 @@ namespace aweXpect.Results;
 ///     <seealso cref="ExpectationResult{TType,TSelf}" />
 /// </remarks>
 public class HasItemWithConditionResult<TCollection, TItem>
-	: HasItemResult<TCollection?>,
-		IOptionsProvider<PredicateOptions<TItem>>
+	: IOptionsProvider<PredicateOptions<TItem>>
 {
 	private readonly CollectionIndexOptions _collectionIndexOptions;
 	private readonly ExpectationBuilder _expectationBuilder;
 	private readonly PredicateOptions<TItem> _options;
-	private readonly IThat<TCollection?> _subject;
+	private readonly IThat<TCollection> _subject;
 
 	internal HasItemWithConditionResult(ExpectationBuilder expectationBuilder,
-		IThat<TCollection?> subject,
+		IThat<TCollection> subject,
 		CollectionIndexOptions collectionIndexOptions,
 		PredicateOptions<TItem> options)
-		: base(expectationBuilder, subject, collectionIndexOptions)
 	{
 		_expectationBuilder = expectationBuilder;
 		_subject = subject;
@@ -39,62 +37,60 @@ public class HasItemWithConditionResult<TCollection, TItem>
 	/// <summary>
 	///     …that satisfies the <paramref name="predicate" />.
 	/// </summary>
-	public HasItemWithConditionResult<TCollection, TItem> Matching(Func<TItem, bool> predicate,
+	public HasItemResult<TCollection> Matching(Func<TItem, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
 		predicate.ThrowIfNull();
 		_options.SetPredicate(predicate,
 			$"matching {doNotPopulateThisValue}");
-		return this;
+		return new HasItemResult<TCollection>(_expectationBuilder, _subject, _collectionIndexOptions);
 	}
 
 	/// <summary>
 	///     …of type <typeparamref name="T" />.
 	/// </summary>
-	public HasItemWithConditionResult<TCollection, T> Matching<T>()
+	public HasItemResult<TCollection> Matching<T>()
 	{
 		_options.SetPredicate(item => item is T,
 			$"of type {Formatter.Format(typeof(T))}");
-		return Cast<T>();
+		return new HasItemResult<TCollection>(_expectationBuilder, _subject, _collectionIndexOptions);
 	}
 
 	/// <summary>
 	///     …of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
 	/// </summary>
-	public HasItemWithConditionResult<TCollection, T> Matching<T>(Func<T, bool> predicate,
+	public HasItemResult<TCollection> Matching<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
 		predicate.ThrowIfNull();
 		_options.SetPredicate(item => item is T typed && predicate(typed),
 			$"of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
-		return Cast<T>();
+		return new HasItemResult<TCollection>(_expectationBuilder, _subject, _collectionIndexOptions);
 	}
 
 	/// <summary>
 	///     …of type <typeparamref name="T" />.
 	/// </summary>
-	public HasItemWithConditionResult<TCollection, T> MatchingExactly<T>()
+	public HasItemResult<TCollection> MatchingExactly<T>()
 	{
 		_options.SetPredicate(item => item is T && item.GetType() == typeof(T),
 			$"exactly of type {Formatter.Format(typeof(T))}");
-		return Cast<T>();
+
+		return new HasItemResult<TCollection>(_expectationBuilder, _subject, _collectionIndexOptions);
 	}
 
 	/// <summary>
 	///     …of type <typeparamref name="T" /> that satisfies the <paramref name="predicate" />.
 	/// </summary>
-	public HasItemWithConditionResult<TCollection, T> MatchingExactly<T>(Func<T, bool> predicate,
+	public HasItemResult<TCollection> MatchingExactly<T>(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 	{
 		predicate.ThrowIfNull();
 		_options.SetPredicate(item => item is T typed && item.GetType() == typeof(T) && predicate(typed),
 			$"exactly of type {Formatter.Format(typeof(T))} matching {doNotPopulateThisValue}");
-		return Cast<T>();
+		return new HasItemResult<TCollection>(_expectationBuilder, _subject, _collectionIndexOptions);
 	}
-
-	private HasItemWithConditionResult<TCollection, T> Cast<T>()
-		=> new(_expectationBuilder, _subject, _collectionIndexOptions, new PredicateOptions<T>());
 }

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -22,13 +22,13 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection has an item…
 	/// </summary>
-	public static HasItemWithConditionResult<IEnumerable<TItem>, TItem> HasItem<TItem>(
+	public static HasItemWithConditionResult<IEnumerable<TItem>?, TItem> HasItem<TItem>(
 		this IThat<IEnumerable<TItem>?> source)
 	{
 		CollectionIndexOptions indexOptions = new();
 		PredicateOptions<TItem> options = new();
 		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
-		return new HasItemWithConditionResult<IEnumerable<TItem>, TItem>(
+		return new HasItemWithConditionResult<IEnumerable<TItem>?, TItem>(
 			expectationBuilder.AddConstraint((it, grammars)
 				=> new HasItemConstraint<TItem>(expectationBuilder, it, grammars,
 					x => options.Matches(x),
@@ -100,13 +100,13 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection has an item…
 	/// </summary>
-	public static HasItemWithConditionResult<IEnumerable, object?> HasItem(
+	public static HasItemWithConditionResult<IEnumerable?, object?> HasItem(
 		this IThat<IEnumerable?> source)
 	{
 		CollectionIndexOptions indexOptions = new();
 		PredicateOptions<object?> options = new();
 		ExpectationBuilder expectationBuilder = source.Get().ExpectationBuilder;
-		return new HasItemWithConditionResult<IEnumerable, object?>(
+		return new HasItemWithConditionResult<IEnumerable?, object?>(
 			expectationBuilder.AddConstraint((it, grammars)
 				=> new HasItemForEnumerableConstraint<IEnumerable, object?>(expectationBuilder, it, grammars, x => options.Matches(x), options.GetDescription, indexOptions)),
 			source,

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -484,12 +484,12 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Immutable.ImmutableArray<TItem>, aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject, int expected) { }
-        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable?> source) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.IEnumerable?, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable?> source) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Generic.IEnumerable<string?>?> HasItem(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, string? expected) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, object? expected) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Immutable.ImmutableArray<string?>> HasItem(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>> source, string? expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.IEnumerable> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Immutable.ImmutableArray<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, TItem expected) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Immutable.ImmutableArray<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> source, TItem expected) { }
@@ -1254,13 +1254,13 @@ namespace aweXpect.Results
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
     }
-    public class HasItemWithConditionResult<TCollection, TItem> : aweXpect.Results.HasItemResult<TCollection?>, aweXpect.Core.IOptionsProvider<aweXpect.Options.PredicateOptions<TItem>>
+    public class HasItemWithConditionResult<TCollection, TItem> : aweXpect.Core.IOptionsProvider<aweXpect.Options.PredicateOptions<TItem>>
     {
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, TItem> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>() { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>() { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemResult<TCollection> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemResult<TCollection> Matching<T>() { }
+        public aweXpect.Results.HasItemResult<TCollection> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemResult<TCollection> MatchingExactly<T>() { }
+        public aweXpect.Results.HasItemResult<TCollection> MatchingExactly<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public class IsParsableResult<TType> : aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>>
         where TType : System.IParsable<TType>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -291,11 +291,11 @@ namespace aweXpect
         public static aweXpect.CollectionCountResult<aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>> HasCount<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject, int expected) { }
         public static aweXpect.Results.AndOrResult<TItem[], aweXpect.Core.IThat<TItem[]?>> HasCount<TItem>(this aweXpect.Core.IThat<TItem[]?> subject, int expected) { }
-        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable?> source) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.IEnumerable?, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable?> source) { }
         public static aweXpect.Results.StringHasItemResult<System.Collections.Generic.IEnumerable<string?>?> HasItem(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source, string? expected) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.IEnumerable, object?> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, object? expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.IEnumerable> HasItem(this aweXpect.Core.IThat<System.Collections.IEnumerable> source, System.Func<object?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IEnumerable<TItem>, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
+        public static aweXpect.Results.HasItemWithConditionResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }
         public static aweXpect.Results.ObjectHasItemResult<System.Collections.Generic.IEnumerable<TItem>?, TItem> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, TItem expected) { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItem<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.HasItemResult<System.Collections.Generic.IEnumerable<TItem>?> HasItemThat<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source, System.Action<aweXpect.Core.IThat<TItem>> expectations) { }
@@ -1223,13 +1223,13 @@ namespace aweXpect.Results
             aweXpect.Results.EventTriggerResult<TSubject> WithParameter<TParameter>(string expression, int? position, System.Func<TParameter, bool> predicate);
         }
     }
-    public class HasItemWithConditionResult<TCollection, TItem> : aweXpect.Results.HasItemResult<TCollection?>, aweXpect.Core.IOptionsProvider<aweXpect.Options.PredicateOptions<TItem>>
+    public class HasItemWithConditionResult<TCollection, TItem> : aweXpect.Core.IOptionsProvider<aweXpect.Options.PredicateOptions<TItem>>
     {
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, TItem> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>() { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>() { }
-        public aweXpect.Results.HasItemWithConditionResult<TCollection, T> MatchingExactly<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemResult<TCollection> Matching(System.Func<TItem, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemResult<TCollection> Matching<T>() { }
+        public aweXpect.Results.HasItemResult<TCollection> Matching<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public aweXpect.Results.HasItemResult<TCollection> MatchingExactly<T>() { }
+        public aweXpect.Results.HasItemResult<TCollection> MatchingExactly<T>(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>
     {


### PR DESCRIPTION
Currently it is possible (and compiles) to specify `HasItem()` without any further restriction, but it does not make any sense. This PR removes the option to make it compile.