### PR TITLE
refactor!: make `IStringMatchType` asynchronous

### DIFF
--- a/Source/aweXpect.Core/Core/IStringMatchType.cs
+++ b/Source/aweXpect.Core/Core/IStringMatchType.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace aweXpect.Core;
 
@@ -11,7 +12,12 @@ public interface IStringMatchType
 	///     Returns <see langword="true" /> if the two strings <paramref name="actual" /> and <paramref name="expected" /> are
 	///     considered equal; otherwise <see langword="false" />.
 	/// </summary>
-	bool AreConsideredEqual(string? actual, string? expected,
+#if NET8_0_OR_GREATER
+	ValueTask<bool>
+#else
+	Task<bool>
+#endif
+	AreConsideredEqual(string? actual, string? expected,
 		bool ignoreCase,
 		IEqualityComparer<string> comparer);
 

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.ExactMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.ExactMatchType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Helpers;
 
@@ -96,20 +97,37 @@ public partial class StringEqualityOptions
 		}
 
 		/// <inheritdoc cref="IStringMatchType.AreConsideredEqual(string?, string?, bool, IEqualityComparer{string})" />
-		public bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
+#if NET8_0_OR_GREATER
+		public ValueTask<bool>
+#else
+		public Task<bool>
+#endif
+		AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
 			IEqualityComparer<string> comparer)
 		{
 			if (actual is null && expected is null)
 			{
-				return true;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(true);
+#else
+				return Task.FromResult(true);
+#endif
 			}
 
 			if (actual is null || expected is null)
 			{
-				return false;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(false);
+#else
+				return Task.FromResult(false);
+#endif
 			}
 
-			return comparer.Equals(actual, expected);
+#if NET8_0_OR_GREATER
+			return ValueTask.FromResult(comparer.Equals(actual, expected));
+#else
+			return Task.FromResult(comparer.Equals(actual, expected));
+#endif
 		}
 
 		/// <inheritdoc cref="IStringMatchType.GetExpectation(string?, ExpectationGrammars)" />

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.PrefixMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.PrefixMatchType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Helpers;
 
@@ -83,20 +84,37 @@ public partial class StringEqualityOptions
 		}
 
 		/// <inheritdoc cref="IStringMatchType.AreConsideredEqual(string?, string?, bool, IEqualityComparer{string})" />
-		public bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
+#if NET8_0_OR_GREATER
+		public ValueTask<bool>
+#else
+		public Task<bool>
+#endif
+		AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
 			IEqualityComparer<string> comparer)
 		{
 			if (actual is null && expected is null)
 			{
-				return true;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(true);
+#else
+				return Task.FromResult(true);
+#endif
 			}
 
 			if (actual is null || expected is null)
 			{
-				return false;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(false);
+#else
+				return Task.FromResult(false);
+#endif
 			}
 
-			return actual.Length >= expected.Length && comparer.Equals(actual[..expected.Length], expected);
+#if NET8_0_OR_GREATER
+			return ValueTask.FromResult(actual.Length >= expected.Length && comparer.Equals(actual[..expected.Length], expected));
+#else
+			return Task.FromResult(actual.Length >= expected.Length && comparer.Equals(actual[..expected.Length], expected));
+#endif
 		}
 
 		/// <inheritdoc cref="IStringMatchType.GetExpectation(string?, ExpectationGrammars)" />

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.RegexMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.RegexMatchType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Helpers;
 
@@ -40,12 +41,21 @@ public partial class StringEqualityOptions
 		}
 
 		/// <inheritdoc cref="IStringMatchType.AreConsideredEqual(string?, string?, bool, IEqualityComparer{string})" />
-		public bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
+#if NET8_0_OR_GREATER
+		public ValueTask<bool>
+#else
+		public Task<bool>
+#endif
+		AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
 			IEqualityComparer<string> comparer)
 		{
 			if (actual is null || expected is null)
 			{
-				return false;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(false);
+#else
+				return Task.FromResult(false);
+#endif
 			}
 
 			RegexOptions options = RegexOptions.Multiline;
@@ -54,7 +64,11 @@ public partial class StringEqualityOptions
 				options |= RegexOptions.IgnoreCase;
 			}
 
-			return Regex.IsMatch(actual, expected, options, RegexTimeout);
+#if NET8_0_OR_GREATER
+			return ValueTask.FromResult(Regex.IsMatch(actual, expected, options, RegexTimeout));
+#else
+			return Task.FromResult(Regex.IsMatch(actual, expected, options, RegexTimeout));
+#endif
 		}
 
 		/// <inheritdoc cref="IStringMatchType.GetExpectation(string?, ExpectationGrammars)" />

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.SuffixMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.SuffixMatchType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Helpers;
 
@@ -90,20 +91,37 @@ public partial class StringEqualityOptions
 		}
 
 		/// <inheritdoc cref="IStringMatchType.AreConsideredEqual(string?, string?, bool, IEqualityComparer{string})" />
-		public bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
+#if NET8_0_OR_GREATER
+		public ValueTask<bool>
+#else
+		public Task<bool>
+#endif
+		AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
 			IEqualityComparer<string> comparer)
 		{
 			if (actual is null && expected is null)
 			{
-				return true;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(true);
+#else
+				return Task.FromResult(true);
+#endif
 			}
 
 			if (actual is null || expected is null)
 			{
-				return false;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(false);
+#else
+				return Task.FromResult(false);
+#endif
 			}
 
-			return actual.Length >= expected.Length && comparer.Equals(actual[^expected.Length..], expected);
+#if NET8_0_OR_GREATER
+			return ValueTask.FromResult(actual.Length >= expected.Length && comparer.Equals(actual[^expected.Length..], expected));
+#else
+			return Task.FromResult(actual.Length >= expected.Length && comparer.Equals(actual[^expected.Length..], expected));
+#endif
 		}
 
 		/// <inheritdoc cref="IStringMatchType.GetExpectation(string?, ExpectationGrammars)" />

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.WildcardMatchType.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.WildcardMatchType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Helpers;
 
