### PR TITLE
feat: add expectations on `Uri`

### DIFF
--- a/Source/aweXpect.SourceGenerators/ExpectationGenerator.cs
+++ b/Source/aweXpect.SourceGenerators/ExpectationGenerator.cs
@@ -104,14 +104,23 @@ public class ExpectationGenerator : IIncrementalGenerator
 		}
 
 		string? outcomeMethod = null;
-		string? name = null;
+		string? positiveName = null;
+		string? negativeName = null;
 		if (attributeData.ConstructorArguments.Length == 2)
 		{
-			name = attributeData.ConstructorArguments[0].Value?.ToString();
+			var name = attributeData.ConstructorArguments[0].Value?.ToString();
+			positiveName = name?.Replace("{Not}", "");
+			negativeName = name?.Replace("{Not}", "Not");
 			outcomeMethod = attributeData.ConstructorArguments[1].Value?.ToString();
 		}
+		else if (attributeData.ConstructorArguments.Length == 3)
+		{
+			positiveName = attributeData.ConstructorArguments[0].Value?.ToString();
+			negativeName = attributeData.ConstructorArguments[1].Value?.ToString();
+			outcomeMethod = attributeData.ConstructorArguments[2].Value?.ToString();
+		}
 
-		if (outcomeMethod == null || name == null)
+		if (outcomeMethod == null || positiveName == null)
 		{
 			return null;
 		}
@@ -125,7 +134,8 @@ public class ExpectationGenerator : IIncrementalGenerator
 			containingNamespace,
 			classSymbol.Name,
 			targetType,
-			name,
+			positiveName,
+			negativeName,
 			outcomeMethod,
 			attributeData);
 	}

