### PR TITLE
refactor!: Consolidate `StartsWith`/`EndsWith` and `AsPrefix`/`AsSuffix` for strings

### DIFF
--- a/Source/aweXpect.Core/Options/CollectionMatchOptions.cs
+++ b/Source/aweXpect.Core/Options/CollectionMatchOptions.cs
@@ -364,7 +364,7 @@ public partial class CollectionMatchOptions(
 	{
 		private readonly CancellationToken _cancellationToken;
 		private readonly IEvaluationContext _context;
-		internal readonly ManualExpectationBuilder<TItem> _itemExpectationBuilder;
+		internal readonly ManualExpectationBuilder<TItem> ItemExpectationBuilder;
 
 		/// <inheritdoc cref="ExpectationItem{TItem}" />
 		public ExpectationItem(Action<IThat<TItem>> expectation,
@@ -374,8 +374,8 @@ public partial class CollectionMatchOptions(
 		{
 			_context = context;
 			_cancellationToken = cancellationToken;
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, grammars);
-			expectation.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
+			ItemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, grammars);
+			expectation.Invoke(new ThatSubject<TItem>(ItemExpectationBuilder));
 		}
 
 		/// <summary>
@@ -387,7 +387,7 @@ public partial class CollectionMatchOptions(
 		public async Task<bool> IsMetBy(TItem value)
 #endif
 		{
-			ConstraintResult result = await _itemExpectationBuilder.IsMetBy(value, _context, _cancellationToken);
+			ConstraintResult result = await ItemExpectationBuilder.IsMetBy(value, _context, _cancellationToken);
 			return result.Outcome == Outcome.Success;
 		}
 
@@ -395,13 +395,13 @@ public partial class CollectionMatchOptions(
 		public override bool Equals(object? obj) => obj is ExpectationItem<TItem> other && Equals(other);
 
 		private bool Equals(ExpectationItem<TItem> other)
-			=> _itemExpectationBuilder.Equals(other._itemExpectationBuilder);
+			=> ItemExpectationBuilder.Equals(other.ItemExpectationBuilder);
 
 		/// <inheritdoc cref="object.GetHashCode()" />
-		public override int GetHashCode() => _itemExpectationBuilder.GetHashCode();
+		public override int GetHashCode() => ItemExpectationBuilder.GetHashCode();
 
 		/// <inheritdoc cref="object.ToString()" />
-		public override string ToString() => _itemExpectationBuilder.ToString();
+		public override string ToString() => ItemExpectationBuilder.ToString();
 	}
 
 	internal sealed class ExpectationItemEqualityComparer<TItem> : IEqualityComparer<ExpectationItem<TItem>>
@@ -423,9 +423,9 @@ public partial class CollectionMatchOptions(
 				return false;
 			}
 
-			return x._itemExpectationBuilder.Equals(y._itemExpectationBuilder);
+			return x.ItemExpectationBuilder.Equals(y.ItemExpectationBuilder);
 		}
 
-		public int GetHashCode(ExpectationItem<TItem> obj) => obj._itemExpectationBuilder.GetHashCode();
+		public int GetHashCode(ExpectationItem<TItem> obj) => obj.ItemExpectationBuilder.GetHashCode();
 	}
 }

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItemThat.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.HasItemThat.cs
@@ -51,7 +51,7 @@ public static partial class ThatAsyncEnumerable
 			_it = it;
 			_options = options;
 
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(_expectationBuilder, Grammars);
+			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, Grammars);
 			expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 		}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItemThat.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItemThat.cs
@@ -73,7 +73,7 @@ public static partial class ThatEnumerable
 			_it = it;
 			_options = options;
 
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(_expectationBuilder, Grammars);
+			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, Grammars);
 			expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 		}
 
@@ -189,7 +189,7 @@ public static partial class ThatEnumerable
 			_it = it;
 			_options = options;
 
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(_expectationBuilder, Grammars);
+			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, Grammars);
 			expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 		}
 

