### PR TITLE
chore: bump nuke to v10.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
 		<PackageVersion Include="IsExternalInit" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Nuke.Common" Version="9.0.4" />
-		<PackageVersion Include="Nuke.Components" Version="9.0.4" />
+		<PackageVersion Include="Nuke.Common" Version="10.1.0" />
+		<PackageVersion Include="Nuke.Components" Version="10.1.0" />
 		<PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
 		<PackageVersion Include="SharpCompress" Version="0.41.0" />
 	</ItemGroup>

--- a/Pipeline/Build.csproj
+++ b/Pipeline/Build.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
 		<NukeRootDirectory>..</NukeRootDirectory>
 		<NukeScriptDirectory>..</NukeScriptDirectory>


### PR DESCRIPTION
This PR upgrades the NUKE build automation system from version 9.0.4 to 10.1.0, which requires updating both the NUKE package versions and the target framework for the build project.

### Key Changes:
- Updated NUKE packages (Nuke.Common and Nuke.Components) from 9.0.4 to 10.1.0
- Updated build project target framework from .NET 8.0 to .NET 10.0