### PR TITLE
chore: bump aweXpect.Core to v2.27.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.28.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.27.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
This PR updates the `aweXpect.Core` package dependency from version 2.26.0 to 2.27.0, maintaining alignment with the library's dependency versioning strategy.