### PR TITLE
coverage: re-enable mutation tests

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -22,7 +22,7 @@ namespace Build;
 
 partial class Build
 {
-	private static bool DisableMutationTests = true;
+	private static bool DisableMutationTests = false;
 	AbsolutePath StrykerOutputDirectory => ArtifactsDirectory / "Stryker";
 	AbsolutePath StrykerToolPath => TestResultsDirectory / "dotnet-stryker";
 


### PR DESCRIPTION
This pull request makes a small but important change to the mutation testing configuration. Mutation tests, which were previously disabled, are now enabled by setting `DisableMutationTests` to `false` in the `Build` namespace.