--- a/Source/aweXpect.SourceGenerators/Helpers/SourceGenerationHelper.cs
+++ b/Source/aweXpect.SourceGenerators/Helpers/SourceGenerationHelper.cs
@@ -16,17 +16,32 @@ internal static class SourceGenerationHelper
 		[System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
 		internal class CreateExpectationOnAttribute<TTarget> : System.Attribute
 		{
-		    public CreateExpectationOnAttribute(string methodName, string name)
+		    public CreateExpectationOnAttribute(string name, string outcomeMethod)
 		    {
 		        TargetType = typeof(TTarget);
-		        MethodName = methodName;
-		        Name = name;
+		        PositiveName = name.Replace("{Not}", "");
+		        if (name.Contains("{Not}"))
+		        {
+		            NegativeName = name.Replace("{Not}", "Not");
+		        }
+		        OutcomeMethod = outcomeMethod;
+		    }
+		    
+		    public CreateExpectationOnAttribute(string positiveName, string negativeName, string outcomeMethod)
+		    {
+		        TargetType = typeof(TTarget);
+		        PositiveName = positiveName;
+		        NegativeName = negativeName;
+		        OutcomeMethod = outcomeMethod;
 		    }
 
 		    public Type TargetType { get; }
-		    public string MethodName { get; }
-		    public string Name { get; set; }
+		    public string PositiveName { get; }
+		    public string? NegativeName { get; }
+		    public string OutcomeMethod { get; set; }
 		    public string? ExpectationText { get; set; }
+		    public string? PositiveExpectationText { get; set; }
+		    public string? NegativeExpectationText { get; set; }
 		    public string? Remarks { get; set; }
 		    public string[] Using { get; set; } = [];
 		}
@@ -113,7 +128,7 @@ internal static class SourceGenerationHelper
 			            		public ConstraintResult IsMetBy({{expectationToGenerate.TargetType}} actual)
 			            		{
 			            			Actual = actual;
-			            			Outcome = actual is not null && {{expectationToGenerate.OutcomeMethod.Replace("{value}", "actual.Value")}} ? Outcome.Success : Outcome.Failure;
+			            			Outcome = actual is not null && {{expectationToGenerate.OutcomeMethod.Replace("{value}", "actual")}} ? Outcome.Success : Outcome.Failure;
 			            			return this;
 			            		}
 			            	

--- a/Source/aweXpect.SourceGenerators/Helpers/SourceGenerationHelper.cs
+++ b/Source/aweXpect.SourceGenerators/Helpers/SourceGenerationHelper.cs
@@ -16,34 +16,34 @@ internal static class SourceGenerationHelper
 		[System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
 		internal class CreateExpectationOnAttribute<TTarget> : System.Attribute
 		{
-		    public CreateExpectationOnAttribute(string name, string outcomeMethod)
-		    {
-		        TargetType = typeof(TTarget);
-		        PositiveName = name.Replace("{Not}", "");
-		        if (name.Contains("{Not}"))
-		        {
-		            NegativeName = name.Replace("{Not}", "Not");
-		        }
-		        OutcomeMethod = outcomeMethod;
-		    }
-		    
-		    public CreateExpectationOnAttribute(string positiveName, string negativeName, string outcomeMethod)
-		    {
-		        TargetType = typeof(TTarget);
-		        PositiveName = positiveName;
-		        NegativeName = negativeName;
-		        OutcomeMethod = outcomeMethod;
-		    }
+			public CreateExpectationOnAttribute(string name, string outcomeMethod)
+			{
+				TargetType = typeof(TTarget);
+				PositiveName = name.Replace("{Not}", "");
+				if (name.Contains("{Not}"))
+				{
+					NegativeName = name.Replace("{Not}", "Not");
+				}
+				OutcomeMethod = outcomeMethod;
+			}
+			
+			public CreateExpectationOnAttribute(string positiveName, string negativeName, string outcomeMethod)
+			{
+				TargetType = typeof(TTarget);
+				PositiveName = positiveName;
+				NegativeName = negativeName;
+				OutcomeMethod = outcomeMethod;
+			}
 
-		    public Type TargetType { get; }
-		    public string PositiveName { get; }
-		    public string? NegativeName { get; }
-		    public string OutcomeMethod { get; set; }
-		    public string? ExpectationText { get; set; }
-		    public string? PositiveExpectationText { get; set; }
-		    public string? NegativeExpectationText { get; set; }
-		    public string? Remarks { get; set; }
-		    public string[] Using { get; set; } = [];
+			public Type TargetType { get; }
+			public string PositiveName { get; }
+			public string? NegativeName { get; }
+			public string OutcomeMethod { get; set; }
+			public string? ExpectationText { get; set; }
+			public string? PositiveExpectationText { get; set; }
+			public string? NegativeExpectationText { get; set; }
+			public string? Remarks { get; set; }
+			public string[] Using { get; set; } = [];
 		}
 		#nullable disable
 		""";
@@ -62,19 +62,34 @@ internal static class SourceGenerationHelper
 		[System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
 		internal class CreateExpectationOnNullableAttribute<TTarget> : System.Attribute
 		{
-		    public CreateExpectationOnNullableAttribute(string methodName, string name)
-		    {
-		        TargetType = typeof(TTarget);
-		        MethodName = methodName;
-		        Name = name;
-		    }
-
-		    public Type TargetType { get; }
-		    public string MethodName { get; }
-		    public string Name { get; set; }
-		    public string? ExpectationText { get; set; }
-		    public string? Remarks { get; set; }
-		    public string[] Using { get; set; } = [];
+			public CreateExpectationOnNullableAttribute(string name, string outcomeMethod)
+			{
+				TargetType = typeof(TTarget);
+				PositiveName = name.Replace("{Not}", "");
+				if (name.Contains("{Not}"))
+				{
+					NegativeName = name.Replace("{Not}", "Not");
+				}
+				OutcomeMethod = outcomeMethod;
+			}
+			
+			public CreateExpectationOnNullableAttribute(string positiveName, string negativeName, string outcomeMethod)
+			{
+				TargetType = typeof(TTarget);
+				PositiveName = positiveName;
+				NegativeName = negativeName;
+				OutcomeMethod = outcomeMethod;
+			}
+			
+			public Type TargetType { get; }
+			public string PositiveName { get; }
+			public string? NegativeName { get; }
+			public string OutcomeMethod { get; set; }
+			public string? ExpectationText { get; set; }
+			public string? PositiveExpectationText { get; set; }
+			public string? NegativeExpectationText { get; set; }
+			public string? Remarks { get; set; }
+			public string[] Using { get; set; } = [];
 		}
 		#nullable disable
 		""";
@@ -93,26 +108,26 @@ internal static class SourceGenerationHelper
 		                  #nullable enable
 		                  public static partial class {{expectationToGenerate.ClassName}}
 		                  {
-		                      /// <summary>
-		                      ///     Verifies that the subject {{expectationToGenerate.ExpectationText}}.
-		                      /// </summary>{{expectationToGenerate.AppendRemarks()}}
-		                      public static AndOrResult<{{expectationToGenerate.TargetType}}, IThat<{{expectationToGenerate.TargetType}}>> {{expectationToGenerate.Name}}(this IThat<{{expectationToGenerate.TargetType}}> source)
-		                      	=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-		                      			new {{expectationToGenerate.Name}}Constraint(it, grammars)),
-		                      		source);
+		                  	/// <summary>
+		                  	///     Verifies that the subject {{expectationToGenerate.ExpectationText}}.
+		                  	/// </summary>{{expectationToGenerate.AppendRemarks()}}
+		                  	public static AndOrResult<{{expectationToGenerate.TargetType}}, IThat<{{expectationToGenerate.TargetType}}>> {{expectationToGenerate.Name}}(this IThat<{{expectationToGenerate.TargetType}}> source)
+		                  		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+		                  			new {{expectationToGenerate.Name}}Constraint(it, grammars)),
+		                  		source);
 
 
 		                  """;
 		if (expectationToGenerate.IncludeNegated)
 		{
 			result += $$"""
