### PR TITLE
fix: enhance error messages for collection element expectations

### DIFF
--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Elements.ComplyWith.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
+using aweXpect.Customization;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -52,22 +53,26 @@ public static partial class ThatAsyncEnumerable
 		: ConstraintResult.WithValue<IAsyncEnumerable<TItem>?>,
 			IAsyncContextConstraint<IAsyncEnumerable<TItem>?>
 	{
+		private readonly ExpectationBuilder _expectationBuilder;
 		private readonly ExpectationGrammars _grammars;
 		private readonly string _it;
 		private readonly ManualExpectationBuilder<TItem> _itemExpectationBuilder;
 		private readonly EnumerableQuantifier _quantifier;
 		private int _matchingCount;
+		private LimitedCollection<TItem>? _matchingItems;
 		private int _notMatchingCount;
+		private LimitedCollection<TItem>? _notMatchingItems;
 		private int? _totalCount;
 
 		public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
 			EnumerableQuantifier quantifier,
 			Action<IThatSubject<TItem>> expectations) : base(grammars)
 		{
+			_expectationBuilder = expectationBuilder;
 			_it = it;
 			_grammars = grammars;
 			_quantifier = quantifier;
-			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder, grammars);
+			_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, grammars);
 			expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 		}
 
@@ -87,6 +92,10 @@ public static partial class ThatAsyncEnumerable
 				context.UseMaterializedAsyncEnumerable<TItem, IAsyncEnumerable<TItem>>(actual);
 			_matchingCount = 0;
 			_notMatchingCount = 0;
+			int maxItems = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get() + 1;
+			LimitedCollection<TItem> items = new(maxItems);
+			_matchingItems = new LimitedCollection<TItem>(maxItems);
+			_notMatchingItems = new LimitedCollection<TItem>(maxItems);
 
 			await foreach (TItem item in materialized.WithCancellation(cancellationToken))
 			{
@@ -94,15 +103,22 @@ public static partial class ThatAsyncEnumerable
 				if (isMatch.Outcome == Outcome.Success)
 				{
 					_matchingCount++;
+					_matchingItems.Add(item);
 				}
 				else
 				{
 					_notMatchingCount++;
+					_notMatchingItems.Add(item);
 				}
 
-				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
+				items.Add(item);
+
+				// items.IsReadOnly is set to true, once the limit is reached.
+				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount) && items.IsReadOnly)
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+					AppendContexts(true);
+					_expectationBuilder.AddCollectionContext(items, true);
 					return this;
 				}
 			}
@@ -110,11 +126,14 @@ public static partial class ThatAsyncEnumerable
 			if (cancellationToken.IsCancellationRequested)
 			{
 				Outcome = Outcome.Undecided;
+				_expectationBuilder.AddCollectionContext(items, true);
 				return this;
 			}
 
 			_totalCount = _matchingCount + _notMatchingCount;
 			Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+			AppendContexts(false);
+			_expectationBuilder.AddCollectionContext(items);
 			return this;
 		}
 
@@ -157,6 +176,27 @@ public static partial class ThatAsyncEnumerable
 			else
 			{
 				_quantifier.AppendResult(stringBuilder, _grammars, _matchingCount, _notMatchingCount, _totalCount);
+			}
+		}
+
+		private void AppendContexts(bool isIncomplete)
+		{
+			EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
+			{
+				_expectationBuilder.AddContext(new ResultContext.SyncCallback("Matching items",
+						() => Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption(_matchingItems?.Count))
+							.AppendIsIncomplete(isIncomplete),
+						int.MaxValue));
+			}
+
+			if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
+			{
+				_expectationBuilder.AddContext(new ResultContext.SyncCallback("Not matching items",
+						() => Formatter.Format(_notMatchingItems,
+								typeof(TItem).GetFormattingOption(_notMatchingItems?.Count))
+							.AppendIsIncomplete(isIncomplete),
+						int.MaxValue));
 			}
 		}
 	}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.EvaluationContext;
