### PR TITLE
fix: Missing WorkflowRunId in Mutation tests dashboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,7 @@ jobs:
                 run: ./build.sh MutationTestsDashboard
                 env:
                     GithubToken: ${{ secrets.GITHUB_TOKEN }}
+                    WorkflowRunId: ${{ github.run_id }}
     
     benchmarks:
         name: "Benchmarks"


### PR DESCRIPTION
This PR fixes a missing environment variable in the GitHub Actions workflow for mutation tests dashboard reporting. The change adds the WorkflowRunId environment variable set to [`${{ github.run_id }}`](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context):
> A unique number for each workflow run within a repository. This number does not change if you re-run the workflow run.