### PR TITLE
feat: support async `Because` reason

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -296,6 +296,15 @@ public abstract class ExpectationBuilder
 	}
 
 	/// <summary>
+	///     Adds a <paramref name="reason" /> to the current expectation constraint.
+	/// </summary>
+	internal void AddReason(Task<string> reason)
+	{
+		AsyncBecauseReason becauseReason = new(reason);
+		_node.SetReason(becauseReason);
+	}
+
+	/// <summary>
 	///     Supports chaining for subsequent expectation constraints with the <paramref name="textSeparator" />.
 	/// </summary>
 	public ExpectationBuilder And(string textSeparator = " and ")

--- a/Source/aweXpect.Core/Core/Helpers/AsyncBecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/AsyncBecauseReason.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+using aweXpect.Core.Constraints;
+
+namespace aweXpect.Core.Helpers;
+
+internal struct AsyncBecauseReason(Task<string> reason) : IBecauseReason
+{
+	private string? _message;
+
+	private static string CreateMessage(string reason)
+	{
+		const string prefix = "because";
+		string message = reason.Trim();
+
+		return !message.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+			? $", {prefix} {message}"
+			: $", {message}";
+	}
+
+#if NET8_0_OR_GREATER
+	public async ValueTask<ConstraintResult>
+#else
+	public async Task<ConstraintResult>
+#endif
+		ApplyTo(ConstraintResult result)
+	{
+		if (_message is null)
+		{
+			_message = CreateMessage(await reason.ConfigureAwait(false));
+		}
+
+		string message = _message;
+		return result.AppendExpectationText(e => e.Append(message));
+	}
+}

--- a/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/BecauseReason.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Threading.Tasks;
 using aweXpect.Core.Constraints;
 
 namespace aweXpect.Core.Helpers;
 
-internal readonly struct BecauseReason(string reason)
+internal readonly struct BecauseReason(string reason) : IBecauseReason
 {
 	private readonly Lazy<string> _message = new(() => CreateMessage(reason));
 
@@ -19,10 +20,19 @@ internal readonly struct BecauseReason(string reason)
 
 	public override string ToString()
 		=> _message.Value;
-
-	public ConstraintResult ApplyTo(ConstraintResult result)
+	
+#if NET8_0_OR_GREATER
+	public ValueTask<ConstraintResult>
+#else
+	public Task<ConstraintResult>
+#endif
+	ApplyTo(ConstraintResult result)
 	{
 		string message = _message.Value;
-		return result.AppendExpectationText(e => e.Append(message));
+#if NET8_0_OR_GREATER
+		return ValueTask.FromResult(result.AppendExpectationText(e => e.Append(message)));
+#else
+		return Task.FromResult(result.AppendExpectationText(e => e.Append(message)));
+#endif
 	}
 }

--- a/Source/aweXpect.Core/Core/Helpers/IBecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/IBecauseReason.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using aweXpect.Core.Constraints;
+
+namespace aweXpect.Core.Helpers;
+
+internal interface IBecauseReason
+{
+	
+#if NET8_0_OR_GREATER
+	public ValueTask<ConstraintResult>
+#else
+	public Task<ConstraintResult>
+#endif
+		ApplyTo(ConstraintResult result);
+}

--- a/Source/aweXpect.Core/Core/Nodes/AndNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/AndNode.cs
@@ -77,8 +77,8 @@ internal class AndNode : Node
 		return combinedResult!;
 	}
 