+using aweXpect.Customization;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
@@ -36,10 +37,13 @@ public static partial class ThatEnumerable
 			: ConstraintResult.WithNotNullValue<IEnumerable<TItem>?>,
 				IAsyncContextConstraint<IEnumerable<TItem>?>
 		{
+			private readonly ExpectationBuilder _expectationBuilder;
 			private readonly ManualExpectationBuilder<TItem> _itemExpectationBuilder;
 			private readonly EnumerableQuantifier _quantifier;
 			private int _matchingCount;
+			private LimitedCollection<TItem>? _matchingItems;
 			private int _notMatchingCount;
+			private LimitedCollection<TItem>? _notMatchingItems;
 			private int? _totalCount;
 
 			public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
@@ -47,8 +51,9 @@ public static partial class ThatEnumerable
 				Action<IThatSubject<TItem>> expectations)
 				: base(it, grammars)
 			{
+				_expectationBuilder = expectationBuilder;
 				_quantifier = quantifier;
-				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder, grammars);
+				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, grammars);
 				expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 			}
 
@@ -68,6 +73,9 @@ public static partial class ThatEnumerable
 				bool cancelEarly = actual is not ICollection<TItem>;
 				_matchingCount = 0;
 				_notMatchingCount = 0;
+				int maxItems = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get() + 1;
+				_matchingItems = new LimitedCollection<TItem>(maxItems);
+				_notMatchingItems = new LimitedCollection<TItem>(maxItems);
 
 				foreach (TItem item in materialized)
 				{
@@ -75,27 +83,34 @@ public static partial class ThatEnumerable
 					if (isMatch.Outcome == Outcome.Success)
 					{
 						_matchingCount++;
+						_matchingItems.Add(item);
 					}
 					else
 					{
 						_notMatchingCount++;
+						_notMatchingItems.Add(item);
 					}
 
 					if (cancelEarly && _quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+						AppendContexts(true);
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 
 					if (cancellationToken.IsCancellationRequested)
 					{
 						Outcome = Outcome.Undecided;
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 				}
 
 				_totalCount = _matchingCount + _notMatchingCount;
 				Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+				AppendContexts(false);
+				_expectationBuilder.AddCollectionContext(materialized);
 				return this;
 			}
 
@@ -123,6 +138,27 @@ public static partial class ThatEnumerable
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 				=> _quantifier.AppendResult(stringBuilder, Grammars, _matchingCount, _notMatchingCount,
 					_totalCount);
+
+			private void AppendContexts(bool isIncomplete)
+			{
+				EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Matching items",
+							() => Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption(_matchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Not matching items",
+							() => Formatter.Format(_notMatchingItems,
+									typeof(TItem).GetFormattingOption(_notMatchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+			}
 		}
 	}
 
@@ -146,10 +182,13 @@ public static partial class ThatEnumerable
 			: ConstraintResult.WithNotNullValue<IEnumerable<string?>?>,
 				IAsyncContextConstraint<IEnumerable<string?>?>
 		{
+			private readonly ExpectationBuilder _expectationBuilder;
 			private readonly ManualExpectationBuilder<string?> _itemExpectationBuilder;
 			private readonly EnumerableQuantifier _quantifier;
 			private int _matchingCount;
+			private LimitedCollection<string?>? _matchingItems;
 			private int _notMatchingCount;
+			private LimitedCollection<string?>? _notMatchingItems;
 			private int? _totalCount;
 
 			public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
@@ -157,8 +196,9 @@ public static partial class ThatEnumerable
 				Action<IThatSubject<string?>> expectations)
 				: base(it, grammars)
 			{
+				_expectationBuilder = expectationBuilder;
 				_quantifier = quantifier;
-				_itemExpectationBuilder = new ManualExpectationBuilder<string?>(expectationBuilder, grammars);
+				_itemExpectationBuilder = new ManualExpectationBuilder<string?>(null, grammars);
 				expectations.Invoke(new ThatSubject<string?>(_itemExpectationBuilder));
 			}
 
@@ -178,6 +218,9 @@ public static partial class ThatEnumerable
 				bool cancelEarly = actual is not ICollection<string?>;
 				_matchingCount = 0;
 				_notMatchingCount = 0;
+				int maxItems = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get() + 1;
+				_matchingItems = new LimitedCollection<string?>(maxItems);
+				_notMatchingItems = new LimitedCollection<string?>(maxItems);
 
 				foreach (string? item in materialized)
 				{
@@ -185,27 +228,34 @@ public static partial class ThatEnumerable
 					if (isMatch.Outcome == Outcome.Success)
 					{
 						_matchingCount++;
+						_matchingItems.Add(item);
 					}
 					else
 					{
 						_notMatchingCount++;
+						_notMatchingItems.Add(item);
 					}
 
 					if (cancelEarly && _quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+						AppendContexts(true);
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 
 					if (cancellationToken.IsCancellationRequested)
 					{
 						Outcome = Outcome.Undecided;
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 				}
 
 				_totalCount = _matchingCount + _notMatchingCount;
 				Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+				AppendContexts(false);
+				_expectationBuilder.AddCollectionContext(materialized);
 				return this;
 			}
 
@@ -233,6 +283,28 @@ public static partial class ThatEnumerable
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 				=> _quantifier.AppendResult(stringBuilder, Grammars, _matchingCount, _notMatchingCount,
 					_totalCount);
+
+			private void AppendContexts(bool isIncomplete)
+			{
+				EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Matching items",
+							() => Formatter.Format(_matchingItems,
+									typeof(string).GetFormattingOption(_matchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Not matching items",
+							() => Formatter.Format(_notMatchingItems,
+									typeof(string).GetFormattingOption(_notMatchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+			}
 		}
 	}
 
@@ -256,10 +328,14 @@ public static partial class ThatEnumerable
 			: ConstraintResult.WithNotNullValue<TEnumerable?>,
 				IAsyncContextConstraint<TEnumerable?>
 		{
+			private readonly ExpectationBuilder _expectationBuilder;
 			private readonly ManualExpectationBuilder<object?> _itemExpectationBuilder;
 			private readonly EnumerableQuantifier _quantifier;
+			private Type? _itemType;
 			private int _matchingCount;
+			private LimitedCollection<object?>? _matchingItems;
 			private int _notMatchingCount;
+			private LimitedCollection<object?>? _notMatchingItems;
 			private int? _totalCount;
 
 			public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
@@ -267,8 +343,9 @@ public static partial class ThatEnumerable
 				Action<IThatSubject<object?>> expectations)
 				: base(it, grammars)
 			{
+				_expectationBuilder = expectationBuilder;
 				_quantifier = quantifier;
-				_itemExpectationBuilder = new ManualExpectationBuilder<object?>(expectationBuilder, grammars);
+				_itemExpectationBuilder = new ManualExpectationBuilder<object?>(null, grammars);
 				expectations.Invoke(new ThatSubject<object?>(_itemExpectationBuilder));
 			}
 
@@ -288,34 +365,49 @@ public static partial class ThatEnumerable
 				bool cancelEarly = actual is not ICollection<object?>;
 				_matchingCount = 0;
 				_notMatchingCount = 0;
+				int maxItems = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get() + 1;
+				_matchingItems = new LimitedCollection<object?>(maxItems);
+				_notMatchingItems = new LimitedCollection<object?>(maxItems);
 
 				foreach (object? item in materialized)
 				{
+					if (_itemType is null && item is not null)
+					{
+						_itemType = item.GetType();
+					}
+
 					ConstraintResult isMatch = await _itemExpectationBuilder.IsMetBy(item, context, cancellationToken);
 					if (isMatch.Outcome == Outcome.Success)
 					{
 						_matchingCount++;
+						_matchingItems.Add(item);
 					}
 					else
 					{
 						_notMatchingCount++;
+						_notMatchingItems.Add(item);
 					}
 
 					if (cancelEarly && _quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+						AppendContexts(true);
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 
 					if (cancellationToken.IsCancellationRequested)
 					{
 						Outcome = Outcome.Undecided;
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 				}
 
 				_totalCount = _matchingCount + _notMatchingCount;
 				Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+				AppendContexts(false);
+				_expectationBuilder.AddCollectionContext(materialized);
 				return this;
 			}
 
@@ -343,6 +435,28 @@ public static partial class ThatEnumerable
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 				=> _quantifier.AppendResult(stringBuilder, Grammars, _matchingCount, _notMatchingCount,
 					_totalCount);
+
+			private void AppendContexts(bool isIncomplete)
+			{
+				EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Matching items",
+							() => Formatter.Format(_matchingItems,
+									(_itemType ?? typeof(object)).GetFormattingOption(_matchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Not matching items",
+							() => Formatter.Format(_notMatchingItems,
+									(_itemType ?? typeof(object)).GetFormattingOption(_notMatchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+			}
 		}
 	}
 
@@ -366,10 +480,13 @@ public static partial class ThatEnumerable
 			: ConstraintResult.WithNotNullValue<TEnumerable>,
 				IAsyncContextConstraint<TEnumerable>
 		{
+			private readonly ExpectationBuilder _expectationBuilder;
 			private readonly ManualExpectationBuilder<TItem> _itemExpectationBuilder;
 			private readonly EnumerableQuantifier _quantifier;
 			private int _matchingCount;
+			private LimitedCollection<TItem>? _matchingItems;
 			private int _notMatchingCount;
+			private LimitedCollection<TItem>? _notMatchingItems;
 			private int? _totalCount;
 
 			public ComplyWithConstraint(ExpectationBuilder expectationBuilder, string it, ExpectationGrammars grammars,
@@ -377,8 +494,9 @@ public static partial class ThatEnumerable
 				Action<IThatSubject<TItem>> expectations)
 				: base(it, grammars)
 			{
+				_expectationBuilder = expectationBuilder;
 				_quantifier = quantifier;
-				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(expectationBuilder, grammars);
+				_itemExpectationBuilder = new ManualExpectationBuilder<TItem>(null, grammars);
 				expectations.Invoke(new ThatSubject<TItem>(_itemExpectationBuilder));
 			}
 
@@ -393,6 +511,9 @@ public static partial class ThatEnumerable
 				bool cancelEarly = actual is not ICollection<TItem>;
 				_matchingCount = 0;
 				_notMatchingCount = 0;
+				int maxItems = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get() + 1;
+				_matchingItems = new LimitedCollection<TItem>(maxItems);
+				_notMatchingItems = new LimitedCollection<TItem>(maxItems);
 
 				foreach (TItem item in materialized)
 				{
@@ -400,27 +521,34 @@ public static partial class ThatEnumerable
 					if (isMatch.Outcome == Outcome.Success)
 					{
 						_matchingCount++;
+						_matchingItems.Add(item);
 					}
 					else
 					{
 						_notMatchingCount++;
+						_notMatchingItems.Add(item);
 					}
 
 					if (cancelEarly && _quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+						AppendContexts(true);
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 
 					if (cancellationToken.IsCancellationRequested)
 					{
 						Outcome = Outcome.Undecided;
+						_expectationBuilder.AddCollectionContext(materialized, true);
 						return this;
 					}
 				}
 
 				_totalCount = _matchingCount + _notMatchingCount;
 				Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+				AppendContexts(false);
+				_expectationBuilder.AddCollectionContext(materialized);
 				return this;
 			}
 
@@ -448,6 +576,27 @@ public static partial class ThatEnumerable
 			protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 				=> _quantifier.AppendResult(stringBuilder, Grammars, _matchingCount, _notMatchingCount,
 					_totalCount);
+
+			private void AppendContexts(bool isIncomplete)
+			{
+				EnumerableQuantifier.QuantifierContexts quantifierContexts = _quantifier.GetQuantifierContext();
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.MatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Matching items",
+							() => Formatter.Format(_matchingItems, typeof(TItem).GetFormattingOption(_matchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+
+				if (quantifierContexts.HasFlag(EnumerableQuantifier.QuantifierContexts.NotMatchingItems))
+				{
+					_expectationBuilder.AddContext(new ResultContext.SyncCallback("Not matching items",
+							() => Formatter.Format(_notMatchingItems,
+									typeof(TItem).GetFormattingOption(_notMatchingItems?.Count))
+								.AppendIsIncomplete(isIncomplete),
+							int.MaxValue));
+				}
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
+++ b/Tests/aweXpect.Internal.Tests/ThatTests/Collections/QuantifiableCollectionItems.AreEquivalentTests.cs
@@ -44,8 +44,33 @@ public sealed partial class QuantifiableCollectionItems
 				               } for all items,
 				             but only 3 of 4 were
 				             
-				             Equivalency options:
-				              - include public fields and properties
+				             Not matching items:
+				             [
+				               QuantifiableCollectionItems.MyClass {
+				                 Inner = <null>,
+				                 Value = "Bar"
+				               }
+				             ]
+				             
+				             Collection:
+				             [
+				               QuantifiableCollectionItems.MyClass {
+				                 Inner = <null>,
+				                 Value = "Foo"
+				               },
+				               QuantifiableCollectionItems.MyClass {
+				                 Inner = <null>,
+				                 Value = "Foo"
+				               },
+				               QuantifiableCollectionItems.MyClass {
+				                 Inner = <null>,
+				                 Value = "Foo"
+				               },
+				               QuantifiableCollectionItems.MyClass {
+				                 Inner = <null>,
+				                 Value = "Bar"
+				               }
+				             ]
 				             """);
 		}
 

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.ComplyWith.Tests.cs
@@ -29,6 +29,9 @@ public sealed partial class ThatAsyncEnumerable
 						             Expected that subject
 						             is less than 6 for all items,
 						             but could not verify, because it was already cancelled
+
+						             Collection:
+						             [0, 1, 2, 3, 4, (… and maybe others)]
 						             """);
 				}
 
@@ -57,6 +60,24 @@ public sealed partial class ThatAsyncEnumerable
 						             Expected that subject
 						             is equal to 1 for all items,
 						             but not all were
+
+						             Not matching items:
+						             [2, 3, 5, 8, 13, 21, 34, 55, 89, (… and maybe others)]
+
+						             Collection:
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -72,7 +93,13 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             is equal to 1 for all items,
-						             but not all were
+						             but only 4 of 7 were
+
+						             Not matching items:
+						             [2, 2, 3]
+
+						             Collection:
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 
@@ -151,16 +178,19 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             starts with "a" for all items,
-						             but not all were
-						             
-						             Actual:
-						             apple
-						             
-						             Actual:
-						             banana
-						             
-						             Expected:
-						             a
+						             but only 2 of 3 were
+
+						             Not matching items:
+						             [
+						               "banana"
+						             ]
+
+						             Collection:
+						             [
+						               "apple",
+						               "banana",
+						               "avocado"
+						             ]
 						             """);
 				}
 
@@ -195,7 +225,13 @@ public sealed partial class ThatAsyncEnumerable
 						.WithMessage("""
 						             Expected that subject
 						             is not equal to 1 for all items,
-						             but not all were
+						             but none of 7 were
+
+						             Not matching items:
+						             [1, 1, 1, 1, 1, 1, 1]
+
+						             Collection:
+						             [1, 1, 1, 1, 1, 1, 1]
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.All.Tests.cs
@@ -27,7 +27,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is less than 6 for all items,
 					             but could not verify, because it was already cancelled
-					             """);
+					             """).AsPrefix();
 			}
 
 			[Fact]
@@ -55,7 +55,7 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is equal to 1 for all items,
 					             but not all were
-					             """);
+					             """).AsPrefix();
 			}
 
 			[Fact]
@@ -70,8 +70,8 @@ public sealed partial class ThatAsyncEnumerable
 					.WithMessage("""
 					             Expected that subject
 					             is equal to 1 for all items,
-					             but not all were
-					             """);
+					             but only 4 of 7 were
+					             """).AsPrefix();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Any.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Any.Tests.cs
@@ -33,6 +33,9 @@ public sealed partial class ThatAsyncEnumerable
 					             Expected that subject
 					             is equal to 99 for at least one item,
 					             but found only 0
+
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -80,17 +83,11 @@ public sealed partial class ThatAsyncEnumerable
 					             starts with "b" for at least one item,
 					             but found only 0
 
-					             Actual:
-					             apple
-
-					             Expected:
-					             b
-
-					             Actual:
-					             cherry
-
-					             Expected:
-					             b
+					             Collection:
+					             [
+					               "apple",
+					               "cherry"
+					             ]
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.EnumerableTests.cs
@@ -29,6 +29,21 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             satisfies y => (int?)y < 6 for all items,
 						             but could not verify, because it was already cancelled
+
+						             Collection:
+						             [
+						               0,
+						               1,
+						               2,
+						               3,
+						               4,
+						               5,
+						               6,
+						               7,
+						               8,
+						               9,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -57,6 +72,24 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equal to 1 for all items,
 						             but not all were
+
+						             Not matching items:
+						             [2, (… and maybe others)]
+
+						             Collection:
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -76,6 +109,12 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equal to 1 for all items,
 						             but not all were
+
+						             Not matching items:
+						             [2, (… and maybe others)]
+
+						             Collection:
+						             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
 						             """);
 				}
 
@@ -133,6 +172,21 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is not equal to 1 for all items,
 						             but not all were
+
+						             Not matching items:
+						             [1, (… and maybe others)]
+
+						             Collection:
+						             [
+						               1,
+						               1,
+						               1,
+						               1,
+						               1,
+						               1,
+						               1,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.ImmutableTests.cs
@@ -26,6 +26,12 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equal to 1 for all items,
 						             but only 4 of 7 were
+
+						             Not matching items:
+						             [2, 2, 3]
+
+						             Collection:
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 
@@ -67,6 +73,12 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is not equal to 1 for all items,
 						             but none of 7 were
+
+						             Not matching items:
+						             [1, 1, 1, 1, 1, 1, 1]
+
+						             Collection:
+						             [1, 1, 1, 1, 1, 1, 1]
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
@@ -49,6 +49,21 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is less than 6 for all items,
 						             but could not verify, because it was already cancelled
+
+						             Collection:
+						             [
+						               0,
+						               1,
+						               2,
+						               3,
+						               4,
+						               5,
+						               6,
+						               7,
+						               8,
+						               9,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -77,6 +92,24 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equal to 1 for all items,
 						             but not all were
+
+						             Not matching items:
+						             [2, (… and maybe others)]
+
+						             Collection:
+						             [
+						               1,
+						               1,
+						               2,
+						               3,
+						               5,
+						               8,
+						               13,
+						               21,
+						               34,
+						               55,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 
@@ -93,6 +126,12 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is equal to 1 for all items,
 						             but only 4 of 7 were
+
+						             Not matching items:
+						             [2, 2, 3]
+
+						             Collection:
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 
@@ -150,6 +189,21 @@ public sealed partial class ThatEnumerable
 						             Expected that subject
 						             is not equal to 1 for all items,
 						             but not all were
+
+						             Not matching items:
+						             [1, (… and maybe others)]
+
+						             Collection:
+						             [
+						               1,
+						               1,
+						               1,
+						               1,
+						               1,
+						               1,
+						               1,
+						               (… and maybe others)
+						             ]
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Any.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Any.Tests.cs
@@ -49,6 +49,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is equal to 99 for at least one item,
 					             but found only 0
+
+					             Collection:
+					             [1, 2, 3, 4, 5]
 					             """);
 			}
 
@@ -65,6 +68,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is equal to 1 for at least one item,
 					             but found only 0
+
+					             Collection:
+					             []
 					             """);
 			}
 
@@ -149,17 +155,11 @@ public sealed partial class ThatEnumerable
 					             starts with "b" for at least one item,
 					             but found only 0
 
-					             Actual:
-					             apple
-
-					             Expected:
-					             b
-
-					             Actual:
-					             cherry
-
-					             Expected:
-					             b
+					             Collection:
+					             [
+					               "apple",
+					               "cherry"
+					             ]
 					             """);
 			}
 		}
@@ -191,6 +191,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is equal to 99 for at least one item,
 					             but found only 0
+
+					             Collection:
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtLeast.ComplyWith.Tests.cs
@@ -30,6 +30,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is equal to 99 for at least one item,
 					             but found only 0
+
+					             Collection:
+					             [1, 2, 3, 4, 5]
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.ComplyWith.Tests.cs
@@ -30,6 +30,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             is equal to 2 for exactly one item,
 					             but found 2
+
+					             Collection:
+					             [1, 2, 3, 2, 5]
 					             """);
 			}
 
@@ -73,6 +76,9 @@ public sealed partial class ThatEnumerable
 					             Expected that subject
 					             exactly one for is equal to 3 item,
 					             but it did
+
+					             Collection:
+					             [1, 2, 3, 4, 5]
 					             """);
 			}
 		}


### PR DESCRIPTION
This PR updates the collection-element `ComplyWith` expectations to enrich failure output with additional diagnostic contexts (notably the evaluated collection and, for some quantifiers, matching/non-matching item lists), and updates the corresponding tests to assert the new message shapes.

**Changes:**
- Add `Collection` context to `ComplyWith` failures for sync/async enumerable element quantifiers.
- Add quantifier-dependent contexts (`Not matching items` / `Matching items`) to improve failure diagnostics for `All`-style quantifiers.
- Update unit tests and internal tests to match the revised failure messages (including `AsPrefix()` where the message now has additional suffix contexts).