### PR TITLE
feat: update `Because` method to handle null reason

### DIFF
--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -31,9 +31,16 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder)
 	///     Provide a <paramref name="reason" /> explaining why the constraint is needed.<br />
 	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
 	/// </summary>
-	public ExpectationResult Because(string reason)
+	/// <remarks>
+	///     When the <paramref name="reason" /> is <see langword="null" /> or empty, it is ignored.
+	/// </remarks>
+	public ExpectationResult Because(string? reason)
 	{
-		expectationBuilder.AddReason(reason);
+		if (!string.IsNullOrEmpty(reason))
+		{
+			expectationBuilder.AddReason(reason);
+		}
+
 		return this;
 	}
 
@@ -167,9 +174,16 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	///     Provide a <paramref name="reason" /> explaining why the constraint is needed.<br />
 	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
 	/// </summary>
-	public TSelf Because(string reason)
+	/// <remarks>
+	///     When the <paramref name="reason" /> is <see langword="null" /> or empty, it is ignored.
+	/// </remarks>
+	public TSelf Because(string? reason)
 	{
-		expectationBuilder.AddReason(reason);
+		if (!string.IsNullOrEmpty(reason))
+		{
+			expectationBuilder.AddReason(reason);
+		}
+
 		return (TSelf)this;
 	}
 

--- a/Tests/aweXpect.Core.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Core.Api.Tests/ApiAcceptance.cs
@@ -10,6 +10,7 @@ public sealed class ApiAcceptance
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
 	[TestCase]
+	[Explicit]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net10.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net10.0.txt
@@ -1193,7 +1193,7 @@ namespace aweXpect.Results
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string> reason) { }
-        public aweXpect.Results.ExpectationResult Because(string reason) { }
+        public aweXpect.Results.ExpectationResult Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
         public override string? ToString() { }
         public aweXpect.Results.ExpectationResult WithCancellation(System.Threading.CancellationToken cancellationToken) { }
@@ -1209,7 +1209,7 @@ namespace aweXpect.Results
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public TSelf Because(System.Threading.Tasks.Task<string> reason) { }
-        public TSelf Because(string reason) { }
+        public TSelf Because(string? reason) { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }
         public override string? ToString() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -1193,7 +1193,7 @@ namespace aweXpect.Results
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string> reason) { }
-        public aweXpect.Results.ExpectationResult Because(string reason) { }
+        public aweXpect.Results.ExpectationResult Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
         public override string? ToString() { }
         public aweXpect.Results.ExpectationResult WithCancellation(System.Threading.CancellationToken cancellationToken) { }
@@ -1209,7 +1209,7 @@ namespace aweXpect.Results
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public TSelf Because(System.Threading.Tasks.Task<string> reason) { }
-        public TSelf Because(string reason) { }
+        public TSelf Because(string? reason) { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }
         public override string? ToString() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -1156,7 +1156,7 @@ namespace aweXpect.Results
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string> reason) { }
-        public aweXpect.Results.ExpectationResult Because(string reason) { }
+        public aweXpect.Results.ExpectationResult Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
         public override string? ToString() { }
         public aweXpect.Results.ExpectationResult WithCancellation(System.Threading.CancellationToken cancellationToken) { }
@@ -1171,7 +1171,7 @@ namespace aweXpect.Results
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
         public TSelf Because(System.Threading.Tasks.Task<string> reason) { }
-        public TSelf Because(string reason) { }
+        public TSelf Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }
         public override string? ToString() { }
         public TSelf WithCancellation(System.Threading.CancellationToken cancellationToken) { }

--- a/Tests/aweXpect.Core.Tests/Core/BecauseTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/BecauseTests.cs
@@ -33,6 +33,22 @@ public class BecauseTests
 		await That(Act).ThrowsException().WithMessage($"*{because}*").AsWildcard();
 	}
 
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public async Task ActionDelegate_WhenReasonIsNullOrEmpty_ShouldNotIncludeBecause(string? because)
+	{
+		Action subject = () => throw new MyException();
+
+		async Task Act()
+		{
+			await That(subject).DoesNotThrow().Because(because);
+		}
+
+		Exception exception = await That(Act).ThrowsException();
+		await That(exception.Message).DoesNotContain("because");
+	}
+
 	[Fact]
 	public async Task ASpecifiedBecauseReason_ShouldBeIncludedInMessage()
 	{
@@ -170,6 +186,26 @@ public class BecauseTests
 		async Task Act()
 		{
 			await That(subject).IsFalse();
+		}
+
+		await That(Act).ThrowsException()
+			.WithMessage("""
+			             Expected that subject
+			             is False,
+			             but it was True
+			             """);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public async Task WhenReasonIsNullOrEmpty_ShouldNotIncludeBecause(string? because)
+	{
+		bool subject = true;
+
+		async Task Act()
+		{
+			await That(subject).IsFalse().Because(because);
 		}
 
 		await That(Act).ThrowsException()


### PR DESCRIPTION
Updates the `Because` method to gracefully handle `null` and empty reasons instead of throwing.

Previously, calling `.Because(null)` would throw a `NullReferenceException` (the reason was passed straight into `BecauseReason`, which calls `reason.Trim()`), and an empty string produced a dangling `", because "` fragment. Now both `null` and empty reasons are simply ignored.

## Changes

- `ExpectationResult.Because` and `ExpectationResult<TType, TSelf>.Because` now accept `string?` and skip adding the reason when it is `null` or empty.
- Updated the XML docs with a `<remarks>` note describing the null/empty behavior.
- Regenerated the public-API approval files (`net8.0`, `net10.0`, `netstandard2.0`) to reflect the `string?` signature.
- Marked `aweXpect.Core.Api.Tests`' `AcceptApiChanges` as `[Explicit]`, consistent with `aweXpect.Api.Tests`, so the API-regeneration helper no longer runs as part of the normal test suite (verification still happens in `ApiApprovalTests`).

## Behavior

| Call | Before | After |
|------|--------|-------|
| `.Because("reason")` | adds reason | adds reason (unchanged) |
| `.Because("")` | `", because "` | ignored |
| `.Because(null)` | `NullReferenceException` | ignored |
