### PR TITLE
fix: negation of wrapper `ConstraintResult` in extensions

### DIFF
--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResult.FromException.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResult.FromException.cs
@@ -13,7 +13,7 @@ public abstract partial class ConstraintResult
 	/// <summary>
 	///     A failed <see cref="ConstraintResult" /> due to an <see cref="Exception" />.
 	/// </summary>
-	internal class ExceptionConstraintResult : ConstraintResult
+	internal class FromException : ConstraintResult
 	{
 		private readonly Exception _exception;
 		private readonly ConstraintResult _inner;
@@ -21,7 +21,7 @@ public abstract partial class ConstraintResult
 		/// <summary>
 		///     A failed <see cref="ConstraintResult" /> due to a thrown <paramref name="exception" />.
 		/// </summary>
-		public ExceptionConstraintResult(
+		public FromException(
 			ConstraintResult inner,
 			Exception exception,
 			ExpectationBuilder expectationBuilder)

--- a/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
+++ b/Source/aweXpect.Core/Core/Constraints/ConstraintResultExtensions.cs
@@ -90,7 +90,12 @@ public static class ConstraintResultExtensions
 			return typeof(TValue).IsAssignableFrom(typeof(T));
 		}
 
-		public override ConstraintResult Negate() => _inner.Negate();
+		public override ConstraintResult Negate()
+		{
+			_inner.Negate();
+			Outcome = _inner.Outcome;
+			return this;
+		}
 	}
 
 	private sealed class ConstraintResultFailure<T> : ConstraintResult
@@ -151,7 +156,12 @@ public static class ConstraintResultExtensions
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 			=> _inner.TryGetValue(out value);
 
-		public override ConstraintResult Negate() => _inner.Negate();
+		public override ConstraintResult Negate()
+		{
+			_inner.Negate();
+			Outcome = _inner.Outcome;
+			return this;
+		}
 
 		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{

--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -567,7 +567,7 @@ internal class ExpectationBuilder<TValue> : ExpectationBuilder
 			ConstraintResult expectation = await rootNode.IsMetBy(default(TValue), context, cancellationToken);
 			Customize.aweXpect.TraceWriter.Value?.WriteMessage(
 				$"Checking expectation for {Subject} threw an exception");
-			return new ConstraintResult.ExceptionConstraintResult(expectation, exception, this);
+			return new ConstraintResult.FromException(expectation, exception, this);
 		}
 
 		return await rootNode.IsMetBy(data, context, cancellationToken);

--- a/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
@@ -28,6 +28,27 @@ public sealed class TestFrameworkAdapterTests : IDisposable
 	}
 
 	[Fact]
+	public async Task Inconclusive_ValidAssemblyName_ShouldThrowNotSupportedException()
+	{
+		MyTestFrameworkAdapter adapter = new(ExistingAssembly);
+		_ = adapter.IsAvailable;
+
+		await That(() => adapter.Inconclusive("foo")).Throws<NotSupportedException>()
+			.WithMessage("Failed to create the inconclusive assertion type");
+	}
+
+	[Fact]
+	public async Task Inconclusive_ValidAssemblyName_WithException_ShouldThrowProvidedException()
+	{
+		MyException exception = new("my-message");
+		MyTestFrameworkAdapter adapter = new(ExistingAssembly, inconclusiveException: exception);
+		_ = adapter.IsAvailable;
+
+		await That(() => adapter.Inconclusive("foo")).Throws<MyException>()
+			.WithMessage("my-message");
+	}
+
+	[Fact]
 	public async Task MissingAssemblyName_ShouldNotBeAvailable()
 	{
 		MyTestFrameworkAdapter adapter = new(MissingAssembly);

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultExtensionsTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultExtensionsTests.cs
@@ -45,6 +45,21 @@ public sealed class ConstraintResultExtensionsTests
 			await That(result).IsTrue();
 			await That(value).IsNull();
 		}
+
+		[Theory]
+		[InlineData(Outcome.Failure, Outcome.Success)]
+		[InlineData(Outcome.Success, Outcome.Failure)]
+		[InlineData(Outcome.Undecided, Outcome.Undecided)]
+		public async Task Negate_ShouldForwardToInnerResult(Outcome innerOutcome, Outcome expectedAfterNegation)
+		{
+			ConstraintResult inner = new DummyConstraintResult<string>(innerOutcome, "value", "foo");
+			ConstraintResult sut = inner.Fail("bar", 1);
+
+			sut.Negate();
+
+			await That(inner.Outcome).IsEqualTo(expectedAfterNegation);
+			await That(sut.Outcome).IsEqualTo(Outcome.Failure);
+		}
 	}
 
 	public sealed class UseValueTests
