### PR TITLE
fix: correct URI casing in documentation links

### DIFF
--- a/Docs/pages/00-index.mdx
+++ b/Docs/pages/00-index.mdx
@@ -51,7 +51,7 @@ Because the chain is awaited, `Because(...)` and `WithCancellation(...)` attach 
 </TabItem>
 <TabItem value="performant" label="Performant">
 
-The happy path — passing assertions, the common case in a healthy test suite — is the path that has been optimised. See the [benchmarks](https://docs.testably.org/awexpect/benchmarks) for numbers.
+The happy path — passing assertions, the common case in a healthy test suite — is the path that has been optimised. See the [benchmarks](https://docs.testably.org/aweXpect/benchmarks) for numbers.
 
 </TabItem>
 <TabItem value="extensible" label="Extensible">

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Assert unit tests in natural language using awesome expectations.
    This brings the static `Expect` class and lots of extension methods into scope.
 
 
-3. See the [documentation](https://docs.testably.org/awexpect/getting-started#write-your-first-expectation) or
-   the [migration guide](https://docs.testably.org/awexpect/getting-started#migration) for more information.
+3. See the [documentation](https://docs.testably.org/aweXpect/getting-started#write-your-first-expectation) or
+   the [migration guide](https://docs.testably.org/aweXpect/getting-started#migration) for more information.
 
 ## Features
 
@@ -46,7 +46,7 @@ By using async assertions per default, we have a consistent API and other perks:
 
 A focus on performance allows you to execute your tests as fast as possible.  
 Special care is taken for the happy case (succeeding tests) to be as performant as possible. See
-the [benchmarks](https://docs.testably.org/awexpect/benchmarks) for more details.
+the [benchmarks](https://docs.testably.org/aweXpect/benchmarks) for more details.
 
 ### Extensible
 
@@ -55,7 +55,7 @@ The [aweXpect.Core](https://www.nuget.org/packages/aweXpect.Core/) package is in
 extensions, so that the risk of version conflicts between different extensions can be reduced.
 
 You can extend the functionality for any types, by adding extension methods on `IThat<TType>`.
-More information can be found in the [extensibility guide](https://docs.testably.org/awexpect/write-extension).
+More information can be found in the [extensibility guide](https://docs.testably.org/aweXpect/write-extension).
 
 **Extension projects**
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -8,7 +8,7 @@
 		<Copyright>Copyright (c) 2024 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
 		<RepositoryUrl>https://github.com/Testably/aweXpect.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<PackageProjectUrl>https://docs.testably.org/awexpect</PackageProjectUrl>
+		<PackageProjectUrl>https://docs.testably.org/aweXpect</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/Logo.png</PackageIcon>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>


### PR DESCRIPTION
This pull request updates documentation and metadata links throughout the project to consistently use the correct casing for the `aweXpect` project name in URLs. This ensures that all references point to the intended documentation pages and improves the overall professionalism and accuracy of the project.