### PR TITLE
chore: bump aweXpect to v2.34.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.33.0" />
+		<PackageVersion Include="aweXpect" Version="2.34.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.31.1" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.1.0" />
 	</ItemGroup>


### PR DESCRIPTION
Updates the repository’s centrally managed NuGet dependency on `aweXpect` to the next minor release, so Release/non-Debug builds that consume the published package will restore `aweXpect` v2.34.0.

**Changes:**
- Bump `aweXpect` PackageVersion from `2.33.0` to `2.34.0` in central package management.




