### PR TITLE
chore: update aweXpect to v2.22.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.21.1" />
+		<PackageVersion Include="aweXpect" Version="2.22.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.19.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.MainOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect library version from 2.21.1 to 2.22.0 and resets the build scope configuration. The changes include updating the package reference and restoring the default build behavior after what appears to be a maintenance cycle.

### Key changes:
- Updates aweXpect package version to 2.22.0
- Resets BuildScope from MainOnly back to Default configuration