### PR TITLE
chore: update aweXpect.Core to v2.24.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.24.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.22.2" />
+		<PackageVersion Include="aweXpect" Version="2.25.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.24.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Tests/aweXpect.Tests/Booleans/ThatBool.cs
+++ b/Tests/aweXpect.Tests/Booleans/ThatBool.cs
@@ -3,7 +3,6 @@
 // ReSharper disable once ClassNeverInstantiated.Global
 public sealed partial class ThatBool
 {
-/* TODO: Enable after next Core update
 	public sealed class Tests
 	{
 		[Fact]
@@ -49,5 +48,4 @@ public sealed partial class ThatBool
 			await That(Act).DoesNotThrow();
 		}
 	}
-*/
 }


### PR DESCRIPTION
This PR updates the aweXpect.Core package version from 2.22.2 to 2.24.0 and enables previously disabled test code that was awaiting this core update.

### Key changes:
- Updates package versions in central package management
- Enables previously commented-out test code for boolean functionality