### PR TITLE
fix: only annotate `Collection` as incomplete when the formatter truncates

### DIFF
--- a/Source/aweXpect/That/Collections/CollectionHelpers.cs
+++ b/Source/aweXpect/That/Collections/CollectionHelpers.cs
@@ -177,31 +177,33 @@ internal static class CollectionHelpers
 	internal static bool ExceedsFormatterLimit<TItem>(this IEnumerable<TItem> source)
 	{
 		int limit = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
-		int seen = 0;
-		foreach (TItem _ in source)
+		if (source is ICollection<TItem> collection)
 		{
-			if (++seen > limit)
-			{
-				return true;
-			}
+			return collection.Count > limit;
 		}
 
-		return false;
+		if (source is ICountable { Count: { } countableCount })
+		{
+			return countableCount > limit;
+		}
+
+		return source.Skip(limit).Any();
 	}
 
 	internal static bool ExceedsFormatterLimit(this IEnumerable source)
 	{
 		int limit = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
-		int seen = 0;
-		foreach (object? _ in source)
+		if (source is ICollection collection)
 		{
-			if (++seen > limit)
-			{
-				return true;
-			}
+			return collection.Count > limit;
 		}
 
-		return false;
+		if (source is ICountable { Count: { } countableCount })
+		{
+			return countableCount > limit;
+		}
+
+		return source.Cast<object?>().Skip(limit).Any();
 	}
 
 	internal static string AppendIsIncomplete(this string formattedItems, bool isIncomplete)

--- a/Source/aweXpect/That/Collections/CollectionHelpers.cs
+++ b/Source/aweXpect/That/Collections/CollectionHelpers.cs
@@ -174,6 +174,36 @@ internal static class CollectionHelpers
 		});
 	}
 
+	internal static bool ExceedsFormatterLimit<TItem>(this IEnumerable<TItem> source)
+	{
+		int limit = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
+		int seen = 0;
+		foreach (TItem _ in source)
+		{
+			if (++seen > limit)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	internal static bool ExceedsFormatterLimit(this IEnumerable source)
+	{
+		int limit = Customize.aweXpect.Formatting().MaximumNumberOfCollectionItems.Get();
+		int seen = 0;
+		foreach (object? _ in source)
+		{
+			if (++seen > limit)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	internal static string AppendIsIncomplete(this string formattedItems, bool isIncomplete)
 	{
 		if (!isIncomplete || formattedItems.Length < 3)

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -95,7 +95,7 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, true);
+						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 						return this;
 					}
 
@@ -240,7 +240,7 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, true);
+						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 						return this;
 					}
 
@@ -392,7 +392,7 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, true);
+						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 						return this;
 					}
 
@@ -533,7 +533,7 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, true);
+						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 						return this;
 					}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.Elements.ComplyWith.cs
@@ -95,7 +95,8 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+						_expectationBuilder.AddCollectionContext(materialized,
+							Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 						return this;
 					}
 
@@ -240,7 +241,8 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+						_expectationBuilder.AddCollectionContext(materialized,
+							Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 						return this;
 					}
 
@@ -392,7 +394,8 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+						_expectationBuilder.AddCollectionContext(materialized,
+							Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 						return this;
 					}
 
@@ -533,7 +536,8 @@ public static partial class ThatEnumerable
 					{
 						Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 						AppendContexts(true);
-						_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+						_expectationBuilder.AddCollectionContext(materialized,
+							Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 						return this;
 					}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.EndsWith.cs
@@ -532,7 +532,8 @@ public static partial class ThatEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					_expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -653,7 +654,8 @@ public static partial class ThatEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					_expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.StartsWith.cs
@@ -519,7 +519,8 @@ public static partial class ThatEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					_expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -634,7 +635,8 @@ public static partial class ThatEnumerable
 				{
 					_firstMismatchItem = item;
 					_foundMismatch = true;
-					_expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					_expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -69,7 +69,8 @@ public static partial class ThatEnumerable
 				{
 					_failure = failure ?? TooManyDeviationsError();
 					Outcome = Outcome.Failure;
-					expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					return this;
 				}
 			}
@@ -173,7 +174,8 @@ public static partial class ThatEnumerable
 				{
 					_failure = failure ?? TooManyDeviationsError();
 					Outcome = Outcome.Failure;
-					expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					return this;
 				}
 			}
