### PR TITLE
fix: failing CI-Analysis build when BuildScope is not default

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -44,6 +44,7 @@ partial class Build
 		.After(MutationTestsMain)
 		.After(MutationTestsCore)
 		.DependsOn(MutationTestsDashboard)
+		.OnlyWhenDynamic(() => BuildScope == BuildScope.Default)
 		.Executes(async () =>
 		{
 			if (!File.Exists(ArtifactsDirectory / "aweXpect" / "PR.txt"))


### PR DESCRIPTION
This PR fixes a CI-Analysis build failure by adding a conditional execution guard to the mutation testing target. The change ensures mutation tests only run when the BuildScope is set to Default, preventing failures in other build scopes.

### Key Changes
- Added conditional execution logic to the MutationTests target to restrict execution based on BuildScope