### PR TITLE
chore: bump aweXpect

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.22.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.21.1" />
+		<PackageVersion Include="aweXpect" Version="2.23.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.21.2" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
This PR updates the aweXpect library versions in the centralized package management configuration, bumping the main aweXpect package from version 2.22.0 to 2.23.0 and aweXpect.Core from version 2.21.1 to 2.21.2.

- Updated aweXpect package version to 2.23.0
- Updated aweXpect.Core package version to 2.21.2