### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.20.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.16.1" />
+		<PackageVersion Include="aweXpect" Version="2.21.1" />
+		<PackageVersion Include="aweXpect.Core" Version="2.17.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect package group versions and resets the build scope to default after a core-only release cycle.

- Updated aweXpect package versions (main: 2.20.0 → 2.21.1, Core: 2.16.1 → 2.17.0)
- Reset BuildScope from CoreOnly back to Default to enable full build pipeline