### PR TITLE
chore: update aweXpect to v2.27.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.27.0" />
+		<PackageVersion Include="aweXpect" Version="2.27.1" />
 		<PackageVersion Include="aweXpect.Core" Version="2.25.1" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.MainOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 	[GitRepository] readonly GitRepository Repository;


### PR DESCRIPTION
This PR updates the aweXpect library version from 2.27.0 to 2.27.1 and restores normal build scope configuration.

- Updated aweXpect package version to 2.27.1
- Reset build scope from MainOnly back to Default