-			                /// <summary>
-			                ///     Verifies that the subject {{expectationToGenerate.NegatedExpectationText}}.
-			                /// </summary>{{expectationToGenerate.AppendRemarks()}}
-			                public static AndOrResult<{{expectationToGenerate.TargetType}}, IThat<{{expectationToGenerate.TargetType}}>> {{expectationToGenerate.NegatedName}}(this IThat<{{expectationToGenerate.TargetType}}> source)
-			                	=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
-			                			new {{expectationToGenerate.Name}}Constraint(it, grammars).Invert()),
-			                		source);
+			            	/// <summary>
+			            	///     Verifies that the subject {{expectationToGenerate.NegatedExpectationText}}.
+			            	/// </summary>{{expectationToGenerate.AppendRemarks()}}
+			            	public static AndOrResult<{{expectationToGenerate.TargetType}}, IThat<{{expectationToGenerate.TargetType}}>> {{expectationToGenerate.NegatedName}}(this IThat<{{expectationToGenerate.TargetType}}> source)
+			            		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+			            			new {{expectationToGenerate.Name}}Constraint(it, grammars).Invert()),
+			            		source);
 
 
 			            """;

--- a/Source/aweXpect/That/Chars/ThatNullableChar.IsALetter.cs
+++ b/Source/aweXpect/That/Chars/ThatNullableChar.IsALetter.cs
@@ -6,7 +6,7 @@ using aweXpect.SourceGenerators;
 
 namespace aweXpect;
 
-[CreateExpectationOnNullable<char>("Is{Not}ALetter", "char.IsLetter({value})",
+[CreateExpectationOnNullable<char>("Is{Not}ALetter", "char.IsLetter({value}.Value)",
 	ExpectationText = "is {not} a letter",
 	Remarks = """
 	          This means, that the specified Unicode character is categorized as a Unicode letter.<br />

--- a/Source/aweXpect/That/Chars/ThatNullableChar.IsANumber.cs
+++ b/Source/aweXpect/That/Chars/ThatNullableChar.IsANumber.cs
@@ -6,7 +6,7 @@ using aweXpect.SourceGenerators;
 
 namespace aweXpect;
 
