### PR TITLE
fix: add `OverloadResolutionPriority` to collection expectations

### DIFF
--- a/Source/aweXpect/Polyfills/OverloadResolutionPriorityAttribute.cs
+++ b/Source/aweXpect/Polyfills/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,32 @@
+﻿#if !NET10_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+///     Specifies the priority of a member in overload resolution. When unspecified, the default priority is 0.
+/// </summary>
+[AttributeUsage(
+	AttributeTargets.Method |
+	AttributeTargets.Constructor |
+	AttributeTargets.Property,
+	Inherited = false)]
+[ExcludeFromCodeCoverage]
+internal sealed class OverloadResolutionPriorityAttribute : Attribute
+{
+	/// <summary>
+	///     Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute" /> class.
+	/// </summary>
+	/// <param name="priority">The priority of the attributed member. Higher numbers are prioritized, lower numbers are deprioritized. 0 is the default if no attribute is present.</param>
+	public OverloadResolutionPriorityAttribute(int priority)
+	{
+		Priority = priority;
+	}
+
+	/// <summary>
+	///     The priority of the member.
+	/// </summary>
+	public int Priority { get; }
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatEnumerable.All.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.All.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -27,6 +28,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection all items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> All(
 		this IThat<IEnumerable> subject)
 		=> new(subject, EnumerableQuantifier.All(subject.Get().ExpectationBuilder.ExpectationGrammars));

--- a/Source/aweXpect/That/Collections/ThatEnumerable.AreAllUnique.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.AreAllUnique.cs
@@ -103,6 +103,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection only contains unique items.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, object?> AreAllUnique(
 		this IThat<IEnumerable> source)
 	{
@@ -120,6 +121,7 @@ public static partial class ThatEnumerable
 	///     Verifies that the collection only contains items with unique members specified by the
 	///     <paramref name="memberAccessor" />.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TMember> AreAllUnique<TMember>(
 		this IThat<IEnumerable> source,
 		Func<object?, TMember> memberAccessor,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.AtLeast.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.AtLeast.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -29,6 +30,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection at least <paramref name="minimum" /> items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> AtLeast(
 		this IThat<IEnumerable> subject,
 		int minimum)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.AtMost.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.AtMost.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -29,6 +30,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection at most <paramref name="maximum" /> items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> AtMost(
 		this IThat<IEnumerable> subject,
 		int maximum)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Between.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Between.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Results;
@@ -32,6 +33,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection between <paramref name="minimum" />…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static BetweenResult<ElementsForEnumerable<IEnumerable>> Between(
 		this IThat<IEnumerable> subject,
 		int minimum)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Contains.cs
@@ -102,6 +102,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection contains the <paramref name="expected" /> value.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCountResult<IEnumerable, IThat<IEnumerable>, object?>
 		Contains(
 			this IThat<IEnumerable> source,
@@ -301,6 +302,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection contains the provided <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCollectionContainResult<IEnumerable, IThat<IEnumerable>, TItem>
 		Contains<TItem>(
 			this IThat<IEnumerable> source,
@@ -493,6 +495,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not contain the <paramref name="unexpected" /> value.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCountResult<IEnumerable, IThat<IEnumerable>, object?>
 		DoesNotContain(
 			this IThat<IEnumerable> source,
@@ -695,6 +698,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not contain the provided <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCollectionContainResult<IEnumerable, IThat<IEnumerable>, TItem>
 		DoesNotContain<TItem>(
 			this IThat<IEnumerable> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.AreEqualTo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
@@ -282,6 +283,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     …are equal to the <paramref name="expected" /> value.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, object?>
 		AreEqualTo(this ElementsForEnumerable<IEnumerable> elements, object? expected)
 	{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
@@ -108,6 +108,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection ends with the provided <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		EndsWith<TItem>(
 			this IThat<IEnumerable> source,
@@ -128,6 +129,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection ends with the provided <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		EndsWith<TItem>(
 			this IThat<IEnumerable> source,
@@ -328,6 +330,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not end with the provided <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		DoesNotEndWith<TItem>(
 			this IThat<IEnumerable> source,
@@ -348,6 +351,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not end with the provided <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		DoesNotEndWith<TItem>(
 			this IThat<IEnumerable> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Exactly.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Exactly.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -31,6 +32,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection exactly <paramref name="expected" /> items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> Exactly(
 		this IThat<IEnumerable> subject,
 		int expected)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasCount.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasCount.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
@@ -71,6 +72,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the <paramref name="subject" /> has an item count of…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static CollectionCountResult<AndOrResult<IEnumerable, IThat<IEnumerable>>> HasCount(
 		this IThat<IEnumerable> subject)
 	{
@@ -163,6 +165,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the <paramref name="subject" /> does not have <paramref name="unexpected" /> items.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static AndOrResult<IEnumerable, IThat<IEnumerable>> DoesNotHaveCount(
 		this IThat<IEnumerable> subject, int unexpected)
 	{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasItem.cs
@@ -120,6 +120,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection has an item matching the <paramref name="predicate" />…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static HasItemResult<IEnumerable> HasItem(
 		this IThat<IEnumerable> source, Func<object?, bool> predicate,
 		[CallerArgumentExpression("predicate")]

--- a/Source/aweXpect/That/Collections/ThatEnumerable.HasSingle.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.HasSingle.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
@@ -37,6 +38,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection contains exactly one item.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static SingleItemResult<IEnumerable, object?> HasSingle(
 		this IThat<IEnumerable> source)
 	{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsContainedIn.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsContainedIn.cs
@@ -66,6 +66,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection is contained in the provided <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCollectionBeContainedInResult<IEnumerable, IThat<IEnumerable>, TItem>
 		IsContainedIn<TItem>(
 			this IThat<IEnumerable> source,
@@ -234,6 +235,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection is not contained in the provided <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCollectionBeContainedInResult<IEnumerable, IThat<IEnumerable>, TItem>
 		IsNotContainedIn<TItem>(
 			this IThat<IEnumerable> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsEqualTo.cs
@@ -391,6 +391,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection matches the <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCollectionMatchResult<IEnumerable, IThat<IEnumerable>, TItem>
 		IsEqualTo<TItem>(
 			this IThat<IEnumerable> source,
@@ -895,6 +896,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not match the <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectCollectionMatchResult<IEnumerable, IThat<IEnumerable>, TItem>
 		IsNotEqualTo<TItem>(
 			this IThat<IEnumerable> source,

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsInAscendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsInAscendingOrder.cs
@@ -64,6 +64,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection is in ascending order.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static CollectionOrderResult<object?, IEnumerable, IThat<IEnumerable>>
 		IsInAscendingOrder(this IThat<IEnumerable> source)
 	{
@@ -204,6 +205,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection is not in ascending order.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static CollectionOrderResult<object?, IEnumerable, IThat<IEnumerable>>
 		IsNotInAscendingOrder(this IThat<IEnumerable> source)
 	{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.IsInDescendingOrder.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.IsInDescendingOrder.cs
@@ -64,6 +64,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection is in descending order.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static CollectionOrderResult<object?, IEnumerable, IThat<IEnumerable>>
 		IsInDescendingOrder(this IThat<IEnumerable> source)
 	{
@@ -204,6 +205,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection is not in descending order.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static CollectionOrderResult<object?, IEnumerable, IThat<IEnumerable>>
 		IsNotInDescendingOrder(this IThat<IEnumerable> source)
 	{

--- a/Source/aweXpect/That/Collections/ThatEnumerable.LessThan.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.LessThan.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -29,6 +30,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection less than <paramref name="maximum" /> items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> LessThan(
 		this IThat<IEnumerable> subject,
 		int maximum)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.MoreThan.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.MoreThan.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -29,6 +30,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection more than <paramref name="minimum" /> items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> MoreThan(
 		this IThat<IEnumerable> subject,
 		int minimum)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.None.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.None.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using aweXpect.Core;
 using aweXpect.Helpers;
 #if NET8_0_OR_GREATER
@@ -29,6 +30,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that in the collection no items…
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ElementsForEnumerable<IEnumerable> None(
 		this IThat<IEnumerable> subject)
 		=> new(subject, EnumerableQuantifier.None(subject.Get().ExpectationBuilder.ExpectationGrammars |

--- a/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
@@ -108,6 +108,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection starts with the provided <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		StartsWith<TItem>(
 			this IThat<IEnumerable> source,
@@ -128,6 +129,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection starts with the provided <paramref name="expected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		StartsWith<TItem>(
 			this IThat<IEnumerable> source,
@@ -328,6 +330,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not start with the provided <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		DoesNotStartWith<TItem>(
 			this IThat<IEnumerable> source,
@@ -348,6 +351,7 @@ public static partial class ThatEnumerable
 	/// <summary>
 	///     Verifies that the collection does not start with the provided <paramref name="unexpected" /> collection.
 	/// </summary>
+	[OverloadResolutionPriority(-1)]
 	public static ObjectEqualityResult<IEnumerable, IThat<IEnumerable>, TItem>
 		DoesNotStartWith<TItem>(
 			this IThat<IEnumerable> source,

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
@@ -45,7 +45,6 @@ public sealed partial class ThatEnumerable
 					             """);
 			}
 
-
 			[Fact]
 			public async Task CompletelyDifferentCollections_ShouldFail()
 			{
@@ -192,6 +191,17 @@ public sealed partial class ThatEnumerable
 					             but it cannot compare to <null>
 					             """);
 			}
+			
+			[Fact]
+			public async Task WhenReferenceTypeDoesNotMatchNullability_ShouldStillWork()
+			{
+				IEnumerable<string?> subject = ["foo", null, "baz",];
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(["foo", "", "baz",]);
+				
+				await That(Act).DoesNotThrow();
+			}
 
 			[Fact]
 			public async Task WhenSubjectAndExpectedIsNull_ShouldSucceed()
@@ -219,6 +229,17 @@ public sealed partial class ThatEnumerable
 					             matches collection Array.Empty<string>() in order,
 					             but it was <null>
 					             """);
+			}
+			
+			[Fact]
+			public async Task WhenTypeDoesNotMatchNullability_ShouldStillWork()
+			{
+				IEnumerable<int?> subject = [1, 2, 3,];
+
+				async Task Act()
+					=> await That(subject).IsEqualTo([1, 2, 3,]);
+				
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsEqualTo.Tests.cs
@@ -195,10 +195,10 @@ public sealed partial class ThatEnumerable
 			[Fact]
 			public async Task WhenReferenceTypeDoesNotMatchNullability_ShouldStillWork()
 			{
-				IEnumerable<string?> subject = ["foo", null, "baz",];
+				IEnumerable<string?> subject = ["foo", "bar", "baz",];
 
 				async Task Act()
-					=> await That(subject).IsNotEqualTo(["foo", "", "baz",]);
+					=> await That(subject).IsEqualTo(["foo", "bar", "baz",]);
 				
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsNotEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.IsNotEqualTo.Tests.cs
@@ -69,6 +69,17 @@ public sealed partial class ThatEnumerable
 
 				await That(Act).DoesNotThrow();
 			}
+			
+			[Fact]
+			public async Task WhenReferenceTypeDoesNotMatchNullability_ShouldStillWork()
+			{
+				IEnumerable<string?> subject = ["foo", null, "bar",];
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo(["foo", "", "bar",]);
+				
+				await That(Act).DoesNotThrow();
+			}
 
 			[Fact]
 			public async Task WhenSubjectAndExpectedIsNull_ShouldFail()
@@ -95,6 +106,17 @@ public sealed partial class ThatEnumerable
 				async Task Act()
 					=> await That(subject).IsNotEqualTo(Array.Empty<string>());
 
+				await That(Act).DoesNotThrow();
+			}
+			
+			[Fact]
+			public async Task WhenTypeDoesNotMatchNullability_ShouldStillWork()
+			{
+				IEnumerable<int?> subject = [1, null, 3,];
+
+				async Task Act()
+					=> await That(subject).IsNotEqualTo([1, 2, 3,]);
+				
 				await That(Act).DoesNotThrow();
 			}
 


### PR DESCRIPTION
This PR addresses overload-resolution issues in aweXpect’s collection expectations by deprioritizing the non-generic `IEnumerable` overloads, improving call-site behavior (notably around nullability/type inference) across target frameworks.

### Key Changes:
- Added a polyfill for `System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute` for TFMs below `net10.0`.
- Applied `[OverloadResolutionPriority(-1)]` to multiple `IThat<IEnumerable>` collection expectation overloads to prefer the generic `IThat<IEnumerable<T>>` APIs.
- Added regression tests to ensure nullability/type-mismatch scenarios still compile and run without throwing.