### PR TITLE
chore: update aweXpect to v2.28.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.27.1" />
+		<PackageVersion Include="aweXpect" Version="2.28.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.25.2" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.MainOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 	[GitRepository] readonly GitRepository Repository;


### PR DESCRIPTION
This PR updates the aweXpect package dependency from version 2.27.1 to 2.28.0 and resets the build scope configuration to its default state, completing the package update workflow.

### Key Changes:
- Updated aweXpect package version to 2.28.0
- Reset BuildScope flag from MainOnly back to Default