-[CreateExpectationOnNullable<char>("Is{Not}ANumber", "char.IsNumber({value})",
+[CreateExpectationOnNullable<char>("Is{Not}ANumber", "char.IsNumber({value}.Value)",
 	ExpectationText = "is {not} a number",
 	Remarks = """
 	          This means, that the specified Unicode character is categorized as a number.<br />

--- a/Source/aweXpect/That/Chars/ThatNullableChar.IsAnAsciiLetter.cs
+++ b/Source/aweXpect/That/Chars/ThatNullableChar.IsAnAsciiLetter.cs
@@ -7,7 +7,7 @@ using aweXpect.SourceGenerators;
 namespace aweXpect;
 
 #if NET8_0_OR_GREATER
-[CreateExpectationOnNullable<char>("Is{Not}AnAsciiLetter", "char.IsAsciiLetter({value})",
+[CreateExpectationOnNullable<char>("Is{Not}AnAsciiLetter", "char.IsAsciiLetter({value}.Value)",
 	ExpectationText = "is {not} an ASCII letter",
 	Remarks = """
 	          This means, that the specified Unicode character is categorized as an ASCII letter.<br />
@@ -15,7 +15,7 @@ namespace aweXpect;
 	          """
 )]
 #else
-[CreateExpectationOnNullable<char>("Is{Not}AnAsciiLetter", "{value} is >= 'a' and <= 'z' or >= 'A' and <= 'Z'",
+[CreateExpectationOnNullable<char>("Is{Not}AnAsciiLetter", "{value}.Value is >= 'a' and <= 'z' or >= 'A' and <= 'Z'",
 	ExpectationText = "is {not} an ASCII letter"
 )]
 #endif

--- a/Source/aweXpect/That/Chars/ThatNullableChar.IsWhiteSpace.cs
+++ b/Source/aweXpect/That/Chars/ThatNullableChar.IsWhiteSpace.cs
@@ -6,7 +6,7 @@ using aweXpect.SourceGenerators;
 
 namespace aweXpect;
 
-[CreateExpectationOnNullable<char>("Is{Not}WhiteSpace", "char.IsWhiteSpace({value})",
+[CreateExpectationOnNullable<char>("Is{Not}WhiteSpace", "char.IsWhiteSpace({value}.Value)",
 	ExpectationText = "is {not} white-space",
 	Remarks = """
 	          This means, that the specified Unicode character is categorized as white-space.<br />

--- a/Source/aweXpect/That/Uris/ThatUri.HasDefaultPort.cs
+++ b/Source/aweXpect/That/Uris/ThatUri.HasDefaultPort.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using aweXpect.SourceGenerators;
+
+namespace aweXpect;
+
+[CreateExpectationOn<Uri>("HasDefaultPort", "DoesNotHaveDefaultPort", "{value}.IsDefaultPort",
+	PositiveExpectationText = "has the default port for the used scheme",
+	NegativeExpectationText = "does not have the default port for the used scheme",
+	Using = ["System",],
+	Remarks = """
+	          <seealso cref="Uri.IsDefaultPort" />
+	          """
+)]
+public static partial class ThatUri;

--- a/Source/aweXpect/That/Uris/ThatUri.IsAbsolute.cs
+++ b/Source/aweXpect/That/Uris/ThatUri.IsAbsolute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using aweXpect.SourceGenerators;
+
+namespace aweXpect;
+
+[CreateExpectationOn<Uri>("Is{Not}Absolute", "{value}.IsAbsoluteUri",
+	ExpectationText = "is {not} an absolute URI",
+	Using = ["System",],
+	Remarks = """
+	          <seealso cref="Uri.IsAbsoluteUri" />
+	          """
+)]
+public static partial class ThatUri;

--- a/Source/aweXpect/That/Uris/ThatUri.IsFile.cs
+++ b/Source/aweXpect/That/Uris/ThatUri.IsFile.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using aweXpect.SourceGenerators;
+
+namespace aweXpect;
+
+[CreateExpectationOn<Uri>("Is{Not}File", "{value}.IsFile",
+	ExpectationText = "is {not} a file URI",
+	Using = ["System",],
+	Remarks = """
+	          <seealso cref="Uri.IsFile" />
+	          """
+)]
+public static partial class ThatUri;

--- a/Source/aweXpect/That/Uris/ThatUri.IsLoopback.cs
+++ b/Source/aweXpect/That/Uris/ThatUri.IsLoopback.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using aweXpect.SourceGenerators;
+
+namespace aweXpect;
+
+[CreateExpectationOn<Uri>("Is{Not}Loopback", "{value}.IsLoopback",
+	PositiveExpectationText = "references the local host",
+	NegativeExpectationText = "does not reference the local host",
+	Using = ["System",],
+	Remarks = """
+	          <seealso cref="Uri.IsLoopback" />
+	          """
+)]
+public static partial class ThatUri;

--- a/Source/aweXpect/That/Uris/ThatUri.IsUnc.cs
+++ b/Source/aweXpect/That/Uris/ThatUri.IsUnc.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using aweXpect.SourceGenerators;
+
+namespace aweXpect;
+
+[CreateExpectationOn<Uri>("Is{Not}Unc", "{value}.IsUnc",
+	ExpectationText = "is {not} an UNC path",
+	Using = ["System",],
+	Remarks = """
+	          <seealso cref="Uri.IsUnc" />
+	          """
+)]
+public static partial class ThatUri;

--- a/Source/aweXpect/That/Uris/ThatUri.cs
+++ b/Source/aweXpect/That/Uris/ThatUri.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace aweXpect;
+
+/// <summary>
+///     Expectations on <see cref="Uri" /> values.
+/// </summary>
+public static partial class ThatUri;

--- a/Source/aweXpect/aweXpect.csproj.DotSettings
+++ b/Source/aweXpect/aweXpect.csproj.DotSettings
@@ -21,4 +21,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Cstreams/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Cstrings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Ctimeonlys/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Ctimespans/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Ctimespans/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=that_005Curis/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -1232,6 +1232,19 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, params System.TimeSpan?[] expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsPositive(this aweXpect.Core.IThat<System.TimeSpan> source) { }
     }
+    public static class ThatUri
+    {
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> DoesNotHaveDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> HasDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+    }
 }
 namespace aweXpect.Equivalency
 {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -1178,6 +1178,19 @@ namespace aweXpect
         public static aweXpect.Results.TimeToleranceResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsOneOf(this aweXpect.Core.IThat<System.TimeSpan> source, params System.TimeSpan?[] expected) { }
         public static aweXpect.Results.AndOrResult<System.TimeSpan, aweXpect.Core.IThat<System.TimeSpan>> IsPositive(this aweXpect.Core.IThat<System.TimeSpan> source) { }
     }
+    public static class ThatUri
+    {
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> DoesNotHaveDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> HasDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+    }
 }
 namespace aweXpect.Equivalency
 {

--- a/Tests/aweXpect.Tests/Uris/ThatUri.DoesNotHaveDefaultPort.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.DoesNotHaveDefaultPort.Tests.cs
@@ -1,0 +1,77 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class DoesNotHaveDefaultPort
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotHaveDefaultPort();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotHaveDefaultPort();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.DoesNotHaveDefaultPort());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.DoesNotHaveDefaultPort());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.HasDefaultPort.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.HasDefaultPort.Tests.cs
@@ -1,0 +1,77 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class HasDefaultPort
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).HasDefaultPort();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).HasDefaultPort();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasDefaultPort());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasDefaultPort());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsAbsolute.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsAbsolute.Tests.cs
@@ -1,0 +1,69 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsAbsolute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsAbsolute();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldFail()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).IsAbsolute();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an absolute URI,
+					             but it was foo/bar
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsAbsolute());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an absolute URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldSucceed()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsAbsolute());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsFile.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsFile.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsFile
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsFile();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsFile();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is a file URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsFile());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not a file URI,
+					             but it was file://server/filename.ext
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsFile());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsLoopback.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsLoopback.Tests.cs
@@ -1,0 +1,73 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsLoopback
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsLoopback_ShouldSucceed(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).IsLoopback();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsLoopback();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             references the local host,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsLoopback_ShouldFail(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsLoopback());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not reference the local host,
+					              but it was {subject}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsLoopback());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsNotAbsolute.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsNotAbsolute.Tests.cs
@@ -1,0 +1,69 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotAbsolute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotAbsolute();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an absolute URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldSucceed()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).IsNotAbsolute();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotAbsolute());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldFail()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotAbsolute());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an absolute URI,
+					             but it was foo/bar
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsNotFile.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsNotFile.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotFile
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsNotFile();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not a file URI,
+					             but it was file://server/filename.ext
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotFile();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotFile());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotFile());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is a file URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsNotLoopback.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsNotLoopback.Tests.cs
@@ -1,0 +1,73 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotLoopback
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsNotLoopback_ShouldFail(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).IsNotLoopback();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not reference the local host,
+					              but it was {subject}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotLoopback();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotLoopback());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             references the local host,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsNotLoopback_ShouldSucceed(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotLoopback());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsNotUnc.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsNotUnc.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotUnc
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsNotUnc();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an UNC path,
+					             but it was file://server/filename.ext
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotUnc();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotUnc());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an UNC path,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotUnc());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.IsUnc.Tests.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.IsUnc.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsUnc
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsUnc();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an UNC path,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsUnc_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsUnc();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsUnc());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsUnc_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsUnc());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an UNC path,
+					             but it was file://server/filename.ext
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.cs
@@ -1,0 +1,16 @@
+﻿namespace aweXpect.Tests;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public sealed partial class ThatUri
+{
+	/// <summary>
+	///     Use a fixed random <see cref="Guid" /> in each test run to ensure, that the tests don't rely on special times.
+	/// </summary>
+	private static readonly Lazy<Guid> FixedGuidLazy = new(Guid.NewGuid);
+
+	private static Guid FixedGuid()
+		=> FixedGuidLazy.Value;
+
+	private static Guid OtherGuid()
+		=> Guid.NewGuid();
+}

