### PR TITLE
fix: drain pending `WhichNode` in chained `ForWhich` calls

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -349,6 +349,13 @@ public abstract class ExpectationBuilder
 		string? replaceIt = null,
 		Func<ExpectationGrammars, ExpectationGrammars>? expectationGrammar = null)
 	{
+		if (_whichNode != null)
+		{
+			_whichNode.AddNode(_node);
+			_node = _whichNode;
+			_whichNode = null;
+		}
+
 		Node? parentNode = null;
 		if (_node is not ExpectationNode e || !e.IsEmpty())
 		{
@@ -377,6 +384,13 @@ public abstract class ExpectationBuilder
 		Func<TSource, Task<TTarget?>> asyncMemberAccessor,
 		string? separator = null)
 	{
+		if (_whichNode != null)
+		{
+			_whichNode.AddNode(_node);
+			_node = _whichNode;
+			_whichNode = null;
+		}
+
 		Node? parentNode = null;
 		if (_node is not ExpectationNode e || !e.IsEmpty())
 		{

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -139,6 +139,57 @@ public class ExpectationBuilderTests
 	}
 
 	[Fact]
+	public async Task ForWhich_CalledTwice_OuterConstraintFails_ShouldStillEvaluateOuterConstraint()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foo", "is foo"));
+		sut.ForWhich<string, int>(s => s.Length, " whose length ");
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 3, "is 3"));
+		sut.ForWhich<string, char>(s => s[0], " and whose first char ");
+		sut.AddConstraint((_, _) => new DummyConstraint<char>(c => c == 'B', "is 'B'"));
+
+		ConstraintResult result = await sut.IsMetBy("BAR", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Failure);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is foo whose length is 3 and whose first char is 'B'");
+	}
+
+	[Fact]
+	public async Task ForWhich_CalledTwice_SecondProjectionFails_ShouldIncludeAllProjectionsInOrder()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foo", "is foo"));
+		sut.ForWhich<string, int>(s => s.Length, " whose length ");
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 3, "is 3"));
+		sut.ForWhich<string, char>(s => s[0], " and whose first char ");
+		sut.AddConstraint((_, _) => new DummyConstraint<char>(c => c == 'x', "is 'x'"));
+
+		ConstraintResult result = await sut.IsMetBy("foo", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Failure);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is foo whose length is 3 and whose first char is 'x'");
+	}
+
+	[Fact]
+	public async Task ForWhich_CalledTwice_ShouldHonorConstraintsFromAllLevels()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foo", "is foo"));
+		sut.ForWhich<string, int>(s => s.Length, " whose length ");
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 3, "is 3"));
+		sut.ForWhich<string, char>(s => s[0], " and whose first char ");
+		sut.AddConstraint((_, _) => new DummyConstraint<char>(c => c == 'f', "is 'f'"));
+
+		ConstraintResult result = await sut.IsMetBy("foo", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is foo whose length is 3 and whose first char is 'f'");
+	}
+
+	[Fact]
 	public async Task WhenSubjectHasMultipleLines_ShouldTrimCommonWhiteSpace()
 	{
 		async Task Act() => await That(new[]

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -139,6 +139,25 @@ public class ExpectationBuilderTests
 	}
 
 	[Fact]
+	public async Task ForWhich_Async_CalledTwice_ShouldHonorConstraintsFromAllLevels()
+	{
+		Func<string, Task<string?>> upperAccessor = s => Task.FromResult<string?>(s.ToUpperInvariant());
+		Func<string, Task<string?>> doubledAccessor = s => Task.FromResult<string?>(s + s);
+		ManualExpectationBuilder<string> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foo", "is foo"));
+		sut.ForWhich(upperAccessor, " whose upper ");
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "FOO", "is FOO"));
+		sut.ForWhich(doubledAccessor, " and whose doubled ");
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foofoo", "is foofoo"));
+
+		ConstraintResult result = await sut.IsMetBy("foo", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is foo whose upper is FOO and whose doubled is foofoo");
+	}
+
+	[Fact]
 	public async Task ForWhich_CalledTwice_OuterConstraintFails_ShouldStillEvaluateOuterConstraint()
 	{
 		ManualExpectationBuilder<string> sut = new(null);


### PR DESCRIPTION
A second call to `ExpectationBuilder.ForWhich` overwrote the pending `_whichNode` field, silently dropping the previous projection's parent constraints. Drain the pending node into the graph before creating the new one in both the sync and async overloads (`GetRootNode` still performs the final drain when no further `ForWhich` is called).