### PR TITLE
chore: update TUnit to v0.88.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
 		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
 		<PackageVersion Include="FluentAssertions" Version="8.8.0" />
-		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.0" />
+		<PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.1" />
 		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
 		<PackageVersion Include="MSTest.TestAdapter" Version="4.0.1" />


### PR DESCRIPTION
This PR updates the TUnit testing framework packages from version 0.70.0 to 0.88.0, aligning both the core TUnit package and TUnit.Assertions to the same version.

- Updated TUnit package version from 0.70.0 to 0.88.0
- Updated TUnit.Assertions package version from 0.70.0 to 0.88.0
- Updated Microsoft.Testing.Extensions.TrxReport version from 1.9.0 to 2.0.1