### PR TITLE
feat: support `ISpanParsable` and `IUtf8SpanParsable`

### DIFF
--- a/Source/aweXpect.Core/Core/SpanWrapper.cs
+++ b/Source/aweXpect.Core/Core/SpanWrapper.cs
@@ -1,0 +1,69 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace aweXpect.Core;
+
+/// <summary>
+///     Wraps a span by providing access to the underlying data.
+/// </summary>
+public class SpanWrapper<T> : ICollection<T>
+{
+	private readonly T[] _value;
+
+	/// <inheritdoc cref="SpanWrapper{T}" />
+	public SpanWrapper(ReadOnlySpan<T> span)
+	{
+		_value = span.ToArray();
+	}
+
+	/// <inheritdoc cref="SpanWrapper{T}" />
+	public SpanWrapper(Span<T> span)
+	{
+		_value = span.ToArray();
+	}
+
+	/// <summary>
+	///     Creates a new span over the wrapped array.
+	/// </summary>
+	public Span<T> AsSpan() => _value.AsSpan();
+
+	/// <inheritdoc cref="IEnumerable{T}.GetEnumerator()" />
+	public IEnumerator<T> GetEnumerator()
+		=> (_value as IEnumerable<T>).GetEnumerator();
+
+	/// <inheritdoc cref="IEnumerable.GetEnumerator()" />
+	IEnumerator IEnumerable.GetEnumerator()
+		=> GetEnumerator();
+
+	/// <inheritdoc cref="ICollection{T}.Add(T)" />
+	public void Add(T item)
+		=> throw new NotSupportedException("You may not change a SpanWrapper!");
+
+	/// <inheritdoc cref="ICollection{T}.Clear()" />
+	public void Clear()
+		=> throw new NotSupportedException("You may not change a SpanWrapper!");
+
+	/// <inheritdoc cref="ICollection{T}.Contains(T)" />
+	public bool Contains(T item)
+		=> _value.Contains(item);
+
+	/// <inheritdoc cref="ICollection{T}.CopyTo(T[], int)" />
+	public void CopyTo(T[] array, int arrayIndex)
+		=> _value.CopyTo(array, arrayIndex);
+
+	/// <inheritdoc cref="ICollection{T}.Remove(T)" />
+	public bool Remove(T item)
+		=> throw new NotSupportedException("You may not change a SpanWrapper!");
+
+	/// <inheritdoc cref="ICollection{T}.Count" />
+	public int Count
+		=> _value.Length;
+
+	/// <inheritdoc cref="ICollection{T}.IsReadOnly" />
+	public bool IsReadOnly
+		=> true;
+}
+#endif

--- a/Source/aweXpect.Core/Expect.cs
+++ b/Source/aweXpect.Core/Expect.cs
@@ -40,6 +40,26 @@ public static class Expect
 
 #if NET8_0_OR_GREATER
 	/// <summary>
