### PR TITLE
feat: add implicit conversion to `Times`

### DIFF
--- a/Source/aweXpect.Core/Core/Times.cs
+++ b/Source/aweXpect.Core/Core/Times.cs
@@ -17,4 +17,12 @@ public readonly struct Times(int value)
 	{
 		return new Times(value);
 	}
+
+	/// <summary>
+	///     Implicitly convert the <paramref name="value" /> to an <see langword="int" />.
+	/// </summary>
+	public static implicit operator int(Times value)
+	{
+		return value.Value;
+	}
 }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net10.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net10.0.txt
@@ -351,6 +351,7 @@ namespace aweXpect.Core
     {
         public Times(int value) { }
         public int Value { get; }
+        public static int op_Implicit(aweXpect.Core.Times value) { }
         public static aweXpect.Core.Times op_Implicit(int value) { }
     }
     public static class TimesExtensions

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -351,6 +351,7 @@ namespace aweXpect.Core
     {
         public Times(int value) { }
         public int Value { get; }
+        public static int op_Implicit(aweXpect.Core.Times value) { }
         public static aweXpect.Core.Times op_Implicit(int value) { }
     }
     public static class TimesExtensions

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -337,6 +337,7 @@ namespace aweXpect.Core
     {
         public Times(int value) { }
         public int Value { get; }
+        public static int op_Implicit(aweXpect.Core.Times value) { }
         public static aweXpect.Core.Times op_Implicit(int value) { }
     }
     public static class TimesExtensions

--- a/Tests/aweXpect.Core.Tests/Core/TimesTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/TimesTests.cs
@@ -1,0 +1,16 @@
+﻿namespace aweXpect.Core.Tests.Core;
+
+public class TimesTests
+{
+	[Fact]
+	public async Task ImplicitConversion_ShouldWorkAsExpected()
+	{
+		int expectedValue = 5;
+
+		Times times = expectedValue;
+		int actualValue = times;
+
+		await That(times.Value).IsEqualTo(expectedValue);
+		await That(actualValue).IsEqualTo(expectedValue);
+	}
+}


### PR DESCRIPTION
This PR adds bidirectional implicit conversion between `Times` and `int` types. Previously, only `int` to `Times` conversion existed; now `Times` can also be implicitly converted back to `int`.

### Key Changes:
- Added implicit operator to convert `Times` to `int`
- Added unit test validating both conversion directions
- Updated API baseline files for all target frameworks