-	/// <inheritdoc />
-	public override void SetReason(BecauseReason becauseReason)
+	/// <inheritdoc cref="Node.SetReason(IBecauseReason)" />
+	public override void SetReason(IBecauseReason becauseReason)
 	{
 		if (_nodes.Any() && Current is ExpectationNode expectationNode && expectationNode.IsEmpty())
 		{

--- a/Source/aweXpect.Core/Core/Nodes/Node.cs
+++ b/Source/aweXpect.Core/Core/Nodes/Node.cs
@@ -47,7 +47,7 @@ internal abstract class Node
 	/// <summary>
 	///     Set the <paramref name="becauseReason" /> on the current node.
 	/// </summary>
-	public abstract void SetReason(BecauseReason becauseReason);
+	public abstract void SetReason(IBecauseReason becauseReason);
 
 	/// <summary>
 	///     Appends the expectation to the <paramref name="stringBuilder" />.

--- a/Source/aweXpect.Core/Core/Nodes/OrNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/OrNode.cs
@@ -71,8 +71,8 @@ internal class OrNode : Node
 		return combinedResult!;
 	}
 
-	/// <inheritdoc />
-	public override void SetReason(BecauseReason becauseReason)
+	/// <inheritdoc cref="Node.SetReason(IBecauseReason)" />
+	public override void SetReason(IBecauseReason becauseReason)
 	{
 		if (_nodes.Any() && Current is ExpectationNode expectationNode && expectationNode.IsEmpty())
 		{

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -138,8 +138,8 @@ internal class WhichNode<TSource, TMember> : Node
 			value);
 	}
 
-	/// <inheritdoc />
-	public override void SetReason(BecauseReason becauseReason)
+	/// <inheritdoc cref="Node.SetReason(IBecauseReason)" />
+	public override void SetReason(IBecauseReason becauseReason)
 		=> _inner?.SetReason(becauseReason);
 
 	/// <inheritdoc />

--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -38,6 +38,16 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder)
 	}
 
 	/// <summary>
+	///     Provide an <see langword="async" /> <paramref name="reason" /> explaining why the constraint is needed.<br />
+	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+	/// </summary>
+	public ExpectationResult Because(Task<string> reason)
+	{
+		expectationBuilder.AddReason(reason);
+		return this;
+	}
+
+	/// <summary>
 	///     Sets the <see cref="CancellationToken" /> to be passed to expectations.
 	/// </summary>
 	/// <remarks>
@@ -158,6 +168,16 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
 	/// </summary>
 	public TSelf Because(string reason)
