### PR TITLE
chore: update aweXpect.Core to v2.19.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.21.1" />
-		<PackageVersion Include="aweXpect.Core" Version="2.18.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.19.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.MainOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect.Core package reference from version 2.18.0 to 2.19.0 and resets the build scope to default after a core-only build cycle.

- Updates aweXpect.Core package version to 2.19.0
- Resets BuildScope from CoreOnly back to Default to enable full solution builds