### PR TITLE
feat: exclude netstandard and WindowsBase assembly prefixes by default

### DIFF
--- a/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
+++ b/Source/aweXpect.Core/Customization/AwexpectCustomization.Reflection.cs
@@ -61,6 +61,8 @@ public partial class AwexpectCustomization
 		///     - mscorlib<br />
 		///     - System<br />
 		///     - Microsoft<br />
+		///     - netstandard<br />
+		///     - WindowsBase<br />
 		///     - JetBrains<br />
 		///     - xunit<br />
 		///     - Castle<br />
@@ -71,6 +73,8 @@ public partial class AwexpectCustomization
 			"mscorlib",
 			"System",
 			"Microsoft",
+			"netstandard",
+			"WindowsBase",
 			"JetBrains",
 			"xunit",
 			"Castle",

--- a/Tests/aweXpect.Core.Tests/Customization/CustomizeReflectionTests.cs
+++ b/Tests/aweXpect.Core.Tests/Customization/CustomizeReflectionTests.cs
@@ -34,6 +34,8 @@ public sealed class CustomizeReflectionTests
 			"mscorlib",
 			"System",
 			"Microsoft",
+			"netstandard",
+			"WindowsBase",
 			"JetBrains",
 			"xunit",
 			"Castle",


### PR DESCRIPTION
Add "netstandard" and "WindowsBase" to the default ExcludedAssemblyPrefixes so that these framework assemblies are ignored during reflection scanning.