### PR TITLE
fix: chain projected values across nested `WhichNode`s

### DIFF
--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -90,26 +90,38 @@ internal class WhichNode<TSource, TMember> : Node
 				FurtherProcessingStrategy.IgnoreResult, default);
 		}
 
-		if (value is TSource typedValue)
+		TSource? source;
+		if (value is TSource directValue)
 		{
-			TMember? matchingValue;
-			if (_memberAccessor != null)
-			{
-				matchingValue = _memberAccessor(typedValue);
-			}
-			else
-			{
-				matchingValue = await _asyncMemberAccessor!.Invoke(typedValue);
-			}
-
-			ConstraintResult result = await _inner.IsMetBy(matchingValue, context, cancellationToken);
-			return CombineResults(parentResult, result, _separator ?? "", FurtherProcessingStrategy.IgnoreResult,
-				matchingValue);
+			source = directValue;
+		}
+		else if (parentResult != null && parentResult.TryGetValue(out TSource? projectedValue))
+		{
+			// A parent WhichNode already projected the outer subject to TSource;
+			// use that projection so chained ForWhich calls compose
+			// (e.g. .Which.X.Which.Y, where Y's accessor operates on X's output).
+			source = projectedValue;
+		}
+		else
+		{
+			throw new InvalidOperationException(
+					$"The member type for the actual value in the which node did not match.{Environment.NewLine}     Found: {Formatter.Format(value.GetType())}{Environment.NewLine}  Expected: {Formatter.Format(typeof(TSource))}")
+				.LogTrace();
 		}
 
-		throw new InvalidOperationException(
-				$"The member type for the actual value in the which node did not match.{Environment.NewLine}     Found: {Formatter.Format(value.GetType())}{Environment.NewLine}  Expected: {Formatter.Format(typeof(TSource))}")
-			.LogTrace();
+		TMember? matchingValue;
+		if (_memberAccessor != null)
+		{
+			matchingValue = source is null ? default : _memberAccessor(source);
+		}
+		else
+		{
+			matchingValue = source is null ? default : await _asyncMemberAccessor!.Invoke(source);
+		}
+
+		ConstraintResult innerResult = await _inner.IsMetBy(matchingValue, context, cancellationToken);
+		return CombineResults(parentResult, innerResult, _separator ?? "", FurtherProcessingStrategy.IgnoreResult,
+			matchingValue);
 	}
 
 	/// <inheritdoc cref="object.Equals(object?)" />

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -90,38 +90,34 @@ internal class WhichNode<TSource, TMember> : Node
 				FurtherProcessingStrategy.IgnoreResult, default);
 		}
 
-		TSource? source;
-		if (value is TSource directValue)
-		{
-			source = directValue;
-		}
-		else if (parentResult != null && parentResult.TryGetValue(out TSource? projectedValue))
-		{
-			// A parent WhichNode already projected the outer subject to TSource;
-			// use that projection so chained ForWhich calls compose
-			// (e.g. .Which.X.Which.Y, where Y's accessor operates on X's output).
-			source = projectedValue;
-		}
-		else
-		{
-			throw new InvalidOperationException(
-					$"The member type for the actual value in the which node did not match.{Environment.NewLine}     Found: {Formatter.Format(value.GetType())}{Environment.NewLine}  Expected: {Formatter.Format(typeof(TSource))}")
-				.LogTrace();
-		}
-
-		TMember? matchingValue;
-		if (_memberAccessor != null)
-		{
-			matchingValue = source is null ? default : _memberAccessor(source);
-		}
-		else
-		{
-			matchingValue = source is null ? default : await _asyncMemberAccessor!.Invoke(source);
-		}
+		TSource source = ResolveSource(parentResult, value);
+		TMember? matchingValue = _memberAccessor != null
+			? _memberAccessor(source)
+			: await _asyncMemberAccessor!.Invoke(source);
 
 		ConstraintResult innerResult = await _inner.IsMetBy(matchingValue, context, cancellationToken);
 		return CombineResults(parentResult, innerResult, _separator ?? "", FurtherProcessingStrategy.IgnoreResult,
 			matchingValue);
