### PR TITLE
docs: refresh landing page hero example and tabs

### DIFF
--- a/Docs/pages/00-index.mdx
+++ b/Docs/pages/00-index.mdx
@@ -5,20 +5,25 @@ sidebar_position: -1
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import BenchmarkResult from '@site/src/components/BenchmarkResult';
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect?label=aweXpect&logo=nuget)](https://www.nuget.org/packages/aweXpect)
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Core?label=aweXpect.Core&logo=nuget)](https://www.nuget.org/packages/aweXpect.Core)
 
-`aweXpect` is a fluent assertion library for .NET. It turns test verifications into readable sentences and produces failure messages that explain — in plain English — what was expected and what actually happened.
+`aweXpect` is a fluent assertion library for .NET. It turns test verifications into readable sentences and produces failure messages that explain in plain English what was expected and what actually happened.
 
 ```csharp
-await Expect.That(result).IsEqualTo(42);
+await Expect.That(message).IsEqualTo("It's a compliment");
 ```
 
 > ```
-> Expected result to
-> be equal to 42,
-> but it was 41
+> Expected that message
+> is equal to "It's a compliment",
+> but it was "It's a complement" which differs at index 12:
+>                ↓ (actual)
+>   "It's a complement"
+>   "It's a compliment"
+>                ↑ (expected)
 > ```
 
 ## Why aweXpect?
@@ -26,7 +31,7 @@ await Expect.That(result).IsEqualTo(42);
 <Tabs groupId="aweXpectFeatures">
 <TabItem value="async" label="Async-first" default>
 
-Every expectation is awaited. The same fluent chain works for sync values, `Task`, `IAsyncEnumerable`, exceptions and HTTP responses — there is no parallel `…Async()` API to remember.
+Every expectation is awaited. The same fluent chain works for sync values, `Task`, `IAsyncEnumerable`, exceptions and HTTP responses - there is no parallel `…Async()` API to remember.
 
 ```csharp
 // Plain value
@@ -36,7 +41,7 @@ await Expect.That(result).IsEqualTo(42);
 await Expect.That(_users.GetAsync(id))
     .Satisfies(u => u.IsActive);
 
-// IAsyncEnumerable<T> — the cancellation token flows through the stream
+// IAsyncEnumerable<T> - the cancellation token flows through the stream
 await Expect.That(_orders.StreamAsync())
     .Contains(o => o.IsPriority)
     .WithCancellation(cancellationToken);
@@ -46,12 +51,17 @@ await Expect.That(() => _payments.ChargeAsync(-1m))
     .ThrowsExactly<ArgumentOutOfRangeException>();
 ```
 
-Because the chain is awaited, `Because(...)` and `WithCancellation(...)` attach once at the end instead of being threaded through every method. Multiple expectations compose directly via `Expect.ThatAll(...)` — no thread-static assertion scope.
+Because the chain is awaited, `Because(...)` and `WithCancellation(...)` attach once at the end instead of being threaded through every method. Multiple expectations compose directly via `Expect.ThatAll(...)` - no thread-static assertion scope.
 
 </TabItem>
 <TabItem value="performant" label="Performant">
 
-The happy path — passing assertions, the common case in a healthy test suite — is the path that has been optimised. See the [benchmarks](https://docs.testably.org/aweXpect/benchmarks) for numbers.
+The happy path - passing assertions, the common case in a healthy test suite - is the path that has been optimised.                                            
+
+**Comparing strings, ignoring case**     
+<BenchmarkResult name="String" />
+
+See the [benchmarks](https://docs.testably.org/aweXpect/benchmarks) for the full set.
 
 </TabItem>
 <TabItem value="extensible" label="Extensible">
@@ -69,30 +79,20 @@ public static AndOrResult<string, IThat<string>> IsAbsolutePath(
 await Expect.That("/var/log").IsAbsolutePath();
 ```
 
-The full walkthrough is at [Write your own extension](/write-your-own-extension).
+The full walkthrough is at [Write your own extension](./write-extension).
 
 </TabItem>
-<TabItem value="frameworks" label="Test-framework agnostic">
-
-xUnit (v2 and v3), NUnit (v3 and v4), MSTest and TUnit are detected automatically. The matching framework-native exception is thrown, so failures integrate cleanly with each runner.
+<TabItem value="frameworks" label="Any runner">
 
 ```csharp
-// xUnit
-[Fact] public async Task IsActive()
-    => await Expect.That(user.IsActive).IsTrue();
-
-// NUnit
-[Test] public async Task IsActive()
-    => await Expect.That(user.IsActive).IsTrue();
-
-// MSTest
-[TestMethod] public async Task IsActive()
-    => await Expect.That(user.IsActive).IsTrue();
-
-// TUnit
-[Test] public async Task IsActive()
+[Fact]        // xUnit
+[Test]        // NUnit / TUnit
+[TestMethod]  // MSTest
+public async Task IsActive()
     => await Expect.That(user.IsActive).IsTrue();
 ```
+
+xUnit (v2 and v3), NUnit (v3 and v4), MSTest and TUnit are detected automatically - failures throw the framework-native exception, so they integrate cleanly with each runner.
 
 </TabItem>
 </Tabs>
@@ -105,15 +105,15 @@ The [aweXpect.Migration](https://github.com/aweXpect/aweXpect.Migration) analyze
 
 `aweXpect` ships a small core with focused extensions for common ecosystems:
 
-- **[aweXpect.Json](https://github.com/aweXpect/aweXpect.Json)** — expectations for `System.Text.Json`.
-- **[aweXpect.Web](https://github.com/aweXpect/aweXpect.Web)** — expectations for `HttpClient` and `HttpResponseMessage`.
-- **[aweXpect.Reflection](https://github.com/aweXpect/aweXpect.Reflection)** — expectations for reflection types.
-- **[aweXpect.Testably](https://github.com/aweXpect/aweXpect.Testably)** — expectations for [Testably.Abstractions](https://github.com/Testably/Testably.Abstractions) file and time systems.
-- **[aweXpect.Mockolate](https://github.com/aweXpect/aweXpect.Mockolate)** — expectations for [Mockolate](https://github.com/aweXpect/Mockolate) mock interactions.
+- **[aweXpect.Json](https://github.com/aweXpect/aweXpect.Json)** - expectations for `System.Text.Json`.
+- **[aweXpect.Web](https://github.com/aweXpect/aweXpect.Web)** - expectations for `HttpClient` and `HttpResponseMessage`.
+- **[aweXpect.Reflection](https://github.com/aweXpect/aweXpect.Reflection)** - expectations for reflection types.
+- **[aweXpect.Testably](https://github.com/aweXpect/aweXpect.Testably)** - expectations for [Testably.Abstractions](https://github.com/Testably/Testably.Abstractions) file and time systems.
+- **[aweXpect.Mockolate](https://github.com/aweXpect/aweXpect.Mockolate)** - expectations for [Mockolate](https://github.com/aweXpect/Mockolate) mock interactions.
 
 ## Where to go next
 
-- **[Getting Started](./getting-started)** — install the package and write your first expectation.
-- **[Migration](./migration)** — automated code fixes for moving from FluentAssertions or `xunit.Assert`.
-- **[Advanced](./advanced)** — multiple expectations, cancellation, customization, and more.
-- **[Write your own extension](../extensions/write-extensions)** — add expectations for your own types using `aweXpect.Core`.
+- **[Getting Started](./getting-started)** - install the package and write your first expectation.
+- **[Migration](./migration)** - automated code fixes for moving from FluentAssertions or `xunit.Assert`.
+- **[Advanced](./advanced)** - multiple expectations, cancellation, customization, and more.
+- **[Write your own extension](./write-extension)** - add expectations for your own types using `aweXpect.Core`.

--- a/Docs/pages/08-benchmarks.mdx
+++ b/Docs/pages/08-benchmarks.mdx
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import BenchmarkResult from '@site/src/components/BenchmarkResult';
 
-These benchmarks compare aweXpect's happy-path overhead — passing assertions, the dominant case in a healthy test suite — against the equivalent [FluentAssertions](https://fluentassertions.com/) calls.
+These benchmarks compare aweXpect's happy-path overhead - passing assertions, the dominant case in a healthy test suite - against the equivalent [FluentAssertions](https://fluentassertions.com/) calls.
 
 :::info[Methodology]
 


### PR DESCRIPTION
Updates the docs landing page and benchmarks page copy to refresh the hero example and feature tabs, aiming for clearer positioning and more representative examples.

**Changes:**
- Refreshes the landing page hero snippet and rewrites parts of the feature tabs (async/performance/extensibility/frameworks).
- Updates internal navigation links (notably the “Write your own extension” link) and rephrases several sentences for consistency.
- Tweaks the benchmarks intro wording (typography/punctuation changes).