### PR TITLE
chore: bump aweXpect.Core to v2.29.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.30.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.28.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.29.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 	[GitRepository] readonly GitRepository Repository;

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -1037,7 +1037,6 @@ namespace aweXpect
     }
     public static class ThatObject
     {
-        public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> Is<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> Is<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsEqualTo(this aweXpect.Core.IThat<object?> source, object? expected) { }
@@ -1047,8 +1046,6 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected expected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
-        public static aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<object?>> IsExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNot<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T?, aweXpect.Core.IThat<T?>> IsNot<T>(this aweXpect.Core.IThat<T?> source, System.Type type)
             where T :  class { }
         public static aweXpect.Results.ObjectEqualityResult<object?, aweXpect.Core.IThat<object?>, object?> IsNotEqualTo(this aweXpect.Core.IThat<object?> source, object? unexpected) { }
@@ -1058,7 +1055,6 @@ namespace aweXpect
             where T :  struct { }
         public static aweXpect.Results.AndOrResult<TSubject, aweXpect.Core.IThat<TSubject>> IsNotEquivalentTo<TSubject, TExpected>(this aweXpect.Core.IThat<TSubject> source, TExpected unexpected, System.Func<aweXpect.Equivalency.EquivalencyOptions<TExpected>, aweXpect.Equivalency.EquivalencyOptions>? options = null) { }
         public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly(this aweXpect.Core.IThat<object?> source, System.Type type) { }
-        public static aweXpect.Results.AndOrResult<object?, aweXpect.Core.IThat<object?>> IsNotExactly<TType>(this aweXpect.Core.IThat<object?> source) { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)
             where T :  class { }
         public static aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T?>> IsNotNull<T>(this aweXpect.Core.IThat<T?> source)

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -232,10 +232,10 @@ namespace aweXpect.Core
     public interface IThatDelegateThrows<out T> : aweXpect.Core.IExpectThat<T>, aweXpect.Core.IThat<T> { }
     public interface IThatSubject<T> : aweXpect.Core.IThat<T>
     {
-        aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<T>> Is<TType>();
-        aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<T>> IsExactly<TType>();
-        aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> IsNot<TType>();
-        aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> IsNotExactly<TType>();
+        aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThatSubject<T>> Is<TType>();
+        aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThatSubject<T>> IsExactly<TType>();
+        aweXpect.Results.AndOrResult<T, aweXpect.Core.IThatSubject<T>> IsNot<TType>();
+        aweXpect.Results.AndOrResult<T, aweXpect.Core.IThatSubject<T>> IsNotExactly<TType>();
     }
     public interface IThat<out T>
     {
@@ -341,10 +341,10 @@ namespace aweXpect.Core
     {
         public ThatSubject(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Core.ExpectationBuilder ExpectationBuilder { get; }
-        public aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<T>> Is<TType>() { }
-        public aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThat<T>> IsExactly<TType>() { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> IsNot<TType>() { }
-        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThat<T>> IsNotExactly<TType>() { }
+        public aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThatSubject<T>> Is<TType>() { }
+        public aweXpect.Results.AndOrWhoseResult<TType, aweXpect.Core.IThatSubject<T>> IsExactly<TType>() { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThatSubject<T>> IsNot<TType>() { }
+        public aweXpect.Results.AndOrResult<T, aweXpect.Core.IThatSubject<T>> IsNotExactly<TType>() { }
     }
     public readonly struct Times
     {


### PR DESCRIPTION
This pull request updates package dependencies and makes several breaking changes to the public API surface of the `aweXpect` and `aweXpect.Core` libraries, primarily involving the generic type parameters and return types for several methods and interfaces. 