+	}
+
+	private static TSource ResolveSource(ConstraintResult? parentResult, object value)
+	{
+		if (value is TSource directValue)
+		{
+			return directValue;
+		}
+
+		// A parent WhichNode already projected the outer subject to TSource; use that
+		// projection so chained ForWhich calls compose (e.g. .Which.X.Which.Y, where Y's
+		// accessor operates on X's output).
+		if (parentResult != null && parentResult.TryGetValue(out TSource? projectedValue))
+		{
+			return projectedValue;
+		}
+
+		throw new InvalidOperationException(
+				$"The member type for the actual value in the which node did not match.{Environment.NewLine}     Found: {Formatter.Format(value.GetType())}{Environment.NewLine}  Expected: {Formatter.Format(typeof(TSource))}")
+			.LogTrace();
 	}
 
 	/// <inheritdoc cref="object.Equals(object?)" />
@@ -237,7 +233,7 @@ internal class WhichNode<TSource, TMember> : Node
 			}
 
 			value = default;
-			return typeof(TValue).IsAssignableFrom(typeof(TMember));
+			return false;
 		}
 
 		public override ConstraintResult Negate()

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -90,17 +90,15 @@ internal class WhichNode<TSource, TMember> : Node
 				FurtherProcessingStrategy.IgnoreResult, default);
 		}
 
-		TSource source = ResolveSource(parentResult, value);
-		TMember? matchingValue = _memberAccessor != null
-			? _memberAccessor(source)
-			: await _asyncMemberAccessor!.Invoke(source);
+		TSource? source = ResolveSource(parentResult, value);
+		TMember? matchingValue = await ComputeMatchingValueAsync(source);
 
 		ConstraintResult innerResult = await _inner.IsMetBy(matchingValue, context, cancellationToken);
 		return CombineResults(parentResult, innerResult, _separator ?? "", FurtherProcessingStrategy.IgnoreResult,
 			matchingValue);
 	}
 
-	private static TSource ResolveSource(ConstraintResult? parentResult, object value)
+	private static TSource? ResolveSource(ConstraintResult? parentResult, object value)
 	{
 		if (parentResult != null && parentResult.TryGetValue(out TSource? projectedValue))
 		{
@@ -115,6 +113,20 @@ internal class WhichNode<TSource, TMember> : Node
 		throw new InvalidOperationException(
 				$"The member type for the actual value in the which node did not match.{Environment.NewLine}     Found: {Formatter.Format(value.GetType())}{Environment.NewLine}  Expected: {Formatter.Format(typeof(TSource))}")
 			.LogTrace();
+	}
+
+	private async Task<TMember?> ComputeMatchingValueAsync(TSource? source)
+	{
+#pragma warning disable S2583
+		if (source is null)
+		{
+			return default;
+		}
+#pragma warning restore S2583
+
+		return _memberAccessor != null
+			? _memberAccessor(source)
+			: await _asyncMemberAccessor!.Invoke(source);
 	}
 
 	/// <inheritdoc cref="object.Equals(object?)" />
@@ -230,7 +242,12 @@ internal class WhichNode<TSource, TMember> : Node
 			}
 
 			value = default;
-			return false;
+			// When neither this result nor its sub-chains carry a TValue, fall through to a
+			// type-compatibility check so chained WhichNodes can keep propagating projections
+			// even when the recorded matching value happens to be null (e.g. an outer
+			// `Which(p => p.Address)` projecting `null`). The caller is expected to guard
+			// against null `value` even though `[NotNullWhen(true)]` is annotated on the base.
+			return typeof(TValue).IsAssignableFrom(typeof(TMember));
 		}
 
 		public override ConstraintResult Negate()

