### PR TITLE
fix: build error with MTP mode of dotnet test

### DIFF
--- a/Pipeline/Build.FrameworkTest.cs
+++ b/Pipeline/Build.FrameworkTest.cs
@@ -84,7 +84,7 @@ partial class Build
 					framework,
 				};
 
-			DotNetTest(s => s
+			DotNetRun(s => s
 				.SetConfiguration(Configuration)
 				.SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
 				.EnableNoBuild()

--- a/Tests/Frameworks/Directory.Build.props
+++ b/Tests/Frameworks/Directory.Build.props
@@ -4,7 +4,7 @@
 			Condition="Exists('$(MSBuildThisFileDirectory)/../../Directory.Build.props')"/>
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Tests/Frameworks/aweXpect.Frameworks.Tunit.Tests/aweXpect.Frameworks.Tunit.Tests.csproj
+++ b/Tests/Frameworks/aweXpect.Frameworks.Tunit.Tests/aweXpect.Frameworks.Tunit.Tests.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="TUnit"/>
@@ -7,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\Source\aweXpect.Frameworks\aweXpect.Frameworks.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\..\..\Source\aweXpect.Frameworks\aweXpect.Frameworks.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
 		<ProjectReference Include="..\..\..\Source\aweXpect\aweXpect.csproj"/>
 	</ItemGroup>
 


### PR DESCRIPTION
This PR fixes a build error that occurred when running TUnit tests with the Multi-Threaded Project (MTP) mode of `dotnet test`. The fix involves configuring TUnit tests to run as an executable and switching the test execution method in the build pipeline.

### Key changes:
- Configured TUnit test project to output as an executable to support MTP mode
- Updated framework test target from .NET 8.0 to .NET 10.0
- Changed build pipeline to use `DotNetRun` instead of `DotNetTest` for framework tests