### PR TITLE
feat: improve ignoring members for equivalency

### DIFF
--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.Default;
+	readonly BuildScope BuildScope = BuildScope.CoreOnly;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 

--- a/Source/aweXpect.Core/Equivalency/EquivalencyTypeOptions.cs
+++ b/Source/aweXpect.Core/Equivalency/EquivalencyTypeOptions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 
 namespace aweXpect.Equivalency;
@@ -18,7 +19,7 @@ public record EquivalencyTypeOptions
 	/// <summary>
 	///     The members that should be ignored when checking for equivalency.
 	/// </summary>
-	public string[] MembersToIgnore { get; init; } = [];
+	public MemberToIgnore[] MembersToIgnore { get; init; } = [];
 
 	/// <summary>
 	///     Specifies which fields to include in the object comparison.

--- a/Source/aweXpect.Core/Equivalency/MemberToIgnore.cs
+++ b/Source/aweXpect.Core/Equivalency/MemberToIgnore.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Reflection;
+
+namespace aweXpect.Equivalency;
+
+/// <summary>
+///     Class to specify which members to ignore.
+/// </summary>
+public abstract class MemberToIgnore
+{
+	/// <summary>
+	///     Checks if the member should be ignored.
+	/// </summary>
+	public abstract bool IgnoreMember(string memberPath, Type memberType, MemberInfo? memberInfo);
+
+	/// <summary>
+	///     Ignores all members that satisfy the <paramref name="predicate" />.
+	/// </summary>
+	public class ByPredicate(Func<string, Type, MemberInfo?, bool> predicate, string description) : MemberToIgnore
+	{
+		/// <inheritdoc cref="MemberToIgnore.IgnoreMember(string, Type, MemberInfo?)" />
+		public override bool IgnoreMember(string memberPath, Type memberType, MemberInfo? memberInfo)
+			=> predicate(memberPath, memberType, memberInfo);
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString() => description;
+	}
+
+	/// <summary>
+	///     Ignores all members that have the provided <paramref name="memberName" />.
+	/// </summary>
+	public class ByName(string memberName) : MemberToIgnore
+	{
+		/// <inheritdoc cref="MemberToIgnore.IgnoreMember(string, Type, MemberInfo?)" />
+		public override bool IgnoreMember(string memberPath, Type memberType, MemberInfo? memberInfo)
+			=> memberPath.EndsWith(memberName, StringComparison.OrdinalIgnoreCase);
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString() => $"\"{memberName}\"";
+	}
+}

--- a/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
+++ b/Source/aweXpect/Equivalency/EquivalencyOptionsExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using aweXpect.Customization;
 
 namespace aweXpect.Equivalency;
