### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.23.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.22.0" />
+		<PackageVersion Include="aweXpect" Version="2.24.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.22.2" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.ItIs.Tests.cs
+++ b/Tests/aweXpect.Tests/Objects/ThatObject.IsEquivalentTo.ItIs.Tests.cs
@@ -200,7 +200,7 @@ public sealed partial class ThatObject
 				/// <summary>
 				///     It is not possible to determine the type of <see langword="null" />!
 				/// </summary>
-				[Fact(Skip="TODO: Re-Enable after the next Core update")]
+				[Fact]
 				public async Task WhenCheckForNullAndItIsNull_ShouldSucceed()
 				{
 					DummyClass subject = new()

--- a/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.EndsWith.Tests.cs
@@ -100,7 +100,7 @@ public sealed partial class ThatString
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact(Skip = "TODO: Re-Enable after next core update")]
+			[Fact]
 			public async Task WhenActualIsEmpty_ShouldFail()
 			{
 				string subject = "";

--- a/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Strings/ThatString.StartsWith.Tests.cs
@@ -101,7 +101,7 @@ public sealed partial class ThatString
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact(Skip = "TODO: Re-Enable after next core update")]
+			[Fact]
 			public async Task WhenActualIsEmpty_ShouldFail()
 			{
 				string subject = "";


### PR DESCRIPTION
This PR updates the aweXpect library dependencies to newer versions and re-enables previously skipped tests that were waiting for the core library update.

### Key changes:
- Updates aweXpect from 2.23.0 to 2.24.0 and aweXpect.Core from 2.22.0 to 2.22.2
- Re-enables three previously skipped unit tests that were dependent on the core library update