### PR TITLE
fix: infinite loop in result contexts

### DIFF
--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 // ReSharper disable PossibleMultipleEnumeration


### PR DESCRIPTION
This PR fixes an infinite loop issue in the `ResultContexts` class by correcting the linked list insertion logic. When adding a new context to a non-empty list, the previous implementation incorrectly inserted the new node between the first node and its successor, creating a circular reference. The fix properly prepends the new context to the front of the list.

### Key Changes
- Corrected the linked list insertion logic in `ResultContexts.Add()` method to prevent infinite loops