### PR TITLE
chore: update TUnit to v0.70.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
 		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.0" />
 		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
-		<PackageVersion Include="MSTest.TestAdapter" Version="4.0.0" />
-		<PackageVersion Include="MSTest.TestFramework" Version="4.0.0" />
+		<PackageVersion Include="MSTest.TestAdapter" Version="3.11.0" />
+		<PackageVersion Include="MSTest.TestFramework" Version="3.11.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates several test-related package dependencies to newer versions in the `Directory.Packages.props` file. The changes focus on keeping the test infrastructure up to date and improving compatibility and features.

### Dependency updates:
* Upgraded `Microsoft.NET.Test.Sdk` from version 17.13.0 to 17.14.1.
* Updated `TUnit` and `TUnit.Assertions` from version 0.25.21 to 0.70.0.
* Updated `Microsoft.Testing.Extensions.TrxReport` from version 1.6.3 to 1.9.0.
* Downgraded `MSTest.TestAdapter` and `MSTest.TestFramework` from version 4.0.0 to 3.11.0 for compatibility.