### PR TITLE
fix: Outcome of `OrConstraintResult`

### DIFF
--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -108,7 +108,20 @@ internal class AndNode : Node
 	private bool Equals(AndNode other) => Current.Equals(other.Current) && _nodes.SequenceEqual(other._nodes);
 
 	/// <inheritdoc cref="object.GetHashCode()" />
-	public override int GetHashCode() => Current.GetHashCode() ^ _nodes.GetHashCode();
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			// ReSharper disable once NonReadonlyMemberInGetHashCode
+			int hash = 19 * Current.GetHashCode();
+			foreach (Node node in _nodes.Select(x => x.Item2))
+			{
+				hash = (hash * 31) + node.GetHashCode();
+			}
+
+			return hash;
+		}
+	}
 
 	private static ConstraintResult CombineResults(
 		ConstraintResult? combinedResult,

--- a/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/ExpectationNode.cs
@@ -155,5 +155,9 @@ internal class ExpectationNode : Node
 	}
 
 	/// <inheritdoc cref="object.GetHashCode()" />
-	public override int GetHashCode() => GetType().GetHashCode();
+	// ReSharper disable NonReadonlyMemberInGetHashCode
+	public override int GetHashCode()
+		=> _constraint?.GetType().GetHashCode() ?? 17
+			+ _inner?.GetHashCode() ?? 0;
+	// ReSharper restore NonReadonlyMemberInGetHashCode
 }

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -102,7 +102,20 @@ internal class OrNode : Node
 	private bool Equals(OrNode other) => Current.Equals(other.Current) && _nodes.SequenceEqual(other._nodes);
 
 	/// <inheritdoc cref="object.GetHashCode()" />
-	public override int GetHashCode() => Current.GetHashCode() ^ _nodes.GetHashCode();
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			// ReSharper disable once NonReadonlyMemberInGetHashCode
+			int hash = 19 * Current.GetHashCode();
+			foreach (Node node in _nodes.Select(x => x.Item2))
+			{
+				hash = (hash * 31) + node.GetHashCode();
+			}
+
+			return hash;
+		}
+	}
 
 	private static ConstraintResult CombineResults(
 		ConstraintResult? combinedResult,
@@ -143,9 +156,9 @@ internal class OrNode : Node
 			=> (left, right) switch
 			{
 				(Outcome.Failure, Outcome.Failure) => Outcome.Failure,
-				(_, Outcome.Undecided) => Outcome.Undecided,
-				(Outcome.Undecided, _) => Outcome.Undecided,
-				(_, _) => Outcome.Success,
+				(_, Outcome.Success) => Outcome.Success,
+				(Outcome.Success, _) => Outcome.Success,
+				(_, _) => Outcome.Undecided,
 			};
 
 		public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)

--- a/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Adapters/TestFrameworkAdapterTests.cs
@@ -28,6 +28,16 @@ public sealed class TestFrameworkAdapterTests : IDisposable
 	}
 
 	[Fact]
+	public async Task Inconclusive_MissingAssemblyName_ShouldThrowNotSupportedException()
+	{
+		MyTestFrameworkAdapter adapter = new(MissingAssembly, skipException: new MyException());
+		_ = adapter.IsAvailable;
+
+		await That(() => adapter.Inconclusive("foo")).Throws<NotSupportedException>()
+			.WithMessage("Failed to create the inconclusive assertion type");
+	}
+
+	[Fact]
 	public async Task Inconclusive_ValidAssemblyName_ShouldThrowNotSupportedException()
 	{
 		MyTestFrameworkAdapter adapter = new(ExistingAssembly);

--- a/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.FromExceptionTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Constraints/ConstraintResultTests.FromExceptionTests.cs
@@ -50,6 +50,23 @@ public partial class ConstraintResultTests
 			await That(sb.ToString()).IsEqualTo("it did throw an ArgumentException");
 		}
 
