### PR TITLE
feat: add `Any()` quantifier across collection variants

### DIFF
--- a/Docs/pages/03-collections.md
+++ b/Docs/pages/03-collections.md
@@ -371,11 +371,11 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).MoreThan(8).Satisfy(i => i < 10);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### At least
 
-You can verify that at least `minimum` items in the collection, satisfy an expectation:
+You can verify that at least `minimum` items in the collection satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -383,11 +383,11 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).AtLeast(9).Satisfy(i => i < 10);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### Any
 
-You can verify that any (at least one) item in the collection, satisfies an expectation. This is a shorthand for
+You can verify that any (at least one) item in the collection satisfies an expectation. This is a shorthand for
 `AtLeast(1)`:
 
 ```csharp
@@ -396,11 +396,11 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).Any().Satisfy(i => i == 13);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### At most
 
-You can verify that at most `maximum` items in the collection, satisfy an expectation:
+You can verify that at most `maximum` items in the collection satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -408,11 +408,11 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).AtMost(1).Satisfy(i => i < 2);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### Less than
 
-You can verify that less than `maximum` items in the collection, satisfy an expectation:
+You can verify that less than `maximum` items in the collection satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -420,11 +420,11 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).LessThan(2).Satisfy(i => i < 2);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### Between
 
-You can verify that between `minimum` and `maximum` items in the collection, satisfy an expectation:
+You can verify that between `minimum` and `maximum` items in the collection satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -432,11 +432,11 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).Between(1).And(2).Satisfy(i => i < 2);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### Exactly
 
-You can verify that exactly `expected` items in the collection, satisfy an expectation:
+You can verify that exactly `expected` items in the collection satisfy an expectation:
 
 ```csharp
 IEnumerable<int> values = Enumerable.Range(1, 20);
@@ -444,7 +444,7 @@ IEnumerable<int> values = Enumerable.Range(1, 20);
 await Expect.That(values).Exactly(9).Satisfy(i => i < 10);
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ### None
 
@@ -464,7 +464,7 @@ IEnumerable<int> values = Array.Empty<int>();
 await Expect.That(values).IsEmpty();
 ```
 
-*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+*Note: The same expectations work also for `IAsyncEnumerable<T>`.*
 
 ## Have single
 

--- a/Docs/pages/03-collections.md
+++ b/Docs/pages/03-collections.md
@@ -127,6 +127,7 @@ You can verify that items in a collection comply with an expectation on the indi
 
 ```csharp
 await Expect.That([1, 2, 3]).All().ComplyWith(item => item.IsLessThan(4));
+await Expect.That([1, 2, 3]).Any().ComplyWith(item => item.IsEqualTo(2));
 await Expect.That([1, 2, 3]).AtLeast(2).ComplyWith(item => item.IsGreaterThanOrEqualTo(2));
 await Expect.That([1, 2, 3]).AtMost(1).ComplyWith(item => item.IsNegative());
 await Expect.That([1, 2, 3]).Between(2).And(3).ComplyWith(item => item.IsPositive());
@@ -142,6 +143,7 @@ You can verify that items in a collection satisfy a condition:
 
 ```csharp
 await Expect.That([1, 2, 3]).All().Satisfy(item => item < 4);
+await Expect.That([1, 2, 3]).Any().Satisfy(item => item == 2);
 await Expect.That([1, 2, 3]).AtLeast(2).Satisfy(item => item >= 2);
 await Expect.That([1, 2, 3]).AtMost(1).Satisfy(item => item < 0);
 await Expect.That([1, 2, 3]).Between(2).And(3).Satisfy(item => item > 0);
@@ -379,6 +381,19 @@ You can verify that at least `minimum` items in the collection, satisfy an expec
 IEnumerable<int> values = Enumerable.Range(1, 20);
 
 await Expect.That(values).AtLeast(9).Satisfy(i => i < 10);
+```
+
+*Note: The same expectations works also for `IAsyncEnumerable<T>`.*
+
+### Any
+
+You can verify that any (at least one) item in the collection, satisfies an expectation. This is a shorthand for
+`AtLeast(1)`:
+
+```csharp
+IEnumerable<int> values = Enumerable.Range(1, 20);
+
+await Expect.That(values).Any().Satisfy(i => i == 13);
 ```
 
 *Note: The same expectations works also for `IAsyncEnumerable<T>`.*