@@ -84,10 +99,40 @@ public sealed class ConstraintResultExtensionsTests
 			await That(result).IsTrue();
 			await That(value).IsNull();
 		}
+
+		[Theory]
+		[InlineData(Outcome.Failure, Outcome.Success)]
+		[InlineData(Outcome.Success, Outcome.Failure)]
+		[InlineData(Outcome.Undecided, Outcome.Undecided)]
+		public async Task Negate_ShouldForwardToInnerResult(Outcome innerOutcome, Outcome expectedAfterNegation)
+		{
+			ConstraintResult inner = new DummyConstraintResult<string>(innerOutcome, "value", "foo");
+			ConstraintResult sut = inner.UseValue("bar");
+
+			sut.Negate();
+
+			await That(inner.Outcome).IsEqualTo(expectedAfterNegation);
+			await That(sut.Outcome).IsEqualTo(expectedAfterNegation);
+		}
 	}
 
 	public sealed class AppendExpectationTextTests
 	{
+		[Theory]
+		[InlineData(Outcome.Failure, Outcome.Success)]
+		[InlineData(Outcome.Success, Outcome.Failure)]
+		[InlineData(Outcome.Undecided, Outcome.Undecided)]
+		public async Task Negate_ShouldForwardToInnerResult(Outcome innerOutcome, Outcome expectedAfterNegation)
+		{
+			ConstraintResult inner = new DummyConstraintResult<string>(innerOutcome, "value", "foo");
+			ConstraintResult sut = inner.AppendExpectationText(s => s.Append("bar"));
+
+			sut.Negate();
+
+			await That(inner.Outcome).IsEqualTo(expectedAfterNegation);
+			await That(sut.Outcome).IsEqualTo(expectedAfterNegation);
+		}
+
 		[Fact]
 		public async Task ShouldAppendAfterExpectationText()
 		{
@@ -114,6 +159,21 @@ public sealed class ConstraintResultExtensionsTests
 
 	public sealed class PrependExpectationTextTests
 	{
+		[Theory]
+		[InlineData(Outcome.Failure, Outcome.Success)]
+		[InlineData(Outcome.Success, Outcome.Failure)]
+		[InlineData(Outcome.Undecided, Outcome.Undecided)]
+		public async Task Negate_ShouldForwardToInnerResult(Outcome innerOutcome, Outcome expectedAfterNegation)
+		{
+			ConstraintResult inner = new DummyConstraintResult<string>(innerOutcome, "value", "foo");
+			ConstraintResult sut = inner.PrependExpectationText(s => s.Append("bar"));
+
+			sut.Negate();
+
+			await That(inner.Outcome).IsEqualTo(expectedAfterNegation);
+			await That(sut.Outcome).IsEqualTo(expectedAfterNegation);
+		}
+
 		[Fact]
 		public async Task ShouldAppendAfterExpectationText()
 		{

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.ExpecationOnlyTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.ExpecationOnlyTests.cs
@@ -17,6 +17,21 @@ public partial class ConstraintResultTests
 			await That(sut.Outcome).IsEqualTo(Outcome.Success);
 		}
 
+
+		[Theory]
+		[InlineData(Outcome.Success)]
+		[InlineData(Outcome.Failure)]
+		[InlineData(Outcome.Undecided)]
+		public async Task SetOutcome_ShouldBeForwardedToInner(Outcome outcome)
+		{
+			MyExpectationOnlyConstraintResult<int> sut = new(
+				ExpectationGrammars.None, null, "negated-foo");
+
+			sut.SetOutcome(outcome);
+
+			await That(sut.Outcome).IsEqualTo(outcome);
+		}
+
 		[Fact]
 		public async Task TryGetValue_ShouldReturnFalse()
 		{
@@ -90,6 +105,15 @@ public partial class ConstraintResultTests
 
 			await That(expectationText).IsEmpty();
 			await That(resultText).IsEmpty();
+		}
+
+		private class MyExpectationOnlyConstraintResult<T>(
+			ExpectationGrammars grammars,
+			string? expectation = null,
+			string? negatedExpectation = null)
+			: ConstraintResult.ExpectationOnly<T>(grammars, expectation, negatedExpectation)
+		{
+			public void SetOutcome(Outcome outcome) => Outcome = outcome;
 		}
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.FromExceptionTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.FromExceptionTests.cs
@@ -1,0 +1,87 @@
+﻿using System.Text;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.Tests.TestHelpers;
+
+namespace aweXpect.Core.Tests.Core.Constraints;
+
+public partial class ConstraintResultTests
+{
+	public sealed class FromExceptionTests
+	{
+		[Fact]
+		public async Task AppendExpectation_ShouldUseInnerExpectation()
+		{
+			DummyConstraintResult inner = new(Outcome.Success, "foo");
+			Exception exception = new("bar");
+			DummyExpectationBuilder expectationBuilder = new();
+			ConstraintResult sut = new ConstraintResult.FromException(inner, exception, expectationBuilder);
+			StringBuilder sb = new();
+
+			sut.AppendExpectation(sb);
+
+			await That(sb.ToString()).IsEqualTo("foo");
+		}
+
+		[Fact]
+		public async Task AppendResult_Exception_ShouldAppendExpectedValue()
+		{
+			DummyConstraintResult inner = new(Outcome.Success, "foo");
+			Exception exception = new("bar");
+			DummyExpectationBuilder expectationBuilder = new();
+			ConstraintResult sut = new ConstraintResult.FromException(inner, exception, expectationBuilder);
+			StringBuilder sb = new();
+
+			sut.AppendResult(sb);
+
+			await That(sb.ToString()).IsEqualTo("it did throw an exception");
+		}
+
+		[Fact]
+		public async Task AppendResult_SpecificException_ShouldAppendExpectedValue()
+		{
+			DummyConstraintResult inner = new(Outcome.Success, "foo");
+			ArgumentException exception = new("bar");
+			DummyExpectationBuilder expectationBuilder = new();
+			ConstraintResult sut = new ConstraintResult.FromException(inner, exception, expectationBuilder);
+			StringBuilder sb = new();
+
+			sut.AppendResult(sb);
+
+			await That(sb.ToString()).IsEqualTo("it did throw an ArgumentException");
+		}
+
+		[Fact]
+		public async Task Outcome_ShouldBeFailure()
+		{
+			DummyConstraintResult inner = new(Outcome.Success, "foo");
+			Exception exception = new("bar");
+			DummyExpectationBuilder expectationBuilder = new();
+			ConstraintResult sut = new ConstraintResult.FromException(inner, exception, expectationBuilder);
+
+			await That(sut.Outcome).IsEqualTo(Outcome.Failure);
+		}
+
+
+		[Fact]
+		public async Task SetOutcome_ShouldBeForwardedToInner()
+		{
+			DummyConstraintResult inner = new(Outcome.Success, "foo");
+			Exception exception = new("bar");
+			DummyExpectationBuilder expectationBuilder = new();
+			MyFromExceptionConstraintResult sut = new(inner, exception, expectationBuilder);
+			sut.SetOutcome(Outcome.Undecided);
+
+			await That(sut.Outcome).IsEqualTo(Outcome.Failure);
+			await That(inner.Outcome).IsEqualTo(Outcome.Undecided);
+		}
+
+		private class MyFromExceptionConstraintResult(
+			ConstraintResult inner,
+			Exception exception,
+			ExpectationBuilder expectationBuilder)
+			: ConstraintResult.FromException(inner, exception, expectationBuilder)
+		{
+			public void SetOutcome(Outcome outcome) => Outcome = outcome;
+		}
+	}
+}

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyExpectationBuilder.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyExpectationBuilder.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading;
+using aweXpect.Core.Constraints;
+using aweXpect.Core.Nodes;
+using aweXpect.Core.TimeSystem;
+
+namespace aweXpect.Core.Tests.TestHelpers;
+
+public class DummyExpectationBuilder() : ExpectationBuilder("")
+{
+	internal override Task<ConstraintResult> IsMet(Node rootNode, EvaluationContext.EvaluationContext context,
+		ITimeSystem timeSystem, TimeSpan? timeout,
+		CancellationToken cancellationToken)
+		=> Task.FromResult<ConstraintResult>(new DummyConstraintResult(Outcome.Success));
+}


### PR DESCRIPTION
This PR fixes the negation behavior of wrapper `ConstraintResult` types in extension methods. The main issue was that when negating wrapped constraint results, the wrapper's outcome wasn't being updated to reflect the negated inner result's outcome.

### Key changes:
- Fixed negation in wrapper constraint result classes to properly update their own outcome after negating the inner result
- Renamed `ExceptionConstraintResult` to `FromException` for consistency
- Added comprehensive tests to verify negation behavior across different wrapper types