@@ -282,7 +284,8 @@ public static partial class ThatEnumerable
 				{
 					_failure = failure ?? TooManyDeviationsError();
 					Outcome = Outcome.Failure;
-					expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					return this;
 				}
 			}
@@ -391,7 +394,8 @@ public static partial class ThatEnumerable
 				{
 					_failure = failure ?? TooManyDeviationsError();
 					Outcome = Outcome.Failure;
-					expectationBuilder.AddCollectionContext(materializedEnumerable, true);
+					expectationBuilder.AddCollectionContext(materializedEnumerable,
+						materializedEnumerable.ExceedsFormatterLimit());
 					return this;
 				}
 			}
@@ -516,7 +520,8 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+					_expectationBuilder.AddCollectionContext(materialized,
+						Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 					return Task.FromResult<ConstraintResult>(this);
 				}
 
@@ -676,7 +681,8 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+					_expectationBuilder.AddCollectionContext(materialized,
+						Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 					return this;
 				}
 
@@ -836,7 +842,8 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+					_expectationBuilder.AddCollectionContext(materialized,
+						Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 					return Task.FromResult<ConstraintResult>(this);
 				}
 
@@ -1005,7 +1012,8 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
+					_expectationBuilder.AddCollectionContext(materialized,
+						Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 					return this;
 				}
 
@@ -1145,8 +1153,9 @@ public static partial class ThatEnumerable
 
 				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 				{
-					_expectationBuilder.AddCollectionContext(materialized, true);
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+					_expectationBuilder.AddCollectionContext(materialized,
+						Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 					return Task.FromResult<ConstraintResult>(this);
 				}
 
@@ -1242,8 +1251,9 @@ public static partial class ThatEnumerable
 
 				if (_quantifier.IsDeterminable(_matchingCount, _notMatchingCount))
 				{
-					_expectationBuilder.AddCollectionContext(materialized, true);
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
+					_expectationBuilder.AddCollectionContext(materialized,
+						Outcome == Outcome.Failure && materialized.ExceedsFormatterLimit());
 					return Task.FromResult<ConstraintResult>(this);
 				}
 

--- a/Source/aweXpect/That/Collections/ThatEnumerable.cs
+++ b/Source/aweXpect/That/Collections/ThatEnumerable.cs
@@ -516,7 +516,7 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, true);
+					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 					return Task.FromResult<ConstraintResult>(this);
 				}
 
@@ -676,7 +676,7 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, true);
+					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 					return this;
 				}
 
@@ -836,7 +836,7 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, true);
+					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 					return Task.FromResult<ConstraintResult>(this);
 				}
 