--- a/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Any.cs
+++ b/Source/aweXpect/That/Collections/ThatAsyncEnumerable.Any.cs
@@ -1,0 +1,26 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using aweXpect.Core;
+using aweXpect.Helpers;
+
+namespace aweXpect;
+
+public static partial class ThatAsyncEnumerable
+{
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	public static Elements<TItem> Any<TItem>(
+		this IThat<IAsyncEnumerable<TItem>?> subject)
+		=> new(subject,
+			EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	public static Elements Any(
+		this IThat<IAsyncEnumerable<string?>?> subject)
+		=> new(subject,
+			EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+}
+#endif

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Any.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Any.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Helpers;
+#if NET8_0_OR_GREATER
+using System.Collections.Immutable;
+#endif
+
+namespace aweXpect;
+
+public static partial class ThatEnumerable
+{
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	public static Elements<TItem> Any<TItem>(
+		this IThat<IEnumerable<TItem>?> subject)
+		=> new(subject, EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	public static Elements Any(
+		this IThat<IEnumerable<string?>?> subject)
+		=> new(subject, EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	[OverloadResolutionPriority(-1)]
+	public static ElementsForEnumerable<IEnumerable> Any(
+		this IThat<IEnumerable> subject)
+		=> new(subject, EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	public static ElementsForStructEnumerable<ImmutableArray<TItem>, TItem> Any<TItem>(
+		this IThat<ImmutableArray<TItem>> subject)
+		=> new(subject, EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+#endif
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that in the collection any (at least one) item…
+	/// </summary>
+	public static ElementsForStructEnumerable<ImmutableArray<string?>> Any(
+		this IThat<ImmutableArray<string?>> subject)
+		=> new(subject, EnumerableQuantifier.AtLeast(1, subject.Get().ExpectationBuilder.ExpectationGrammars));
+#endif
+}

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net10.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net10.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect
     {
         public static aweXpect.ThatAsyncEnumerable.Elements All(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject) { }
         public static aweXpect.ThatAsyncEnumerable.Elements<TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
+        public static aweXpect.ThatAsyncEnumerable.Elements Any(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject) { }
+        public static aweXpect.ThatAsyncEnumerable.Elements<TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Func<TItem, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
@@ -390,6 +392,11 @@ namespace aweXpect
         public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<string?>> All(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>> subject) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
         public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<TItem>, TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject) { }
+        public static aweXpect.ThatEnumerable.Elements Any(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForEnumerable<System.Collections.IEnumerable> Any(this aweXpect.Core.IThat<System.Collections.IEnumerable> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<string?>> Any(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>> subject) { }
+        public static aweXpect.ThatEnumerable.Elements<TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<TItem>, TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.IEnumerable, aweXpect.Core.IThat<System.Collections.IEnumerable>, object?> AreAllUnique(this aweXpect.Core.IThat<System.Collections.IEnumerable> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Immutable.ImmutableArray<string?>, aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>?> source) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_net8.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect
     {
         public static aweXpect.ThatAsyncEnumerable.Elements All(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject) { }
         public static aweXpect.ThatAsyncEnumerable.Elements<TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
+        public static aweXpect.ThatAsyncEnumerable.Elements Any(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> subject) { }
+        public static aweXpect.ThatAsyncEnumerable.Elements<TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<string?>?> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>, TItem> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?>> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TItem>?> source, System.Func<TItem, string> memberAccessor, [System.Runtime.CompilerServices.CallerArgumentExpression("memberAccessor")] string doNotPopulateThisValue = "") { }
@@ -390,6 +392,11 @@ namespace aweXpect
         public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<string?>> All(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>> subject) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
         public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<TItem>, TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject) { }
+        public static aweXpect.ThatEnumerable.Elements Any(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForEnumerable<System.Collections.IEnumerable> Any(this aweXpect.Core.IThat<System.Collections.IEnumerable> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<string?>> Any(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>> subject) { }
+        public static aweXpect.ThatEnumerable.Elements<TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForStructEnumerable<System.Collections.Immutable.ImmutableArray<TItem>, TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<TItem>> subject) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.IEnumerable, aweXpect.Core.IThat<System.Collections.IEnumerable>, object?> AreAllUnique(this aweXpect.Core.IThat<System.Collections.IEnumerable> source) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Immutable.ImmutableArray<string?>, aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Immutable.ImmutableArray<string?>?> source) { }

--- a/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
+++ b/Tests/aweXpect.Api.Tests/Expected/aweXpect_netstandard2.0.txt
@@ -221,6 +221,9 @@ namespace aweXpect
         public static aweXpect.ThatEnumerable.Elements All(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject) { }
         public static aweXpect.ThatEnumerable.ElementsForEnumerable<System.Collections.IEnumerable> All(this aweXpect.Core.IThat<System.Collections.IEnumerable> subject) { }
         public static aweXpect.ThatEnumerable.Elements<TItem> All<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
+        public static aweXpect.ThatEnumerable.Elements Any(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> subject) { }
+        public static aweXpect.ThatEnumerable.ElementsForEnumerable<System.Collections.IEnumerable> Any(this aweXpect.Core.IThat<System.Collections.IEnumerable> subject) { }
+        public static aweXpect.ThatEnumerable.Elements<TItem> Any<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> subject) { }
         public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<string?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?>> AreAllUnique(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<string?>?> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.IEnumerable, aweXpect.Core.IThat<System.Collections.IEnumerable>, object?> AreAllUnique(this aweXpect.Core.IThat<System.Collections.IEnumerable> source) { }
         public static aweXpect.Results.ObjectEqualityResult<System.Collections.Generic.IEnumerable<TItem>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?>, TItem> AreAllUnique<TItem>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TItem>?> source) { }

--- a/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Any.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatAsyncEnumerable.Any.Tests.cs
@@ -1,0 +1,99 @@
+﻿#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatAsyncEnumerable
+{
+	public sealed class Any
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3, 4, 5);
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(3));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				IAsyncEnumerable<int> subject = ToAsyncEnumerable(1, 2, 3);
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(99));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 99 for at least one item,
+					             but found only 0
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(1));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 1 for at least one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				IAsyncEnumerable<string?> subject = ToAsyncEnumerable<string?>("apple", "banana", "cherry");
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.StartsWith("b"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				IAsyncEnumerable<string?> subject = ToAsyncEnumerable<string?>("apple", "cherry");
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.StartsWith("b"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "b" for at least one item,
+					             but found only 0
+
+					             Actual:
+					             apple
+
+					             Expected:
+					             b
+
+					             Actual:
+					             cherry
+
+					             Expected:
+					             b
+					             """);
+			}
+		}
+	}
+}
+#endif

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Any.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Any.Tests.cs
@@ -1,0 +1,210 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Collections.Immutable;
+#endif
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatEnumerable
+{
+	public sealed class Any
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(3));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMultipleItemsMatch_ShouldSucceed()
+			{
+				int[] subject = [1, 2, 2, 3, 2,];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(2));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				int[] subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(99));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 99 for at least one item,
+					             but found only 0
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsEmpty_ShouldFail()
+			{
+				IEnumerable<int> subject = [];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(1));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 1 for at least one item,
+					             but found only 0
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				IEnumerable<int>? subject = null;
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(1));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 1 for at least one item,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				IEnumerable subject = new object[] { "a", 1, "b", };
+
+				async Task Act()
+					=> await That(subject).Any().Satisfy(x => x is int);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				IEnumerable subject = new object[] { "a", "b", "c", };
+
+				async Task Act()
+					=> await That(subject).Any().Satisfy(x => x is int);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             satisfies x => x is int for at least one item,
+					             but only 0 of 3 did
+
+					             Collection:
+					             [
+					               "a",
+					               "b",
+					               "c"
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class StringTests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				IEnumerable<string?> subject = ["apple", "banana", "cherry",];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.StartsWith("b"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				IEnumerable<string?> subject = ["apple", "cherry",];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.StartsWith("b"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             starts with "b" for at least one item,
+					             but found only 0
+
+					             Actual:
+					             apple
+
+					             Expected:
+					             b
+
+					             Actual:
+					             cherry
+
+					             Expected:
+					             b
+					             """);
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class ImmutableTests
+		{
+			[Fact]
+			public async Task WhenAtLeastOneItemMatches_ShouldSucceed()
+			{
+				ImmutableArray<int> subject = [1, 2, 3, 4, 5,];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(3));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoItemsMatch_ShouldFail()
+			{
+				ImmutableArray<int> subject = [1, 2, 3,];
+
+				async Task Act()
+					=> await That(subject).Any().ComplyWith(it => it.IsEqualTo(99));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is equal to 99 for at least one item,
+					             but found only 0
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsImmutableArrayOfStrings_ShouldSucceed()
+			{
+				ImmutableArray<string?> subject = ["apple", "banana",];
+
+				async Task Act()
+					=> await That(subject).Any().Satisfy(x => x == "banana");
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#endif
+	}
+}


### PR DESCRIPTION
Introduce `Any()` as a one-word shorthand for `AtLeast(1)`, completing the All/None/Any quantifier triad. It chains the same way as the other quantifier entry points:

```csharp
    await That(items).Any().ComplyWith(it => it.IsActive());
    await That(items).Any().Satisfy(x => x > 0);
```

Wire up overloads for `IEnumerable<T>`, `IEnumerable<string?>`, `IEnumerable`, `ImmutableArray<T>`, `ImmutableArray<string?>`, and the `IAsyncEnumerable` side. Failure messages render "at least one" via the existing `AtLeastQuantifier`.