@@ -17,7 +19,82 @@ public static class EquivalencyOptionsExtensions
 		where TEquivalencyOptions : EquivalencyTypeOptions
 		=> @this with
 		{
-			MembersToIgnore = [..@this.MembersToIgnore, memberToIgnore,],
+			MembersToIgnore = [..@this.MembersToIgnore, new MemberToIgnore.ByName(memberToIgnore),],
+		};
+
+	/// <summary>
+	///     Ignores members matching the <paramref name="predicate" /> when checking for equivalency.
+	/// </summary>
+	public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		Func<string, Type, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		where TEquivalencyOptions : EquivalencyTypeOptions
+		=> @this with
+		{
+			MembersToIgnore =
+			[
+				..@this.MembersToIgnore,
+				new MemberToIgnore.ByPredicate((memberName, memberType, _) => predicate(memberName, memberType),
+					doNotPopulateThisValue),
+			],
+		};
+
+	/// <summary>
+	///     Ignores members matching the <paramref name="predicate" /> when checking for equivalency.
+	/// </summary>
+	public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		Func<string, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		where TEquivalencyOptions : EquivalencyTypeOptions
+		=> @this with
+		{
+			MembersToIgnore =
+			[
+				..@this.MembersToIgnore,
+				new MemberToIgnore.ByPredicate((memberName, _, _) => predicate(memberName),
+					doNotPopulateThisValue),
+			],
+		};
+
+	/// <summary>
+	///     Ignores members matching the <paramref name="predicate" /> when checking for equivalency.
+	/// </summary>
+	public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		Func<Type, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		where TEquivalencyOptions : EquivalencyTypeOptions
+		=> @this with
+		{
+			MembersToIgnore =
+			[
+				..@this.MembersToIgnore,
+				new MemberToIgnore.ByPredicate((_, memberType, _) => predicate(memberType),
+					doNotPopulateThisValue),
+			],
+		};
+
+	/// <summary>
+	///     Ignores members matching the <paramref name="predicate" /> when checking for equivalency.
+	/// </summary>
+	public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(
+		this TEquivalencyOptions @this,
+		Func<string, Type, MemberInfo?, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		where TEquivalencyOptions : EquivalencyTypeOptions
+		=> @this with
+		{
+			MembersToIgnore =
+			[
+				..@this.MembersToIgnore,
+				new MemberToIgnore.ByPredicate(predicate, doNotPopulateThisValue),
+			],
 		};
 
 	/// <summary>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1236,6 +1236,14 @@ namespace aweXpect.Equivalency
     }
     public static class EquivalencyOptionsExtensions
     {
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<string, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<string, System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<string, System.Type, System.Reflection.MemberInfo?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringCollectionOrder<TEquivalencyOptions>(this TEquivalencyOptions @this, bool ignoreCollectionOrder = true)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -1182,6 +1182,14 @@ namespace aweXpect.Equivalency
     }
     public static class EquivalencyOptionsExtensions
     {
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<string, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<string, System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
+        public static TEquivalencyOptions Ignoring<TEquivalencyOptions>(this TEquivalencyOptions @this, System.Func<string, System.Type, System.Reflection.MemberInfo?, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringCollectionOrder<TEquivalencyOptions>(this TEquivalencyOptions @this, bool ignoreCollectionOrder = true)
             where TEquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions { }
         public static TEquivalencyOptions IgnoringMember<TEquivalencyOptions>(this TEquivalencyOptions @this, string memberToIgnore)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -568,7 +568,7 @@ namespace aweXpect.Equivalency
         public aweXpect.Equivalency.EquivalencyComparisonType? ComparisonType { get; init; }
         public aweXpect.Equivalency.IncludeMembers Fields { get; init; }
         public bool IgnoreCollectionOrder { get; init; }
-        public string[] MembersToIgnore { get; init; }
+        public aweXpect.Equivalency.MemberToIgnore[] MembersToIgnore { get; init; }
         public aweXpect.Equivalency.IncludeMembers Properties { get; init; }
     }
     [System.Flags]
@@ -588,6 +588,23 @@ namespace aweXpect.Equivalency
             public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
             public aweXpect.Core.IThat<T> That { get; }
             public override string? ToString() { }
+        }
+    }
+    public abstract class MemberToIgnore
+    {
+        protected MemberToIgnore() { }
+        public abstract bool IgnoreMember(string memberPath, System.Type memberType, System.Reflection.MemberInfo? memberInfo);
+        public class ByName : aweXpect.Equivalency.MemberToIgnore
+        {
+            public ByName(string memberName) { }
+            public override bool IgnoreMember(string memberPath, System.Type memberType, System.Reflection.MemberInfo? memberInfo) { }
+            public override string ToString() { }
+        }
+        public class ByPredicate : aweXpect.Equivalency.MemberToIgnore
+        {
+            public ByPredicate(System.Func<string, System.Type, System.Reflection.MemberInfo?, bool> predicate, string description) { }
+            public override bool IgnoreMember(string memberPath, System.Type memberType, System.Reflection.MemberInfo? memberInfo) { }
+            public override string ToString() { }
         }
     }
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -554,7 +554,7 @@ namespace aweXpect.Equivalency
         public aweXpect.Equivalency.EquivalencyComparisonType? ComparisonType { get; init; }
         public aweXpect.Equivalency.IncludeMembers Fields { get; init; }
         public bool IgnoreCollectionOrder { get; init; }
-        public string[] MembersToIgnore { get; init; }
+        public aweXpect.Equivalency.MemberToIgnore[] MembersToIgnore { get; init; }
         public aweXpect.Equivalency.IncludeMembers Properties { get; init; }
     }
     [System.Flags]
@@ -574,6 +574,23 @@ namespace aweXpect.Equivalency
             public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
             public aweXpect.Core.IThat<T> That { get; }
             public override string? ToString() { }
+        }
+    }
+    public abstract class MemberToIgnore
+    {
+        protected MemberToIgnore() { }
+        public abstract bool IgnoreMember(string memberPath, System.Type memberType, System.Reflection.MemberInfo? memberInfo);
+        public class ByName : aweXpect.Equivalency.MemberToIgnore
+        {
+            public ByName(string memberName) { }
+            public override bool IgnoreMember(string memberPath, System.Type memberType, System.Reflection.MemberInfo? memberInfo) { }
+            public override string ToString() { }
+        }
+        public class ByPredicate : aweXpect.Equivalency.MemberToIgnore
+        {
+            public ByPredicate(System.Func<string, System.Type, System.Reflection.MemberInfo?, bool> predicate, string description) { }
+            public override bool IgnoreMember(string memberPath, System.Type memberType, System.Reflection.MemberInfo? memberInfo) { }
+            public override string ToString() { }
         }
     }
 }

