### PR TITLE
chore: move SonarCloud project to Testably organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect) with quality gate requiring to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -19,8 +19,8 @@ partial class Build
 			Configuration = Configuration.Debug;
 
 			SonarScannerTasks.SonarScannerBegin(s => s
-				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_aweXpect")
+				.SetOrganization("testably")
+				.SetProjectKey("Testably_aweXpect")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, BranchName)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Nuget](https://img.shields.io/nuget/v/aweXpect?label=aweXpect)](https://www.nuget.org/packages/aweXpect)
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Core?label=Core)](https://www.nuget.org/packages/aweXpect.Core)
 [![Build](https://github.com/Testably/aweXpect/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/aweXpect/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect/main)
 
 Assert unit tests in natural language using awesome expectations.


### PR DESCRIPTION
Moves the repository’s SonarCloud configuration and documentation links from the previous SonarCloud organization/project key to the new **testably / Testably_aweXpect** identity, keeping CI analysis and badges aligned with the new SonarCloud project.

**Changes:**
- Update NUKE SonarScanner configuration to use `organization=testably` and `projectKey=Testably_aweXpect`.
- Refresh SonarCloud badge links in the README to point at the new project.
- Update the SonarCloud link in CONTRIBUTING to reference the new project overview.