@@ -49,20 +50,34 @@ public partial class StringEqualityOptions
 		}
 
 		/// <inheritdoc cref="IStringMatchType.AreConsideredEqual(string?, string?, bool, IEqualityComparer{string})" />
-		public bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
+#if NET8_0_OR_GREATER
+		public ValueTask<bool>
+#else
+		public Task<bool>
+#endif
+		AreConsideredEqual(string? actual, string? expected, bool ignoreCase,
 			IEqualityComparer<string> comparer)
 		{
 			if (actual is null || expected is null)
 			{
-				return false;
+#if NET8_0_OR_GREATER
+				return ValueTask.FromResult(false);
+#else
+				return Task.FromResult(false);
+#endif
 			}
 
 			RegexOptions options = ignoreCase
 				? RegexOptions.Multiline | RegexOptions.IgnoreCase
 				: RegexOptions.Multiline;
 
-			return Regex.IsMatch(actual, WildcardToRegularExpression(expected), options,
-				RegexTimeout);
+#if NET8_0_OR_GREATER
+			return ValueTask.FromResult(Regex.IsMatch(actual, WildcardToRegularExpression(expected), options,
+				RegexTimeout));
+#else
+			return Task.FromResult(Regex.IsMatch(actual, WildcardToRegularExpression(expected), options,
+				RegexTimeout));
+#endif
 		}
 
 		/// <inheritdoc cref="IStringMatchType.GetExpectation(string?, ExpectationGrammars)" />

--- a/Source/aweXpect.Core/Options/StringEqualityOptions.cs
+++ b/Source/aweXpect.Core/Options/StringEqualityOptions.cs
@@ -24,21 +24,17 @@ public partial class StringEqualityOptions : IOptionsEquality<string?>
 
 	/// <inheritdoc />
 #if NET8_0_OR_GREATER
-	public ValueTask<bool> AreConsideredEqual<TExpected>(string? actual, TExpected expected)
+	public async ValueTask<bool> AreConsideredEqual<TExpected>(string? actual, TExpected expected)
 #else
-	public Task<bool> AreConsideredEqual<TExpected>(string? actual, TExpected expected)
+	public async Task<bool> AreConsideredEqual<TExpected>(string? actual, TExpected expected)
 #endif
 	{
 		bool result;
 		if (expected is not string expectedString)
 		{
-			result = _matchType.AreConsideredEqual(actual, null, _ignoreCase,
+			result = await _matchType.AreConsideredEqual(actual, null, _ignoreCase,
 				_comparer ?? UseDefaultComparer(_ignoreCase));
-#if NET8_0_OR_GREATER
-			return ValueTask.FromResult(result);
-#else
-			return Task.FromResult(result);
-#endif
+			return result;
 		}
 
 		if (_ignoreNewlineStyle)
@@ -59,13 +55,9 @@ public partial class StringEqualityOptions : IOptionsEquality<string?>
 			expectedString = expectedString.TrimEnd();
 		}
 
-		result = _matchType.AreConsideredEqual(actual, expectedString, _ignoreCase,
+		result = await _matchType.AreConsideredEqual(actual, expectedString, _ignoreCase,
 			_comparer ?? UseDefaultComparer(_ignoreCase));
-#if NET8_0_OR_GREATER
-		return ValueTask.FromResult(result);
-#else
-		return Task.FromResult(result);
-#endif
+		return result;
 	}
 
 	/// <summary>

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -220,7 +220,7 @@ namespace aweXpect.Core
     }
     public interface IStringMatchType
     {
-        bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
+        System.Threading.Tasks.ValueTask<bool> AreConsideredEqual(string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
         string GetExpectation(string? expected, aweXpect.Core.ExpectationGrammars grammars);
         string GetExtendedFailure(string it, string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer, aweXpect.Core.StringDifferenceSettings? settings);
         string GetOptionString(bool ignoreCase, System.Collections.Generic.IEqualityComparer<string>? comparer);

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -220,7 +220,7 @@ namespace aweXpect.Core
     }
     public interface IStringMatchType
     {
-        bool AreConsideredEqual(string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
+        System.Threading.Tasks.Task<bool> AreConsideredEqual(string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer);
         string GetExpectation(string? expected, aweXpect.Core.ExpectationGrammars grammars);
         string GetExtendedFailure(string it, string? actual, string? expected, bool ignoreCase, System.Collections.Generic.IEqualityComparer<string> comparer, aweXpect.Core.StringDifferenceSettings? settings);
         string GetOptionString(bool ignoreCase, System.Collections.Generic.IEqualityComparer<string>? comparer);


### PR DESCRIPTION
This pull request refactors the `IStringMatchType` interface to make the `AreConsideredEqual` method asynchronous, changing the return type from `bool` to `Task<bool>` for .NET Standard 2.0 and `ValueTask<bool>` for .NET 8.0+. This is a breaking change that modernizes the API to support async-first patterns.

### Key changes include:
- Interface method signature updated to return asynchronous types
- All implementations updated to return wrapped task results
- Calling code updated to use async/await patterns