@@ -1005,7 +1005,7 @@ public static partial class ThatEnumerable
 				{
 					Outcome = _quantifier.GetOutcome(_matchingCount, _notMatchingCount, _totalCount);
 					AppendContexts(true);
-					_expectationBuilder.AddCollectionContext(materialized, true);
+					_expectationBuilder.AddCollectionContext(materialized, materialized.ExceedsFormatterLimit());
 					return this;
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKeys.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatDictionary.ContainsKeys.Tests.cs
@@ -105,8 +105,7 @@ public sealed partial class ThatDictionary
 
 					             Collection:
 					             [
-					               <null>,
-					               (… and maybe others)
+					               <null>
 					             ]
 
 					             Dictionary:
@@ -141,8 +140,7 @@ public sealed partial class ThatDictionary
 					             Collection:
 					             [
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 
 					             Dictionary:
@@ -176,8 +174,7 @@ public sealed partial class ThatDictionary
 
 					             Collection:
 					             [
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 
 					             Dictionary:
@@ -230,8 +227,7 @@ public sealed partial class ThatDictionary
 					             [
 					               "foo",
 					               <null>,
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 
 					             Dictionary:

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.EnumerableTests.cs
@@ -69,8 +69,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.Are.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -162,8 +161,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.Are.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.Are.Tests.cs
@@ -69,8 +69,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.Are.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -162,8 +161,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.Are.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.EnumerableTests.cs
@@ -69,8 +69,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.AreExactly.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -142,8 +141,7 @@ public sealed partial class ThatEnumerable
 						               ThatEnumerable.All.AreExactly.MyClass {
 						                 Bar = 0,
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -221,8 +219,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.AreExactly.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -307,8 +304,7 @@ public sealed partial class ThatEnumerable
 						               ThatEnumerable.All.AreExactly.MyClass {
 						                 Bar = 0,
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.AreExactly.Tests.cs
@@ -66,8 +66,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.AreExactly.MyBaseClass {
 						                 Foo = 0
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -139,8 +138,7 @@ public sealed partial class ThatEnumerable
 						               ThatEnumerable.All.AreExactly.MyClass {
 						                 Bar = 0,
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -218,8 +216,7 @@ public sealed partial class ThatEnumerable
 						               },
 						               ThatEnumerable.All.AreExactly.MyBaseClass {
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}
@@ -304,8 +301,7 @@ public sealed partial class ThatEnumerable
 						               ThatEnumerable.All.AreExactly.MyClass {
 						                 Bar = 0,
 						                 Foo = 10
-						               },
-						               (… and maybe others)
+						               }
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.EnumerableTests.cs
@@ -114,7 +114,7 @@ public sealed partial class ThatEnumerable
 						             [2, (… and maybe others)]
 
 						             Collection:
-						             [1, 1, 1, 1, 2, 2, 3, (… and maybe others)]
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 
@@ -177,16 +177,7 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 
 						             Collection:
-						             [
-						               1,
-						               1,
-						               1,
-						               1,
-						               1,
-						               1,
-						               1,
-						               (… and maybe others)
-						             ]
+						             [1, 1, 1, 1, 1, 1, 1]
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.All.ComplyWith.Tests.cs
@@ -194,16 +194,7 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 
 						             Collection:
-						             [
-						               1,
-						               1,
-						               1,
-						               1,
-						               1,
-						               1,
-						               1,
-						               (… and maybe others)
-						             ]
+						             [1, 1, 1, 1, 1, 1, 1]
 						             """);
 				}
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.EnumerableTests.cs
@@ -159,16 +159,7 @@ public sealed partial class ThatEnumerable
 					             [1, 1, 1, 1, (… and maybe others)]
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.AtMost.Tests.cs
@@ -153,16 +153,7 @@ public sealed partial class ThatEnumerable
 					             [1, 1, 1, 1, (… and maybe others)]
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 
@@ -210,8 +201,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "FOO",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}
@@ -252,8 +242,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.EnumerableTests.cs
@@ -133,16 +133,7 @@ public sealed partial class ThatEnumerable
 					             but at least 4 were
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Between.Tests.cs
@@ -133,16 +133,7 @@ public sealed partial class ThatEnumerable
 					             but at least 4 were
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 
@@ -183,8 +174,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "FOO",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}
@@ -242,8 +232,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.EnumerableTests.cs
@@ -66,7 +66,7 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 at index 3 instead of 1
 
 					             Collection:
-					             [0, 0, 1, 2, 3, (… and maybe others)]
+					             [0, 0, 1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.ImmutableTests.cs
@@ -55,7 +55,7 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 at index 3 instead of 1
 
 					             Collection:
-					             [0, 0, 1, 2, 3, (… and maybe others)]
+					             [0, 0, 1, 2, 3]
 					             """);
 			}
 
@@ -125,8 +125,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "bar",
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.EndsWith.Tests.cs
@@ -65,7 +65,7 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 at index 3 instead of 1
 
 					             Collection:
-					             [0, 0, 1, 2, 3, (… and maybe others)]
+					             [0, 0, 1, 2, 3]
 					             """);
 			}
 
@@ -151,8 +151,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "bar",
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.EnumerableTests.cs
@@ -134,16 +134,7 @@ public sealed partial class ThatEnumerable
 					             but at least 4 were
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.Exactly.Tests.cs
@@ -134,16 +134,7 @@ public sealed partial class ThatEnumerable
 					             but at least 4 were
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 
@@ -184,8 +175,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "FOO",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}
@@ -243,8 +233,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtLeast.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtLeast.Tests.cs
@@ -219,8 +219,7 @@ public sealed partial class ThatEnumerable
 						             [
 						               1,
 						               2,
-						               3,
-						               (… and maybe others)
+						               3
 						             ]
 						             """);
 				}
@@ -256,8 +255,7 @@ public sealed partial class ThatEnumerable
 						             [
 						               1,
 						               2,
-						               3,
-						               (… and maybe others)
+						               3
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtMost.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.AtMost.Tests.cs
@@ -125,12 +125,7 @@ public sealed partial class ThatEnumerable
 						             but found at least 3
 
 						             Collection:
-						             [
-						               1,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 2, 3]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.Between.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.Between.Tests.cs
@@ -141,16 +141,7 @@ public sealed partial class ThatEnumerable
 						             but found at least 7
 
 						             Collection:
-						             [
-						               1,
-						               2,
-						               3,
-						               4,
-						               5,
-						               6,
-						               7,
-						               (… and maybe others)
-						             ]
+						             [1, 2, 3, 4, 5, 6, 7]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.EqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.EqualTo.Tests.cs
@@ -141,12 +141,7 @@ public sealed partial class ThatEnumerable
 						             but found at least 3
 
 						             Collection:
-						             [
-						               1,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 2, 3]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.ImmutableTests.cs
@@ -57,7 +57,7 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [1, 2, 3, (… and maybe others)]
+					             [1, 2, 3]
 					             """);
 			}
 		}
@@ -109,7 +109,7 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [1, 2, 3, (… and maybe others)]
+					             [1, 2, 3]
 					             """);
 			}
 		}
