### PR TITLE
feat: add `IsNullOrEmpty` expectation for nullable `Guid`

### DIFF
--- a/Docs/pages/docs/expectations/13-guid.md
+++ b/Docs/pages/docs/expectations/13-guid.md
@@ -17,9 +17,14 @@ await Expect.That(subject).IsNotEqualTo(Guid.Parse("cdd7a485-40a1-4bba-bb8b-d0e9
 
 ## Empty
 
-You can verify that the `Guid` is empty or not:
+You can verify that the `Guid` is (null or) empty or not:
 
 ```csharp
 await Expect.That(Guid.Empty).IsEmpty();
 await Expect.That(Guid.NewGuid()).IsNotEmpty();
+
+Guid? guid1 = Guid.Empty;
+await Expect.That(guid1).IsNullOrEmpty();
+Guid? guid2 = Guid.NewGuid();
+await Expect.That(guid2).IsNotNullOrEmpty();
 ```

--- a/Source/aweXpect.SourceGenerators/Helpers/ExpectationToGenerate.cs
+++ b/Source/aweXpect.SourceGenerators/Helpers/ExpectationToGenerate.cs
@@ -40,6 +40,9 @@ internal readonly record struct ExpectationToGenerate
 				case "Remarks":
 					Remarks = namedArgument.Value.Value?.ToString();
 					break;
+				case "FailOnNull":
+					FailOnNull = namedArgument.Value.Value as bool? ?? true;
+					break;
 				case "Using":
 					Usings =
 						namedArgument.Value.Values.Select(x => x.Value?.ToString()).Where(x => x != null).ToArray()!;
@@ -59,6 +62,7 @@ internal readonly record struct ExpectationToGenerate
 		FileName = $"{ClassName}.{Name}.g.cs";
 	}
 
+	public bool FailOnNull { get; } = true;
 	public string[] Usings { get; } = [];
 	public string FileName { get; }
 	public bool IncludeNegated { get; }

--- a/Source/aweXpect.SourceGenerators/Helpers/SourceGenerationHelper.cs
+++ b/Source/aweXpect.SourceGenerators/Helpers/SourceGenerationHelper.cs
@@ -81,6 +81,7 @@ internal static class SourceGenerationHelper
 				OutcomeMethod = outcomeMethod;
 			}
 			
+			public bool FailOnNull { get; set; } = true;
 			public Type TargetType { get; }
 			public string PositiveName { get; }
 			public string? NegativeName { get; }
@@ -133,7 +134,7 @@ internal static class SourceGenerationHelper
 			            """;
 		}
 
-		if (expectationToGenerate.IsNullable)
+		if (expectationToGenerate.IsNullable && expectationToGenerate.FailOnNull)
 		{
 			result += $$"""
 			            	private sealed class {{expectationToGenerate.Name}}Constraint(string it, ExpectationGrammars grammars)

--- a/Source/aweXpect/That/Guids/ThatNullableGuid.IsNullOrEmpty.cs
+++ b/Source/aweXpect/That/Guids/ThatNullableGuid.IsNullOrEmpty.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using aweXpect.SourceGenerators;
+
+namespace aweXpect;
+
+[CreateExpectationOnNullable<Guid>("Is{Not}NullOrEmpty", "{value} is null || {value} == Guid.Empty",
+	ExpectationText = "is {not} null or empty",
+	Using = ["System",],
+	FailOnNull = false
+)]
+public static partial class ThatNullableGuid;

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -891,6 +891,8 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsEqualTo(this aweXpect.Core.IThat<System.Guid?> source, System.Guid? expected) { }
         public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNotEmpty(this aweXpect.Core.IThat<System.Guid?> source) { }
         public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNotEqualTo(this aweXpect.Core.IThat<System.Guid?> source, System.Guid? unexpected) { }
