### PR TITLE
feat: handle null/empty async `Because` reasons

### DIFF
--- a/Source/aweXpect.Core/Core/ExpectationBuilder.cs
+++ b/Source/aweXpect.Core/Core/ExpectationBuilder.cs
@@ -309,7 +309,7 @@ public abstract class ExpectationBuilder
 	/// <summary>
 	///     Adds a <paramref name="reason" /> to the current expectation constraint.
 	/// </summary>
-	internal void AddReason(Task<string> reason)
+	internal void AddReason(Task<string?> reason)
 	{
 		AsyncBecauseReason becauseReason = new(reason);
 		_node.SetReason(becauseReason);

--- a/Source/aweXpect.Core/Core/Helpers/AsyncBecauseReason.cs
+++ b/Source/aweXpect.Core/Core/Helpers/AsyncBecauseReason.cs
@@ -4,7 +4,7 @@ using aweXpect.Core.Constraints;
 
 namespace aweXpect.Core.Helpers;
 
-internal struct AsyncBecauseReason(Task<string> reason) : IBecauseReason
+internal struct AsyncBecauseReason(Task<string?> reason) : IBecauseReason
 {
 	private string? _message;
 
@@ -27,7 +27,13 @@ internal struct AsyncBecauseReason(Task<string> reason) : IBecauseReason
 	{
 		if (_message is null)
 		{
-			_message = CreateMessage(await reason.ConfigureAwait(false));
+			string? resolvedReason = await reason.ConfigureAwait(false);
+			if (string.IsNullOrEmpty(resolvedReason))
+			{
+				return result;
+			}
+
+			_message = CreateMessage(resolvedReason);
 		}
 
 		string message = _message;

--- a/Source/aweXpect.Core/Results/ExpectationResult.cs
+++ b/Source/aweXpect.Core/Results/ExpectationResult.cs
@@ -48,7 +48,10 @@ public class ExpectationResult(ExpectationBuilder expectationBuilder)
 	///     Provide an <see langword="async" /> <paramref name="reason" /> explaining why the constraint is needed.<br />
 	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
 	/// </summary>
-	public ExpectationResult Because(Task<string> reason)
+	/// <remarks>
+	///     When the <paramref name="reason" /> resolves to <see langword="null" /> or empty, it is ignored.
+	/// </remarks>
+	public ExpectationResult Because(Task<string?> reason)
 	{
 		expectationBuilder.AddReason(reason);
 		return this;
@@ -191,7 +194,10 @@ public class ExpectationResult<TType, TSelf>(ExpectationBuilder expectationBuild
 	///     Provide an <see langword="async" /> <paramref name="reason" /> explaining why the constraint is needed.<br />
 	///     If the phrase does not start with the word <i>because</i>, it is prepended automatically.
 	/// </summary>
-	public TSelf Because(Task<string> reason)
+	/// <remarks>
+	///     When the <paramref name="reason" /> resolves to <see langword="null" /> or empty, it is ignored.
+	/// </remarks>
+	public TSelf Because(Task<string?> reason)
 	{
 		expectationBuilder.AddReason(reason);
 		return (TSelf)this;

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net10.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net10.0.txt
@@ -1192,7 +1192,7 @@ namespace aweXpect.Results
     public class ExpectationResult : aweXpect.Results.Expectation, aweXpect.Core.IOptionsProvider<aweXpect.Core.ExpectationBuilder>
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-        public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string> reason) { }
+        public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string?> reason) { }
         public aweXpect.Results.ExpectationResult Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
         public override string? ToString() { }
@@ -1208,7 +1208,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ExpectationResult<TType, TSelf>
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-        public TSelf Because(System.Threading.Tasks.Task<string> reason) { }
+        public TSelf Because(System.Threading.Tasks.Task<string?> reason) { }
         public TSelf Because(string? reason) { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_net8.0.txt
@@ -1192,7 +1192,7 @@ namespace aweXpect.Results
     public class ExpectationResult : aweXpect.Results.Expectation, aweXpect.Core.IOptionsProvider<aweXpect.Core.ExpectationBuilder>
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-        public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string> reason) { }
+        public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string?> reason) { }
         public aweXpect.Results.ExpectationResult Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
         public override string? ToString() { }
@@ -1208,7 +1208,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ExpectationResult<TType, TSelf>
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-        public TSelf Because(System.Threading.Tasks.Task<string> reason) { }
+        public TSelf Because(System.Threading.Tasks.Task<string?> reason) { }
         public TSelf Because(string? reason) { }
         [System.Diagnostics.StackTraceHidden]
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }

--- a/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
+++ b/Tests/aweXpect.Core.Api.Tests/Expected/aweXpect.Core_netstandard2.0.txt
@@ -1155,7 +1155,7 @@ namespace aweXpect.Results
     public class ExpectationResult : aweXpect.Results.Expectation, aweXpect.Core.IOptionsProvider<aweXpect.Core.ExpectationBuilder>
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-        public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string> reason) { }
+        public aweXpect.Results.ExpectationResult Because(System.Threading.Tasks.Task<string?> reason) { }
         public aweXpect.Results.ExpectationResult Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() { }
         public override string? ToString() { }
@@ -1170,7 +1170,7 @@ namespace aweXpect.Results
         where TSelf : aweXpect.Results.ExpectationResult<TType, TSelf>
     {
         public ExpectationResult(aweXpect.Core.ExpectationBuilder expectationBuilder) { }
-        public TSelf Because(System.Threading.Tasks.Task<string> reason) { }
+        public TSelf Because(System.Threading.Tasks.Task<string?> reason) { }
         public TSelf Because(string? reason) { }
         public System.Runtime.CompilerServices.TaskAwaiter<TType> GetAwaiter() { }
         public override string? ToString() { }

--- a/Tests/aweXpect.Core.Tests/Core/BecauseTests.cs
+++ b/Tests/aweXpect.Core.Tests/Core/BecauseTests.cs
@@ -36,6 +36,23 @@ public class BecauseTests
 	[Theory]
 	[InlineData(null)]
 	[InlineData("")]
+	public async Task ActionDelegate_WhenAsyncReasonIsNullOrEmpty_ShouldNotIncludeBecause(string? because)
+	{
+		Task<string?> becauseTask = Task.FromResult(because);
+		Action subject = () => throw new MyException();
+
+		async Task Act()
+		{
+			await That(subject).DoesNotThrow().Because(becauseTask);
+		}
+
+		Exception exception = await That(Act).ThrowsException();
+		await That(exception.Message).DoesNotContain("because");
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
 	public async Task ActionDelegate_WhenReasonIsNullOrEmpty_ShouldNotIncludeBecause(string? because)
 	{
 		Action subject = () => throw new MyException();
@@ -123,6 +140,27 @@ public class BecauseTests
 		}
 
 		await That(Act).ThrowsException().WithMessage($"*{because1}*").AsWildcard();
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public async Task WhenAsyncReasonIsNullOrEmpty_ShouldNotIncludeBecause(string? because)
+	{
+		Task<string?> becauseTask = Task.FromResult(because);
+		bool subject = true;
+
+		async Task Act()
+		{
+			await That(subject).IsFalse().Because(becauseTask);
+		}
+
+		await That(Act).ThrowsException()
+			.WithMessage("""
+			             Expected that subject
+			             is False,
+			             but it was True
+			             """);
 	}
 
 	[Fact]


### PR DESCRIPTION
The synchronous `Because(string?)` overloads were already updated (#973) to ignore null or empty reasons. This applies the same behavior to the asynchronous `Because(Task<string>)` overloads.

The async overloads now accept `Task<string?>`, mirroring the nullable `string?` of the synchronous variants: the task reference is still required, but the value it resolves to may be null or empty. When the resolved value is null or empty, the reason is ignored (no `because` text is appended) instead of throwing a `NullReferenceException` (from `reason.Trim()`) or producing a dangling ", because " fragment.

Because the resolved string is only available after awaiting, the null/empty guard lives in `AsyncBecauseReason.ApplyTo`, where the result is left unchanged when the reason resolves to null or empty.

**Changes:**
- `ExpectationResult.Because` and `ExpectationResult<TType, TSelf>.Because` now take `Task<string?>`.
- `ExpectationBuilder.AddReason` and `AsyncBecauseReason` updated to `Task<string?>`; the resolved value is checked for null/empty.
- Regenerated the public-API approval files for all target frameworks.
- Added tests covering null and empty resolved reasons for both the non-generic and generic async overloads.