### PR TITLE
refactor: also remove core mutation tests on tags

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -28,7 +28,7 @@ partial class Build
 	Target MutationTestsCore => _ => _
 		.DependsOn(Compile)
 		.OnlyWhenDynamic(() => BuildScope == BuildScope.Default)
-		.OnlyWhenDynamic(() => Repository.Branch != "main")
+		.OnlyWhenDynamic(() => Repository.Branch != "main" && Repository.Tags.Count == 0)
 		.Executes(() =>
 		{
 			ExecuteMutationTest(Solution.aweXpect_Core,
@@ -121,7 +121,7 @@ partial class Build
 			await "MutationTestsMain".DownloadArtifactTo(ArtifactsDirectory / "aweXpect", GithubToken);
 
 			Dictionary<Project, Project[]> projects;
-			if (Repository.Branch != "main")
+			if (Repository.Branch != "main" && Repository.Tags.Count == 0)
 			{
 				projects = new Dictionary<Project, Project[]>
 				{


### PR DESCRIPTION
Improving on #768, this refactor updates the mutation testing conditions to also exclude builds when Git tags are present, extending the existing exclusion for the main branch. This prevents mutation tests from running on tagged releases in addition to the main branch.

### Key changes:
- Updates mutation test execution conditions to check for both main branch and presence of Git tags
- Applies the same logic to both core mutation tests and mutation test reporting