### PR TITLE
docs: Add GitHub sponsor username to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [vbreuss]


### PR DESCRIPTION
This PR adds GitHub Sponsors funding configuration to enable sponsorship for the repository. The change adds a single GitHub sponsor username to the FUNDING.yml file, which will display sponsorship options on the repository's main page.

- Adds GitHub Sponsors configuration file