### PR TITLE
chore: update aweXpect.Core to v2.25.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.27.0-pre.1" />
-		<PackageVersion Include="aweXpect.Core" Version="2.24.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.25.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
Update central package management to bump aweXpect.Core from 2.24.0 to 2.25.0.