--- a/Tests/aweXpect.Tests/Uris/ThatUri.cs
+++ b/Tests/aweXpect.Tests/Uris/ThatUri.cs
@@ -1,16 +1,4 @@
 ﻿namespace aweXpect.Tests;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public sealed partial class ThatUri
-{
-	/// <summary>
-	///     Use a fixed random <see cref="Guid" /> in each test run to ensure, that the tests don't rely on special times.
-	/// </summary>
-	private static readonly Lazy<Guid> FixedGuidLazy = new(Guid.NewGuid);
-
-	private static Guid FixedGuid()
-		=> FixedGuidLazy.Value;
-
-	private static Guid OtherGuid()
-		=> Guid.NewGuid();
-}
+public sealed partial class ThatUri;

--- a/Tests/aweXpect.Tests/aweXpect.Tests.csproj.DotSettings
+++ b/Tests/aweXpect.Tests/aweXpect.Tests.csproj.DotSettings
@@ -20,4 +20,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=strings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=testhelpers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=timeonlys/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=timespans/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=timespans/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=uris/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This PR introduces expectations for Uri objects in the aweXpect assertion library, adding fluent API methods for validating common Uri properties and characteristics.

### Key changes:
- Added Uri-specific assertion methods for absolute, file, loopback, and UNC path validation
  - `ThatUri.Is{Not}Absolute()`
  - `ThatUri.Is{Not}File()`
  - `ThatUri.Is{Not}Loopback()`
  - `ThatUri.Is{Not}Unc()`
- Added port validation methods for checking default port usage
  - `ThatUri.HasDefaultPort()` / `ThatUri.DoesNotHaveDefaultPort()`
- Enhanced source generator to support more flexible naming patterns