### PR TITLE
fix: use `Environment.NewLine` in `AppendIsIncomplete` failure messages

### DIFF
--- a/Source/aweXpect/That/Collections/CollectionHelpers.cs
+++ b/Source/aweXpect/That/Collections/CollectionHelpers.cs
@@ -220,19 +220,14 @@ internal static class CollectionHelpers
 
 		if (formattedItems.EndsWith($"…{Environment.NewLine}]"))
 		{
-			return $"""
-			        {formattedItems[..^(Environment.NewLine.Length + 2)]}(… and maybe others)
-			        ]
-			        """;
+			return formattedItems[..^(Environment.NewLine.Length + 2)] +
+			       $"(… and maybe others){Environment.NewLine}]";
 		}
 
 		if (formattedItems.EndsWith($"{Environment.NewLine}]"))
 		{
-			return $"""
-			        {formattedItems[..^(Environment.NewLine.Length + 1)]},
-			          (… and maybe others)
-			        ]
-			        """;
+			return formattedItems[..^(Environment.NewLine.Length + 1)] +
+			       $",{Environment.NewLine}  (… and maybe others){Environment.NewLine}]";
 		}
 
 		return $"""


### PR DESCRIPTION
Two return paths in `AppendIsIncomplete` were C# raw-string literals whose newlines are embedded at compile time from the source file's line endings. The official NuGet builds on Linux (LF), but the surrounding `Formatter.Format` output uses `Environment.NewLine` at runtime — so Windows consumers got messages with mixed `\r\n` and bare `\n` in the "(… and maybe others)" block.

Replace the raw strings with explicit concatenation using `Environment.NewLine` so the appended newlines match what `Formatter.Format` already produces.

---

- *Fixes #965*