--- a/Source/aweXpect/That/Strings/ThatString.EndsWith.cs
+++ b/Source/aweXpect/That/Strings/ThatString.EndsWith.cs
@@ -13,14 +13,14 @@ public static partial class ThatString
 	/// <summary>
 	///     Verifies that the subject ends with the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityTypeResult<string?, IThat<string?>> EndsWith(
+	public static StringEqualityResult<string?, IThat<string?>> EndsWith(
 		this IThat<string?> source,
 		string expected)
 	{
-		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<string?, IThat<string?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint(it, grammars, expected, options)),
+		StringEqualityOptions options = new StringEqualityOptions().AsSuffix();
+		return new StringEqualityResult<string?, IThat<string?>>(
+			source.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars) =>
+				new IsEqualToConstraint(expectationBuilder, it, grammars, expected, options)),
 			source,
 			options);
 	}
@@ -28,14 +28,14 @@ public static partial class ThatString
 	/// <summary>
 	///     Verifies that the subject does not end with the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityTypeResult<string?, IThat<string?>> DoesNotEndWith(
+	public static StringEqualityResult<string?, IThat<string?>> DoesNotEndWith(
 		this IThat<string?> source,
 		string unexpected)
 	{
-		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<string?, IThat<string?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new EndsWithConstraint(it, grammars, unexpected, options).Invert()),
+		StringEqualityOptions options = new StringEqualityOptions().AsSuffix();
+		return new StringEqualityResult<string?, IThat<string?>>(
+			source.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars) =>
+				new IsEqualToConstraint(expectationBuilder, it, grammars, unexpected, options).Invert()),
 			source,
 			options);
 	}

--- a/Source/aweXpect/That/Strings/ThatString.StartsWith.cs
+++ b/Source/aweXpect/That/Strings/ThatString.StartsWith.cs
@@ -13,14 +13,14 @@ public static partial class ThatString
 	/// <summary>
 	///     Verifies that the subject starts with the <paramref name="expected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityTypeResult<string?, IThat<string?>> StartsWith(
+	public static StringEqualityResult<string?, IThat<string?>> StartsWith(
 		this IThat<string?> source,
 		string expected)
 	{
-		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<string?, IThat<string?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint(it, grammars, expected, options)),
+		StringEqualityOptions options = new StringEqualityOptions().AsPrefix();
+		return new StringEqualityResult<string?, IThat<string?>>(
+			source.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars) =>
+				new IsEqualToConstraint(expectationBuilder, it, grammars, expected, options)),
 			source,
 			options);
 	}
@@ -28,14 +28,14 @@ public static partial class ThatString
 	/// <summary>
 	///     Verifies that the subject does not start with the <paramref name="unexpected" /> <see langword="string" />.
 	/// </summary>