+	///     Specify expectations for the current <paramref name="subject" />.
+	/// </summary>
+	public static IThat<SpanWrapper<T>> That<T>(ReadOnlySpan<T> subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new ThatSubject<SpanWrapper<T>>(new ExpectationBuilder<SpanWrapper<T>>(
+			new ValueSource<SpanWrapper<T>>(new SpanWrapper<T>(subject)), doNotPopulateThisValue));
+#endif
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Specify expectations for the current <paramref name="subject" />.
+	/// </summary>
+	public static IThat<SpanWrapper<T>> That<T>(Span<T> subject,
+		[CallerArgumentExpression("subject")] string doNotPopulateThisValue = "")
+		=> new ThatSubject<SpanWrapper<T>>(new ExpectationBuilder<SpanWrapper<T>>(
+			new ValueSource<SpanWrapper<T>>(new SpanWrapper<T>(subject)), doNotPopulateThisValue));
+#endif
+
+#if NET8_0_OR_GREATER
+	/// <summary>
 	///     Specify expectations for the current asynchronous <paramref name="subject" />.
 	/// </summary>
 	public static IThat<T> That<T>(ValueTask<T> subject,

--- a/Source/aweXpect/Results/IsParsableResult.cs
+++ b/Source/aweXpect/Results/IsParsableResult.cs
@@ -5,7 +5,8 @@ using aweXpect.Core;
 namespace aweXpect.Results;
 
 /// <summary>
-///     The result for verifying that the subject is parsable into <typeparamref name="TType" />.
+///     The result for verifying that the <see cref="IParsable{TType}" /> subject is parsable
+///     into <typeparamref name="TType" />.
 /// </summary>
 public class IsParsableResult<TType>(
 	ExpectationBuilder expectationBuilder,

--- a/Source/aweXpect/Results/IsSpanParsableResult.cs
+++ b/Source/aweXpect/Results/IsSpanParsableResult.cs
@@ -5,7 +5,8 @@ using aweXpect.Core;
 namespace aweXpect.Results;
 
 /// <summary>
-///     The result for verifying that the subject is span-parsable into <typeparamref name="TType" />.
+///     The result for verifying that the <see cref="ISpanParsable{TType}" /> subject is parsable
+///     into <typeparamref name="TType" />.
 /// </summary>
 public class IsSpanParsableResult<TType>(
 	ExpectationBuilder expectationBuilder,

--- a/Source/aweXpect/Results/IsSpanParsableResult.cs
+++ b/Source/aweXpect/Results/IsSpanParsableResult.cs
@@ -1,0 +1,34 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result for verifying that the subject is span-parsable into <typeparamref name="TType" />.
+/// </summary>
+public class IsSpanParsableResult<TType>(
+	ExpectationBuilder expectationBuilder,
+	IThat<SpanWrapper<char>> subject,
+	IFormatProvider? formatProvider)
+	: AndOrResult<SpanWrapper<char>, IThat<SpanWrapper<char>>>(expectationBuilder, subject)
+	where TType : ISpanParsable<TType>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     Gives access to the parsed value.
+	/// </summary>
+	public IThat<TType> Which
+		=> new ThatSubject<TType>(_expectationBuilder
+			.ForWhich<SpanWrapper<char>, TType?>(d =>
+			{
+				if (TType.TryParse(d.AsSpan(), formatProvider, out TType? result))
+				{
+					return result;
+				}
+
+				return default;
+			}, " which "));
+}
+#endif

--- a/Source/aweXpect/Results/IsUtf8SpanParsableResult.cs
+++ b/Source/aweXpect/Results/IsUtf8SpanParsableResult.cs
@@ -5,7 +5,8 @@ using aweXpect.Core;
 namespace aweXpect.Results;
 
 /// <summary>
-///     The result for verifying that the subject is UTF8-span-parsable into <typeparamref name="TType" />.
+///     The result for verifying that the <see cref="IUtf8SpanParsable{TType}" /> subject is parsable
+///     into <typeparamref name="TType" />.
 /// </summary>
 public class IsUtf8SpanParsableResult<TType>(
 	ExpectationBuilder expectationBuilder,

--- a/Source/aweXpect/Results/IsUtf8SpanParsableResult.cs
+++ b/Source/aweXpect/Results/IsUtf8SpanParsableResult.cs
@@ -1,0 +1,34 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+
+namespace aweXpect.Results;
+
+/// <summary>
+///     The result for verifying that the subject is UTF8-span-parsable into <typeparamref name="TType" />.
+/// </summary>
+public class IsUtf8SpanParsableResult<TType>(
+	ExpectationBuilder expectationBuilder,
+	IThat<SpanWrapper<byte>> subject,
+	IFormatProvider? formatProvider)
+	: AndOrResult<SpanWrapper<byte>, IThat<SpanWrapper<byte>>>(expectationBuilder, subject)
+	where TType : IUtf8SpanParsable<TType>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+
+	/// <summary>
+	///     Gives access to the parsed value.
+	/// </summary>
+	public IThat<TType> Which
+		=> new ThatSubject<TType>(_expectationBuilder
+			.ForWhich<SpanWrapper<byte>, TType?>(d =>
+			{
+				if (TType.TryParse(d.AsSpan(), formatProvider, out TType? result))
+				{
+					return result;
+				}
+
+				return default;
+			}, " which "));
+}
+#endif

--- a/Source/aweXpect/That/Spans/ThatSpan.IsParsableInto.cs
+++ b/Source/aweXpect/That/Spans/ThatSpan.IsParsableInto.cs
@@ -1,0 +1,218 @@
+﻿#if NET8_0_OR_GREATER
+using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatSpan
+{
+	/// <summary>
+	///     Verifies that the subject is parsable into type <typeparamref name="TType" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="formatProvider" /> provides culture-specific formatting information
+	///     in the call to <see cref="IParsable{TType}.Parse(string, IFormatProvider)" />.
+	/// </remarks>
+	public static IsSpanParsableResult<TType> IsParsableInto<TType>(
+		this IThat<SpanWrapper<char>> source,
+		IFormatProvider? formatProvider = null)
+		where TType : ISpanParsable<TType>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsParsableIntoConstraint<TType>(it, grammars, formatProvider)),
+			source,
+			formatProvider);
+
+	/// <summary>
+	///     Verifies that the subject is parsable into type <typeparamref name="TType" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="formatProvider" /> provides culture-specific formatting information
+	///     in the call to <see cref="IParsable{TType}.Parse(string, IFormatProvider)" />.
+	/// </remarks>
+	public static IsUtf8SpanParsableResult<TType> IsParsableInto<TType>(
+		this IThat<SpanWrapper<byte>> source,
+		IFormatProvider? formatProvider = null)
+		where TType : IUtf8SpanParsable<TType>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsUtf8ParsableIntoConstraint<TType>(it, grammars, formatProvider)),
+			source,
+			formatProvider);
+
+	/// <summary>
+	///     Verifies that the subject is not parsable into type <typeparamref name="TType" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="formatProvider" /> provides culture-specific formatting information
+	///     in the call to <see cref="IParsable{TType}.Parse(string, IFormatProvider)" />.
+	/// </remarks>
+	public static AndOrResult<SpanWrapper<char>, IThat<SpanWrapper<char>>> IsNotParsableInto<TType>(
+		this IThat<SpanWrapper<char>> source,
+		IFormatProvider? formatProvider = null)
+		where TType : ISpanParsable<TType>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsParsableIntoConstraint<TType>(it, grammars, formatProvider).Invert()),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not parsable into type <typeparamref name="TType" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="formatProvider" /> provides culture-specific formatting information
+	///     in the call to <see cref="IParsable{TType}.Parse(string, IFormatProvider)" />.
+	/// </remarks>
+	public static AndOrResult<SpanWrapper<byte>, IThat<SpanWrapper<byte>>> IsNotParsableInto<TType>(
+		this IThat<SpanWrapper<byte>> source,
+		IFormatProvider? formatProvider = null)
+		where TType : IUtf8SpanParsable<TType>
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsUtf8ParsableIntoConstraint<TType>(it, grammars, formatProvider).Invert()),
+			source);
+
+	private sealed class IsParsableIntoConstraint<TType> : ConstraintResult.WithValue<SpanWrapper<char>>,
+		IValueConstraint<SpanWrapper<char>>
+		where TType : ISpanParsable<TType>
+	{
+		private readonly IFormatProvider? _formatProvider;
+		private readonly string _it;
+		private string? _exceptionMessage;
+
+		public IsParsableIntoConstraint(string it,
+			ExpectationGrammars grammars,
+			IFormatProvider? formatProvider) : base(grammars)
+		{
+			_it = it;
+			_formatProvider = formatProvider;
+			FurtherProcessingStrategy = FurtherProcessingStrategy.IgnoreResult;
+		}
+
+		public ConstraintResult IsMetBy(SpanWrapper<char> actual)
+		{
+			Actual = actual;
+
+			try
+			{
+				_ = TType.Parse(actual.AsSpan(), _formatProvider);
+				Outcome = Outcome.Success;
+			}
+			catch (Exception ex)
+			{
+				if (string.IsNullOrEmpty(ex.Message) || ex.Message.Length < 2)
+				{
+					_exceptionMessage = "an unknown error occurred";
+				}
+				else
+				{
+					_exceptionMessage = char.ToLowerInvariant(ex.Message[0]) + ex.Message[1..^1];
+				}
+
+				Outcome = Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is parsable into ");
+			Formatter.Format(stringBuilder, typeof(TType));
+			if (_formatProvider is not null)
+			{
+				stringBuilder.Append(" using ");
+				Formatter.Format(stringBuilder, _formatProvider);
+			}
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_it).Append(" was not because ").Append(_exceptionMessage);
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not parsable into ");
+			Formatter.Format(stringBuilder, typeof(TType));
+			if (_formatProvider is not null)
+			{
+				stringBuilder.Append(" using ");
+				Formatter.Format(stringBuilder, _formatProvider);
+			}
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_it).Append(" was");
+	}
+
+	private sealed class IsUtf8ParsableIntoConstraint<TType> : ConstraintResult.WithValue<SpanWrapper<byte>>,
+		IValueConstraint<SpanWrapper<byte>>
+		where TType : IUtf8SpanParsable<TType>
+	{
+		private readonly IFormatProvider? _formatProvider;
+		private readonly string _it;
+		private string? _exceptionMessage;
+
+		public IsUtf8ParsableIntoConstraint(string it,
+			ExpectationGrammars grammars,
+			IFormatProvider? formatProvider) : base(grammars)
+		{
+			_it = it;
+			_formatProvider = formatProvider;
+			FurtherProcessingStrategy = FurtherProcessingStrategy.IgnoreResult;
+		}
+
+		public ConstraintResult IsMetBy(SpanWrapper<byte> actual)
+		{
+			Actual = actual;
+
+			try
+			{
+				_ = TType.Parse(actual.AsSpan(), _formatProvider);
+				Outcome = Outcome.Success;
+			}
+			catch (Exception ex)
+			{
+				if (string.IsNullOrEmpty(ex.Message) || ex.Message.Length < 2)
+				{
+					_exceptionMessage = "an unknown error occurred";
+				}
+				else
+				{
+					_exceptionMessage = char.ToLowerInvariant(ex.Message[0]) + ex.Message[1..^1];
+				}
+
+				Outcome = Outcome.Failure;
+			}
+
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is parsable into ");
+			Formatter.Format(stringBuilder, typeof(TType));
+			if (_formatProvider is not null)
+			{
+				stringBuilder.Append(" using ");
+				Formatter.Format(stringBuilder, _formatProvider);
+			}
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_it).Append(" was not because ").Append(_exceptionMessage);
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("is not parsable into ");
+			Formatter.Format(stringBuilder, typeof(TType));
+			if (_formatProvider is not null)
+			{
+				stringBuilder.Append(" using ");
+				Formatter.Format(stringBuilder, _formatProvider);
+			}
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_it).Append(" was");
+	}
+}
+#endif

