### PR TITLE
chore: bump aweXpect.Core to v2.30.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.30.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.29.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.30.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.1.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -20,7 +20,7 @@ partial class Build : NukeBuild
 	///     <para />
 	///     Afterward, you can update the package reference in `Directory.Packages.props` and reset this flag.
 	/// </summary>
-	readonly BuildScope BuildScope = BuildScope.CoreOnly;
+	readonly BuildScope BuildScope = BuildScope.Default;
 
 	[Parameter("Github Token")] readonly string GithubToken;
 	[GitRepository] readonly GitRepository Repository;


### PR DESCRIPTION
This pull request updates package dependencies and modifies the build configuration to use the default build scope. The most important changes are:

Dependency updates:
* Updated the `aweXpect.Core` package version from `2.29.0` to `2.30.0` in `Directory.Packages.props`.

Build configuration:
* Changed the `BuildScope` in the `Build` class (`Pipeline/Build.cs`) from `CoreOnly` to `Default`, which will affect which parts of the project are built by default.