### PR TITLE
refactor: remove core mutation tests only on `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,31 @@ jobs:
                         ./Artifacts/*
                         ./TestResults/*.trx
     
+    mutation-tests-core:
+        name: "Mutation tests (aweXpect.Core)"
+        runs-on: ubuntu-latest
+        env:
+            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+            DOTNET_NOLOGO: true
+        steps:
+            -   uses: actions/checkout@v5
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+            -   name: Run mutation tests
+                run: ./build.sh MutationTestsCore
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: MutationTestsCore
+                    path: |
+                        ./Artifacts/*
+    
     mutation-tests-main:
         name: "Mutation tests (aweXpect)"
         runs-on: ubuntu-latest
@@ -91,7 +116,7 @@ jobs:
     
     mutation-tests-dashboard:
         name: "Mutation tests Dashboard"
-        needs: [ mutation-tests-main ]
+        needs: [ mutation-tests-main, mutation-tests-core ]
         runs-on: ubuntu-latest
         env:
             STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}


### PR DESCRIPTION
After #766 only remove the core mutation tests on builds on the `main` branch