--- a/Source/aweXpect/That/Spans/ThatSpan.cs
+++ b/Source/aweXpect/That/Spans/ThatSpan.cs
@@ -1,0 +1,10 @@
+﻿#if NET8_0_OR_GREATER
+using aweXpect.Core;
+
+namespace aweXpect;
+
+/// <summary>
+///     Expectations on <see cref="SpanWrapper{T}" /> values.
+/// </summary>
+public static partial class ThatSpan;
+#endif

--- a/Source/aweXpect/aweXpect.csproj.DotSettings
+++ b/Source/aweXpect/aweXpect.csproj.DotSettings
@@ -17,6 +17,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Cobjects/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Crecording/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Csignaling/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Cspans/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Cstreams/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Cstrings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Ctimeonlys/@EntryIndexedValue">True</s:Boolean>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1088,6 +1088,17 @@ namespace aweXpect
         public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source) { }
         public static aweXpect.Results.SignalCountWhoseResult<TParameter> Signaled<TParameter>(this aweXpect.Core.IThat<aweXpect.Signaling.Signaler<TParameter>> source, aweXpect.Core.Times times) { }
     }
+    public static class ThatSpan
+    {
+        public static aweXpect.Results.AndOrResult<aweXpect.Core.SpanWrapper<byte>, aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<byte>>> IsNotParsableInto<TType>(this aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<byte>> source, System.IFormatProvider? formatProvider = null)
+            where TType : System.IUtf8SpanParsable<TType> { }
+        public static aweXpect.Results.AndOrResult<aweXpect.Core.SpanWrapper<char>, aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<char>>> IsNotParsableInto<TType>(this aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<char>> source, System.IFormatProvider? formatProvider = null)
+            where TType : System.ISpanParsable<TType> { }
+        public static aweXpect.Results.IsUtf8SpanParsableResult<TType> IsParsableInto<TType>(this aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<byte>> source, System.IFormatProvider? formatProvider = null)
+            where TType : System.IUtf8SpanParsable<TType> { }
+        public static aweXpect.Results.IsSpanParsableResult<TType> IsParsableInto<TType>(this aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<char>> source, System.IFormatProvider? formatProvider = null)
+            where TType : System.ISpanParsable<TType> { }
+    }
     public static class ThatStream
     {
         public static aweXpect.Results.PropertyResult.Long<System.IO.Stream?> HasLength(this aweXpect.Core.IThat<System.IO.Stream?> source) { }
@@ -1266,6 +1277,18 @@ namespace aweXpect.Results
         where TType : System.IParsable<TType>
     {
         public IsParsableResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<string?> subject, System.IFormatProvider? formatProvider) { }
+        public aweXpect.Core.IThat<TType> Which { get; }
+    }
+    public class IsSpanParsableResult<TType> : aweXpect.Results.AndOrResult<aweXpect.Core.SpanWrapper<char>, aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<char>>>
+        where TType : System.ISpanParsable<TType>
+    {
+        public IsSpanParsableResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<char>> subject, System.IFormatProvider? formatProvider) { }
+        public aweXpect.Core.IThat<TType> Which { get; }
+    }
+    public class IsUtf8SpanParsableResult<TType> : aweXpect.Results.AndOrResult<aweXpect.Core.SpanWrapper<byte>, aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<byte>>>
+        where TType : System.IUtf8SpanParsable<TType>
+    {
+        public IsUtf8SpanParsableResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<byte>> subject, System.IFormatProvider? formatProvider) { }
         public aweXpect.Core.IThat<TType> Which { get; }
     }
     public class ObjectCollectionBeContainedInResult<TType, TThat, TItem> : aweXpect.Results.ObjectCollectionMatchResult<TType, TThat, TItem>

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -272,6 +272,20 @@ namespace aweXpect.Core
         public aweXpect.Core.ResultContexts Remove(System.Predicate<aweXpect.Core.ResultContext> predicate) { }
         public aweXpect.Core.ResultContexts Remove(string title, System.StringComparison stringComparison = 5) { }
     }