+		[Theory]
+		[InlineData(Outcome.Failure, Outcome.Success)]
+		[InlineData(Outcome.Success, Outcome.Failure)]
+		[InlineData(Outcome.Undecided, Outcome.Undecided)]
+		public async Task Negate_ShouldNegateInnerOutcome(Outcome innerOutcome, Outcome expectedAfterNegation)
+		{
+			DummyConstraintResult inner = new(innerOutcome, "foo");
+			Exception exception = new("bar");
+			DummyExpectationBuilder expectationBuilder = new();
+			MyFromExceptionConstraintResult sut = new(inner, exception, expectationBuilder);
+
+			sut.Negate();
+
+			await That(sut.Outcome).IsEqualTo(Outcome.Failure);
+			await That(inner.Outcome).IsEqualTo(expectedAfterNegation);
+		}
+
 		[Fact]
 		public async Task Outcome_ShouldBeFailure()
 		{
@@ -60,7 +77,6 @@ public partial class ConstraintResultTests
 
 			await That(sut.Outcome).IsEqualTo(Outcome.Failure);
 		}
-
 
 		[Fact]
 		public async Task SetOutcome_ShouldBeForwardedToInner()

--- a/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ManualExpectationBuilderTests.cs
@@ -94,6 +94,16 @@ public class ManualExpectationBuilderTests
 	}
 
 	[Fact]
