### PR TITLE
refactor: move needs from pack to push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,6 @@ jobs:
     pack:
         name: "Pack"
         runs-on: ubuntu-latest
-        needs: [ publish-test-results, static-code-analysis ]
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -227,7 +226,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack, build-pages, mutation-tests-dashboard ]
+        needs: [ pack, publish-test-results, static-code-analysis, build-pages, mutation-tests-dashboard ]
         permissions:
             contents: write
         steps:
@@ -271,7 +270,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/core/v') }}
         runs-on: macos-latest
         environment: production
-        needs: [ pack, build-pages ]
+        needs: [ pack, publish-test-results, static-code-analysis, build-pages ]
         steps:
             -   name: Download packages
                 uses: actions/download-artifact@v6


### PR DESCRIPTION
This refactoring relocates dependency declarations in the GitHub Actions workflow to improve job orchestration. The `pack` job no longer depends on `publish-test-results` and `static-code-analysis`, allowing it to run earlier in the pipeline. These dependencies are instead moved to the downstream `push` and `push-core` jobs, ensuring quality gates are still enforced before publishing.

### Key changes:
- Removed `needs` dependencies from the `pack` job
- Added `publish-test-results` and `static-code-analysis` as dependencies to both `push` jobs