### PR TITLE
refactor: rename `QuantifierContext` to `QuantifierContexts`

### DIFF
--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.All.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.All.cs
@@ -39,8 +39,8 @@ public abstract partial class EnumerableQuantifier
 		}
 
 		/// <inheritdoc />
-		public override QuantifierContext GetQuantifierContext()
-			=> QuantifierContext.NotMatchingItems;
+		public override QuantifierContexts GetQuantifierContext()
+			=> QuantifierContexts.NotMatchingItems;
 
 		/// <inheritdoc />
 		public override void AppendResult(StringBuilder stringBuilder,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.AtLeast.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.AtLeast.cs
@@ -45,8 +45,8 @@ public abstract partial class EnumerableQuantifier
 		}
 
 		/// <inheritdoc />
-		public override QuantifierContext GetQuantifierContext()
-			=> QuantifierContext.None;
+		public override QuantifierContexts GetQuantifierContext()
+			=> QuantifierContexts.None;
 
 		/// <inheritdoc />
 		public override void AppendResult(StringBuilder stringBuilder,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.AtMost.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.AtMost.cs
@@ -45,8 +45,8 @@ public abstract partial class EnumerableQuantifier
 		}
 
 		/// <inheritdoc />
-		public override QuantifierContext GetQuantifierContext()
-			=> QuantifierContext.MatchingItems;
+		public override QuantifierContexts GetQuantifierContext()
+			=> QuantifierContexts.MatchingItems;
 
 		/// <inheritdoc />
 		public override void AppendResult(StringBuilder stringBuilder,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.LessThan.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.LessThan.cs
@@ -45,8 +45,8 @@ public abstract partial class EnumerableQuantifier
 		}
 
 		/// <inheritdoc />
-		public override QuantifierContext GetQuantifierContext()
-			=> QuantifierContext.MatchingItems;
+		public override QuantifierContexts GetQuantifierContext()
+			=> QuantifierContexts.MatchingItems;
 
 		/// <inheritdoc />
 		public override void AppendResult(StringBuilder stringBuilder,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.MoreThan.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.MoreThan.cs
@@ -45,8 +45,8 @@ public abstract partial class EnumerableQuantifier
 		}
 
 		/// <inheritdoc />
-		public override QuantifierContext GetQuantifierContext()
-			=> QuantifierContext.NotMatchingItems;
+		public override QuantifierContexts GetQuantifierContext()
+			=> QuantifierContexts.NotMatchingItems;
 
 		/// <inheritdoc />
 		public override void AppendResult(StringBuilder stringBuilder,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.None.cs
@@ -46,8 +46,8 @@ public abstract partial class EnumerableQuantifier
 		}
 
 		/// <inheritdoc />
-		public override QuantifierContext GetQuantifierContext()
-			=> QuantifierContext.MatchingItems;
+		public override QuantifierContexts GetQuantifierContext()
+			=> QuantifierContexts.MatchingItems;
 
 		/// <inheritdoc />
 		public override void AppendResult(StringBuilder stringBuilder,

--- a/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
+++ b/Source/aweXpect/That/Collections/EnumerableQuantifier.cs
@@ -13,7 +13,7 @@ public abstract partial class EnumerableQuantifier
 	///     Specifies which context is helpful for the <see cref="EnumerableQuantifier" />.
 	/// </summary>
 	[Flags]
-	public enum QuantifierContext
+	public enum QuantifierContexts
 	{
 		/// <summary>
 		///     Include the matching items in the context.
@@ -54,10 +54,10 @@ public abstract partial class EnumerableQuantifier
 		int? totalCount);
 
 	/// <summary>
-	///     Returns the <see cref="QuantifierContext" /> which specifies which context values are helpful.
+	///     Returns the <see cref="QuantifierContexts" /> which specifies which context values are helpful.
 	/// </summary>
-	public virtual QuantifierContext GetQuantifierContext()
-		=> QuantifierContext.None;
+	public virtual QuantifierContexts GetQuantifierContext()
+		=> QuantifierContexts.None;
 
 	/// <summary>
 	///     Appends the result text to the <paramref name="stringBuilder" />.

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.cs
@@ -157,8 +157,8 @@ public static partial class ThatAsyncEnumerable
 
 		private void AppendContexts(bool isIncomplete)
 		{
-			EnumerableQuantifier.QuantifierContext quantifierContext = _quantifier.GetQuantifierContext();
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.MatchingItems))
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
@@ -168,7 +168,7 @@ public static partial class ThatAsyncEnumerable
 						int.MaxValue)));
 			}
 
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.NotMatchingItems))
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
@@ -348,8 +348,8 @@ public static partial class ThatAsyncEnumerable
 
 		private void AppendContexts(bool isIncomplete)
 		{
-			EnumerableQuantifier.QuantifierContext quantifierContext = _quantifier.GetQuantifierContext();
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.MatchingItems))
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
@@ -359,7 +359,7 @@ public static partial class ThatAsyncEnumerable
 						int.MaxValue)));
 			}
 
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.NotMatchingItems))
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -586,8 +586,8 @@ public static partial class ThatEnumerable
 
 		private void AppendContexts(bool isIncomplete)
 		{
-			EnumerableQuantifier.QuantifierContext quantifierContext = _quantifier.GetQuantifierContext();
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.MatchingItems))
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
@@ -596,7 +596,7 @@ public static partial class ThatEnumerable
 						int.MaxValue)));
 			}
 
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.NotMatchingItems))
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
@@ -749,8 +749,8 @@ public static partial class ThatEnumerable
 
 		private void AppendContexts(bool isIncomplete)
 		{
-			EnumerableQuantifier.QuantifierContext quantifierContext = _quantifier.GetQuantifierContext();
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.MatchingItems))
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
@@ -759,7 +759,7 @@ public static partial class ThatEnumerable
 						int.MaxValue)));
 			}
 
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.NotMatchingItems))
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
@@ -910,8 +910,8 @@ public static partial class ThatEnumerable
 
 		private void AppendContexts(bool isIncomplete)
 		{
-			EnumerableQuantifier.QuantifierContext quantifierContext = _quantifier.GetQuantifierContext();
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.MatchingItems))
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
@@ -921,7 +921,7 @@ public static partial class ThatEnumerable
 						int.MaxValue)));
 			}
 
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.NotMatchingItems))
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",
@@ -1081,8 +1081,8 @@ public static partial class ThatEnumerable
 
 		private void AppendContexts(bool isIncomplete)
 		{
-			EnumerableQuantifier.QuantifierContext quantifierContext = _quantifier.GetQuantifierContext();
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.MatchingItems))
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Matching items",
@@ -1092,7 +1092,7 @@ public static partial class ThatEnumerable
 						int.MaxValue)));
 			}
 