--- a/Tests/aweXpect.Core.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Equivalency/EquivalencyOptionsExtensionsTests.cs
@@ -4,6 +4,92 @@ namespace aweXpect.Core.Tests.Equivalency;
 
 public sealed class EquivalencyOptionsExtensionsTests
 {
+	[Fact]
+	public async Task Generic_For_Ignoring_StringAndTypePredicate_ShouldSetOptionForType()
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result =
+			options.For<MyClass>(o => o.Ignoring((n, t) => n.EndsWith("At") && t == typeof(DateTime)));
+
+		await That(result.MembersToIgnore).IsEmpty();
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass))
+			.WhoseValue.IsEquivalentTo(new
+			{
+				MembersToIgnore = It.Is<MemberToIgnore[]>().That.HasCount(1),
+			});
+		await That(result.ToString()).IsEqualTo("""
+		                                         - include public fields and properties
+		                                         - for EquivalencyOptionsExtensionsTests.MyClass:
+		                                           - include public fields and properties
+		                                           - ignore members: [(n, t) => n.EndsWith("At") && t == typeof(DateTime)]
+		                                        """);
+	}
+
+	[Fact]
+	public async Task Generic_For_Ignoring_StringPredicate_ShouldSetOptionForType()
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o => o.Ignoring(x => x == "foo"));
+
+		await That(result.MembersToIgnore).IsEmpty();
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass))
+			.WhoseValue.IsEquivalentTo(new
+			{
+				MembersToIgnore = It.Is<MemberToIgnore[]>().That.HasCount(1),
+			});
+		await That(result.ToString()).IsEqualTo("""
+		                                         - include public fields and properties
+		                                         - for EquivalencyOptionsExtensionsTests.MyClass:
+		                                           - include public fields and properties
+		                                           - ignore members: [x => x == "foo"]
+		                                        """);
+	}
+
+	[Fact]
+	public async Task Generic_For_Ignoring_StringTypeAndMemberInfoPredicate_ShouldSetOptionForType()
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o
+			=> o.Ignoring((n, t, f) => n.EndsWith("At") && t == typeof(DateTime) && f != null));
+
+		await That(result.MembersToIgnore).IsEmpty();
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass))
+			.WhoseValue.IsEquivalentTo(new
+			{
+				MembersToIgnore = It.Is<MemberToIgnore[]>().That.HasCount(1),
+			});
+		await That(result.ToString()).IsEqualTo("""
+		                                         - include public fields and properties
+		                                         - for EquivalencyOptionsExtensionsTests.MyClass:
+		                                           - include public fields and properties
+		                                           - ignore members: [(n, t, f) => n.EndsWith("At") && t == typeof(DateTime) && f != null]
+		                                        """);
+	}
+
+	[Fact]
+	public async Task Generic_For_Ignoring_TypePredicate_ShouldSetOptionForType()
+	{
+		EquivalencyOptions options = new();
+
+		EquivalencyOptions result = options.For<MyClass>(o => o.Ignoring(x => x == typeof(DateTime)));
+
+		await That(result.MembersToIgnore).IsEmpty();
+		await That(result.CustomOptions).ContainsKey(typeof(MyClass))
+			.WhoseValue.IsEquivalentTo(new
+			{
+				MembersToIgnore = It.Is<MemberToIgnore[]>().That.HasCount(1),
+			});
+		await That(result.ToString()).IsEqualTo("""
+		                                         - include public fields and properties
+		                                         - for EquivalencyOptionsExtensionsTests.MyClass:
+		                                           - include public fields and properties
+		                                           - ignore members: [x => x == typeof(DateTime)]
+		                                        """);
+	}
+
 	[Theory]
 	[InlineData(true)]
 	[InlineData(false)]