--- a/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
+++ b/Source/aweXpect.Core/Core/Nodes/WhichNode.cs
@@ -102,17 +102,14 @@ internal class WhichNode<TSource, TMember> : Node
 
 	private static TSource ResolveSource(ConstraintResult? parentResult, object value)
 	{
-		if (value is TSource directValue)
-		{
-			return directValue;
-		}
-
-		// A parent WhichNode already projected the outer subject to TSource; use that
-		// projection so chained ForWhich calls compose (e.g. .Which.X.Which.Y, where Y's
-		// accessor operates on X's output).
 		if (parentResult != null && parentResult.TryGetValue(out TSource? projectedValue))
 		{
 			return projectedValue;
+		}
+
+		if (value is TSource directValue)
+		{
+			return directValue;
 		}
 
 		throw new InvalidOperationException(

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Globalization;
+using System.Threading;
 using aweXpect.Core.Constraints;
 using aweXpect.Core.Tests.TestHelpers;
 
@@ -158,6 +159,45 @@ public class ExpectationBuilderTests
 	}
 
 	[Fact]
+	public async Task ForWhich_Async_CalledTwice_WhereSecondProjectsFromFirstResult_ShouldChainProjections()
+	{
+		Func<int, Task<string?>> stringify = i =>
+			Task.FromResult<string?>(i.ToString(CultureInfo.InvariantCulture));
+		Func<string, Task<string?>> doubled = s => Task.FromResult<string?>(s + s);
+		ManualExpectationBuilder<int> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 12, "is 12"));
+		sut.ForWhich(stringify, " whose string ");
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "12", "is \"12\""));
+		sut.ForWhich(doubled, " and whose doubled ");
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "1212", "is \"1212\""));
+
+		ConstraintResult result = await sut.IsMetBy(12, null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is 12 whose string is \"12\" and whose doubled is \"1212\"");
+	}
+
+	[Fact]
+	public async Task ForWhich_CalledThreeTimes_EachProjectionChainsFromPrevious_ShouldEvaluateDeeply()
+	{
+		ManualExpectationBuilder<string> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foo", "is foo"));
+		sut.ForWhich<string, char>(s => s[0], " whose first char ");
+		sut.AddConstraint((_, _) => new DummyConstraint<char>(c => c == 'f', "is 'f'"));
+		sut.ForWhich<char, int>(c => c, " whose code point ");
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 'f', "is 102"));
+		sut.ForWhich<int, bool>(i => i % 2 == 0, " whose is-even ");
+		sut.AddConstraint((_, _) => new DummyConstraint<bool>(b => b, "is true"));
+
+		ConstraintResult result = await sut.IsMetBy("foo", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is foo whose first char is 'f' whose code point is 102 whose is-even is true");
+	}
+
+	[Fact]
 	public async Task ForWhich_CalledTwice_OuterConstraintFails_ShouldStillEvaluateOuterConstraint()
 	{
 		ManualExpectationBuilder<string> sut = new(null);
@@ -206,6 +246,24 @@ public class ExpectationBuilderTests
 		await That(result.Outcome).IsEqualTo(Outcome.Success);
 		await That(result.GetExpectationText())
 			.IsEqualTo("is foo whose length is 3 and whose first char is 'f'");
+	}
+
+	[Fact]
+	public async Task ForWhich_CalledTwice_WhereSecondProjectsFromFirstResult_ShouldChainProjections()
+	{
+		ManualExpectationBuilder<int> sut = new(null);
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 123, "is 123"));
+		sut.ForWhich<int, string>(i => i.ToString(CultureInfo.InvariantCulture),
+			" whose string ");
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "123", "is \"123\""));
+		sut.ForWhich<string, int>(s => s.Length, " and whose length ");
+		sut.AddConstraint((_, _) => new DummyConstraint<int>(i => i == 3, "is 3"));
+
+		ConstraintResult result = await sut.IsMetBy(123, null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(result.GetExpectationText())
+			.IsEqualTo("is 123 whose string is \"123\" and whose length is 3");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/ExpectationBuilderTests.cs
@@ -149,13 +149,13 @@ public class ExpectationBuilderTests
 		sut.ForWhich(upperAccessor, " whose upper ");
 		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "FOO", "is FOO"));
 		sut.ForWhich(doubledAccessor, " and whose doubled ");
