### PR TITLE
fix: download large benchmarks file

### DIFF
--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -210,7 +210,7 @@ partial class Build
 		var contentStream = await client.GetStreamAsync(
 			$"https://raw.githubusercontent.com/aweXpect/aweXpect/refs/heads/{BenchmarkBranch}/Docs/pages/static/js/{filename}");
 		using StreamReader reader = new(contentStream, Encoding.UTF8);
-		string content = reader.ReadToEnd();
+		string content = await reader.ReadToEndAsync();
 		string sha = document.RootElement.GetProperty("sha").GetString();
 		return new BenchmarkFile(content, sha);
 	}

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -207,7 +207,10 @@ partial class Build
 		}
 
 		using JsonDocument document = JsonDocument.Parse(responseContent);
-		string content = Base64Decode(document.RootElement.GetProperty("content").GetString());
+		var contentStream = await client.GetStreamAsync(
+			$"https://raw.githubusercontent.com/aweXpect/aweXpect/refs/heads/{BenchmarkBranch}/Docs/pages/static/js/{filename}");
+		using StreamReader reader = new(contentStream, Encoding.UTF8);
+		string content = reader.ReadToEnd();
 		string sha = document.RootElement.GetProperty("sha").GetString();
 		return new BenchmarkFile(content, sha);
 	}


### PR DESCRIPTION
This PR fixes an issue with downloading large benchmark files by switching from GitHub's Contents API to direct raw file downloads. The GitHub Contents API has size limitations that were preventing proper retrieval of large benchmark files.