### PR TITLE
fix: formatting of nullable types

### DIFF
--- a/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
+++ b/Source/aweXpect.Core/Formatting/ValueFormatters.Type.cs
@@ -121,11 +121,7 @@ public static partial class ValueFormatters
 			FormatType(value.GetElementType()!, stringBuilder);
 			stringBuilder.Append("[]");
 		}
-		else if (TryFindPrimitiveAlias(value, out string? alias))
-		{
-			stringBuilder.Append(alias);
-		}
-		else
+		else if (!AppendedPrimitiveAlias(value, stringBuilder))
 		{
 			if (value.IsNested && value.DeclaringType is not null)
 			{
@@ -163,24 +159,28 @@ public static partial class ValueFormatters
 	}
 #pragma warning restore S3776
 
-	private static bool TryFindPrimitiveAlias(Type value, [NotNullWhen(true)] out string? alias)
+	private static bool AppendedPrimitiveAlias(Type value, StringBuilder stringBuilder)
 	{
 		if (Aliases.TryGetValue(value, out string? typeAlias))
 		{
-			alias = typeAlias;
+			stringBuilder.Append(typeAlias);
 			return true;
 		}
 
 		Type? underlyingType = Nullable.GetUnderlyingType(value);
 
-		if (underlyingType != null &&
-		    Aliases.TryGetValue(underlyingType, out string? underlyingAlias))
+		if (underlyingType != null)
 		{
-			alias = $"{underlyingAlias}?";
+			if (Aliases.TryGetValue(underlyingType, out string? underlyingAlias))
+			{
+				stringBuilder.Append(underlyingAlias).Append('?');
+				return true;
+			}
+			FormatType(underlyingType, stringBuilder);
+			stringBuilder.Append('?');
 			return true;
 		}
 
-		alias = null;
 		return false;
 	}
 }

--- a/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Formatting/ValueFormatters.TypeTests.cs
@@ -209,6 +209,22 @@ public partial class ValueFormatters
 		}
 
 		[Fact]
+		public async Task WhenNullable_ShouldUseQuestionMarkSyntax()
+		{
+			string expectedResult = "DateTime?";
+			Type value = typeof(DateTime?);
+			StringBuilder sb = new();
+
+			string result = Formatter.Format(value);
+			string objectResult = Formatter.Format((object?)value);
+			Formatter.Format(sb, value);
+
+			await That(result).IsEqualTo(expectedResult);
+			await That(objectResult).IsEqualTo(expectedResult);
+			await That(sb.ToString()).IsEqualTo(expectedResult);
+		}
+
+		[Fact]
 		public async Task WhenNull_ShouldUseDefaultNullString()
 		{
 			Type? value = null;


### PR DESCRIPTION
This PR fixes the formatting of nullable types in the aweXpect library to use proper question mark syntax. The fix ensures that nullable types are consistently formatted with the `?` suffix, regardless of whether they have primitive aliases or not.

---

- *Fixes #804*