-		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "foofoo", "is foofoo"));
+		sut.AddConstraint((_, _) => new DummyConstraint<string>(s => s == "FOOFOO", "is FOOFOO"));
 
 		ConstraintResult result = await sut.IsMetBy("foo", null!, CancellationToken.None);
 
 		await That(result.Outcome).IsEqualTo(Outcome.Success);
 		await That(result.GetExpectationText())
-			.IsEqualTo("is foo whose upper is FOO and whose doubled is foofoo");
+			.IsEqualTo("is foo whose upper is FOO and whose doubled is FOOFOO");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -260,7 +260,7 @@ public sealed class WhichNodeTests
 		Task<ConstraintResult> Act() => whichNode.IsMetBy("foo", null!, CancellationToken.None);
 
 		await That(Act).Throws<InvalidOperationException>()
-			.WithMessage("The expectation node does not support int with value 3");
+			.WithMessage("The expectation node does not support int with value 1");
 	}
 
 	[Fact]
@@ -281,36 +281,27 @@ public sealed class WhichNodeTests
 	}
 
 	[Fact]
-	public async Task IsMetBy_WhenParentWhichNodeProjectsToInnerSource_ShouldEvaluateAgainstProjectedValue()
+	public async Task IsMetBy_WhenOuterTypeDoesNotMatchButParentExposesProjectedValue_ShouldFallBackToParentProjection()
 	{
-		// Outer subject is `string` "food" (length 4).
-		// Parent WhichNode projects string → int (length).
-		// Inner WhichNode (TSource = int) projects int → bool (even).
-		// Without the fix the inner WhichNode receives the outer string instead of the projected int
-		// and throws "the member type for the actual value in the which node did not match".
-		WhichNode<string, int> outerWhich = new(null, s => s!.Length);
-		outerWhich.AddNode(new ExpectationNode());
-		outerWhich.AddConstraint(new DummyConstraint<int>(_ => true, "length"));
-
-		bool? observed = null;
-		WhichNode<int, bool> innerWhich = new(outerWhich, i => i % 2 == 0);
-		innerWhich.AddNode(new ExpectationNode());
-		innerWhich.AddConstraint(new DummyConstraint<bool>(b =>
+		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "abcd", ""));
+		WhichNode<string, int> whichNode = new(node1, s => s.Length);
+		whichNode.AddNode(new ExpectationNode());
+		int? observed = null;
+		whichNode.AddConstraint(new DummyConstraint<int>(i =>
 		{
-			observed = b;
-			return b;
-		}, "is true"));
+			observed = i;
+			return true;
+		}, "is anything"));
 
-		ConstraintResult result = await innerWhich.IsMetBy("food", null!, CancellationToken.None);
+		ConstraintResult result = await whichNode.IsMetBy(DateTime.Now, null!, CancellationToken.None);
 
 		await That(result.Outcome).IsEqualTo(Outcome.Success);
-		await That(observed).IsEqualTo(true);
+		await That(observed).IsEqualTo(4);
 	}
 
 	[Fact]
 	public async Task IsMetBy_WhenParentChainProjectsThroughThreeLevels_ShouldPropagateInnermostValue()
 	{
-		// string ("foo") → first char ('f') → code point (102) → is-even (true)
 		WhichNode<string, char> level1 = new(null, s => s![0]);
 		level1.AddNode(new ExpectationNode());
 		level1.AddConstraint(new DummyConstraint<char>(_ => true, "first"));
@@ -335,31 +326,30 @@ public sealed class WhichNodeTests
 	}
 
 	[Fact]