+    public class SpanWrapper<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+    {
+        public SpanWrapper(System.ReadOnlySpan<T> span) { }
+        public SpanWrapper(System.Span<T> span) { }
+        public int Count { get; }
+        public bool IsReadOnly { get; }
+        public void Add(T item) { }
+        public System.Span<T> AsSpan() { }
+        public void Clear() { }
+        public bool Contains(T item) { }
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
+        public bool Remove(T item) { }
+    }
     public sealed class StringDifference
     {
         public StringDifference(string? actual, string? expected, System.Collections.Generic.IEqualityComparer<string>? comparer = null, aweXpect.Core.StringDifferenceSettings? settings = null) { }
@@ -585,6 +599,8 @@ namespace aweXpect
         public static aweXpect.Delegates.ThatDelegate.WithValue<TValue> That<TValue>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TValue>> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Delegates.ThatDelegate.WithValue<TValue> That<TValue>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TValue>> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Delegates.ThatDelegate.WithValue<TValue> That<TValue>(System.Func<System.Threading.CancellationToken, TValue> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<T>> That<T>(System.ReadOnlySpan<T> subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Core.IThat<aweXpect.Core.SpanWrapper<T>> That<T>(System.Span<T> subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IThat<T> That<T>(System.Threading.Tasks.Task<T> subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IThat<T> That<T>(System.Threading.Tasks.ValueTask<T> subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Core.IThat<T> That<T>(T subject, [System.Runtime.CompilerServices.CallerArgumentExpression("subject")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Core.Tests/Core/SpanWrapperTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/SpanWrapperTests.cs
@@ -1,0 +1,89 @@
+﻿#if NET8_0_OR_GREATER
+using aweXpect.Synchronous;
+
+// ReSharper disable CollectionNeverUpdated.Local
+// ReSharper disable CollectionNeverQueried.Local
+
+namespace aweXpect.Core.Tests.Core;
+
+public sealed class SpanWrapperTests
+{
+	[Fact]
+	public void Add_ShouldThrowNotSupportedException()
+	{
+		SpanWrapper<char> sut = new("foo".AsSpan());
+
+		void Act()
+			=> sut.Add('b');
+
+		Synchronously.Verify(That(Act).Throws<NotSupportedException>()
+			.WithMessage("You may not change a SpanWrapper!"));
+	}
+
+	[Fact]
+	public void Clear_ShouldThrowNotSupportedException()
+	{
+		SpanWrapper<char> sut = new("foo".AsSpan());
+
+		void Act()
+			=> sut.Clear();
+
+		Synchronously.Verify(That(Act).Throws<NotSupportedException>()
+			.WithMessage("You may not change a SpanWrapper!"));
+	}
+
+	[Theory]
+	[InlineData('o', true)]
+	[InlineData('x', false)]
+	public void Contains_ShouldReturnExpectedResult(char character, bool expectedResult)
+	{
+		SpanWrapper<char> sut = new("foo".AsSpan());
+
+		bool result = sut.Contains(character);
+
+		Synchronously.Verify(That(result).IsEqualTo(expectedResult));
+	}
+
+	[Fact]
+	public void CopyTo_ShouldCopyValuesToArray()
+	{
+		char[] buffer = "some-prefilled-buffer".ToCharArray();
+		SpanWrapper<char> sut = new("foo".AsSpan());
+
+		sut.CopyTo(buffer, 1);
+
+		Synchronously.Verify(That(new string(buffer)).IsEqualTo("sfoo-prefilled-buffer"));
+	}
+
+	[Theory]
+	[InlineData("foo", 3)]
+	[InlineData("foobar", 6)]
+	public void Count_ShouldReturnExpectedLength(string subject, int expectedLength)
+	{
+		SpanWrapper<char> sut = new(subject.AsSpan());
+
+		Synchronously.Verify(That(sut.Count).IsEqualTo(expectedLength));
+	}
+
+	[Fact]
+	public void IsReadOnly_ShouldBeTrue()
+	{
+		Span<int> span = [1, 2, 3,];
+		SpanWrapper<int> sut = new(span);
+
+		Synchronously.Verify(That(sut.IsReadOnly).IsTrue());
+	}
+
+	[Fact]
+	public void Remove_ShouldThrowNotSupportedException()
+	{
+		SpanWrapper<char> sut = new("foo".AsSpan());
+
+		void Act()
+			=> sut.Remove('b');
+
+		Synchronously.Verify(That(Act).Throws<NotSupportedException>()
+			.WithMessage("You may not change a SpanWrapper!"));
+	}
+}
+#endif

--- a/Tests/aweXpect.Core.Tests/ExpectTests.cs
+++ b/Tests/aweXpect.Core.Tests/ExpectTests.cs
@@ -115,6 +115,7 @@ public class ExpectTests
 	{
 		internal override Task<Result> GetResult(int index, Dictionary<int, Outcome> outcomes)
 			=> Task.FromResult(result);
+
 		internal override IEnumerable<ResultContext> GetContexts(int index, Dictionary<int, Outcome> outcomes)
 			=> contexts;
 	}

--- a/Tests/aweXpect.Tests/Spans/ThatSpan.IsNotParsableInto.Tests.cs
+++ b/Tests/aweXpect.Tests/Spans/ThatSpan.IsNotParsableInto.Tests.cs
@@ -1,0 +1,55 @@
+﻿#if NET8_0_OR_GREATER
+using System.Globalization;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatSpan
+{
+	public sealed partial class IsNotParsableInto
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSpanIsNotParsable_ShouldSucceed()
+			{
+				async Task Act()
+					=> await That("abc".AsSpan()).IsNotParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSpanIsParsable_ShouldFail()
+			{
+				async Task Act()
+					=> await That("42".AsSpan()).IsNotParsableInto<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that "42".AsSpan()
+					             is not parsable into int,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_ShouldBeUsed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsNotParsableInto<decimal>(formatProvider);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject.AsSpan()
+					              is not parsable into decimal using {cultureName},
+					              but it was
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Spans/ThatSpan.IsNotParsableInto.Utf8Tests.cs
+++ b/Tests/aweXpect.Tests/Spans/ThatSpan.IsNotParsableInto.Utf8Tests.cs
@@ -1,0 +1,61 @@
+﻿#if NET8_0_OR_GREATER
+using System.Globalization;
+using System.Text;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatSpan
+{
+	public sealed partial class IsNotParsableInto
+	{
+		public sealed class Utf8Tests
+		{
+			[Fact]
+			public async Task WhenSpanIsNotParsable_ShouldSucceed()
+			{
+				byte[] subject = "abc"u8.ToArray();
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsNotParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSpanIsParsable_ShouldFail()
+			{
+				byte[] subject = "42"u8.ToArray();
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsNotParsableInto<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject.AsSpan()
+					             is not parsable into int,
+					             but it was
+					             """);
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_ShouldBeUsed(string subjectString, string cultureName)
+			{
+				byte[] subject = Encoding.UTF8.GetBytes(subjectString);
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsNotParsableInto<decimal>(formatProvider);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject.AsSpan()
+					              is not parsable into decimal using {cultureName},
+					              but it was
+					              """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Spans/ThatSpan.IsParsableInto.Tests.cs
+++ b/Tests/aweXpect.Tests/Spans/ThatSpan.IsParsableInto.Tests.cs
@@ -1,0 +1,107 @@
+﻿#if NET8_0_OR_GREATER
+using System.Globalization;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatSpan
+{
+	public sealed partial class IsParsableInto
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSpanIsNotParsable_ShouldFail()
+			{
+				async Task Act()
+					=> await That("abc".AsSpan()).IsParsableInto<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that "abc".AsSpan()
+					             is parsable into int,
+					             but it was not because the input string 'abc' was not in a correct format
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSpanIsParsable_ShouldSucceed()
+			{
+				async Task Act()
+					=> await That("42".AsSpan()).IsParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("-12.34", "de-AT")]
+			[InlineData("-12,34", "en-US")]
+			public async Task WithFormatProvider_WhenFormatDoesNotMatch_ShouldFail(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<uint>(formatProvider);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject.AsSpan()
+					              is parsable into uint using {cultureName},
+					              but it was not because the input string '{subject}' was not in a correct format
+					              """);
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_WhenFormatMatches_ShouldSucceed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<decimal>(formatProvider);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WhichTests
+		{
+			[Fact]
+			public async Task WhenSpanIsNotParsable_ShouldFail()
+			{
+				async Task Act()
+					=> await That("abc".AsSpan()).IsParsableInto<TimeSpan>().Which.IsLessThan(10.Seconds());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that "abc".AsSpan()
+					             is parsable into TimeSpan which is less than 0:10,
+					             but it was not because string 'abc' was not recognized as a valid TimeSpan
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSpanIsParsable_ShouldSucceed()
+			{
+				async Task Act()
+					=> await That("42".AsSpan()).IsParsableInto<int>().Which.IsBetween(41).And(43);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_ShouldBeUsed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<decimal>(formatProvider).Which.IsEqualTo(12.34M);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Spans/ThatSpan.IsParsableInto.Utf8Tests.cs
+++ b/Tests/aweXpect.Tests/Spans/ThatSpan.IsParsableInto.Utf8Tests.cs
@@ -1,0 +1,118 @@
+﻿#if NET8_0_OR_GREATER
+using System.Globalization;
+using System.Text;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatSpan
+{
+	public sealed partial class IsParsableInto
+	{
+		public sealed class Utf8Tests
+		{
+			[Fact]
+			public async Task WhenSpanIsNotParsable_ShouldFail()
+			{
+				byte[] subject = "abc"u8.ToArray();
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject.AsSpan()
+					             is parsable into int,
+					             but it was not because the input string 'System.ReadOnlySpan<Byte>[3]' was not in a correct format
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSpanIsParsable_ShouldSucceed()
+			{
+				byte[] subject = "42"u8.ToArray();
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("-12.34", "de-AT")]
+			[InlineData("-12,34", "en-US")]
+			public async Task WithFormatProvider_WhenFormatDoesNotMatch_ShouldFail(string subjectString,
+				string cultureName)
+			{
+				byte[] subject = Encoding.UTF8.GetBytes(subjectString);
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<uint>(formatProvider);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject.AsSpan()
+					              is parsable into uint using {cultureName},
+					              but it was not because the input string 'System.ReadOnlySpan<Byte>[6]' was not in a correct format
+					              """);
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_WhenFormatMatches_ShouldSucceed(string subjectString,
+				string cultureName)
+			{
+				byte[] subject = Encoding.UTF8.GetBytes(subjectString);
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<decimal>(formatProvider);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class Utf8WhichTests
+		{
+			[Fact]
+			public async Task WhenSpanIsNotParsable_ShouldFail()
+			{
+				byte[] subject = "abc"u8.ToArray();
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<double>().Which.IsLessThan(10.0);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject.AsSpan()
+					             is parsable into double which is less than 10.0,
+					             but it was not because the input string 'System.ReadOnlySpan<Byte>[3]' was not in a correct format
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSpanIsParsable_ShouldSucceed()
+			{
+				async Task Act()
+					=> await That("42".AsSpan()).IsParsableInto<int>().Which.IsBetween(41).And(43);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("12,34", "de-AT")]
+			[InlineData("12.34", "en-US")]
+			public async Task WithFormatProvider_ShouldBeUsed(string subject, string cultureName)
+			{
+				IFormatProvider formatProvider = new CultureInfo(cultureName);
+
+				async Task Act()
+					=> await That(subject.AsSpan()).IsParsableInto<decimal>(formatProvider).Which.IsEqualTo(12.34M);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Spans/ThatSpan.Tests.cs
+++ b/Tests/aweXpect.Tests/Spans/ThatSpan.Tests.cs
@@ -1,0 +1,43 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatSpan
+{
+	public sealed class Tests
+	{
+		[Fact]
+		public async Task ShouldSupportIsEmpty()
+		{
+			var subject = new[]
+			{
+				1, 2, 3,
+			};
+			async Task Act()
+				=> await That(subject.AsSpan()).IsEmpty();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that subject.AsSpan()
+				             is empty,
+				             but it was [
+				               1,
+				               2,
+				               3
+				             ]
+				             """);
+		}
+
+		[Fact]
+		public async Task ShouldSupportIsInAscendingOrder()
+		{
+			async Task Act()
+				=> await That(new[]
+				{
+					1, 2, 3,
+				}.AsSpan()).IsInAscendingOrder();
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Spans/ThatSpan.cs
+++ b/Tests/aweXpect.Tests/Spans/ThatSpan.cs
@@ -1,0 +1,7 @@
+﻿#if NET8_0_OR_GREATER
+namespace aweXpect.Tests;
+
+public sealed partial class ThatSpan
+{
+}
+#endif

--- a/Tests/aweXpect.Tests/aweXpect.Tests.csproj.DotSettings
+++ b/Tests/aweXpect.Tests/aweXpect.Tests.csproj.DotSettings
@@ -15,6 +15,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=objects/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=recording/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=signaling/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=spans/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=streams/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=strings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=testhelpers/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This PR adds support for `ISpanParsable` and `IUtf8SpanParsable` interfaces to the aweXpect assertion library, enabling parsing assertions on span types. The implementation targets .NET 8.0 and later versions where these interfaces are available.

### Key changes include:
- Added `SpanWrapper<T>` class to enable span assertions by wrapping span data
- Implemented parsing assertions for both character and byte spans with format provider support
- Added comprehensive test coverage for the new parsing functionality

---

- *Fixes #699*