### PR TITLE
chore: bump aweXpect.Core to v2.26.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.28.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.25.2" />
+		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 	[GitRepository] readonly GitRepository Repository;


### PR DESCRIPTION
This PR updates the `aweXpect.Core` package dependency from version 2.25.2 to 2.26.0 and restores the build scope to its default state after completing a core-only build cycle.

### Key Changes:
- Bumped `aweXpect.Core` package version to 2.26.0
- Reset build scope from `CoreOnly` back to `Default`