### PR TITLE
fix: branch detection in Nuke pipeline

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -28,7 +28,7 @@ partial class Build
 	Target MutationTestsCore => _ => _
 		.DependsOn(Compile)
 		.OnlyWhenDynamic(() => BuildScope == BuildScope.Default)
-		.OnlyWhenDynamic(() => BranchName != "main")
+		.OnlyWhenDynamic(() => Repository.Branch != "main")
 		.Executes(() =>
 		{
 			ExecuteMutationTest(Solution.aweXpect_Core,
@@ -121,7 +121,7 @@ partial class Build
 			await "MutationTestsMain".DownloadArtifactTo(ArtifactsDirectory / "aweXpect", GithubToken);
 
 			Dictionary<Project, Project[]> projects;
-			if (BranchName != "main")
+			if (Repository.Branch != "main")
 			{
 				projects = new Dictionary<Project, Project[]>
 				{

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -1,5 +1,6 @@
 using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 
@@ -22,6 +23,7 @@ partial class Build : NukeBuild
 	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
+	[GitRepository] readonly GitRepository Repository;
 
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 


### PR DESCRIPTION
This PR fixes branch detection in the NUKE build pipeline by replacing the deprecated `BranchName` property with the [Repository Insights](https://nuke.build/docs/common/repository/) approach. The change uses the `[GitRepository]` attribute to get a `GitRepository` instance and accesses the branch name through its `Branch` property.

### Key Changes
- Adds `GitRepository` dependency injection using the `[GitRepository]` attribute
- Replaces all `BranchName` references with `Repository.Branch` for branch detection