### PR TITLE
refactor: anchor assembly-prefix exclusion at name boundaries

### DIFF
--- a/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
+++ b/Source/aweXpect.Core/Core/Initialization/AweXpectInitialization.cs
@@ -63,8 +63,7 @@ internal static class AweXpectInitialization
 		ExecuteCustomInitializers();
 
 		foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()
-			         .Where(assembly => Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
-				         .All(excludedAssemblyPrefix => !assembly.FullName!.StartsWith(excludedAssemblyPrefix))))
+			         .Where(IsAssemblyIncluded))
 		{
 			try
 			{
@@ -86,12 +85,36 @@ internal static class AweXpectInitialization
 		return new InitializationState(new FallbackTestFramework());
 	}
 
+	private static bool IsAssemblyIncluded(Assembly assembly)
+		=> IsAssemblyNameIncluded(assembly.GetName().Name);
+
+	/// <summary>
+	///     Checks whether an assembly with the given <paramref name="assemblyName" /> (its simple name) should be scanned,
+	///     i.e. it is not excluded by any of the configured
+	///     <see cref="AwexpectCustomization.ReflectionCustomizationValue.ExcludedAssemblyPrefixes" />.
+	/// </summary>
+	/// <remarks>
+	///     A prefix matches the assembly name only at a name-segment boundary, so that e.g. <c>System</c> excludes
+	///     <c>System</c> and <c>System.Net.Http</c>, but not an unrelated assembly named <c>Systemics</c>.<br />
+	///     Assemblies without a name are never scanned, as they cannot host a test framework adapter or initializer.
+	/// </remarks>
+	internal static bool IsAssemblyNameIncluded(string? assemblyName)
+	{
+		if (string.IsNullOrEmpty(assemblyName))
+		{
+			return false;
+		}
+
+		return Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
+			.All(prefix => assemblyName != prefix &&
+			               !assemblyName!.StartsWith(prefix + ".", StringComparison.Ordinal));
+	}
+
 	private static void ExecuteCustomInitializers()
 	{
 		Type initializerInterface = typeof(IAweXpectInitializer);
 		foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()
-			         .Where(assembly => Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get()
-				         .All(excludedAssemblyPrefix => !assembly.FullName!.StartsWith(excludedAssemblyPrefix))))
+			         .Where(IsAssemblyIncluded))
 		{
 			try
 			{

--- a/Tests/aweXpect.Core.Tests/Initialization/AweXpectInitializationTests.cs
+++ b/Tests/aweXpect.Core.Tests/Initialization/AweXpectInitializationTests.cs
@@ -1,0 +1,43 @@
+using aweXpect.Core.Initialization;
+
+namespace aweXpect.Core.Tests.Initialization;
+
+public sealed class AweXpectInitializationTests
+{
+	[Theory]
+	[InlineData("System", "exact framework assembly name")]
+	[InlineData("System.Net.Http", "sub-name of an excluded prefix")]
+	[InlineData("Microsoft.Extensions.Logging")]
+	[InlineData("netstandard")]
+	[InlineData("WindowsBase")]
+	[InlineData("xunit.core")]
+	[InlineData("DynamicProxyGenAssembly2")]
+	public async Task IsAssemblyNameIncluded_WhenExcludedByDefault_ShouldReturnFalse(string assemblyName, string? because = null)
+	{
+		bool included = AweXpectInitialization.IsAssemblyNameIncluded(assemblyName);
+
+		await That(included).IsEqualTo(false).Because(because);
+	}
+
+	[Theory]
+	[InlineData("Systemics", "shares the \"System\" prefix, but not at a name boundary")]
+	[InlineData("Microsoftish", "shares the \"Microsoft\" prefix, but not at a name boundary")]
+	[InlineData("WindowsBaseExtensions", "shares the \"WindowsBase\" prefix, but not at a name boundary")]
+	[InlineData("MyCompany.Product")]
+	public async Task IsAssemblyNameIncluded_WhenNotExcluded_ShouldReturnTrue(string assemblyName, string? because = null)
+	{
+		bool included = AweXpectInitialization.IsAssemblyNameIncluded(assemblyName);
+
+		await That(included).IsEqualTo(true).Because(because);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public async Task IsAssemblyNameIncluded_WithoutName_ShouldReturnFalse(string? assemblyName)
+	{
+		bool included = AweXpectInitialization.IsAssemblyNameIncluded(assemblyName);
+
+		await That(included).IsEqualTo(false);
+	}
+}


### PR DESCRIPTION
`ExcludedAssemblyPrefixes` were matched as raw substrings against `Assembly.FullName` with a culture-sensitive `StartsWith`, so e.g. `System` also excluded an unrelated assembly named `Systemics`, letting a first-party assembly be silently skipped during scanning.

Match against the simple assembly name (`GetName().Name`) using an ordinal, name-segment-boundary comparison (`name == prefix || name.StartsWith(prefix + .)`). Single-name entries like `netstandard` and `DynamicProxyGenAssembly2` still match via the equality arm. Assemblies without a name are no longer scanned.