+	public async Task Equals_ObjectNull_ShouldBeFalse()
+	{
+		ManualExpectationBuilder<int> sut = new(null);
+
+		bool result = sut.Equals(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
 	public async Task Equals_SecondNull_ShouldBeFalse()
 	{
 		ManualExpectationBuilder<int> sut = new(null);
@@ -134,6 +144,18 @@ public class ManualExpectationBuilderTests
 		sut2.AddConstraint((_, _, _) => new DummyConstraint("foo"));
 
 		await That(sut1.GetHashCode()).IsEqualTo(sut2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task GetHashCode_WithParameter_ShouldUseHashCodeFromParameter()
+	{
+		ManualExpectationBuilder<int> sut1 = new(null);
+		sut1.AddConstraint((_, _, _) => new DummyConstraint("foo"));
+		ManualExpectationBuilder<int> sut2 = new(null);
+		sut2.ForWhich<int, int>(x => x)
+			.AddConstraint((_, _, _) => new DummyConstraint("foo"));
+
+		await That(sut1.GetHashCode()).IsEqualTo(sut2.GetHashCode(sut1));
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AndNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AndNodeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using System.Threading;
 using aweXpect.Core.Constraints;
+using aweXpect.Core.Helpers;
 using aweXpect.Core.Nodes;
 using aweXpect.Core.Tests.TestHelpers;
 
@@ -8,6 +9,81 @@ namespace aweXpect.Core.Tests.Core.Nodes;
 
 public sealed class AndNodeTests
 {
+	[Fact]
+	public async Task AddAsyncMapping_ShouldUseCurrentNode()
+	{
+		MemberAccessor<string, Task<int>> memberAccessor =
+			MemberAccessor<string, Task<int>>.FromExpression(x => Task.FromResult(x.Length));
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		AndNode node = new(first);
+
+		node.AddAsyncMapping(memberAccessor);
+		node.AddNode(second);
+
+		await That(first.MappingMemberAccessor).IsSameAs(memberAccessor);
+		await That(second.MappingMemberAccessor).IsNull();
+	}
+
+	[Fact]
+	public async Task AddAsyncMapping_ShouldUseSecondNode()
+	{
+		MemberAccessor<string, Task<int>> memberAccessor =
+			MemberAccessor<string, Task<int>>.FromExpression(x => Task.FromResult(x.Length));
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		AndNode node = new(first);
+		node.AddNode(second);
+
+		node.AddAsyncMapping(memberAccessor);
+
+		await That(first.MappingMemberAccessor).IsNull();
+		await That(second.MappingMemberAccessor).IsSameAs(memberAccessor);
+	}
+
+	[Fact]
+	public async Task AddMapping_ShouldUseCurrentNode()
+	{
+		MemberAccessor<string, int> memberAccessor = MemberAccessor<string, int>.FromExpression(x => x.Length);
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		AndNode node = new(first);
+
+		node.AddMapping(memberAccessor);
+		node.AddNode(second);
+
+		await That(first.MappingMemberAccessor).IsSameAs(memberAccessor);
+		await That(second.MappingMemberAccessor).IsNull();
+	}
+
+	[Fact]
+	public async Task AddMapping_ShouldUseSecondNode()
+	{
+		MemberAccessor<string, int> memberAccessor = MemberAccessor<string, int>.FromExpression(x => x.Length);
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		AndNode node = new(first);
+		node.AddNode(second);
+
+		node.AddMapping(memberAccessor);
+
+		await That(first.MappingMemberAccessor).IsNull();
+		await That(second.MappingMemberAccessor).IsSameAs(memberAccessor);
+	}
+
+	[Fact]
+	public async Task AppendExpectation_WithAdditionalNodes_ShouldUseAllNodes()
+	{
+		AndNode node = new(new DummyNode("foo"));
+		node.AddNode(new DummyNode("bar"));
+		node.AddNode(new DummyNode("baz"));
+		StringBuilder sb = new();
+
+		node.AppendExpectation(sb);
+
+		await That(sb.ToString()).IsEqualTo("foo and bar and baz");
+	}
+
 	[Fact]
 	public async Task AppendExpectation_WithoutAdditionalNodes_ShouldUseFirstNode()
 	{
@@ -17,6 +93,134 @@ public sealed class AndNodeTests
 		node.AppendExpectation(sb);
 
 		await That(sb.ToString()).IsEqualTo("foo");
+	}
+
+	[Fact]
+	public async Task Equals_IfCurrentNodeIsDifferent_ShouldBeFalse()
+	{
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		AndNode node1 = new(innerNode1);
+		AndNode node2 = new(innerNode2);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsFalse();
+		await That(node1.GetHashCode()).IsNotEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfCurrentNodeIsTheSame_ShouldBeTrue()
+	{
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		AndNode node1 = new(innerNode1);
+		AndNode node2 = new(innerNode2);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsTrue();
+		await That(node1.GetHashCode()).IsEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfInnerNodesAreDifferent_ShouldBeFalse()
+	{
+		DummyNode innerNode0 = new("0", () => new DummyConstraintResult<string?>(Outcome.Success, "0", ""));
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode currentNode = new("3", () => new DummyConstraintResult<string?>(Outcome.Success, "3", ""));
+		AndNode node1 = new(innerNode0);
+		node1.AddNode(innerNode1);
+		node1.AddNode(currentNode);
+		AndNode node2 = new(innerNode0);
+		node2.AddNode(innerNode2);
+		node2.AddNode(currentNode);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsFalse();
+		await That(node1.GetHashCode()).IsNotEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfInnerNodesAreSame_ShouldBeTrue()
+	{
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode3 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode innerNode4 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode currentNode = new("3", () => new DummyConstraintResult<string?>(Outcome.Success, "3", ""));
+		AndNode node1 = new(innerNode1);
+		node1.AddNode(innerNode3);
+		node1.AddNode(currentNode);
+		AndNode node2 = new(innerNode2);
+		node2.AddNode(innerNode4);
+		node2.AddNode(currentNode);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsTrue();
+		await That(node1.GetHashCode()).IsEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsDifferentNode_ShouldBeFalse()
+	{
+		DummyNode inner = new("foo");
+		AndNode node = new(inner);
+		object other = new OrNode(inner);
+
+		bool result = node.Equals(other);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsNull_ShouldBeFalse()
+	{
+		AndNode node = new(new DummyNode("foo"));
+
+		bool result = node.Equals(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Theory]
+	[InlineData(Outcome.Success, Outcome.Success, Outcome.Failure)]
+	[InlineData(Outcome.Failure, Outcome.Success, Outcome.Success)]
+	[InlineData(Outcome.Success, Outcome.Failure, Outcome.Success)]
+	[InlineData(Outcome.Failure, Outcome.Failure, Outcome.Success)]
+	[InlineData(Outcome.Failure, Outcome.Undecided, Outcome.Success)]
+	[InlineData(Outcome.Undecided, Outcome.Failure, Outcome.Success)]
+	[InlineData(Outcome.Undecided, Outcome.Undecided, Outcome.Undecided)]
+	public async Task NegatedOutcome_ShouldBeExpected(Outcome node1, Outcome node2, Outcome expectedOutcome)
+	{
+		AndNode node = new(new DummyNode("", () => new DummyConstraintResult(node1)));
+		node.AddNode(new DummyNode("", () => new DummyConstraintResult(node2)));
+
+		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
+		result.Negate();
+
+		await That(result.Outcome).IsEqualTo(expectedOutcome);
+	}
+
+	[Fact]
+	public async Task NegatedResult_ShouldUseOrAsSeparator()
+	{
+		AndNode node = new(new DummyNode("", () => new DummyConstraintResult(Outcome.Success, "foo")));
+		node.AddNode(new DummyNode("", () => new DummyConstraintResult(Outcome.Success, "bar")));
+		StringBuilder sb1 = new();
+		StringBuilder sb2 = new();
+
+		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
+		result.AppendExpectation(sb1);
+
+		result.Negate();
+
+		result.AppendExpectation(sb2);
+		await That(sb1.ToString()).IsEqualTo("foo and bar");
+		await That(sb2.ToString()).IsEqualTo("foo or bar");
 	}
 
 	[Theory]
@@ -35,6 +239,50 @@ public sealed class AndNodeTests
 		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
 
 		await That(result.Outcome).IsEqualTo(expectedOutcome);
+	}
+
+	[Fact]
+	public async Task SetReason_WithAdditionalNodes_ShouldUseCurrentNode()
+	{
+		DummyNode node1 = new("node1");
+		DummyNode node2 = new("node2");
+		DummyNode current = new("current");
+		AndNode node = new(node1);
+		node.AddNode(node2);
+		node.AddNode(current);
+
+		node.SetReason(new BecauseReason("bar"));
+
+		await That(current.ReceivedReason).IsEqualTo(", because bar");
+		await That(node1.ReceivedReason).IsNull();
+		await That(node2.ReceivedReason).IsNull();
+	}
+
+	[Fact]
+	public async Task SetReason_WithAdditionalNodes_WhenCurrentNodeIsEmptyExpectationNode_ShouldUseLastNode()
+	{
+		DummyNode node1 = new("node1");
+		DummyNode node2 = new("node2");
+		ExpectationNode current = new();
+		AndNode node = new(node1);
+		node.AddNode(node2);
+		node.AddNode(current);
+
+		node.SetReason(new BecauseReason("bar"));
+
+		await That(node1.ReceivedReason).IsNull();
+		await That(node2.ReceivedReason).IsEqualTo(", because bar");
+	}
+
+	[Fact]
+	public async Task SetReason_WithoutAdditionalNodes_ShouldSetReasonForCurrentNode()
+	{
+		DummyNode current = new("current");
+		AndNode node = new(current);
+
+		node.SetReason(new BecauseReason("bar"));
+
+		await That(current.ReceivedReason).IsEqualTo(", because bar");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/AsyncMappingNodeTests.cs
@@ -11,6 +11,58 @@ namespace aweXpect.Core.Tests.Core.Nodes;
 public class AsyncMappingNodeTests
 {
 	[Fact]
+	public async Task Equals_IfMemberAccessorsAreDifferent_ShouldBeFalse()
+	{
+		AsyncMappingNode<string, int> node1 = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length1 "));
+		AsyncMappingNode<string, int> node2 = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length2 "));
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsFalse();
+		await That(node1.GetHashCode()).IsNotEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfMemberAccessorsAreSame_ShouldBeTrue()
+	{
+		AsyncMappingNode<string, int> node1 = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "));
+		AsyncMappingNode<string, int> node2 = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "));
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsTrue();
+		await That(node1.GetHashCode()).IsEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsDifferentNode_ShouldBeFalse()
+	{
+		AsyncMappingNode<string, int> node = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "));
+		object other = new AsyncMappingNode<int, int>(
+			MemberAccessor<int, Task<int>>.FromFunc(s => Task.FromResult(s * 2), " duplicate "));
+
+		bool result = node.Equals(other);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsNull_ShouldBeFalse()
+	{
+		AsyncMappingNode<string, int> node = new(
+			MemberAccessor<string, Task<int>>.FromFunc(s => Task.FromResult(s.Length), " length "));
+
+		bool result = node.Equals(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
 	public async Task IsMetBy_ShouldUseInnerConstraintWithOuterValue()
 	{
 		AsyncMappingNode<string, int> node =

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/MappingNodeTests.cs
@@ -11,6 +11,55 @@ namespace aweXpect.Core.Tests.Core.Nodes;
 public class MappingNodeTests
 {
 	[Fact]
+	public async Task Equals_IfMemberAccessorsAreDifferent_ShouldBeFalse()
+	{
+		MappingNode<string, int> node1 = new(
+			MemberAccessor<string, int>.FromFunc(s => s.Length, " length1 "));
+		MappingNode<string, int> node2 = new(
+			MemberAccessor<string, int>.FromFunc(s => s.Length, " length2 "));
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsFalse();
+		await That(node1.GetHashCode()).IsNotEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfMemberAccessorsAreSame_ShouldBeTrue()
+	{
+		MappingNode<string, int> node1 = new(
+			MemberAccessor<string, int>.FromFunc(s => s.Length, " length "));
+		MappingNode<string, int> node2 = new(
+			MemberAccessor<string, int>.FromFunc(s => s.Length, " length "));
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsTrue();
+		await That(node1.GetHashCode()).IsEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsDifferentNode_ShouldBeFalse()
+	{
+		MappingNode<string, int> node = new(MemberAccessor<string, int>.FromFunc(s => s.Length, " length "));
+		object other = new MappingNode<int, int>(MemberAccessor<int, int>.FromFunc(s => s * 2, " duplicate "));
+
+		bool result = node.Equals(other);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsNull_ShouldBeFalse()
+	{
+		MappingNode<string, int> node = new(MemberAccessor<string, int>.FromFunc(s => s.Length, " length "));
+
+		bool result = node.Equals(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
 	public async Task IsMetBy_ShouldUseInnerConstraintWithOuterValue()
 	{
 		MappingNode<string, int> node = new(MemberAccessor<string, int>.FromFunc(s => s.Length, " length "));

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/OrNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/OrNodeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using System.Threading;
 using aweXpect.Core.Constraints;
+using aweXpect.Core.Helpers;
 using aweXpect.Core.Nodes;
 using aweXpect.Core.Tests.TestHelpers;
 
@@ -9,9 +10,84 @@ namespace aweXpect.Core.Tests.Core.Nodes;
 public sealed class OrNodeTests
 {
 	[Fact]
+	public async Task AddAsyncMapping_ShouldUseCurrentNode()
+	{
+		MemberAccessor<string, Task<int>> memberAccessor =
+			MemberAccessor<string, Task<int>>.FromExpression(x => Task.FromResult(x.Length));
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		OrNode node = new(first);
+
+		node.AddAsyncMapping(memberAccessor);
+		node.AddNode(second);
+
+		await That(first.MappingMemberAccessor).IsSameAs(memberAccessor);
+		await That(second.MappingMemberAccessor).IsNull();
+	}
+
+	[Fact]
+	public async Task AddAsyncMapping_ShouldUseSecondNode()
+	{
+		MemberAccessor<string, Task<int>> memberAccessor =
+			MemberAccessor<string, Task<int>>.FromExpression(x => Task.FromResult(x.Length));
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		OrNode node = new(first);
+		node.AddNode(second);
+
+		node.AddAsyncMapping(memberAccessor);
+
+		await That(first.MappingMemberAccessor).IsNull();
+		await That(second.MappingMemberAccessor).IsSameAs(memberAccessor);
+	}
+
+	[Fact]
+	public async Task AddMapping_ShouldUseCurrentNode()
+	{
+		MemberAccessor<string, int> memberAccessor = MemberAccessor<string, int>.FromExpression(x => x.Length);
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		OrNode node = new(first);
+
+		node.AddMapping(memberAccessor);
+		node.AddNode(second);
+
+		await That(first.MappingMemberAccessor).IsSameAs(memberAccessor);
+		await That(second.MappingMemberAccessor).IsNull();
+	}
+
+	[Fact]
+	public async Task AddMapping_ShouldUseSecondNode()
+	{
+		MemberAccessor<string, int> memberAccessor = MemberAccessor<string, int>.FromExpression(x => x.Length);
+		DummyNode first = new("foo");
+		DummyNode second = new("bar");
+		OrNode node = new(first);
+		node.AddNode(second);
+
+		node.AddMapping(memberAccessor);
+
+		await That(first.MappingMemberAccessor).IsNull();
+		await That(second.MappingMemberAccessor).IsSameAs(memberAccessor);
+	}
+
+	[Fact]
+	public async Task AppendExpectation_WithAdditionalNodes_ShouldUseAllNodes()
+	{
+		OrNode node = new(new DummyNode("foo"));
+		node.AddNode(new DummyNode("bar"));
+		node.AddNode(new DummyNode("baz"));
+		StringBuilder sb = new();
+
+		node.AppendExpectation(sb);
+
+		await That(sb.ToString()).IsEqualTo("foo or bar or baz");
+	}
+
+	[Fact]
 	public async Task AppendExpectation_WithoutAdditionalNodes_ShouldUseFirstNode()
 	{
-		AndNode node = new(new DummyNode("foo"));
+		OrNode node = new(new DummyNode("foo"));
 		StringBuilder sb = new();
 
 		node.AppendExpectation(sb);
@@ -19,11 +95,143 @@ public sealed class OrNodeTests
 		await That(sb.ToString()).IsEqualTo("foo");
 	}
 
+	[Fact]
+	public async Task Equals_IfCurrentNodeIsDifferent_ShouldBeFalse()
+	{
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		OrNode node1 = new(innerNode1);
+		OrNode node2 = new(innerNode2);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsFalse();
+		await That(node1.GetHashCode()).IsNotEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfCurrentNodeIsTheSame_ShouldBeTrue()
+	{
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		OrNode node1 = new(innerNode1);
+		OrNode node2 = new(innerNode2);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsTrue();
+		await That(node1.GetHashCode()).IsEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfInnerNodesAreDifferent_ShouldBeFalse()
+	{
+		DummyNode innerNode0 = new("0", () => new DummyConstraintResult<string?>(Outcome.Success, "0", ""));
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode currentNode = new("3", () => new DummyConstraintResult<string?>(Outcome.Success, "3", ""));
+		OrNode node1 = new(innerNode0);
+		node1.AddNode(innerNode1);
+		node1.AddNode(currentNode);
+		OrNode node2 = new(innerNode0);
+		node2.AddNode(innerNode2);
+		node2.AddNode(currentNode);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsFalse();
+		await That(node1.GetHashCode()).IsNotEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_IfInnerNodesAreSame_ShouldBeTrue()
+	{
+		DummyNode innerNode1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode2 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode innerNode3 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode innerNode4 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode currentNode = new("3", () => new DummyConstraintResult<string?>(Outcome.Success, "3", ""));
+		OrNode node1 = new(innerNode1);
+		node1.AddNode(innerNode3);
+		node1.AddNode(currentNode);
+		OrNode node2 = new(innerNode2);
+		node2.AddNode(innerNode4);
+		node2.AddNode(currentNode);
+
+		bool result = node1.Equals(node2);
+
+		await That(result).IsTrue();
+		await That(node1.GetHashCode()).IsEqualTo(node2.GetHashCode());
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsDifferentNode_ShouldBeFalse()
+	{
+		DummyNode inner = new("foo");
+		OrNode node = new(inner);
+		object other = new AndNode(inner);
+
+		bool result = node.Equals(other);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task Equals_WhenOtherIsNull_ShouldBeFalse()
+	{
+		OrNode node = new(new DummyNode("foo"));
+
+		bool result = node.Equals(null);
+
+		await That(result).IsFalse();
+	}
+
+	[Theory]
+	[InlineData(Outcome.Success, Outcome.Success, Outcome.Failure)]
+	[InlineData(Outcome.Failure, Outcome.Success, Outcome.Failure)]
+	[InlineData(Outcome.Success, Outcome.Failure, Outcome.Failure)]
+	[InlineData(Outcome.Failure, Outcome.Failure, Outcome.Success)]
+	[InlineData(Outcome.Success, Outcome.Undecided, Outcome.Failure)]
+	[InlineData(Outcome.Undecided, Outcome.Success, Outcome.Failure)]
+	[InlineData(Outcome.Failure, Outcome.Undecided, Outcome.Undecided)]
+	[InlineData(Outcome.Undecided, Outcome.Failure, Outcome.Undecided)]
+	[InlineData(Outcome.Undecided, Outcome.Undecided, Outcome.Undecided)]
+	public async Task NegatedOutcome_ShouldBeExpected(Outcome node1, Outcome node2, Outcome expectedOutcome)
+	{
+		OrNode node = new(new DummyNode("", () => new DummyConstraintResult(node1)));
+		node.AddNode(new DummyNode("", () => new DummyConstraintResult(node2)));
+
+		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
+		result.Negate();
+
+		await That(result.Outcome).IsEqualTo(expectedOutcome);
+	}
+
+	[Fact]
+	public async Task NegatedResult_ShouldUseAndAsSeparator()
+	{
+		OrNode node = new(new DummyNode("", () => new DummyConstraintResult(Outcome.Success, "foo")));
+		node.AddNode(new DummyNode("", () => new DummyConstraintResult(Outcome.Success, "bar")));
+		StringBuilder sb1 = new();
+		StringBuilder sb2 = new();
+
+		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
+		result.AppendExpectation(sb1);
+
+		result.Negate();
+
+		result.AppendExpectation(sb2);
+		await That(sb1.ToString()).IsEqualTo("foo or bar");
+		await That(sb2.ToString()).IsEqualTo("foo and bar");
+	}
+
 	[Theory]
 	[InlineData(Outcome.Success, Outcome.Success, Outcome.Success)]
 	[InlineData(Outcome.Failure, Outcome.Success, Outcome.Success)]
 	[InlineData(Outcome.Success, Outcome.Failure, Outcome.Success)]
 	[InlineData(Outcome.Failure, Outcome.Failure, Outcome.Failure)]
+	[InlineData(Outcome.Success, Outcome.Undecided, Outcome.Success)]
+	[InlineData(Outcome.Undecided, Outcome.Success, Outcome.Success)]
 	[InlineData(Outcome.Failure, Outcome.Undecided, Outcome.Undecided)]
 	[InlineData(Outcome.Undecided, Outcome.Failure, Outcome.Undecided)]
 	[InlineData(Outcome.Undecided, Outcome.Undecided, Outcome.Undecided)]
@@ -35,6 +243,50 @@ public sealed class OrNodeTests
 		ConstraintResult result = await node.IsMetBy(0, null!, CancellationToken.None);
 
 		await That(result.Outcome).IsEqualTo(expectedOutcome);
+	}
+
+	[Fact]
+	public async Task SetReason_WithAdditionalNodes_ShouldUseCurrentNode()
+	{
+		DummyNode node1 = new("node1");
+		DummyNode node2 = new("node2");
+		DummyNode current = new("current");
+		OrNode node = new(node1);
+		node.AddNode(node2);
+		node.AddNode(current);
+
+		node.SetReason(new BecauseReason("bar"));
+
+		await That(current.ReceivedReason).IsEqualTo(", because bar");
+		await That(node1.ReceivedReason).IsNull();
+		await That(node2.ReceivedReason).IsNull();
+	}
+
+	[Fact]
+	public async Task SetReason_WithAdditionalNodes_WhenCurrentNodeIsEmptyExpectationNode_ShouldUseLastNode()
+	{
+		DummyNode node1 = new("node1");
+		DummyNode node2 = new("node2");
+		ExpectationNode current = new();
+		OrNode node = new(node1);
+		node.AddNode(node2);
+		node.AddNode(current);
+
+		node.SetReason(new BecauseReason("bar"));
+
+		await That(node1.ReceivedReason).IsNull();
+		await That(node2.ReceivedReason).IsEqualTo(", because bar");
+	}
+
+	[Fact]
+	public async Task SetReason_WithoutAdditionalNodes_ShouldSetReasonForCurrentNode()
+	{
+		DummyNode current = new("current");
+		OrNode node = new(current);
+
+		node.SetReason(new BecauseReason("bar"));
+
+		await That(current.ReceivedReason).IsEqualTo(", because bar");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -136,8 +136,8 @@ public sealed class WhichNodeTests
 	[Fact]
 	public async Task Equals_IfInnerAreDifferent_ShouldBeFalse()
 	{
-		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
-		DummyNode node2 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode node1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode node2 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
 		WhichNode<string, int> whichNode1 = new(null, s => s.Length);
 		whichNode1.AddNode(node1);
 		WhichNode<string, int> whichNode2 = new(null, s => s.Length);
@@ -151,7 +151,7 @@ public sealed class WhichNodeTests
 	[Fact]
 	public async Task Equals_IfInnerAreSame_ShouldBeTrue()
 	{
-		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode node1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
 		WhichNode<string, int> whichNode1 = new(null, s => s.Length);
 		whichNode1.AddNode(node1);
 		WhichNode<string, int> whichNode2 = new(null, s => s.Length);
@@ -177,8 +177,8 @@ public sealed class WhichNodeTests
 	[Fact]
 	public async Task Equals_IfParentsAreDifferent_ShouldBeFalse()
 	{
-		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
-		DummyNode node2 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
+		DummyNode node1 = new("1", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		DummyNode node2 = new("2", () => new DummyConstraintResult<string?>(Outcome.Success, "2", ""));
 		WhichNode<string, int> whichNode1 = new(node1, s => s.Length);
 		WhichNode<string, int> whichNode2 = new(node2, s => s.Length);
 

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyConstraintResult.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyConstraintResult.cs
@@ -8,6 +8,7 @@ public sealed class DummyConstraintResult : ConstraintResult
 {
 	private readonly string? _expectationText;
 	private readonly string? _failureText;
+	private readonly object? _value;
 
 	public DummyConstraintResult(Outcome outcome,
 		string? expectationText = null,
@@ -18,6 +19,16 @@ public sealed class DummyConstraintResult : ConstraintResult
 		Outcome = outcome;
 		_expectationText = expectationText;
 		_failureText = failureText;
+	}
+
+	public DummyConstraintResult(object value,
+		Outcome outcome,
+		string? expectationText = null,
+		string? failureText = null,
+		FurtherProcessingStrategy furtherProcessingStrategy = FurtherProcessingStrategy.Continue)
+		: this(outcome, expectationText, failureText, furtherProcessingStrategy)
+	{
+		_value = value;
 	}
 
 	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
@@ -38,6 +49,12 @@ public sealed class DummyConstraintResult : ConstraintResult
 
 	public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
 	{
+		if (_value is TValue typedValue)
+		{
+			value = typedValue;
+			return true;
+		}
+
 		value = default;
 		return false;
 	}

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -9,7 +9,9 @@ namespace aweXpect.Core.Tests.TestHelpers;
 
 internal class DummyNode(string name, Func<ConstraintResult>? result = null) : Node
 {
+	private readonly string _name = name;
 	public MemberAccessor? MappingMemberAccessor { get; private set; }
+	public string? ReceivedReason { get; private set; }
 
 	public override void AddConstraint(IConstraint constraint)
 		=> throw new NotSupportedException();
@@ -45,8 +47,16 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 		=> result == null ? throw new NotSupportedException() : Task.FromResult(result());
 
 	public override void SetReason(BecauseReason becauseReason)
-		=> throw new NotSupportedException();
+		=> ReceivedReason = becauseReason.ToString();
 
 	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)
-		=> stringBuilder.Append(name);
+		=> stringBuilder.Append(_name);
+
+	/// <inheritdoc cref="object.Equals(object?)" />
+	public override bool Equals(object? obj) => obj is DummyNode other && Equals(other);
+
+	private bool Equals(DummyNode other) => _name == other._name;
+
+	/// <inheritdoc cref="object.GetHashCode()" />
+	public override int GetHashCode() => _name.GetHashCode();
 }


### PR DESCRIPTION
This PR fixes the outcome logic for `OrConstraintResult` by correcting the order of condition checks in the `Or` method. The fix ensures that `Success` outcomes properly short-circuit the evaluation, returning `Success` immediately when either operand is successful, which aligns with logical OR semantics.

### Key  changes:
- Corrected the `Or` method logic to prioritize `Success` outcomes over `Undecided`
- Enhanced test infrastructure with better equality implementations and value handling
- Added comprehensive test coverage for node equality, negation, and mapping behaviors