+        public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNotNullOrEmpty(this aweXpect.Core.IThat<System.Guid?> source) { }
+        public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNullOrEmpty(this aweXpect.Core.IThat<System.Guid?> source) { }
     }
     public static class ThatNullableTimeOnly
     {

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -630,6 +630,8 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsEqualTo(this aweXpect.Core.IThat<System.Guid?> source, System.Guid? expected) { }
         public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNotEmpty(this aweXpect.Core.IThat<System.Guid?> source) { }
         public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNotEqualTo(this aweXpect.Core.IThat<System.Guid?> source, System.Guid? unexpected) { }
+        public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNotNullOrEmpty(this aweXpect.Core.IThat<System.Guid?> source) { }
+        public static aweXpect.Results.AndOrResult<System.Guid?, aweXpect.Core.IThat<System.Guid?>> IsNullOrEmpty(this aweXpect.Core.IThat<System.Guid?> source) { }
     }
     public static class ThatNullableTimeSpan
     {

--- a/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsNotEmpty.Tests.cs
+++ b/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsNotEmpty.Tests.cs
@@ -11,7 +11,7 @@ public sealed partial class ThatGuid
 				[Fact]
 				public async Task WhenSubjectIsEmpty_ShouldFail()
 				{
-					Guid subject = Guid.Empty;
+					Guid? subject = Guid.Empty;
 
 					async Task Act()
 						=> await That(subject).IsNotEmpty();

--- a/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsNotNullOrEmpty.Tests.cs
+++ b/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsNotNullOrEmpty.Tests.cs
@@ -4,35 +4,35 @@ public sealed partial class ThatGuid
 {
 	public sealed partial class Nullable
 	{
-		public sealed class IsEmpty
+		public sealed class IsNotNullOrEmpty
 		{
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task WhenSubjectIsEmpty_ShouldSucceed()
+				public async Task WhenSubjectIsEmpty_ShouldFail()
 				{
 					Guid? subject = Guid.Empty;
 
 					async Task Act()
-						=> await That(subject).IsEmpty();
-
-					await That(Act).DoesNotThrow();
-				}
-
-				[Fact]
-				public async Task WhenSubjectIsNotEmpty_ShouldFail()
-				{
-					Guid? subject = OtherGuid();
-
-					async Task Act()
-						=> await That(subject).IsEmpty();
+						=> await That(subject).IsNotNullOrEmpty();
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that subject
-						              is empty,
+						              is not null or empty,
 						              but it was {Formatter.Format(subject)}
 						              """);
+				}
+
+				[Fact]
+				public async Task WhenSubjectIsNotEmpty_ShouldSucceed()
+				{
+					Guid? subject = OtherGuid();
+
+					async Task Act()
+						=> await That(subject).IsNotNullOrEmpty();
+
+					await That(Act).DoesNotThrow();
 				}
 
 				[Fact]
@@ -41,12 +41,12 @@ public sealed partial class ThatGuid
 					Guid? subject = null;
 
 					async Task Act()
-						=> await That(subject).IsEmpty();
+						=> await That(subject).IsNotNullOrEmpty();
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("""
 						             Expected that subject
-						             is empty,
+						             is not null or empty,
 						             but it was <null>
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsNullOrEmpty.Tests.cs
+++ b/Tests/aweXpect.Tests/Guids/ThatGuid.Nullable.IsNullOrEmpty.Tests.cs
@@ -4,7 +4,7 @@ public sealed partial class ThatGuid
 {
 	public sealed partial class Nullable
 	{
-		public sealed class IsEmpty
+		public sealed class IsNullOrEmpty
 		{
 			public sealed class Tests
 			{
@@ -14,7 +14,7 @@ public sealed partial class ThatGuid
 					Guid? subject = Guid.Empty;
 
 					async Task Act()
-						=> await That(subject).IsEmpty();
+						=> await That(subject).IsNullOrEmpty();
 
 					await That(Act).DoesNotThrow();
 				}
@@ -25,30 +25,25 @@ public sealed partial class ThatGuid
 					Guid? subject = OtherGuid();
 
 					async Task Act()
-						=> await That(subject).IsEmpty();
+						=> await That(subject).IsNullOrEmpty();
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage($"""
 						              Expected that subject
-						              is empty,
+						              is null or empty,
 						              but it was {Formatter.Format(subject)}
 						              """);
 				}
 
 				[Fact]
-				public async Task WhenSubjectIsNull_ShouldFail()
+				public async Task WhenSubjectIsNull_ShouldSucceed()
 				{
 					Guid? subject = null;
 
 					async Task Act()
-						=> await That(subject).IsEmpty();
+						=> await That(subject).IsNullOrEmpty();
 
-					await That(Act).Throws<XunitException>()
-						.WithMessage("""
-						             Expected that subject
-						             is empty,
-						             but it was <null>
-						             """);
+					await That(Act).DoesNotThrow();
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds the `IsNullOrEmpty` and `IsNotNullOrEmpty` expectation methods for nullable `Guid` types in the aweXpect assertion library. These methods provide consistent null-aware GUID validation following the pattern used for other nullable types.

### Key Changes
- Added source-generated expectations for nullable GUID null-or-empty checks
- Enhanced source generator to support `FailOnNull` configuration for nullable types
- Added comprehensive test coverage for the new expectations