@@ -170,7 +170,7 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [1, 2, 3, (… and maybe others)]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -247,7 +247,7 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [1, 2, 3, (… and maybe others)]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.LessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.LessThan.Tests.cs
@@ -111,12 +111,7 @@ public sealed partial class ThatEnumerable
 						             but found at least 3
 
 						             Collection:
-						             [
-						               1,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 2, 3]
 						             """);
 				}
 
@@ -146,12 +141,7 @@ public sealed partial class ThatEnumerable
 						             but found at least 2
 
 						             Collection:
-						             [
-						               1,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 2, 3]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.MoreThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.MoreThan.Tests.cs
@@ -251,8 +251,7 @@ public sealed partial class ThatEnumerable
 						             [
 						               1,
 						               2,
-						               3,
-						               (… and maybe others)
+						               3
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.HasCount.Tests.cs
@@ -139,12 +139,7 @@ public sealed partial class ThatEnumerable
 					             but found at least 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.LessThan.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.LessThan.EnumerableTests.cs
@@ -159,16 +159,7 @@ public sealed partial class ThatEnumerable
 					             [1, 1, 1, 1, (… and maybe others)]
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.LessThan.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.LessThan.Tests.cs
@@ -153,16 +153,7 @@ public sealed partial class ThatEnumerable
 					             [1, 1, 1, 1, (… and maybe others)]
 
 					             Collection:
-					             [
-					               1,
-					               1,
-					               1,
-					               1,
-					               2,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 1, 1, 1, 2, 2, 3]
 					             """);
 			}
 
@@ -210,8 +201,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "FOO",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}
@@ -241,8 +231,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}
@@ -271,8 +260,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.EnumerableTests.cs
@@ -111,16 +111,7 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 
 						             Collection:
