### PR TITLE
refactor: make `EquivalencyExpectationBuilder` public

### DIFF
--- a/Source/aweXpect.Core/Equivalency/EquivalencyExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Equivalency/EquivalencyExpectationBuilder.cs
@@ -34,8 +34,8 @@ internal class EquivalencyExpectationBuilder<T> : EquivalencyExpectationBuilder
 		return sb.ToString();
 	}
 
-	public override async Task<ConstraintResult> IsMetBy(
-		object? value,
+	public override async Task<ConstraintResult> IsMetBy<TValue>(
+		TValue value,
 		IEvaluationContext context,
 		CancellationToken cancellationToken)
 	{
@@ -94,7 +94,10 @@ internal class EquivalencyExpectationBuilder<T> : EquivalencyExpectationBuilder
 	}
 }
 
-internal abstract class EquivalencyExpectationBuilder : ExpectationBuilder
+/// <summary>
+///     An <see cref="ExpectationBuilder" /> used in equivalency comparison checks.
+/// </summary>
+public abstract class EquivalencyExpectationBuilder : ExpectationBuilder
 {
 	/// <summary>
 	///     Appends the expectation of the root node to the <paramref name="stringBuilder" />.
@@ -105,12 +108,12 @@ internal abstract class EquivalencyExpectationBuilder : ExpectationBuilder
 	/// <summary>
 	///     Evaluate if the expectations are met by the <paramref name="value" />.
 	/// </summary>
-	public abstract Task<ConstraintResult> IsMetBy(
-		object? value,
+	public abstract Task<ConstraintResult> IsMetBy<TValue>(
+		TValue value,
 		IEvaluationContext context,
 		CancellationToken cancellationToken);
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="ExpectationBuilder.IsMet(Node, EvaluationContext, ITimeSystem, TimeSpan?, CancellationToken)" />
 	internal override Task<ConstraintResult> IsMet(Node rootNode,
 		EvaluationContext context,
 		ITimeSystem timeSystem,

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -550,6 +550,13 @@ namespace aweXpect.Equivalency
     {
         public static aweXpect.Equivalency.EquivalencyComparisonType DefaultComparisonType(System.Type type) { }
     }
+    public abstract class EquivalencyExpectationBuilder : aweXpect.Core.ExpectationBuilder
+    {
+        protected EquivalencyExpectationBuilder() { }
+        public void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
+        public abstract System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult> IsMetBy<TValue>(TValue value, aweXpect.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken);
+        public override aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
+    }
     public class EquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions>
     {
         public EquivalencyOptions() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -536,6 +536,13 @@ namespace aweXpect.Equivalency
     {
         public static aweXpect.Equivalency.EquivalencyComparisonType DefaultComparisonType(System.Type type) { }
     }
+    public abstract class EquivalencyExpectationBuilder : aweXpect.Core.ExpectationBuilder
+    {
+        protected EquivalencyExpectationBuilder() { }
+        public void AppendExpectation(System.Text.StringBuilder stringBuilder, string? indentation = null) { }
+        public abstract System.Threading.Tasks.Task<aweXpect.Core.Constraints.ConstraintResult> IsMetBy<TValue>(TValue value, aweXpect.Core.EvaluationContext.IEvaluationContext context, System.Threading.CancellationToken cancellationToken);
+        public override aweXpect.Core.ExpectationBuilder UpdateContexts(System.Action<aweXpect.Core.ResultContexts> callback) { }
+    }
     public class EquivalencyOptions : aweXpect.Equivalency.EquivalencyTypeOptions, System.IEquatable<aweXpect.Equivalency.EquivalencyOptions>
     {
         public EquivalencyOptions() { }


### PR DESCRIPTION
This PR makes the `EquivalencyExpectationBuilder` class public to enable extensibility of the aweXpect equivalency system. The refactor changes the visibility modifier from internal to public and adds proper XML documentation.

### Key changes:
- Changed `EquivalencyExpectationBuilder` from internal to public access modifier
- Added XML documentation for the newly public class
- Updated method signatures to use generic type parameters instead of object parameters