-			if (quantifierContext.HasFlag(EnumerableQuantifier.QuantifierContext.NotMatchingItems))
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
 			{
 				_expectationBuilder.UpdateContexts(contexts => contexts
 					.Add(new ResultContext("Not matching items",

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -18,7 +18,7 @@ namespace aweXpect
         protected EnumerableQuantifier() { }
         public abstract void AppendResult(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammars, int matchingCount, int notMatchingCount, int? totalCount, string? verb = null);
         public abstract aweXpect.Core.Constraints.Outcome GetOutcome(int matchingCount, int notMatchingCount, int? totalCount);
-        public virtual aweXpect.EnumerableQuantifier.QuantifierContext GetQuantifierContext() { }
+        public virtual aweXpect.EnumerableQuantifier.QuantifierContexts GetQuantifierContext() { }
         public abstract bool IsDeterminable(int matchingCount, int notMatchingCount);
         public abstract bool IsSingle();
         public static aweXpect.EnumerableQuantifier All(aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
@@ -30,7 +30,7 @@ namespace aweXpect
         public static aweXpect.EnumerableQuantifier MoreThan(int minimum, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
         public static aweXpect.EnumerableQuantifier None(aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
         [System.Flags]
-        public enum QuantifierContext
+        public enum QuantifierContexts
         {
             MatchingItems = 2,
             NotMatchingItems = 4,

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -18,7 +18,7 @@ namespace aweXpect
         protected EnumerableQuantifier() { }
         public abstract void AppendResult(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammars, int matchingCount, int notMatchingCount, int? totalCount, string? verb = null);
         public abstract aweXpect.Core.Constraints.Outcome GetOutcome(int matchingCount, int notMatchingCount, int? totalCount);
-        public virtual aweXpect.EnumerableQuantifier.QuantifierContext GetQuantifierContext() { }
+        public virtual aweXpect.EnumerableQuantifier.QuantifierContexts GetQuantifierContext() { }
         public abstract bool IsDeterminable(int matchingCount, int notMatchingCount);
         public abstract bool IsSingle();
         public static aweXpect.EnumerableQuantifier All(aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
@@ -30,7 +30,7 @@ namespace aweXpect
         public static aweXpect.EnumerableQuantifier MoreThan(int minimum, aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
         public static aweXpect.EnumerableQuantifier None(aweXpect.Core.ExpectationGrammars expectationGrammars = 0) { }
         [System.Flags]
-        public enum QuantifierContext
+        public enum QuantifierContexts
         {
             MatchingItems = 2,
             NotMatchingItems = 4,


### PR DESCRIPTION
This PR renames the `QuantifierContext` to `QuantifierContexts` to make it clearer that it is a `Flags` enum that can store multiple contexts.