### PR TITLE
chore: bump aweXpect.Core to v2.31.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.33.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.31.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.31.1" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.1.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
## Pull request overview

Updates centrally managed NuGet dependencies by bumping `aweXpect.Core` to the next patch release, keeping the repo aligned with the intended `aweXpect.Core` package version.

**Changes:**
- Bump `aweXpect.Core` NuGet package version from `2.31.0` to `2.31.1` in central package management.