### PR TITLE
feat: format `void` and generic types

### DIFF
--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
@@ -108,7 +108,15 @@ public static partial class ValueFormatters
 		Type value,
 		StringBuilder stringBuilder)
 	{
-		if (value.IsArray)
+		if (value == typeof(void))
+		{
+			stringBuilder.Append("void");
+		}
+		else if (value.IsGenericParameter)
+		{
+			stringBuilder.Append(value.Name);
+		}
+		else if (value.IsArray)
 		{
 			FormatType(value.GetElementType()!, stringBuilder);
 			stringBuilder.Append("[]");

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -193,7 +193,7 @@ public partial class ValueFormatters
 		public async Task WhenGenericParameter_ShouldUseOnlyName()
 		{
 			MethodInfo method = GetType()
-				.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+				.GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
 				.Single(x => x.Name.StartsWith(nameof(DummyMethodToGetSpecialTypes)));
 			string expectedResult = "TParameter";
 			Type value = method.GetGenericArguments()[0];
@@ -227,7 +227,7 @@ public partial class ValueFormatters
 		public async Task WhenVoid_ShouldUseSimpleName()
 		{
 			MethodInfo method = GetType()
-				.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+				.GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
 				.Single(x => x.Name.StartsWith(nameof(DummyMethodToGetSpecialTypes)));
 			string expectedResult = "void";
 			Type value = method.ReturnType;
@@ -246,7 +246,7 @@ public partial class ValueFormatters
 		private class NestedGenericType<T>;
 
 		// ReSharper disable once UnusedParameter.Local
-		private void DummyMethodToGetSpecialTypes<TParameter>(TParameter value)
+		private static void DummyMethodToGetSpecialTypes<TParameter>(TParameter value)
 		{
 			// This method is only used to get a void return type and generic parameter types.
 		}


### PR DESCRIPTION
This PR enhances the type formatting functionality to better handle `void` and generic type parameters. The changes improve the readability and accuracy of type formatting by using simplified representations for these special cases.

**Key changes:**
- Added special formatting for `void` types to display as "void" instead of the full type name
- Added special formatting for generic parameters to display only their parameter name (e.g., "T" instead of "IEnumerable<>.T")
- Updated test expectations to reflect the simplified generic parameter formatting

---

- *Fixes #732*