-	public async Task IsMetBy_WhenOuterTypeDoesNotMatchButParentExposesProjectedValue_ShouldFallBackToParentProjection()
+	public async Task IsMetBy_WhenParentWhichNodeProjectsToInnerSource_ShouldEvaluateAgainstProjectedValue()
 	{
-		// Parent's result carries a string "abcd". WhichNode<string, int> receives an unrelated
-		// outer DateTime, falls back to the parent's projected string, and projects its length.
-		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "abcd", ""));
-		WhichNode<string, int> whichNode = new(node1, s => s.Length);
-		whichNode.AddNode(new ExpectationNode());
-		int? observed = null;
-		whichNode.AddConstraint(new DummyConstraint<int>(i =>
-		{
-			observed = i;
-			return true;
-		}, "is anything"));
+		WhichNode<string, int> outerWhich = new(null, s => s!.Length);
+		outerWhich.AddNode(new ExpectationNode());
+		outerWhich.AddConstraint(new DummyConstraint<int>(_ => true, "length"));
 
-		ConstraintResult result = await whichNode.IsMetBy(DateTime.Now, null!, CancellationToken.None);
+		bool? observed = null;
+		WhichNode<int, bool> innerWhich = new(outerWhich, i => i % 2 == 0);
+		innerWhich.AddNode(new ExpectationNode());
+		innerWhich.AddConstraint(new DummyConstraint<bool>(b =>
+		{
+			observed = b;
+			return b;
+		}, "is true"));
+
+		ConstraintResult result = await innerWhich.IsMetBy("food", null!, CancellationToken.None);
 
 		await That(result.Outcome).IsEqualTo(Outcome.Success);
