### PR TITLE
chore: bump aweXpect.Core to v2.22.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.23.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.21.2" />
+		<PackageVersion Include="aweXpect.Core" Version="2.22.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
This is a maintenance PR that updates the aweXpect.Core package version from v2.21.2 to v2.22.0 in the centralized package management configuration.

- Updates aweXpect.Core dependency to version 2.22.0