### PR TITLE
fix: pluralize item suffix in `ComplyWith` failure messages

### DIFF
--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
@@ -106,7 +106,8 @@ public static partial class ThatAsyncEnumerable
 			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
 			stringBuilder.Append(" for ");
 			stringBuilder.Append(_quantifier);
-			stringBuilder.Append(" items");
+			stringBuilder.Append(' ');
+			stringBuilder.Append(_quantifier.GetItemString());
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -126,7 +127,8 @@ public static partial class ThatAsyncEnumerable
 			stringBuilder.Append(_quantifier);
 			stringBuilder.Append(" for ");
 			_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-			stringBuilder.Append(" items");
+			stringBuilder.Append(' ');
+			stringBuilder.Append(_quantifier.GetItemString());
 		}
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -104,7 +104,8 @@ public static partial class ThatEnumerable
 				_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
 				stringBuilder.Append(For);
 				stringBuilder.Append(_quantifier);
-				stringBuilder.Append(ComplyItems);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(_quantifier.GetItemString());
 			}
 
 			protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -115,7 +116,8 @@ public static partial class ThatEnumerable
 				stringBuilder.Append(_quantifier);
 				stringBuilder.Append(For);
 				_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-				stringBuilder.Append(ComplyItems);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(_quantifier.GetItemString());
 			}
 
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
@@ -212,7 +214,8 @@ public static partial class ThatEnumerable
 				_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
 				stringBuilder.Append(For);
 				stringBuilder.Append(_quantifier);
-				stringBuilder.Append(ComplyItems);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(_quantifier.GetItemString());
 			}
 
 			protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -223,7 +226,8 @@ public static partial class ThatEnumerable
 				stringBuilder.Append(_quantifier);
 				stringBuilder.Append(For);
 				_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-				stringBuilder.Append(ComplyItems);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(_quantifier.GetItemString());
 			}
 
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
@@ -315,7 +319,8 @@ public static partial class ThatEnumerable
 				_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
 				stringBuilder.Append(For);
 				stringBuilder.Append(_quantifier);
-				stringBuilder.Append(ComplyItems);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(_quantifier.GetItemString());
 			}
 
 			protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -326,7 +331,8 @@ public static partial class ThatEnumerable
 				stringBuilder.Append(_quantifier);
 				stringBuilder.Append(For);
 				_itemExpectationBuilder.AppendExpectation(stringBuilder, indentation);
-				stringBuilder.Append(ComplyItems);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(_quantifier.GetItemString());
 			}
 
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -22,7 +22,6 @@ namespace aweXpect;
 public static partial class ThatEnumerable
 {
 	private const string For = " for ";
-	private const string ComplyItems = " items";
 	private const string SortOrder = " order";
 	private const string CannotCompareToNull = " cannot compare to <null>";
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.ComplyWith.Tests.cs
@@ -1,0 +1,37 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class AtLeast
+	{
+		public sealed class ComplyWithTests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).AtLeast(1).ComplyWith(it => it.IsEqualTo(3));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).AtLeast(1).ComplyWith(it => it.IsEqualTo(99));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 99 for at least one item,
+					             but found only 0
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.ComplyWith.Tests.cs
@@ -57,28 +57,23 @@ public sealed partial class ThatEnumerable
 			}
 		}
 
-		public sealed class AtLeastComplyWithTests
+		public sealed class NegatedComplyWithTests
 		{
 			[Fact]
-			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			public async Task WhenExactlyOneItemMatches_ShouldFail()
 			{
 				int[] subject = [1, 2, 3, 4, 5,];
 
 				async Task Act()
-					=> await That(subject).AtLeast(1).ComplyWith(it => it.IsEqualTo(3));
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.Exactly(1).ComplyWith(x => x.IsEqualTo(3)));
 
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenNoItemsMatch_ShouldFail()
-			{
-				int[] subject = [1, 2, 3, 4, 5,];
-
-				async Task Act()
-					=> await That(subject).AtLeast(1).ComplyWith(it => it.IsEqualTo(99));
-
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             exactly one for is equal to 3 item,
+					             but it did
+					             """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.ComplyWith.Tests.cs
@@ -1,0 +1,85 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed partial class Exactly
+	{
+		public sealed class ComplyWithTests
+		{
+			[Fact]
+			public async Task WhenExactlyOneItemMatches_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).Exactly(1).ComplyWith(it => it.IsEqualTo(3));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMoreItemsMatchThanExpected_ShouldFail()
+			{
+				int[] subject = [1, 2, 3, 2, 5,];
+
+				async Task Act()
+					=> await That(subject).Exactly(1).ComplyWith(it => it.IsEqualTo(2));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 2 for exactly one item,
+					             but found 2
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).Exactly(1).ComplyWith(it => it.IsEqualTo(99));
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenRichExpectationMatchesExactCount_ShouldSucceed()
+			{
+				int[] subject = [5, 10, 15, 20, 25, 30, 35,];
+
+				async Task Act()
+					=> await That(subject).Exactly(3)
+						.ComplyWith(it => it.IsGreaterThan(10).And.IsLessThan(30));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class AtLeastComplyWithTests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).AtLeast(1).ComplyWith(it => it.IsEqualTo(3));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).AtLeast(1).ComplyWith(it => it.IsEqualTo(99));
+
+				await That(Act).Throws<XunitException>();
+			}
+		}
+	}
+}


### PR DESCRIPTION
The ComplyWith constraints hardcoded ` items` (always plural), producing ungrammatical output like `for exactly one items`. Route the suffix through EnumerableQuantifier.GetItemString() like the other collection constraints, so singular quantifiers (Exactly(1), AtLeast(1), AtMost(1)) render `item` instead.

Also adds verification tests for the Exactly(n).ComplyWith chain and the AtLeast(n).ComplyWith chain, which previously had no coverage.