-		await That(observed).IsEqualTo(4);
+		await That(observed).IsEqualTo(true);
 	}
 
 	[Fact]
 	public async Task IsMetBy_WhenTypeDoesNotMatch_ShouldThrowInvalidOperationException()
 	{
-		// The parent node deliberately exposes no value of TSource, so the WhichNode cannot
-		// recover the projected value from the parent chain and must surface the type mismatch.
 		DummyNode node1 = new("", () => new DummyConstraintResult(Outcome.Success));
 		WhichNode<string, int> whichNode = new(node1, s => s.Length);
 		whichNode.AddNode(new ExpectationNode());
@@ -608,7 +598,7 @@ public sealed class WhichNodeTests
 
 			             Actual:
 			             foo
-			             
+
 			             Expected:
 			             bar
 			             """);

--- a/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/Nodes/WhichNodeTests.cs
@@ -281,9 +281,86 @@ public sealed class WhichNodeTests
 	}
 
 	[Fact]
+	public async Task IsMetBy_WhenParentWhichNodeProjectsToInnerSource_ShouldEvaluateAgainstProjectedValue()
+	{
+		// Outer subject is `string` "food" (length 4).
+		// Parent WhichNode projects string → int (length).
+		// Inner WhichNode (TSource = int) projects int → bool (even).
+		// Without the fix the inner WhichNode receives the outer string instead of the projected int
+		// and throws "the member type for the actual value in the which node did not match".
+		WhichNode<string, int> outerWhich = new(null, s => s!.Length);
+		outerWhich.AddNode(new ExpectationNode());
+		outerWhich.AddConstraint(new DummyConstraint<int>(_ => true, "length"));
+
+		bool? observed = null;
+		WhichNode<int, bool> innerWhich = new(outerWhich, i => i % 2 == 0);
+		innerWhich.AddNode(new ExpectationNode());
+		innerWhich.AddConstraint(new DummyConstraint<bool>(b =>
+		{
+			observed = b;
+			return b;
+		}, "is true"));
+
+		ConstraintResult result = await innerWhich.IsMetBy("food", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(observed).IsEqualTo(true);
+	}
+
+	[Fact]
+	public async Task IsMetBy_WhenParentChainProjectsThroughThreeLevels_ShouldPropagateInnermostValue()
+	{
+		// string ("foo") → first char ('f') → code point (102) → is-even (true)
+		WhichNode<string, char> level1 = new(null, s => s![0]);
+		level1.AddNode(new ExpectationNode());
+		level1.AddConstraint(new DummyConstraint<char>(_ => true, "first"));
+
+		WhichNode<char, int> level2 = new(level1, c => c);
+		level2.AddNode(new ExpectationNode());
+		level2.AddConstraint(new DummyConstraint<int>(_ => true, "code"));
+
+		WhichNode<int, bool> level3 = new(level2, i => i % 2 == 0);
+		level3.AddNode(new ExpectationNode());
+		bool? observed = null;
+		level3.AddConstraint(new DummyConstraint<bool>(b =>
+		{
+			observed = b;
+			return b;
+		}, "is true"));
+
+		ConstraintResult result = await level3.IsMetBy("foo", null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(observed).IsEqualTo(true);
+	}
+
+	[Fact]
+	public async Task IsMetBy_WhenOuterTypeDoesNotMatchButParentExposesProjectedValue_ShouldFallBackToParentProjection()
+	{
+		// Parent's result carries a string "abcd". WhichNode<string, int> receives an unrelated
+		// outer DateTime, falls back to the parent's projected string, and projects its length.
+		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "abcd", ""));
+		WhichNode<string, int> whichNode = new(node1, s => s.Length);
+		whichNode.AddNode(new ExpectationNode());
+		int? observed = null;
+		whichNode.AddConstraint(new DummyConstraint<int>(i =>
+		{
+			observed = i;
+			return true;
+		}, "is anything"));
+
+		ConstraintResult result = await whichNode.IsMetBy(DateTime.Now, null!, CancellationToken.None);
+
+		await That(result.Outcome).IsEqualTo(Outcome.Success);
+		await That(observed).IsEqualTo(4);
+	}
+
+	[Fact]
 	public async Task IsMetBy_WhenTypeDoesNotMatch_ShouldThrowInvalidOperationException()
 	{
-		DummyNode node1 = new("", () => new DummyConstraintResult<string?>(Outcome.Success, "1", ""));
+		// The parent node deliberately exposes no value of TSource, so the WhichNode cannot
+		// recover the projected value from the parent chain and must surface the type mismatch.
+		DummyNode node1 = new("", () => new DummyConstraintResult(Outcome.Success));
 		WhichNode<string, int> whichNode = new(node1, s => s.Length);
 		whichNode.AddNode(new ExpectationNode());
 		whichNode.AddConstraint(new DummyConstraint("c2",


### PR DESCRIPTION
`ExpectationBuilder.ForWhich` (since #955) drains a pending `_whichNode` into the graph before creating a new one, so two consecutive `ForWhich` calls produce two sibling `WhichNode`s. At evaluation time both nodes received the original outer subject - including the inner one, whose `TSource` is the *outer* node's `TMember`. That made any chained `ForWhich` whose accessor consumes the previous projection (e.g. `Which.X.Which.Y` or `Which.X.And.WhoseParent`) throw "The member type for the actual value in the which node did not match".

`WhichNode<TSource, TMember>.IsMetBy` now, when the outer value is not itself a `TSource`, asks the parent's `ConstraintResult.TryGetValue` for a `TSource`. `WhichConstraintResult.TryGetValue` already exposes the projection produced by the previous `WhichNode`, so the chained accessor consumes that value instead of the unrelated outer subject. The original type-mismatch error is still thrown when neither the outer value nor the parent chain can supply a `TSource`.

Adds coverage in `WhichNodeTests` (direct, two- and three-level chains plus a regression test for the fallback path) and in `ExpectationBuilderTests` (`ForWhich` and `ForWhich`-async called twice where the second projection consumes the first's result, plus a three-level integration variant).