### PR TITLE
fix: newline in `StringDifference`

### DIFF
--- a/Source/aweXpect.Core/Core/StringDifference.cs
+++ b/Source/aweXpect.Core/Core/StringDifference.cs
@@ -72,7 +72,7 @@ public sealed class StringDifference(
 			return 0;
 		}
 
-		_indexOfFirstMismatch ??= GetIndexOfFirstMismatch(actual, expected, _comparer, fromEnd: matchType is MatchType.Suffix);
+		_indexOfFirstMismatch ??= GetIndexOfFirstMismatch(actual, expected, _comparer, matchType is MatchType.Suffix);
 		return _indexOfFirstMismatch.Value;
 	}
 
@@ -136,10 +136,9 @@ public sealed class StringDifference(
 			if (settings?.MatchType == MatchType.Suffix &&
 			    actual.Length < expected.Length)
 			{
-				return $"""
-				        is shorter than the expected length of {expected.Length} and misses the prefix:
-				          "{expected[..^actual.Length].DisplayWhitespace()}"
-				        """;
+				return
+					$"is shorter than the expected length of {expected.Length} and misses the prefix:{Environment.NewLine}" +
+					$"  \"{expected[..^actual.Length].DisplayWhitespace()}\"";
 			}
 
 			return prefix;


### PR DESCRIPTION
This PR fixes newline handling in the `StringDifference` class by replacing a raw string literal with explicit `Environment.NewLine` concatenation. This ensures consistent line ending behavior across different platforms.

### Key changes:
- Replaces raw string literal with explicit newline handling for cross-platform compatibility