+	{
+		expectationBuilder.AddReason(reason);
+		return (TSelf)this;
+	}
+
+	/// <summary>
+	///     Provide an <see langword="async" /> <paramref name="reason" /> explaining why the constraint is needed.<br />
+	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+	/// </summary>
+	public TSelf Because(Task<string> reason)
 	{
 		expectationBuilder.AddReason(reason);
 		return (TSelf)this;

--- a/Tests/aweXpect.Core.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Core.Api.Tests/ApiAcceptance.cs
@@ -10,7 +10,6 @@ public sealed class ApiAcceptance
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
 	[TestCase]
-	[Explicit]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/aweXpect.Core.Tests/Core/BecauseTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/BecauseTests.cs
@@ -5,25 +5,73 @@ namespace aweXpect.Core.Tests.Core;
 public class BecauseTests
 {
 	[Fact]
+	public async Task ActionDelegate_ShouldApplyAsyncBecauseReason()
+	{
+		string because = "this is the reason";
+		Task<string> becauseTask = Task.Delay(5).ContinueWith(_ => because);
+		Action subject = () => throw new MyException();
+
+		async Task Act()
+		{
+			await That(subject).DoesNotThrow().Because(becauseTask);
+		}
+
+		await That(Act).ThrowsException().WithMessage($"*{because}*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task ActionDelegate_ShouldApplyBecauseReason()
+	{
+		string because = "this is the reason";
+		Action subject = () => throw new MyException();
+
+		async Task Act()
+		{
+			await That(subject).DoesNotThrow().Because(because);
+		}
+
+		await That(Act).ThrowsException().WithMessage($"*{because}*").AsWildcard();
+	}
+
+	[Fact]
 	public async Task ASpecifiedBecauseReason_ShouldBeIncludedInMessage()
 	{
 		string because = "I want to test 'because'";
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsFalse().Because(because);
+		{
+			await That(subject).IsFalse().Because(because);
+		}
 
 		await That(Act).ThrowsException().WithMessage($"*{because}*").AsWildcard();
 	}
 
 	[Fact]
-	public async Task Delegate_ShouldApplyBecauseReason()
+	public async Task FuncDelegate_ShouldApplyAsyncBecauseReason()
 	{
 		string because = "this is the reason";
-		Action subject = () => throw new MyException();
+		Task<string> becauseTask = Task.Delay(5).ContinueWith(_ => because);
+		Func<int> subject = () => throw new MyException();
 
 		async Task Act()
-			=> await That(subject).DoesNotThrow().Because(because);
+		{
+			await That(subject).DoesNotThrow().Because(becauseTask);
+		}
+
+		await That(Act).ThrowsException().WithMessage($"*{because}*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task FuncDelegate_ShouldApplyBecauseReason()
+	{
+		string because = "this is the reason";
+		Func<int> subject = () => throw new MyException();
+
+		async Task Act()
+		{
+			await That(subject).DoesNotThrow().Because(because);
+		}
 
 		await That(Act).ThrowsException().WithMessage($"*{because}*").AsWildcard();
 	}
@@ -37,7 +85,9 @@ public class BecauseTests
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsFalse().Because(because);
+		{
+			await That(subject).IsFalse().Because(because);
+		}
 
 		await That(Act).ThrowsException().WithMessage($"*{expectedWithPrefix}*")
 			.AsWildcard();
@@ -51,8 +101,10 @@ public class BecauseTests
 		bool subject = false;
 
 		async Task Act()
-			=> await That(subject).IsTrue().Because(because1)
+		{
+			await That(subject).IsTrue().Because(because1)
 				.And.IsFalse().Because(because2);
+		}
 
 		await That(Act).ThrowsException().WithMessage($"*{because1}*").AsWildcard();
 	}
@@ -65,8 +117,10 @@ public class BecauseTests
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsTrue().Because(because1)
+		{
+			await That(subject).IsTrue().Because(because1)
 				.And.IsFalse().Because(because2);
+		}
 
 		await That(Act).ThrowsException().WithMessage($"*{because2}*").AsWildcard();
 	}
@@ -78,8 +132,10 @@ public class BecauseTests
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsTrue().Because(because)
+		{
+			await That(subject).IsTrue().Because(because)
 				.And.IsFalse();
+		}
 
 		await That(Act).ThrowsException()
 			.WithMessage("""
@@ -97,8 +153,10 @@ public class BecauseTests
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsFalse().Because(because1)
+		{
+			await That(subject).IsFalse().Because(because1)
 				.Or.IsFalse().Because(because2);
+		}
 
 		await That(Act).ThrowsException().WithMessage($"*{because1}*{because2}*")
 			.AsWildcard();
@@ -110,7 +168,9 @@ public class BecauseTests
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsFalse();
+		{
+			await That(subject).IsFalse();
+		}
 
 		await That(Act).ThrowsException()
 			.WithMessage("""
@@ -127,7 +187,9 @@ public class BecauseTests
 		bool subject = true;
 
 		async Task Act()
-			=> await That(subject).IsFalse().Because(because);
+		{
+			await That(subject).IsFalse().Because(because);
+		}
 
 		Exception exception = await That(Act).ThrowsException()
 			.WithMessage("*because*").AsWildcard();

--- a/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
+++ b/Tests/aweXpect.Core.Tests/TestHelpers/DummyNode.cs
@@ -46,7 +46,7 @@ internal class DummyNode(string name, Func<ConstraintResult>? result = null) : N
 		where TValue : default
 		=> result == null ? throw new NotSupportedException() : Task.FromResult(result());
 
-	public override void SetReason(BecauseReason becauseReason)
+	public override void SetReason(IBecauseReason becauseReason)
 		=> ReceivedReason = becauseReason.ToString();
 
 	public override void AppendExpectation(StringBuilder stringBuilder, string? indentation = null)


### PR DESCRIPTION
This PR adds support for asynchronous `Because` reasons in the aweXpect assertion library, allowing users to provide a `Task<string>` as the reason for an expectation.

### Key Changes:
- Introduces `IBecauseReason` interface to support both synchronous and asynchronous reason handling
- Adds `AsyncBecauseReason` struct to handle `Task<string>` reasons
- Updates `ExpectationResult` to accept `Task<string>` in `Because()` method