-	public static StringEqualityTypeResult<string?, IThat<string?>> DoesNotStartWith(
+	public static StringEqualityResult<string?, IThat<string?>> DoesNotStartWith(
 		this IThat<string?> source,
 		string unexpected)
 	{
-		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<string?, IThat<string?>>(
-			source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-				new StartsWithConstraint(it, grammars, unexpected, options).Invert()),
+		StringEqualityOptions options = new StringEqualityOptions().AsPrefix();
+		return new StringEqualityResult<string?, IThat<string?>>(
+			source.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars) =>
+				new IsEqualToConstraint(expectationBuilder, it, grammars, unexpected, options).Invert()),
 			source,
 			options);
 	}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1146,9 +1146,9 @@ namespace aweXpect
     {
         public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> Contains(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> DoesNotContain(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> DoesNotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> DoesNotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> EndsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> DoesNotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> DoesNotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> EndsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.PropertyResult.Int<string?> HasLength(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsEqualTo(this aweXpect.Core.IThat<string?> source, string? expected) { }
@@ -1172,7 +1172,7 @@ namespace aweXpect
         public static aweXpect.Results.IsParsableResult<TType> IsParsableInto<TType>(this aweXpect.Core.IThat<string?> source, System.IFormatProvider? formatProvider = null)
             where TType : System.IParsable<TType> { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsUpperCased(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
     }
     public static class ThatTimeOnly
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -1121,9 +1121,9 @@ namespace aweXpect
     {
         public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> Contains(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeCountResult<string?, aweXpect.Core.IThat<string?>> DoesNotContain(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> DoesNotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> DoesNotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> EndsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> DoesNotEndWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> DoesNotStartWith(this aweXpect.Core.IThat<string?> source, string unexpected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> EndsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
         public static aweXpect.Results.PropertyResult.Int<string?> HasLength(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsEmpty(this aweXpect.Core.IThat<string?> source) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsEqualTo(this aweXpect.Core.IThat<string?> source, string? expected) { }
@@ -1143,7 +1143,7 @@ namespace aweXpect
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, System.Collections.Generic.IEnumerable<string?> expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> IsOneOf(this aweXpect.Core.IThat<string?> source, params string?[] expected) { }
         public static aweXpect.Results.AndOrResult<string?, aweXpect.Core.IThat<string?>> IsUpperCased(this aweXpect.Core.IThat<string?> source) { }
-        public static aweXpect.Results.StringEqualityTypeResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityResult<string?, aweXpect.Core.IThat<string?>> StartsWith(this aweXpect.Core.IThat<string?> source, string expected) { }
     }
     public static class ThatTimeSpan
     {

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotEndWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotEndWith.Tests.cs
@@ -20,6 +20,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not end with "TEXT" ignoring case,
 					             but it was "some text"
+					             
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -51,6 +54,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not end with "tExt" using IgnoreCaseForVocalsComparer,
 					             but it was "some arbitrary text"
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -69,7 +75,7 @@ public sealed partial class ThatString
 			}
 
 			[Fact]
-			public async Task WhenExpectedIsNull_ShouldFail()
+			public async Task WhenExpectedIsNull_ShouldSucceed()
 			{
 				string subject = "text";
 				string? expected = null;
@@ -77,12 +83,7 @@ public sealed partial class ThatString
 				async Task Act()
 					=> await That(subject).DoesNotEndWith(expected!);
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not end with <null>,
-					             but "text" cannot be validated against <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -99,6 +100,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not end with "text",
 					             but it was "some text"
+					             
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -128,11 +132,14 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not end with "some text",
 					             but it was "some text"
+					             
+					             Actual:
+					             some text
 					             """);
 			}
 
 			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
+			public async Task WhenSubjectIsNull_ShouldSucceed()
 			{
 				string? subject = null;
 				string expected = "text";
@@ -140,12 +147,7 @@ public sealed partial class ThatString
 				async Task Act()
 					=> await That(subject).DoesNotEndWith(expected);
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not end with "text",
-					             but it was <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Strings/ThatString.DoesNotStartWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.DoesNotStartWith.Tests.cs
@@ -32,6 +32,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not start with "some",
 					             but it was "some text"
+					             
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -65,11 +68,14 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not start with "sOmE" using IgnoreCaseForVocalsComparer,
 					             but it was "some arbitrary text"
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
 			[Fact]
-			public async Task WhenExpectedIsNull_ShouldFail()
+			public async Task WhenExpectedIsNull_ShouldSucceed()
 			{
 				string subject = "text";
 				string? expected = null;
@@ -77,12 +83,7 @@ public sealed partial class ThatString
 				async Task Act()
 					=> await That(subject).DoesNotStartWith(expected!);
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not start with <null>,
-					             but "text" cannot be validated against <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -111,6 +112,9 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not start with "SOME" ignoring case,
 					             but it was "some text"
+					             
+					             Actual:
+					             some text
 					             """);
 			}
 
@@ -128,11 +132,14 @@ public sealed partial class ThatString
 					             Expected that subject
 					             does not start with "some text",
 					             but it was "some text"
+					             
+					             Actual:
+					             some text
 					             """);
 			}
 
 			[Fact]
-			public async Task WhenSubjectIsNull_ShouldFail()
+			public async Task WhenSubjectIsNull_ShouldSucceed()
 			{
 				string? subject = null;
 				string expected = "text";
@@ -140,12 +147,7 @@ public sealed partial class ThatString
 				async Task Act()
 					=> await That(subject).DoesNotStartWith(expected);
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not start with "text",
-					             but it was <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
@@ -14,7 +14,7 @@ public sealed partial class ThatString
 					bool ignoreCase)
 			{
 				string subject = "some arbitrary text";
-				string expected = "TEXT";
+				string expected = "Text";
 
 				async Task Act()
 					=> await That(subject).EndsWith(expected).IgnoringCase(ignoreCase);
@@ -23,8 +23,15 @@ public sealed partial class ThatString
 					.OnlyIf(!ignoreCase)
 					.WithMessage("""
 					             Expected that subject
-					             ends with "TEXT",
-					             but it was "some arbitrary text"
+					             ends with "Text",
+					             but it was "some arbitrary text" which differs at index 0:
+					                ↓ (actual)
+					               "some arbitrary text"
+					               "Text"
+					                ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -42,7 +49,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             ends with "SOME" ignoring case,
-					             but it was "some arbitrary text"
+					             but it was "some arbitrary text" which differs at index 4:
+					                    ↓ (actual)
+					               "some arbitrary text"
+					               "SOME"
+					                    ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -61,7 +75,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             ends with "TEXT" using IgnoreCaseForVocalsComparer,
-					             but it was "some arbitrary text"
+					             but it was "some arbitrary text" which differs at index 0:
+					                ↓ (actual)
+					               "some arbitrary text"
+					               "TEXT"
+					                ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -92,7 +113,10 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             ends with <null>,
-					             but "text" cannot be validated against <null>
+					             but it was "text"
+					             
+					             Actual:
+					             text
 					             """);
 			}
 
@@ -109,7 +133,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             ends with "some",
-					             but it was "some arbitrary text"
+					             but it was "some arbitrary text" which differs at index 4:
+					                    ↓ (actual)
+					               "some arbitrary text"
+					               "some"
+					                    ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -167,7 +198,11 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             ends with "text and more",
-					             but it was "text" and with length 4 is shorter than the expected length of 13
+					             but it was "text" with a length of 4 which is shorter than the expected length of 13 and misses:
+					               " and more"
+					             
+					             Actual:
+					             text
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Strings/ThatString.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.IsNotEqualTo.Tests.cs
@@ -7,13 +7,13 @@ public sealed partial class ThatString
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenActualAndUnunexpectedAreNull_ShouldSucceed()
+			public async Task WhenActualAndUnexpectedAreNull_ShouldSucceed()
 			{
 				string? subject = null;
-				string? ununexpected = null;
+				string? unexpected = null;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -27,22 +27,22 @@ public sealed partial class ThatString
 			public async Task WhenActualIsNull_ShouldSucceed()
 			{
 				string? subject = null;
-				string ununexpected = "some text";
+				string unexpected = "some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenUnunexpectedIsNull_ShouldSucceed()
+			public async Task WhenUnexpectedIsNull_ShouldSucceed()
 			{
 				string subject = "some text";
-				string? ununexpected = null;
+				string? unexpected = null;
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -51,10 +51,10 @@ public sealed partial class ThatString
 			public async Task WhenStringHasMissingLeadingWhitespace_ShouldSucceed()
 			{
 				string subject = "some text";
-				string ununexpected = " \t some text";
+				string unexpected = " \t some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -63,34 +63,34 @@ public sealed partial class ThatString
 			public async Task WhenStringHasMissingTrailingWhitespace_ShouldSucceed()
 			{
 				string subject = "some text";
-				string ununexpected = "some text \t ";
+				string unexpected = "some text \t ";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenStringHasUnunexpectedLeadingWhitespace_ShouldSucceed()
+			public async Task WhenStringHasUnexpectedLeadingWhitespace_ShouldSucceed()
 			{
 				string subject = " \t some text";
-				string ununexpected = "some text";
+				string unexpected = "some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenStringHasUnunexpectedTrailingWhitespace_ShouldSucceed()
+			public async Task WhenStringHasUnexpectedTrailingWhitespace_ShouldSucceed()
 			{
 				string subject = "some text \t ";
-				string ununexpected = "some text";
+				string unexpected = "some text";
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(ununexpected);
+					=> await That(subject).IsNotEqualTo(unexpected);
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
@@ -13,7 +13,7 @@ public sealed partial class ThatString
 				IgnoringCase_WhenSubjectStartsWithDifferentCase_ShouldFailUnlessCaseIsIgnored(
 					bool ignoreCase)
 			{
-				string subject = "some arbitrary text";
+				string subject = "Some arbitrary text";
 				string expected = "SOME";
 
 				async Task Act()
@@ -25,7 +25,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             starts with "SOME",
-					             but it was "some arbitrary text"
+					             but it was "Some arbitrary text" which differs at index 1:
+					                 ↓ (actual)
+					               "Some arbitrary text"
+					               "SOME"
+					                 ↑ (expected)
+					             
+					             Actual:
+					             Some arbitrary text
 					             """);
 			}
 
@@ -43,7 +50,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             starts with "TEXT" ignoring case,
-					             but it was "some arbitrary text"
+					             but it was "some arbitrary text" which differs at index 0:
+					                ↓ (actual)
+					               "some arbitrary text"
+					               "TEXT"
+					                ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -62,7 +76,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             starts with "SOME" using IgnoreCaseForVocalsComparer,
-					             but it was "some arbitrary text"
+					             but it was "some arbitrary text" which differs at index 0:
+					                ↓ (actual)
+					               "some arbitrary text"
+					               "SOME"
+					                ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -93,7 +114,10 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             starts with <null>,
-					             but "text" cannot be validated against <null>
+					             but it was "text"
+					             
+					             Actual:
+					             text
 					             """);
 			}
 
@@ -110,7 +134,14 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             starts with "text",
-					             but it was "some arbitrary text"
+					             but it was "some arbitrary text" which differs at index 0:
+					                ↓ (actual)
+					               "some arbitrary text"
+					               "text"
+					                ↑ (expected)
+					             
+					             Actual:
+					             some arbitrary text
 					             """);
 			}
 
@@ -156,7 +187,11 @@ public sealed partial class ThatString
 					.WithMessage("""
 					             Expected that subject
 					             starts with "text and more",
-					             but it was "text" and with length 4 is shorter than the expected length of 13
+					             but it was "text" with a length of 4 which is shorter than the expected length of 13 and misses:
+					               " and more"
+					             
+					             Actual:
+					             text
 					             """);
 			}
 


### PR DESCRIPTION
This PR consolidates the `StartsWith`/`EndsWith` string assertion methods with the existing `AsPrefix`/`AsSuffix` functionality by refactoring them to use a unified `IsEqualToConstraint` approach instead of separate constraint implementations. The change is marked as breaking (`refactor!:`), because the return type was incorrectly set to `StringEqualityTypeResult` and is now fixed.

### Key changes:
- Replaces `StartsWithConstraint` and `EndsWithConstraint` with `IsEqualToConstraint` using prefix/suffix options
- Updates method return types from `StringEqualityTypeResult` to `StringEqualityResult`
- Improves error messages to show detailed diff information and actual values

---

- *Part of the implementation for #702*