### PR TITLE
chore: update aweXpect.Core to v2.21.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.22.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.21.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.21.1" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.22.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.20.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.21.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 


### PR DESCRIPTION
This PR updates the aweXpect.Core package version from v2.20.0 to v2.21.1 and restores the build scope to its default configuration. The changes indicate completion of a breaking change cycle in the core library.

### Key changes:
- Updated aweXpect.Core package version to v2.21.1
- Reset build scope from CoreOnly back to Default to enable full solution builds