-						             [
-						               1,
-						               1,
-						               1,
-						               1,
-						               2,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.AreEqualTo.Tests.cs
@@ -111,16 +111,7 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 
 						             Collection:
-						             [
-						               1,
-						               1,
-						               1,
-						               1,
-						               2,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 
@@ -189,8 +180,7 @@ public sealed partial class ThatEnumerable
 						             [
 						               "FOO",
 						               "BAR",
-						               "BAZ",
-						               (… and maybe others)
+						               "BAZ"
 						             ]
 						             """);
 				}
@@ -219,8 +209,7 @@ public sealed partial class ThatEnumerable
 						             [
 						               "foo",
 						               "bar",
-						               "baz",
-						               (… and maybe others)
+						               "baz"
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.Satisfy.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.None.Satisfy.Tests.cs
@@ -111,16 +111,7 @@ public sealed partial class ThatEnumerable
 						             [1, (… and maybe others)]
 
 						             Collection:
-						             [
-						               1,
-						               1,
-						               1,
-						               1,
-						               2,
-						               2,
-						               3,
-						               (… and maybe others)
-						             ]
+						             [1, 1, 1, 1, 2, 2, 3]
 						             """);
 				}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.EnumerableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.EnumerableTests.cs
@@ -73,12 +73,7 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 at index 1 instead of 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.ImmutableTests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.ImmutableTests.cs
@@ -51,7 +51,7 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 at index 1 instead of 3
 
 					             Collection:
-					             [1, 2, 3, (… and maybe others)]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -109,8 +109,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "bar",
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatEnumerable.StartsWith.Tests.cs
@@ -72,12 +72,7 @@ public sealed partial class ThatEnumerable
 					             but it contained 2 at index 1 instead of 3
 
 					             Collection:
-					             [
-					               1,
-					               2,
-					               3,
-					               (… and maybe others)
-					             ]
+					             [1, 2, 3]
 					             """);
 			}
 
@@ -163,8 +158,7 @@ public sealed partial class ThatEnumerable
 					             [
 					               "foo",
 					               "bar",
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Tests/Collections/ThatReadOnlyDictionary.ContainsKeys.Tests.cs
+++ b/Tests/aweXpect.Tests/Collections/ThatReadOnlyDictionary.ContainsKeys.Tests.cs
@@ -106,8 +106,7 @@ public sealed partial class ThatReadOnlyDictionary
 
 					             Collection:
 					             [
-					               <null>,
-					               (… and maybe others)
+					               <null>
 					             ]
 
 					             Dictionary:
@@ -142,8 +141,7 @@ public sealed partial class ThatReadOnlyDictionary
 					             Collection:
 					             [
 					               "foo",
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 
 					             Dictionary:
@@ -177,8 +175,7 @@ public sealed partial class ThatReadOnlyDictionary
 
 					             Collection:
 					             [
-					               "bar",
-					               (… and maybe others)
+					               "bar"
 					             ]
 
 					             Dictionary:
@@ -231,8 +228,7 @@ public sealed partial class ThatReadOnlyDictionary
 					             [
 					               "foo",
 					               <null>,
-					               "baz",
-					               (… and maybe others)
+					               "baz"
 					             ]
 
 					             Dictionary:

--- a/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
+++ b/Tests/aweXpect.Tests/Delegates/ThatDelegate.ThrowsException.WithRecursiveInnerExceptionsTests.cs
@@ -86,17 +86,16 @@ public sealed partial class ThatDelegate
 					             Expected that action
 					             throws an exception with recursive inner exceptions which all satisfy _ => false,
 					             but not all did
-					             
+
 					             Not matching items:
 					             [
 					               aweXpect.Tests.ThatDelegate+CustomException: WhenInnerExceptionDoesNotMatch_ShouldFail,
 					               (… and maybe others)
 					             ]
-					             
+
 					             Collection:
 					             [
-					               aweXpect.Tests.ThatDelegate+CustomException: WhenInnerExceptionDoesNotMatch_ShouldFail,
-					               (… and maybe others)
+					               aweXpect.Tests.ThatDelegate+CustomException: WhenInnerExceptionDoesNotMatch_ShouldFail
 					             ]
 					             """);
 			}


### PR DESCRIPTION
The `(… and maybe others)` annotation on the `Collection` section was attached whenever a collection constraint exited early on a cancelEarly source, regardless of whether the formatter actually had more items to show. For a small finite source that the formatter walks fully, this was misleading.

Resolve the flag at constraint time by walking the materialized enumerable up to the formatter's display limit + 1. The walk is bounded and the cache is reused by the formatter later.

The `Matching items` / `Not matching items` annotation continues to reflect constraint coverage (incomplete on early exit), since the constraint may not have categorized all source items.