### PR TITLE
chore: bump aweXpect.Core to v2.31.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.30.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.30.0" />
+		<PackageVersion Include="aweXpect" Version="2.33.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.31.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.1.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
## Pull request overview

This PR updates the centrally managed package versions for aweXpect dependencies used by the repository.

**Changes:**
- Bumps `aweXpect` from `2.30.0` to `2.33.0`.
- Bumps `aweXpect.Core` from `2.30.0` to `2.31.1`.