### PR TITLE
refactor: re-enable skipped test

### DIFF
--- a/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
@@ -103,7 +103,7 @@ public class ManualExpectationBuilderTests
 		await That(result).IsFalse();
 	}
 
-	[Fact(Skip = "TODO Re-enable after next core update")]
+	[Fact]
 	public async Task Equals_WithSelf_ShouldBeTrue()
 	{
 		ManualExpectationBuilder<int> sut = new(null);


### PR DESCRIPTION
This PR re-enables a previously skipped unit test by removing the `Skip` parameter from the `[Fact]` attribute. The test was temporarily disabled with a TODO comment indicating it should be re-enabled after a core update.

- Removes the Skip parameter from a test method to make it executable again