@@ -45,7 +131,7 @@ public sealed class EquivalencyOptionsExtensionsTests
 			{
 				MembersToIgnore = new[]
 				{
-					memberToIgnore,
+					new MemberToIgnore.ByName(memberToIgnore),
 				},
 			});
 		await That(result.ToString()).IsEqualTo($"""

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using aweXpect.Equivalency;
 
 // ReSharper disable UnusedMember.Local
@@ -27,6 +28,143 @@ public sealed partial class ThatObject
 
 				async Task Act()
 					=> await That(subject).IsEquivalentTo(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IgnoringMismatchingProperties_ShouldBeEquivalent()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 1,
+					},
+				};
+				OuterClass expected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 2,
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o
+						.For<InnerClass>(x => x.IgnoringMember("IntValue")));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IgnoringMismatchingPropertiesByPathAndTypePredicate_ShouldBeEquivalent()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 1,
+					},
+				};
+				OuterClass expected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 2,
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o
+						.Ignoring((memberPath, memberType)
+							=> memberPath.EndsWith("IntValue") && memberType == typeof(int)));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IgnoringMismatchingPropertiesByPathPredicate_ShouldBeEquivalent()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 1,
+					},
+				};
+				OuterClass expected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 2,
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o
+						.Ignoring(memberPath => memberPath == "Inner.IntValue"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IgnoringMismatchingPropertiesByPathTypeAndMemberInfoPredicate_ShouldBeEquivalent()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 1,
+					},
+				};
+				OuterClass expected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 2,
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o
+						.Ignoring((memberPath, _, memberInfo)
+							=> memberPath.EndsWith("IntValue") && memberInfo is PropertyInfo));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task IgnoringMismatchingPropertiesByTypePredicate_ShouldBeEquivalent()
+			{
+				OuterClass subject = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 1,
+					},
+				};
+				OuterClass expected = new()
+				{
+					Value = "Foo",
+					Inner = new InnerClass
+					{
+						IntValue = 2,
+					},
+				};
+
+				async Task Act()
+					=> await That(subject).IsEquivalentTo(expected, o => o
+						.Ignoring(memberType => memberType == typeof(int)));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -142,8 +280,10 @@ public sealed partial class ThatObject
 					                     "4"
 					                   ],
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
@@ -244,8 +384,10 @@ public sealed partial class ThatObject
 					                     "4"
 					                   ],
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Bart"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
@@ -334,8 +476,10 @@ public sealed partial class ThatObject
 					                   Inner = ThatObject.InnerClass {
 					                     Collection = <null>,
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
@@ -1144,11 +1288,12 @@ public sealed partial class ThatObject
 					                 Inner = ThatObject.InnerClass {
 					                   Collection = <null>,
 					                   Inner = <null>,
+					                   IntValue = 0,
 					                   Value = <null>
 					                 },
 					                 Value = "Foo"
 					               }
-					             
+
 					             Equivalency options:
 					              - include public fields and properties
 					              - ignore members: ["Inner"]

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsNotEquivalentTo.Tests.cs
@@ -106,8 +106,10 @@ public sealed partial class ThatObject
 					                     "4"
 					                   ],
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
@@ -122,13 +124,15 @@ public sealed partial class ThatObject
 					                     "3"
 					                   ],
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
 					               }
-
+					             
 					             Equivalency options:
 					              - include public fields and properties
 					              - ignore members: ["Inner.Inner.Collection[3]"]
@@ -214,8 +218,10 @@ public sealed partial class ThatObject
 					                   Inner = ThatObject.InnerClass {
 					                     Collection = <null>,
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
@@ -226,13 +232,15 @@ public sealed partial class ThatObject
 					                   Inner = ThatObject.InnerClass {
 					                     Collection = <null>,
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
 					               }
-
+					             
 					             Equivalency options:
 					              - include public fields and properties
 					             """);
@@ -284,8 +292,10 @@ public sealed partial class ThatObject
 					                     "3"
 					                   ],
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
@@ -300,13 +310,15 @@ public sealed partial class ThatObject
 					                     "3"
 					                   ],
 					                     Inner = <null>,
+					                     IntValue = 0,
 					                     Value = "Baz"
 					                   },
+					                   IntValue = 0,
 					                   Value = "Bar"
 					                 },
 					                 Value = "Foo"
 					               }
-
+					             
 					             Equivalency options:
 					              - include public fields and properties
 					             """);

--- a/Tests/aweXpect.Tests/Objects/ThatObject.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.cs
@@ -21,6 +21,8 @@ public sealed partial class ThatObject
 
 		public InnerClass? Inner { get; set; }
 		public string? Value { get; set; }
+		
+		public int IntValue { get; set; }
 	}
 
 	private sealed class OuterClass


### PR DESCRIPTION
This PR enhances the equivalency comparison functionality by introducing flexible member ignoring options. It replaces the previous string-based member ignoring mechanism with a predicate-based system that supports multiple matching criteria.

### Key changes:
- Introduces new `MemberToIgnore` abstract class with concrete implementations for name-based and predicate-based member filtering
- Adds multiple overloads to the `Ignoring` extension method supporting different predicate types (by name, type, member info, or combinations)
- Updates the equivalency comparison logic to use the new predicate-based system instead of simple string matching